### PR TITLE
Configurable data directory

### DIFF
--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -410,6 +410,7 @@ public class MegaMek {
         private static final String OPTION_UNIT_EXPORT = "export"; //$NON-NLS-1$
         private static final String OPTION_OFFICAL_UNIT_LIST = "oul"; //$NON-NLS-1$
         private static final String OPTION_UNIT_BATTLEFORCE_CONVERSION = "bfc"; //$NON-NLS-1$
+        private static final String OPTION_DATADIR = "data"; //$NON-NLS-1$
 
         public CommandLineParser(String[] args) {
             super(args);
@@ -473,7 +474,11 @@ public class MegaMek {
                 nextToken();
                 processExtendedEquipmentDb();
             }
-
+            if ((getToken() == TOK_OPTION)
+                    && getTokenValue().equals(OPTION_DATADIR)) {
+                nextToken();
+                processDataDir();
+            }
             if ((getToken() == TOK_OPTION)
                     && getTokenValue().equals(OPTION_UNIT_VALIDATOR)) {
                 nextToken();
@@ -558,6 +563,17 @@ public class MegaMek {
             System.exit(0);
         }
 
+        private void processDataDir() throws ParseException {
+            String dataDirName;
+            if (getToken() == TOK_LITERAL) {
+                dataDirName = getTokenValue();
+                nextToken();
+                Configuration.setDataDir(new File(dataDirName));
+            } else {
+                error("directory name expected"); // $NON-NLS-1$
+            }
+        }
+        
         private void processUnitValidator() throws ParseException {
             String filename;
             if (getToken() == TOK_LITERAL) {

--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -410,7 +410,6 @@ public class MegaMek {
         private static final String OPTION_UNIT_EXPORT = "export"; //$NON-NLS-1$
         private static final String OPTION_OFFICAL_UNIT_LIST = "oul"; //$NON-NLS-1$
         private static final String OPTION_UNIT_BATTLEFORCE_CONVERSION = "bfc"; //$NON-NLS-1$
-        private static final String OPTION_DATADIR = "data"; //$NON-NLS-1$
 
         public CommandLineParser(String[] args) {
             super(args);
@@ -474,11 +473,7 @@ public class MegaMek {
                 nextToken();
                 processExtendedEquipmentDb();
             }
-            if ((getToken() == TOK_OPTION)
-                    && getTokenValue().equals(OPTION_DATADIR)) {
-                nextToken();
-                processDataDir();
-            }
+
             if ((getToken() == TOK_OPTION)
                     && getTokenValue().equals(OPTION_UNIT_VALIDATOR)) {
                 nextToken();
@@ -563,17 +558,6 @@ public class MegaMek {
             System.exit(0);
         }
 
-        private void processDataDir() throws ParseException {
-            String dataDirName;
-            if (getToken() == TOK_LITERAL) {
-                dataDirName = getTokenValue();
-                nextToken();
-                Configuration.setDataDir(new File(dataDirName));
-            } else {
-                error("directory name expected"); // $NON-NLS-1$
-            }
-        }
-        
         private void processUnitValidator() throws ParseException {
             String filename;
             if (getToken() == TOK_LITERAL) {

--- a/megamek/src/megamek/common/QuirksHandler.java
+++ b/megamek/src/megamek/common/QuirksHandler.java
@@ -340,7 +340,7 @@ public class QuirksHandler {
         }
 
         // Load the canon quirks list.
-        String filePath = userDir + "data" + File.separator + "canonUnitQuirks.xml";
+        String filePath = Configuration.dataDir().getAbsolutePath() + File.separator + "canonUnitQuirks.xml";
         canonQuirkMap = loadQuirksFile(filePath);
 
         // Load the custom quirks list.

--- a/megamek/src/megamek/common/QuirksHandler.java
+++ b/megamek/src/megamek/common/QuirksHandler.java
@@ -340,7 +340,7 @@ public class QuirksHandler {
         }
 
         // Load the canon quirks list.
-        String filePath = Configuration.dataDir().getAbsolutePath() + File.separator + "canonUnitQuirks.xml";
+        String filePath = userDir + "data" + File.separator + "canonUnitQuirks.xml";
         canonQuirkMap = loadQuirksFile(filePath);
 
         // Load the custom quirks list.


### PR DESCRIPTION
This commit:

* adds a command line option "-data" to set the data directory used by the game (defaults to "data")
* fixes the `megamek.common.QuirksHandler` class not using `Configuration.dataDir()`

This is useful for developing and keeping multiple (custom) variants of the data directory for different games.