### PR TITLE
Ignore test data when building MegaMek.jar

### DIFF
--- a/megamek/build.xml
+++ b/megamek/build.xml
@@ -98,6 +98,9 @@
         <jar basedir="${builddir}" jarfile="${basedir}/${jarfile}">
             <fileset dir="${propdir}" includes="**/*.properties"/>
             <fileset dir="${srcdir}" includes="**/*.properties"/>
+            <exclude name="**/testreport/**"/>
+            <exclude name="**/teststaging/**"/>
+            <exclude name="**/unittests/**"/>
             <manifest>
                 <attribute name="Built-By" value="${user.name}"/>
                 <attribute name="Class-Path" value=". ${jarclasspath}"/>


### PR DESCRIPTION
I noticed this when working on removing the TinyXML library.  The build.xml file will include the testreport, teststaging, and unittests directories in the MegaMek.jar file.  These really aren't necessary to have in the runtime artifact, so this pull request adds excludes for these directories when creating the jar file.
