### PR TITLE
Adding proper hashCode() implementation and optimising equals() where needed

### DIFF
--- a/megamek/src/megamek/common/Building.java
+++ b/megamek/src/megamek/common/Building.java
@@ -687,14 +687,21 @@ public class Building implements Serializable {
      *         <code>Building</code>.
      */
     @Override
-    public boolean equals(Object other) {
-        if ((other == null) || !(other instanceof Building)) {
+    public boolean equals(Object obj) {
+        if(this == obj) {
+            return true;
+        }
+        if((null == obj) || (getClass() != obj.getClass())) {
             return false;
         }
-
         // True until we're talking about more than one Board per Game.
-        Building bldg = (Building) other;
-        return (id == bldg.id);
+        final Building other = (Building) obj;
+        return (id == other.id);
+    }
+    
+    @Override
+    public int hashCode() {
+        return id;
     }
 
     /**

--- a/megamek/src/megamek/common/ECMInfo.java
+++ b/megamek/src/megamek/common/ECMInfo.java
@@ -15,6 +15,7 @@
 package megamek.common;
 
 import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * A class that keeps track of information related to an ECM field.
@@ -392,6 +393,7 @@ public class ECMInfo {
         return (owner == null) || (other.getOwner() == null) 
                 || owner.isEnemyOf(other.getOwner());
     }
+
     /**
      * Equality is based on whether position, owner, range and all strengths
      * match.
@@ -400,23 +402,24 @@ public class ECMInfo {
      * @return
      */
     @Override
-    public boolean equals(Object o){
-       if (!(o instanceof ECMInfo)) {
-           return false;
-       }
-       ECMInfo other = (ECMInfo)o;
-       boolean ownersMatch = ((owner == null && other.owner == null) 
-               || owner.equals(other.owner));
-       boolean posMatch = pos.equals(other.pos);
-       boolean strMatch = (strength == other.strength) 
-               && (angelStrength == other.angelStrength) 
-               && (eccmStrength == other.eccmStrength) 
-               && (angelECCMStrength == other.angelECCMStrength);
-       boolean novaMatch = isECMNova == other.isECMNova;
-       boolean rangeMatch = range == other.range;
-       return ownersMatch && posMatch && strMatch && rangeMatch && novaMatch;
+    public boolean equals(Object obj){
+        if(this == obj) {
+            return true;
+        }
+        if((null == obj) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        final ECMInfo other = (ECMInfo)obj;
+        return Objects.equals(owner, other.owner) && Objects.equals(pos, other.pos) && (strength == other.strength) 
+                && (angelStrength == other.angelStrength) && (eccmStrength == other.eccmStrength) 
+                && (angelECCMStrength == other.angelECCMStrength) && (isECMNova == other.isECMNova) && (range == other.range);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(owner, pos, strength, angelStrength, eccmStrength, angelECCMStrength, isECMNova, range);
+    }
+    
     public int getRange() {
         return range;
     }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -5859,14 +5859,20 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * Two entities are equal if their ids are equal
      */
     @Override
-    public boolean equals(Object object) {
-        if (this == object) {
+    public boolean equals(Object obj) {
+        if(this == obj) {
             return true;
-        } else if ((object == null) || (getClass() != object.getClass())) {
+        }
+        if((null == obj) || (getClass() != obj.getClass())) {
             return false;
         }
-        Entity other = (Entity) object;
-        return other.getId() == id;
+        final Entity other = (Entity) obj;
+        return (id == other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
     }
 
     /**

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Vector;
 
 import megamek.common.options.GameOptions;
@@ -822,20 +823,20 @@ public class EquipmentType {
     }
 
     @Override
-    public boolean equals(Object e) {
-        if(null == e || !(e instanceof EquipmentType)) {
+    public boolean equals(Object obj) {
+        if(this == obj) {
+            return true;
+        }
+        if((null == obj) || (getClass() != obj.getClass())) {
             return false;
         }
-        try {
-            EquipmentType et = (EquipmentType)e;
-            if (internalName.equals(et.internalName)) {
-                return true;
-            }
-        } catch (Exception ex) {
-            System.err.println(name + "  does not have an internal name set!");
-        }
-        return false;
-
+        final EquipmentType other = (EquipmentType) obj;
+        return Objects.equals(internalName, other.internalName);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(internalName);
     }
 
     public static void writeEquipmentDatabase(File f) {

--- a/megamek/src/megamek/common/INarcPod.java
+++ b/megamek/src/megamek/common/INarcPod.java
@@ -15,6 +15,7 @@ package megamek.common;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Sebastian Brocks This class represents an iNarc pod attached to an
@@ -69,15 +70,20 @@ public class INarcPod implements Serializable, Targetable {
      *         <code>false</code> otherwise.
      */
     @Override
-    public boolean equals(Object other) {
-        boolean equal = false;
-        if (other instanceof INarcPod) {
-            INarcPod pod = (INarcPod) other;
-            if (type == pod.type && team == pod.team) {
-                equal = true;
-            }
+    public boolean equals(Object obj) {
+        if(this == obj) {
+            return true;
         }
-        return equal;
+        if((null == obj) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        final INarcPod other = (INarcPod) obj;
+        return (type == other.type) && (team == other.team);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, team);
     }
 
     /**

--- a/megamek/src/megamek/common/IPlayer.java
+++ b/megamek/src/megamek/common/IPlayer.java
@@ -192,4 +192,9 @@ public interface IPlayer extends ITurnOrdered {
      * @return a vector of relevant entity ids
      */
     Vector<Integer> getAirborneVTOL();
+    
+    // Make sure IPlayer implements both
+    boolean equals(Object obj);
+    
+    int hashCode();
 }

--- a/megamek/src/megamek/common/MechSummary.java
+++ b/megamek/src/megamek/common/MechSummary.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Vector;
 
 
@@ -510,18 +511,21 @@ public class MechSummary implements Serializable {
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof MechSummary)) {
-            return false;
-        }
-        MechSummary msOther = (MechSummary) other;
-        // we match on chassis + model + unittype + sourcefile
-        if (msOther.getChassis().equals(getChassis())
-                && msOther.getModel().equals(getModel())
-                && msOther.getUnitType().equals(getUnitType())
-                && msOther.getSourceFile().equals(getSourceFile())) {
+    public boolean equals(Object obj) {
+        if(this == obj) {
             return true;
         }
-        return false;
+        if((null == obj) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        final MechSummary other = (MechSummary) obj;
+        // we match on chassis + model + unittype + sourcefile
+        return Objects.equals(m_sChassis, other.m_sChassis) && Objects.equals(m_sModel, other.m_sModel)
+                && Objects.equals(m_sUnitType, other.m_sUnitType) && Objects.equals(m_sSourceFile, other.m_sSourceFile);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_sChassis, m_sModel, m_sUnitType, m_sSourceFile);
     }
 }

--- a/megamek/src/megamek/common/Minefield.java
+++ b/megamek/src/megamek/common/Minefield.java
@@ -16,6 +16,7 @@
 package megamek.common;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class Minefield implements Serializable, Cloneable {
 
@@ -117,19 +118,20 @@ public class Minefield implements Serializable, Cloneable {
     }
 
     @Override
-    public boolean equals(Object object) {
-        Minefield mf;
-        try {
-            mf = (Minefield) object;
-        } catch (Exception e) {
-            return false;
-        }
-
-        if (mf.playerId == this.playerId && mf.coords.equals(coords)
-                && mf.type == this.type) {
+    public boolean equals(Object obj) {
+        if(this == obj) {
             return true;
         }
-        return false;
+        if((null == obj) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        final Minefield other = (Minefield) obj;
+        return (playerId == other.playerId) && Objects.equals(coords, other.coords) && (type == other.type);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(playerId, coords, type);
     }
 
     public void setDensity(int density) {

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -328,18 +328,19 @@ public final class Player extends TurnOrdered implements IPlayer {
      */
     @Override
     public boolean equals(Object object) {
-        if (this == object) {
+        if(this == object) {
             return true;
-        } else if ((object == null) || (getClass() != object.getClass())) {
+        }
+        if((null == object) || (getClass() != object.getClass())) {
             return false;
         }
-        IPlayer other = (IPlayer) object;
-        return other.getId() == id;
+        final Player other = (Player) object;
+        return other.id == id;
     }
 
     @Override
     public int hashCode() {
-        return getId();
+        return id;
     }
 
     @Override

--- a/megamek/src/megamek/common/QuirkEntry.java
+++ b/megamek/src/megamek/common/QuirkEntry.java
@@ -14,6 +14,8 @@
 
 package megamek.common;
 
+import java.util.Objects;
+
 import megamek.common.util.StringUtil;
 
 /**
@@ -148,28 +150,20 @@ class QuirkEntry {
 
     @Override
     public boolean equals(Object obj) {
-        return (obj instanceof QuirkEntry) && equals((QuirkEntry) obj);
-    }
-
-    public boolean equals(QuirkEntry quirk) {
-        if (!getQuirk().equalsIgnoreCase(quirk.getQuirk())) {
-            return false;
-        } else if (StringUtil.isNullOrEmpty(getLocation()) && !StringUtil.isNullOrEmpty(quirk.getLocation())) {
-            return false;
-        } else if (!StringUtil.isNullOrEmpty(getLocation()) && StringUtil.isNullOrEmpty(quirk.getLocation())) {
-            return false;
-        } else if (!StringUtil.isNullOrEmpty(getLocation()) && !getLocation().equals(quirk.getLocation())) {
-            return false;
-        } else if (StringUtil.isNullOrEmpty(getWeaponName()) && !StringUtil.isNullOrEmpty(quirk.getWeaponName())) {
-            return false;
-        } else if (!StringUtil.isNullOrEmpty(getWeaponName()) && StringUtil.isNullOrEmpty(quirk.getWeaponName())) {
-            return false;
-        } else if (!StringUtil.isNullOrEmpty(getWeaponName()) && !getLocation().equals(quirk.getWeaponName())) {
-            return false;
-        } else if (getSlot() != quirk.getSlot()) {
+        if(this == obj) {
+            return true;
+        }
+        if((null == obj) || (getClass() != obj.getClass())) {
             return false;
         }
-        return true;
+        final QuirkEntry other = (QuirkEntry) obj;
+        return Objects.equals(location, other.location) && Objects.equals(weaponName, other.weaponName)
+                && (slot == other.slot);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(location, weaponName, slot);
     }
 
     public QuirkEntry copy() {

--- a/megamek/src/megamek/common/SpecialHexDisplay.java
+++ b/megamek/src/megamek/common/SpecialHexDisplay.java
@@ -18,6 +18,7 @@ import java.awt.Image;
 import java.awt.Toolkit;
 import java.io.File;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * @author dirk
@@ -290,15 +291,21 @@ public class SpecialHexDisplay implements Serializable {
         return false;
     }
     
-    public boolean equals(Object o){
-        if (o instanceof SpecialHexDisplay){
-            SpecialHexDisplay other = (SpecialHexDisplay)o;
-            return other.getType() == getType() 
-                    && getOwner().equals(other.getOwner()) 
-                    && getRound() == other.getRound();
-        } else {
+    @Override
+    public boolean equals(Object obj) {
+        if(this == obj) {
+            return true;
+        }
+        if((null == obj) || (getClass() != obj.getClass())) {
             return false;
         }
+        final SpecialHexDisplay other = (SpecialHexDisplay) obj;
+        return (type == other.type) && Objects.equals(owner, other.owner) && (round == other.round);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, owner, round);
     }
     
     public String toString() {

--- a/megamek/src/megamek/common/Team.java
+++ b/megamek/src/megamek/common/Team.java
@@ -15,6 +15,7 @@
 package megamek.common;
 
 import java.util.Enumeration;
+import java.util.Objects;
 import java.util.Vector;
 
 /**
@@ -220,24 +221,19 @@ public final class Team extends TurnOrdered {
      */
     @Override
     public boolean equals(Object object) {
-        if (this == object) {
+        if(this == object) {
             return true;
-        } else if ((object == null) || (getClass() != object.getClass())) {
+        }
+        if((null == object) || (getClass() != object.getClass())) {
             return false;
         }
-        Team other = (Team) object;
-        if ((other.getId() != getId()) || (other.getSize() != getSize())) {
-            return false;
-        }
-        Enumeration<IPlayer> thisPlayers = getPlayers();
-        Enumeration<IPlayer> otherPlayers = other.getPlayers();
-        while (thisPlayers.hasMoreElements()) {
-            if (!thisPlayers.nextElement().equals(otherPlayers.nextElement())) {
-                return false;
-            }
-        }
-        // The teams pass all tests, so they must match.
-        return true;
+        final Team other = (Team) object;
+        return (id == other.id) && Objects.equals(players, other.players);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, players);
     }
     
     @Override

--- a/megamek/src/megamek/common/WeaponOrderHandler.java
+++ b/megamek/src/megamek/common/WeaponOrderHandler.java
@@ -22,6 +22,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -46,21 +47,23 @@ public class WeaponOrderHandler {
         public Map<Integer, Integer> customWeaponOrderMap = 
                 new HashMap<Integer, Integer>();
         
-        public boolean equals(Object o) {
-            if (!(o instanceof WeaponOrder)) {
-                return false;
-            }
-            WeaponOrder other = (WeaponOrder)o;
-            if ((orderType != Entity.WeaponSortOrder.CUSTOM) 
-                    && orderType == other.orderType) {
+        @Override
+        public boolean equals(Object obj) {
+            if(this == obj) {
                 return true;
-            } else if (orderType == other.orderType) { // Both are CUSTOM
-                return customWeaponOrderMap.equals(other.customWeaponOrderMap);
-            } else {
+            }
+            if((null == obj) || (getClass() != obj.getClass())) {
                 return false;
             }
+            final WeaponOrder other = (WeaponOrder) obj;
+            return Objects.equals(orderType, other.orderType)
+                    && Objects.equals(customWeaponOrderMap, other.customWeaponOrderMap);
         }
         
+        @Override
+        public int hashCode() {
+            return Objects.hash(orderType, customWeaponOrderMap);
+        }
     }
     
     public static final String CUSTOM_WEAPON_ORDER_FILENAME = 

--- a/megamek/src/megamek/common/loaders/HmpFile.java
+++ b/megamek/src/megamek/common/loaders/HmpFile.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Hashtable;
+import java.util.Objects;
 import java.util.Vector;
 
 import megamek.common.ArmlessMech;
@@ -2022,29 +2023,20 @@ abstract class HMPType {
     }
 
     @Override
-    public boolean equals(Object other) {
-
-        // Assume the other object doesn't equal this one.
-        boolean result = false;
-
-        // References to the same object are equal.
-        if (this == other) {
-            result = true;
+    public boolean equals(Object obj) {
+        if(this == obj) {
+            return true;
         }
-
-        // If the other object is an instance of
-        // this object's class, then recast it.
-        else if (this.getClass().isInstance(other)) {
-            HMPType cast = (HMPType) other;
-
-            // The two objects match if their names and IDs match.
-            if (name.equals(cast.name) && (id == cast.id)) {
-                result = true;
-            }
+        if((null == obj) || (getClass() != obj.getClass())) {
+            return false;
         }
-
-        // Return the result
-        return result;
+        final HMPType other = (HMPType) obj;
+        return Objects.equals(name, other.name) && Objects.equals(id, other.id);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, id);
     }
 }
 

--- a/megamek/src/megamek/common/loaders/HmvFile.java
+++ b/megamek/src/megamek/common/loaders/HmvFile.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Objects;
 
 import megamek.common.AmmoType;
 import megamek.common.Engine;
@@ -1256,29 +1257,20 @@ abstract class HMVType {
     }
 
     @Override
-    public boolean equals(Object other) {
-
-        // Assume the other object doesn't equal this one.
-        boolean result = false;
-
-        // References to the same object are equal.
-        if (this == other) {
-            result = true;
+    public boolean equals(Object obj) {
+        if(this == obj) {
+            return true;
         }
-
-        // If the other object is an instance of
-        // this object's class, then recast it.
-        else if (this.getClass().isInstance(other)) {
-            HMVType cast = (HMVType) other;
-
-            // The two objects match if their names and IDs match.
-            if (name.equals(cast.name) && (id == cast.id)) {
-                result = true;
-            }
+        if((null == obj) || (getClass() != obj.getClass())) {
+            return false;
         }
+        final HMVType other = (HMVType) obj;
+        return Objects.equals(name, other.name) && Objects.equals(id, other.id);
+    }
 
-        // Return the result
-        return result;
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, id);
     }
 
     public int getId() {


### PR DESCRIPTION
This fixes a bunch of classes which implement equals() to also include hashCode() with the same fields. At the same time, equals() is rewritten to work properly where required, and to use a consistent coding style.

A few classes remain which couldn't be so easily fixed:

`megamek.common.CriticalSlot` compares `megamek.common.Mounted` instances, but that class declares no equals(), which means that the comparison is done by instance - the same as someone would write `mounted1 == mounted2`. Additionally, only *one* instance of that class is included, `mount`, but not the other `mount2` - this looks like a separate bug. Furthermore, the `Mounted` class is a rather big data class, so I can't just whip a quick `equals()` method inside without a longer analysis.

`megamek.common.SpecialHexDisplay` and `megamek.common.Team` have similar problems, but comparing `megamek.common.IPlayer` instances. Those too have no `equals()` method and are complex data types.

`megamek.common.Coords` has an overly complex `hashCode()` which I'd love to simplify, but it also has a method called `public static Coords getFromHashCode(int hash)` which screams "Please don't do this!" to me. Hashes aren't meant to be reversible. It *looks* like it's only used in `megamek.test.TestCoords`, but I'm not feeling comfortable enough touching it until someone with more seniority in team checks it.
