### PR TITLE
Fixing the map resize dialogue having switched "west" and "south" labels

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ResizeMapDialog.java
+++ b/megamek/src/megamek/client/ui/swing/ResizeMapDialog.java
@@ -77,8 +77,8 @@ public class ResizeMapDialog extends JDialog implements ActionListener {
     // General map settings.
     private final JLabel mapNorthLabel = new JLabel(Messages.getString("ExpandMapDialog.labelNorth"));
     private final JLabel mapEastLabel = new JLabel(Messages.getString("ExpandMapDialog.labelEast"));
-    private final JLabel mapSouthLabel = new JLabel(Messages.getString("ExpandMapDialog.labelWest"));
-    private final JLabel mapWestLabel = new JLabel(Messages.getString("ExpandMapDialog.labelSouth"));
+    private final JLabel mapSouthLabel = new JLabel(Messages.getString("ExpandMapDialog.labelSouth"));
+    private final JLabel mapWestLabel = new JLabel(Messages.getString("ExpandMapDialog.labelWest"));
     private final JLabel mapThemeLabel = new JLabel(Messages.getString("RandomMapDialog.labTheme"));
     private final VerifiableTextField mapNorthField = new VerifiableTextField(4);
     private final VerifiableTextField mapEastField = new VerifiableTextField(4);


### PR DESCRIPTION
I'm surprised nobody noticed yet ...