### PR TITLE
Shadows

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -628,6 +628,10 @@ CommonSettingsDialog.tooltipDismissDelay=Tooltip dismiss delay:
 CommonSettingsDialog.tooltipDismissDelayTooltip:Sets the delay before a tooltip is dismised.  -1 uses the default for your look and feel.
 CommonSettingsDialog.Update=Update
 CommonSettingsDialog.showWpsinTT=Show unit weapons in the tooltip
+CommonSettingsDialog.AOHexSHadows=Show ambient-occlusion-like hex shadows at the base of hills
+CommonSettingsDialog.useShadowMap=Show terrain and building shadows
+CommonSettingsDialog.levelHighlight=Level highlighting (thick borders at level changes)
+CommonSettingsDialog.floatingIso=Floating isometric (no hex sides in isometric mode)
 ConfirmDialog.dontBother=Do not bother me again
 
 CustomBattleArmorDialog.title=Build your Battle Armor...

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -804,10 +804,12 @@ public class CommonSettingsDialog extends ClientDialog implements
         gs.setLevelHighlight(levelhighlight.isSelected());
         gs.setShadowMap(shadowMap.isSelected());
 
-        if (gs.getAntiAliasing() != chkAntiAliasing.isSelected()) {
+        if ((gs.getAntiAliasing() != chkAntiAliasing.isSelected()) &&
+                ((clientgui != null) && (clientgui.bv != null))) {            
             clientgui.bv.clearHexImageCache();
             clientgui.bv.repaint();
         }
+
         gs.setAntiAliasing(chkAntiAliasing.isSelected());
 
         gs.setShowDamageLevel(showDamageLevel.isSelected());
@@ -830,6 +832,10 @@ public class CommonSettingsDialog extends ClientDialog implements
         }
 
         if (tileSetChoice.getSelectedIndex() >= 0) {
+            if (!cs.getMapTileset().equals(tileSets[tileSetChoice.getSelectedIndex()]) &&
+                    (clientgui != null) && (clientgui.bv != null))  {
+                clientgui.bv.clearShadowMap();
+            }
             cs.setMapTileset(tileSets[tileSetChoice.getSelectedIndex()]
                     .getName());
         }
@@ -1081,7 +1087,7 @@ public class CommonSettingsDialog extends ClientDialog implements
                 clientgui.bv.repaint();
             }
             return;
-        }
+        } 
         // For Advanced options
         String option = "Advanced" + keys.getModel().getElementAt(keysIndex); 
         GUIPreferences.getInstance().setValue(option, value.getText());

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -162,6 +162,10 @@ public class CommonSettingsDialog extends ClientDialog implements
 
     private JCheckBox showDamageLevel;
     private JCheckBox showMapsheets;
+    private JCheckBox aOHexShadows;
+    private JCheckBox floatingIso;
+    private JCheckBox levelhighlight;
+    private JCheckBox shadowMap;
     private JCheckBox mouseWheelZoom;
     private JCheckBox mouseWheelZoomFlip;
 
@@ -672,10 +676,12 @@ public class CommonSettingsDialog extends ClientDialog implements
         displayLocale.setSelectedIndex(index);
 
         showMapsheets.setSelected(gs.getShowMapsheets());
-
         chkAntiAliasing.setSelected(gs.getAntiAliasing());
-
         showDamageLevel.setSelected(gs.getShowDamageLevel());
+        aOHexShadows.setSelected(gs.getAOHexShadows());
+        floatingIso.setSelected(gs.getFloatingIso());
+        levelhighlight.setSelected(gs.getLevelHighlight());
+        shadowMap.setSelected(gs.getShadowMap());
 
 
         File dir = new File("data" + File.separator + "images" + File.separator
@@ -793,6 +799,10 @@ public class CommonSettingsDialog extends ClientDialog implements
                 .getSelectedIndex()]);
 
         gs.setShowMapsheets(showMapsheets.isSelected());
+        gs.setAOHexShadows(aOHexShadows.isSelected());
+        gs.setFloatingIso(floatingIso.isSelected());
+        gs.setLevelHighlight(levelhighlight.isSelected());
+        gs.setShadowMap(shadowMap.isSelected());
 
         if (gs.getAntiAliasing() != chkAntiAliasing.isSelected()) {
             clientgui.bv.clearHexImageCache();
@@ -1023,7 +1033,32 @@ public class CommonSettingsDialog extends ClientDialog implements
                 clientgui.bv.clearHexImageCache();
                 clientgui.bv.repaint();
             }
+        } else if (source.equals(aOHexShadows)) {
+            guip.setAOHexShadows(aOHexShadows.isSelected());
+            if ((clientgui != null) && (clientgui.bv != null)) {
+                clientgui.bv.clearHexImageCache();
+                clientgui.bv.repaint();
+            }
+        } else if (source.equals(shadowMap)) {
+            guip.setShadowMap(shadowMap.isSelected());
+            if ((clientgui != null) && (clientgui.bv != null)) {
+                clientgui.bv.clearHexImageCache();
+                clientgui.bv.repaint();
+            }
+        } else if (source.equals(levelhighlight)) {
+            guip.setLevelHighlight(levelhighlight.isSelected());
+            if ((clientgui != null) && (clientgui.bv != null)) {
+                clientgui.bv.clearHexImageCache();
+                clientgui.bv.repaint();
+            }
+        } else if (source.equals(floatingIso)) {
+            guip.setFloatingIso(floatingIso.isSelected());
+            if ((clientgui != null) && (clientgui.bv != null)) {
+                clientgui.bv.clearHexImageCache();
+                clientgui.bv.repaint();
+            }
         }
+
     }
 
     public void focusGained(FocusEvent e) {
@@ -1057,6 +1092,9 @@ public class CommonSettingsDialog extends ClientDialog implements
         }
     }
 
+    /** 
+     * The Graphics Tab
+     */
     private JPanel getTacticalOverlaySettingsPanel() {
 
         ArrayList<ArrayList<Component>> comps = new ArrayList<ArrayList<Component>>();
@@ -1087,6 +1125,34 @@ public class CommonSettingsDialog extends ClientDialog implements
         showMapsheets = new JCheckBox(Messages.getString("CommonSettingsDialog.showMapsheets")); //$NON-NLS-1$
         row = new ArrayList<>();
         row.add(showMapsheets);
+        comps.add(row);
+
+        // Hill Base AO Shadows
+        aOHexShadows = new JCheckBox(Messages.getString("CommonSettingsDialog.AOHexSHadows")); //$NON-NLS-1$
+        row = new ArrayList<>();
+        aOHexShadows.addItemListener(this);
+        row.add(aOHexShadows);
+        comps.add(row);
+        
+        // Shadow Map = Terrain and Building shadows
+        shadowMap = new JCheckBox(Messages.getString("CommonSettingsDialog.useShadowMap")); //$NON-NLS-1$
+        row = new ArrayList<>();
+        shadowMap.addItemListener(this);
+        row.add(shadowMap);
+        comps.add(row);
+        
+        // Level Highlight = borders around level changes
+        levelhighlight = new JCheckBox(Messages.getString("CommonSettingsDialog.levelHighlight")); //$NON-NLS-1$
+        row = new ArrayList<>();
+        levelhighlight.addItemListener(this);
+        row.add(levelhighlight);
+        comps.add(row);
+        
+        // Floating Isometric = do not draw hex sides
+        floatingIso = new JCheckBox(Messages.getString("CommonSettingsDialog.floatingIso")); //$NON-NLS-1$
+        row = new ArrayList<>();
+        floatingIso.addItemListener(this);
+        row.add(floatingIso);
         comps.add(row);
         
         // Skin

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -81,12 +81,15 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ADVANCED_KEY_REPEAT_RATE = "AdvancedKeyRepeatRate";
     public static final String ADVANCED_SHOW_FPS = "AdvancedShowFPS";
     public static final String ADVANCED_SHOW_COORDS = "AdvancedShowCoords";
-    public static final String ADVANCED_SHOW_HEX_SHADOWS = "AdvancedShowHexShadows";
     public static final String ADVANCED_BUTTONS_PER_ROW = "AdvancedButtonsPerRow";
     /* --End advanced settings-- */
 
 
     public static final String ANTIALIASING = "AntiAliasing";
+    public static final String SHADOWMAP = "ShadowMap";
+    public static final String AOHEXSHADOWS = "AoHexShadows";
+    public static final String LEVELHIGHLIGHT = "LevelHighlight";
+    public static final String FLOATINGISO = "FloatingIsometric";
     public static final String AUTO_END_FIRING = "AutoEndFiring";
     public static final String AUTO_DECLARE_SEARCHLIGHT = "AutoDeclareSearchlight";
     public static final String CHAT_LOUNGE_TABS = "ChatLoungeTabs";
@@ -243,7 +246,6 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(ADVANCED_KEY_REPEAT_RATE, 20);
         store.setDefault(ADVANCED_SHOW_FPS, "false");
         store.setDefault(ADVANCED_SHOW_COORDS, "true");
-        store.setDefault(ADVANCED_SHOW_HEX_SHADOWS, "false");    
         store.setDefault(ADVANCED_BUTTONS_PER_ROW, 5);
 
         store.setDefault(FOV_HIGHLIGHT_RINGS_RADII, "5 10 15 20 25");
@@ -251,6 +253,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
 
         store.setDefault(ANTIALIASING, true);
+        store.setDefault(AOHEXSHADOWS, false);
+        store.setDefault(SHADOWMAP, false);
+        store.setDefault(FLOATINGISO, false);
+        store.setDefault(LEVELHIGHLIGHT, false);
         store.setDefault(AUTO_END_FIRING, true);
         store.setDefault(AUTO_DECLARE_SEARCHLIGHT, true);
         store.setDefault(CHAT_LOUNGE_TABS, true);
@@ -351,6 +357,22 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public boolean getAntiAliasing() {
         return store.getBoolean(ANTIALIASING);
+    }
+
+    public boolean getAOHexShadows() {
+        return store.getBoolean(AOHEXSHADOWS);
+    }
+    
+    public boolean getFloatingIso() {
+        return store.getBoolean(FLOATINGISO);
+    }
+
+    public boolean getShadowMap() {
+        return store.getBoolean(SHADOWMAP);
+    }
+
+    public boolean getLevelHighlight() {
+        return store.getBoolean(LEVELHIGHLIGHT);
     }
 
     public boolean getAutoEndFiring() {
@@ -698,7 +720,23 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setAntiAliasing(boolean state){
         store.setValue(ANTIALIASING, state);
     }
-
+    
+    public void setShadowMap(boolean state){
+        store.setValue(SHADOWMAP, state);
+    }
+    
+    public void setAOHexShadows(boolean state){
+        store.setValue(AOHEXSHADOWS, state);
+    }
+    
+    public void setFloatingIso(boolean state){
+        store.setValue(FLOATINGISO, state);
+    }
+    
+    public void setLevelHighlight(boolean state){
+        store.setValue(LEVELHIGHLIGHT, state);
+    }
+    
     public boolean getShowDamageLevel(){
         return store.getBoolean(SHOW_DAMAGE_LEVEL);
     }


### PR DESCRIPTION
Hiya,

this branch will add a cast shadow to hex elevations, buildings(!) and trees. In addition, four new checkboxes in the graphics tab of the Client Settings allow switching of cast shadows, hex AO shadows (the ones that could formerly be activated from the advanced settings), the thick line level borders and "floating" isometric mode (that does not draw the hex sides in iso mode). Everything's optional as usual.

The cast shadows use the hex buffer as usual and do not impact performance at all so long as the board stays the same. The shadowmap itself is one board-sized image and thus may use a few MB.

The shadows do not work well in all situations (e.g. when there is a building and a road in the same hex) but I checked almost every map during testing and errors are actually very rare (and not so very visible in the end).

I know that this isn't helping with pilot special ability problems, but it was fun to do and I think it does give some depth, esp. with buildings. Personally I prefer the map to look as un-technical as possible, hurting the eye with hex borders and such stuff only as far as necessary. That's why I dislike the official maps and why I tend to work on these things.

Have fun!
S