### PR TITLE
Bug terrain object contract violation

### DIFF
--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -35,7 +35,7 @@ public class Terrain implements ITerrain, Serializable {
      * types (ie, Light Woods vs Heavy woods). Not to be confused with Hex
      * levels.
      */
-    private int level;
+    private final int level;
     private boolean exitsSpecified = false;
     private int exits;
     private int terrainFactor;
@@ -244,6 +244,15 @@ public class Terrain implements ITerrain, Serializable {
                 (level == other.getLevel());
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + level;
+        result = prime * result + type;
+        return result;
+    }
+
     /**
      * Terrains are equal if their types and levels are equal. Does not pay
      * attention to exits.
@@ -252,11 +261,11 @@ public class Terrain implements ITerrain, Serializable {
     public boolean equals(Object object) {
         if (this == object) {
             return true;
-        } else if ((object == null) || !(object instanceof ITerrain)) {
+        } else if ((object == null) || !getClass().equals(object.getClass())) {
             return false;
         }
-        ITerrain other = (ITerrain) object;
-        return (type == other.getType()) && (level == other.getLevel());
+        Terrain other = (Terrain) object;
+        return (type == other.type) && (level == other.level);
     }
 
     @Override

--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -15,6 +15,7 @@
 package megamek.common;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Represents a single type of terrain or condition in a hex. The type of a
@@ -246,11 +247,7 @@ public class Terrain implements ITerrain, Serializable {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + level;
-        result = prime * result + type;
-        return result;
+        return Objects.hash(level, type);
     }
 
     /**
@@ -261,11 +258,13 @@ public class Terrain implements ITerrain, Serializable {
     public boolean equals(Object object) {
         if (this == object) {
             return true;
-        } else if ((object == null) || !getClass().equals(object.getClass())) {
+        } else if ((object == null) || (getClass() != object.getClass())) {
             return false;
         }
-        Terrain other = (Terrain) object;
+        final Terrain other = (Terrain) object;
         return (type == other.type) && (level == other.level);
+        // Ints don't need special handling. For more complex objects use:
+        // return Objects.equals(level, other.level) && Objects.equals(type, other.type);
     }
 
     @Override


### PR DESCRIPTION
The Java Object contract says (among other things) that two objects which return `o1.equals(o2) == true` for each other *also* have to return the same hashCode(). In practice, this means that you *have* to implement hashCode() if you implement equals(). Doing otherwise is an error (sadly one which the compiler doesn't catch).

In addition, there are transitivity constraints on equals() which - for non-final classes - are easiest solved by making sure the two objects are of the exactly same class. Thus replacing `this instanceof that` with `getClass().equals(that.getClass()`. For in-depth discussion on the topic and the pitfalls see [this article](http://www.drdobbs.com/jvm/java-qa-how-do-i-correctly-implement-th/184405053) and [this StackExchange question](http://stackoverflow.com/questions/27581/what-issues-should-be-considered-when-overriding-equals-and-hashcode-in-java). The comment box has *way* too little space to write it all down.

Finally, all the fields used in hashCode() should be final or effectively final. The setting of `level` to "final" just makes this something the compiler checks for us.

This is a solution for Java 6 (and earlier; down to Java 5 I think). In Java 7, the helper methods `Objects.hash()` and `Objects.equals()` (note: "Objects", not "Object") can also be used for a more concise and less error-prone implementation.

Other classes might also suffer from the same bugs, but I only checked Terrain and TerrainFactory for a bit of reference information, so that's what I'm patching.