### PR TITLE
Bug: Ultra Rubble terrain handled incorrectly for movement and PSR

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -6511,12 +6511,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                 || isLastStep)
             && (curHex.terrainLevel(Terrains.RUBBLE) > 0)
             && (this instanceof Mech)) {
-            int mod = 0;
-            if (curHex.terrainLevel(Terrains.RUBBLE) > 5) {
-                mod++;
-            }
-            // append the reason modifier
-            roll.append(new PilotingRollData(getId(), mod, "entering Rubble"));
+            
             adjustDifficultTerrainPSRModifier(roll);
         } else {
             roll.addModifier(TargetRoll.CHECK_FALSE,

--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -296,7 +296,7 @@ public class Terrain implements ITerrain, Serializable {
             return 1;
         case Terrains.GEYSER:
         case Terrains.RUBBLE:
-            if (level == 2) {
+            if (level == 6) {
                 return 1;
             }
             return 0;
@@ -329,6 +329,12 @@ public class Terrain implements ITerrain, Serializable {
             }
             return 0;
         case Terrains.RUBBLE:
+            if (level == 6) {
+                if ((e instanceof Mech) && ((Mech)e).isSuperHeavy()) {
+                    return 1;
+                }
+                return 2;
+            }
             if ((e instanceof Mech) && ((Mech)e).isSuperHeavy()) {
                 return 0;
             }


### PR DESCRIPTION
Ultra Rubble now checks for the correct level for movement cost and PSR
modifier. By changing this I had to remove a section of checkRubbleMove
so it would not double the modifier.