### PR TITLE
Configurable data directory

### DIFF
--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -410,6 +410,7 @@ public class MegaMek {
         private static final String OPTION_UNIT_EXPORT = "export"; //$NON-NLS-1$
         private static final String OPTION_OFFICAL_UNIT_LIST = "oul"; //$NON-NLS-1$
         private static final String OPTION_UNIT_BATTLEFORCE_CONVERSION = "bfc"; //$NON-NLS-1$
+        private static final String OPTION_DATADIR = "data"; //$NON-NLS-1$
 
         public CommandLineParser(String[] args) {
             super(args);
@@ -473,7 +474,11 @@ public class MegaMek {
                 nextToken();
                 processExtendedEquipmentDb();
             }
-
+            if ((getToken() == TOK_OPTION)
+                    && getTokenValue().equals(OPTION_DATADIR)) {
+                nextToken();
+                processDataDir();
+            }
             if ((getToken() == TOK_OPTION)
                     && getTokenValue().equals(OPTION_UNIT_VALIDATOR)) {
                 nextToken();
@@ -558,6 +563,17 @@ public class MegaMek {
             System.exit(0);
         }
 
+        private void processDataDir() throws ParseException {
+            String dataDirName;
+            if (getToken() == TOK_LITERAL) {
+                dataDirName = getTokenValue();
+                nextToken();
+                Configuration.setDataDir(new File(dataDirName));
+            } else {
+                error("directory name expected"); // $NON-NLS-1$
+            }
+        }
+        
         private void processUnitValidator() throws ParseException {
             String filename;
             if (getToken() == TOK_LITERAL) {


### PR DESCRIPTION
This commit adds a command line option "-data" to set the data directory used by the game (defaults to "data"). It won't work properly without pull request #40, since the game will crash on load if the happens to not be a "data" directory with a unit quirks file inside in the directory the megamek is located/installed in.

This is useful for developing and keeping multiple (custom) variants of the data directory for different games.