### PR TITLE
Bug: Ultra Rubble terrain level missing +2 movement cost

### DIFF
--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -329,6 +329,12 @@ public class Terrain implements ITerrain, Serializable {
             }
             return 0;
         case Terrains.RUBBLE:
+            if (level == 6) {
+                if ((e instanceof Mech) && ((Mech)e).isSuperHeavy()) {
+                    return 1;
+                }
+                return 2;
+            }
             if ((e instanceof Mech) && ((Mech)e).isSuperHeavy()) {
                 return 0;
             }


### PR DESCRIPTION
All rubble types were being set to +1MP. Corrected to Rubble being +1
and Ultra Rubble at +2.

Now split from PSR fix in PR #44 