### PR TITLE
Bugfix: Look for canonUnitQuirks.xml in the globally configured data dir

### DIFF
--- a/megamek/src/megamek/common/QuirksHandler.java
+++ b/megamek/src/megamek/common/QuirksHandler.java
@@ -340,7 +340,7 @@ public class QuirksHandler {
         }
 
         // Load the canon quirks list.
-        String filePath = userDir + "data" + File.separator + "canonUnitQuirks.xml";
+        String filePath = Configuration.dataDir().getAbsolutePath() + File.separator + "canonUnitQuirks.xml";
         canonQuirkMap = loadQuirksFile(filePath);
 
         // Load the custom quirks list.


### PR DESCRIPTION
This fixes the `megamek.common.QuirksHandler` class not using `Configuration.dataDir()`.