### PR TITLE
Adding Simplex-based random landscape generator

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1905,7 +1905,7 @@ RandomMapDialog.woodsCombo.toolTip=Frequency and size of forests along with the 
 RandomMapDialog.lakesCombo.toolTip=Frequency and size of bodies of water, not counting rivers.  Also affects the chance of deep water.
 RandomMapDialog.riversCombo.toolTip=Chance to have a single river running across the map.
 RandomMapDialog.iceCombo.toolTip=Frequency and size of ice patches.
-RandomMapDialog.elevationAlgorithmField.toolTip=Which landscape generation Algortihm to use. 0 = rolling hills, 1 = steeper hills, 2 = mix of both.
+RandomMapDialog.elevationAlgorithmField.toolTip=Which landscape generation algorithm to use. 0 = rolling hills, 1 = steeper hills, 2 = mix of both, 3 = random.
 RandomMapDialog.hillinessField.toolTip=How frequent hills should be (0-99).
 RandomMapDialog.elevationRangeField.toolTip=Maximum difference between highest elevation and lowest sink.
 RandomMapDialog.elevationCliffsField.toolTip=Chance to change a steep slope into a cliff.

--- a/megamek/src/megamek/client/ui/swing/RandomMapPanelAdvanced.java
+++ b/megamek/src/megamek/client/ui/swing/RandomMapPanelAdvanced.java
@@ -19,6 +19,7 @@ import megamek.client.ui.swing.util.VerifyIsInteger;
 import megamek.client.ui.swing.util.VerifyIsPositiveInteger;
 import megamek.client.ui.swing.widget.VerifiableTextField;
 import megamek.common.MapSettings;
+import megamek.common.util.BoardUtilities;
 
 import javax.swing.*;
 import javax.swing.border.LineBorder;
@@ -1699,7 +1700,7 @@ public class RandomMapPanelAdvanced extends JPanel {
         constraints.weightx = 1;
         elevationAlgorithmField.setRequired(true);
         elevationAlgorithmField.setSelectAllTextOnGotFocus(true);
-        elevationAlgorithmField.addVerifier(new VerifyInRange(0, 2, true));
+        elevationAlgorithmField.addVerifier(new VerifyInRange(0, BoardUtilities.getAmountElevationGenerators() - 1, true));
         elevationAlgorithmField.setToolTipText(Messages.getString("RandomMapDialog.elevationAlgorithmField.toolTip"));
         elevationAlgorithmField.setName(algorithmLabel.getText());
         panel.add(elevationAlgorithmField, constraints);

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import megamek.common.Board;
@@ -31,8 +32,21 @@ import megamek.common.ITerrainFactory;
 import megamek.common.MapSettings;
 import megamek.common.PlanetaryConditions;
 import megamek.common.Terrains;
+import megamek.common.util.generator.ElevationGenerator;
+import megamek.common.util.generator.SimplexGenerator;
 
 public class BoardUtilities {
+    private static List<ElevationGenerator> elevationGenerators = new ArrayList<ElevationGenerator>();
+    static {
+        // TODO: make this externally accessible via registerElevationGenerator()
+        elevationGenerators.add(new SimplexGenerator());
+    }
+
+    /** @return how many elevation generator algorithms there are; three built-in */
+    public static int getAmountElevationGenerators() {
+        return 3 + elevationGenerators.size();
+    }
+    
     /**
      * Combines one or more boards into one huge megaboard!
      *
@@ -1049,6 +1063,11 @@ public class BoardUtilities {
                 cutSteps(hilliness, width, height, elevationMap);
                 midPoint(hilliness, width, height, elevationMap);
                 break;
+            default:
+                // Non-hardcoded generators, if we have any
+                if((algorithm > 2) && (algorithm - 3 < elevationGenerators.size())) {
+                    elevationGenerators.get(algorithm - 3).generate(hilliness, width, height, elevationMap);
+                }
         }
 
         /* and now normalize it */

--- a/megamek/src/megamek/common/util/SimplexNoise.java
+++ b/megamek/src/megamek/common/util/SimplexNoise.java
@@ -1,0 +1,489 @@
+/*
+ * MegaMek - Copyright (C) 2000-2016 Ben Mazur (bmazur@sev.org)
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ *  for more details.
+ */
+package megamek.common.util;
+
+/*
+ * A speed-improved simplex noise algorithm for 2D, 3D and 4D in Java.
+ *
+ * Based on example code by Stefan Gustavson (stegu@itn.liu.se).
+ * Optimisations by Peter Eastman (peastman@drizzle.stanford.edu).
+ * Better rank ordering method by Stefan Gustavson in 2012.
+ *
+ * This could be speeded up even further, but it's useful as it is.
+ *
+ * Version 2012-03-09
+ *
+ * This code was placed in the public domain by its original author,
+ * Stefan Gustavson. You may use it as you see fit, but
+ * attribution is appreciated.
+ *
+ */
+
+public final class SimplexNoise { // Simplex noise in 2D, 3D and 4D
+    private static Grad grad3[] = { new Grad(1, 1, 0), new Grad(-1, 1, 0), new Grad(1, -1, 0), new Grad(-1, -1, 0), new Grad(1, 0, 1), new Grad(-1, 0, 1), new Grad(1, 0, -1), new Grad(-1, 0, -1), new Grad(0, 1, 1), new Grad(0, -1, 1),
+        new Grad(0, 1, -1), new Grad(0, -1, -1) };
+
+    private static Grad grad4[] = { new Grad(0, 1, 1, 1), new Grad(0, 1, 1, -1), new Grad(0, 1, -1, 1), new Grad(0, 1, -1, -1), new Grad(0, -1, 1, 1), new Grad(0, -1, 1, -1), new Grad(0, -1, -1, 1), new Grad(0, -1, -1, -1), new Grad(1, 0, 1, 1),
+        new Grad(1, 0, 1, -1), new Grad(1, 0, -1, 1), new Grad(1, 0, -1, -1), new Grad(-1, 0, 1, 1), new Grad(-1, 0, 1, -1), new Grad(-1, 0, -1, 1), new Grad(-1, 0, -1, -1), new Grad(1, 1, 0, 1), new Grad(1, 1, 0, -1), new Grad(1, -1, 0, 1),
+        new Grad(1, -1, 0, -1), new Grad(-1, 1, 0, 1), new Grad(-1, 1, 0, -1), new Grad(-1, -1, 0, 1), new Grad(-1, -1, 0, -1), new Grad(1, 1, 1, 0), new Grad(1, 1, -1, 0), new Grad(1, -1, 1, 0), new Grad(1, -1, -1, 0), new Grad(-1, 1, 1, 0),
+        new Grad(-1, 1, -1, 0), new Grad(-1, -1, 1, 0), new Grad(-1, -1, -1, 0) };
+
+    private static short p[] = { 151, 160, 137, 91, 90, 15, 131, 13, 201, 95, 96, 53, 194, 233, 7, 225, 140, 36, 103, 30, 69, 142, 8, 99, 37, 240, 21, 10, 23, 190, 6, 148, 247, 120, 234, 75, 0, 26, 197, 62, 94, 252, 219, 203, 117, 35, 11, 32, 57,
+        177, 33, 88, 237, 149, 56, 87, 174, 20, 125, 136, 171, 168, 68, 175, 74, 165, 71, 134, 139, 48, 27, 166, 77, 146, 158, 231, 83, 111, 229, 122, 60, 211, 133, 230, 220, 105, 92, 41, 55, 46, 245, 40, 244, 102, 143, 54, 65, 25, 63, 161, 1, 216,
+        80, 73, 209, 76, 132, 187, 208, 89, 18, 169, 200, 196, 135, 130, 116, 188, 159, 86, 164, 100, 109, 198, 173, 186, 3, 64, 52, 217, 226, 250, 124, 123, 5, 202, 38, 147, 118, 126, 255, 82, 85, 212, 207, 206, 59, 227, 47, 16, 58, 17, 182, 189,
+        28, 42, 223, 183, 170, 213, 119, 248, 152, 2, 44, 154, 163, 70, 221, 153, 101, 155, 167, 43, 172, 9, 129, 22, 39, 253, 19, 98, 108, 110, 79, 113, 224, 232, 178, 185, 112, 104, 218, 246, 97, 228, 251, 34, 242, 193, 238, 210, 144, 12, 191, 179,
+        162, 241, 81, 51, 145, 235, 249, 14, 239, 107, 49, 192, 214, 31, 181, 199, 106, 157, 184, 84, 204, 176, 115, 121, 50, 45, 127, 4, 150, 254, 138, 236, 205, 93, 222, 114, 67, 29, 24, 72, 243, 141, 128, 195, 78, 66, 215, 61, 156, 180 };
+
+    // To remove the need for index wrapping, double the permutation table length
+    private static short perm[] = new short[512];
+    private static short permMod12[] = new short[512];
+
+    static {
+        for(int i = 0; i < 512; i++) {
+            perm[i] = p[i & 255];
+            permMod12[i] = (short) (perm[i] % 12);
+        }
+    }
+
+    // Skewing and unskewing factors for 2, 3, and 4 dimensions
+    private static final double F2 = 0.5 * (Math.sqrt(3.0) - 1.0);
+    private static final double G2 = (3.0 - Math.sqrt(3.0)) / 6.0;
+    private static final double F3 = 1.0 / 3.0;
+    private static final double G3 = 1.0 / 6.0;
+    private static final double F4 = (Math.sqrt(5.0) - 1.0) / 4.0;
+    private static final double G4 = (5.0 - Math.sqrt(5.0)) / 20.0;
+
+    // This method is a *lot* faster than using (int)Math.floor(x)
+    private static int fastfloor(double x) {
+        int xi = (int) x;
+        return (x < xi) ? xi - 1 : xi;
+    }
+
+    private static double dot(Grad g, double x, double y) {
+        return g.x * x + g.y * y;
+    }
+
+    private static double dot(Grad g, double x, double y, double z) {
+        return g.x * x + g.y * y + g.z * z;
+    }
+
+    private static double dot(Grad g, double x, double y, double z, double w) {
+        return g.x * x + g.y * y + g.z * z + g.w * w;
+    }
+
+    public static double noiseOctaves(double xin, double yin, int octaves) {
+        return noiseOctaves(xin, yin, octaves, 2.0);
+    }
+
+    /** Limit the value to be between the two supplied ones, inclusive */
+    private static double limit(double min, double max, double val) {
+        return (val < min) ? min : ((val > max) ? max : val);
+    }
+
+    public static double noiseOctaves(double xin, double yin, int octaves, double scale) {
+        if(octaves <= 0) {
+            throw new IllegalArgumentException("Octaves have to be non-null"); // $NON-NLS-0$
+        }
+        double result = 0.0;
+        double overallScale = 0.0;
+        for(int i = 0; i < octaves; ++i) {
+            double octaveScale = Math.pow(2.0, i);
+            result += noise(xin * octaveScale + i, yin * octaveScale + i) / Math.pow(scale, i);
+            overallScale += 1.0 / Math.pow(scale, i);
+        }
+        return result / overallScale;
+    }
+
+    /**
+     * 2D simplex noise, returns values in the range [-1.0, +1.0]
+     * <p>
+     * Mostly linear within the range of [-4/9 sqrt(2), +4/9 sqrt(2)], strong falloff afterwards.
+     */
+    public static double noise(double xin, double yin) {
+        double n0, n1, n2; // Noise contributions from the three corners
+        // Skew the input space to determine which simplex cell we're in
+        double s = (xin + yin) * F2; // Hairy factor for 2D
+        int i = fastfloor(xin + s);
+        int j = fastfloor(yin + s);
+        double t = (i + j) * G2;
+        double X0 = i - t; // Unskew the cell origin back to (x,y) space
+        double Y0 = j - t;
+        double x0 = xin - X0; // The x,y distances from the cell origin
+        double y0 = yin - Y0;
+        // For the 2D case, the simplex shape is an equilateral triangle.
+        // Determine which simplex we are in.
+        int i1, j1; // Offsets for second (middle) corner of simplex in (i,j) coords
+        if(x0 > y0) {
+            i1 = 1;
+            j1 = 0;
+        } // lower triangle, XY order: (0,0)->(1,0)->(1,1)
+        else {
+            i1 = 0;
+            j1 = 1;
+        } // upper triangle, YX order: (0,0)->(0,1)->(1,1)
+          // A step of (1,0) in (i,j) means a step of (1-c,-c) in (x,y), and
+          // a step of (0,1) in (i,j) means a step of (-c,1-c) in (x,y), where
+          // c = (3-sqrt(3))/6
+        double x1 = x0 - i1 + G2; // Offsets for middle corner in (x,y) unskewed
+                                  // coords
+        double y1 = y0 - j1 + G2;
+        double x2 = x0 - 1.0 + 2.0 * G2; // Offsets for last corner in (x,y)
+                                         // unskewed coords
+        double y2 = y0 - 1.0 + 2.0 * G2;
+        // Work out the hashed gradient indices of the three simplex corners
+        int ii = i & 255;
+        int jj = j & 255;
+        int gi0 = permMod12[ii + perm[jj]];
+        int gi1 = permMod12[ii + i1 + perm[jj + j1]];
+        int gi2 = permMod12[ii + 1 + perm[jj + 1]];
+        // Calculate the contribution from the three corners
+        double t0 = 0.5 - x0 * x0 - y0 * y0;
+        if(t0 < 0) {
+            n0 = 0.0;
+        } else {
+            t0 *= t0;
+            n0 = t0 * t0 * dot(grad3[gi0], x0, y0); // (x,y) of grad3 used for
+                                                    // 2D gradient
+        }
+        double t1 = 0.5 - x1 * x1 - y1 * y1;
+        if(t1 < 0) {
+            n1 = 0.0;
+        } else {
+            t1 *= t1;
+            n1 = t1 * t1 * dot(grad3[gi1], x1, y1);
+        }
+        double t2 = 0.5 - x2 * x2 - y2 * y2;
+        if(t2 < 0) {
+            n2 = 0.0;
+        } else {
+            t2 *= t2;
+            n2 = t2 * t2 * dot(grad3[gi2], x2, y2);
+        }
+        // Add contributions from each corner to get the final noise value.
+        // The result is scaled to return values in the interval [-1,1].
+        return limit(-1.0, 1.0, 70.0 * (n0 + n1 + n2) / 0.9978893541475 /* sampled correction factor */);
+    }
+
+    // 3D simplex noise
+    public static double noise(double xin, double yin, double zin) {
+        double n0, n1, n2, n3; // Noise contributions from the four corners
+        // Skew the input space to determine which simplex cell we're in
+        double s = (xin + yin + zin) * F3; // Very nice and simple skew factor
+                                           // for 3D
+        int i = fastfloor(xin + s);
+        int j = fastfloor(yin + s);
+        int k = fastfloor(zin + s);
+        double t = (i + j + k) * G3;
+        double X0 = i - t; // Unskew the cell origin back to (x,y,z) space
+        double Y0 = j - t;
+        double Z0 = k - t;
+        double x0 = xin - X0; // The x,y,z distances from the cell origin
+        double y0 = yin - Y0;
+        double z0 = zin - Z0;
+        // For the 3D case, the simplex shape is a slightly irregular
+        // tetrahedron.
+        // Determine which simplex we are in.
+        int i1, j1, k1; // Offsets for second corner of simplex in (i,j,k)
+                        // coords
+        int i2, j2, k2; // Offsets for third corner of simplex in (i,j,k) coords
+        if(x0 >= y0) {
+            if(y0 >= z0) {
+                i1 = 1;
+                j1 = 0;
+                k1 = 0;
+                i2 = 1;
+                j2 = 1;
+                k2 = 0;
+            } // X Y Z order
+            else if(x0 >= z0) {
+                i1 = 1;
+                j1 = 0;
+                k1 = 0;
+                i2 = 1;
+                j2 = 0;
+                k2 = 1;
+            } // X Z Y order
+            else {
+                i1 = 0;
+                j1 = 0;
+                k1 = 1;
+                i2 = 1;
+                j2 = 0;
+                k2 = 1;
+            } // Z X Y order
+        } else { // x0<y0
+            if(y0 < z0) {
+                i1 = 0;
+                j1 = 0;
+                k1 = 1;
+                i2 = 0;
+                j2 = 1;
+                k2 = 1;
+            } // Z Y X order
+            else if(x0 < z0) {
+                i1 = 0;
+                j1 = 1;
+                k1 = 0;
+                i2 = 0;
+                j2 = 1;
+                k2 = 1;
+            } // Y Z X order
+            else {
+                i1 = 0;
+                j1 = 1;
+                k1 = 0;
+                i2 = 1;
+                j2 = 1;
+                k2 = 0;
+            } // Y X Z order
+        }
+        // A step of (1,0,0) in (i,j,k) means a step of (1-c,-c,-c) in (x,y,z),
+        // a step of (0,1,0) in (i,j,k) means a step of (-c,1-c,-c) in (x,y,z),
+        // and
+        // a step of (0,0,1) in (i,j,k) means a step of (-c,-c,1-c) in (x,y,z),
+        // where
+        // c = 1/6.
+        double x1 = x0 - i1 + G3; // Offsets for second corner in (x,y,z) coords
+        double y1 = y0 - j1 + G3;
+        double z1 = z0 - k1 + G3;
+        double x2 = x0 - i2 + 2.0 * G3; // Offsets for third corner in (x,y,z)
+                                        // coords
+        double y2 = y0 - j2 + 2.0 * G3;
+        double z2 = z0 - k2 + 2.0 * G3;
+        double x3 = x0 - 1.0 + 3.0 * G3; // Offsets for last corner in (x,y,z)
+                                         // coords
+        double y3 = y0 - 1.0 + 3.0 * G3;
+        double z3 = z0 - 1.0 + 3.0 * G3;
+        // Work out the hashed gradient indices of the four simplex corners
+        int ii = i & 255;
+        int jj = j & 255;
+        int kk = k & 255;
+        int gi0 = permMod12[ii + perm[jj + perm[kk]]];
+        int gi1 = permMod12[ii + i1 + perm[jj + j1 + perm[kk + k1]]];
+        int gi2 = permMod12[ii + i2 + perm[jj + j2 + perm[kk + k2]]];
+        int gi3 = permMod12[ii + 1 + perm[jj + 1 + perm[kk + 1]]];
+        // Calculate the contribution from the four corners
+        double t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0;
+        if(t0 < 0) {
+            n0 = 0.0;
+        } else {
+            t0 *= t0;
+            n0 = t0 * t0 * dot(grad3[gi0], x0, y0, z0);
+        }
+        double t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1;
+        if(t1 < 0) {
+            n1 = 0.0;
+        } else {
+            t1 *= t1;
+            n1 = t1 * t1 * dot(grad3[gi1], x1, y1, z1);
+        }
+        double t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2;
+        if(t2 < 0) {
+            n2 = 0.0;
+        } else {
+            t2 *= t2;
+            n2 = t2 * t2 * dot(grad3[gi2], x2, y2, z2);
+        }
+        double t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3;
+        if(t3 < 0) {
+            n3 = 0.0;
+        } else {
+            t3 *= t3;
+            n3 = t3 * t3 * dot(grad3[gi3], x3, y3, z3);
+        }
+        // Add contributions from each corner to get the final noise value.
+        // The result is scaled to stay just inside [-1,1]
+        return limit(-1.0, 1.0, 32.0 * (n0 + n1 + n2 + n3) / 0.9787095282039 /* sampled correction factor */);
+    }
+
+    // 4D simplex noise, better simplex rank ordering method 2012-03-09
+    public static double noise(double x, double y, double z, double w) {
+
+        double n0, n1, n2, n3, n4; // Noise contributions from the five corners
+        // Skew the (x,y,z,w) space to determine which cell of 24 simplices
+        // we're in
+        double s = (x + y + z + w) * F4; // Factor for 4D skewing
+        int i = fastfloor(x + s);
+        int j = fastfloor(y + s);
+        int k = fastfloor(z + s);
+        int l = fastfloor(w + s);
+        double t = (i + j + k + l) * G4; // Factor for 4D unskewing
+        double X0 = i - t; // Unskew the cell origin back to (x,y,z,w) space
+        double Y0 = j - t;
+        double Z0 = k - t;
+        double W0 = l - t;
+        double x0 = x - X0; // The x,y,z,w distances from the cell origin
+        double y0 = y - Y0;
+        double z0 = z - Z0;
+        double w0 = w - W0;
+        // For the 4D case, the simplex is a 4D shape I won't even try to
+        // describe.
+        // To find out which of the 24 possible simplices we're in, we need to
+        // determine the magnitude ordering of x0, y0, z0 and w0.
+        // Six pair-wise comparisons are performed between each possible pair
+        // of the four coordinates, and the results are used to rank the
+        // numbers.
+        int rankx = 0;
+        int ranky = 0;
+        int rankz = 0;
+        int rankw = 0;
+        if(x0 > y0) {
+            rankx++;
+        } else {
+            ranky++;
+        }
+        if(x0 > z0) {
+            rankx++;
+        } else {
+            rankz++;
+        }
+        if(x0 > w0) {
+            rankx++;
+        } else {
+            rankw++;
+        }
+        if(y0 > z0) {
+            ranky++;
+        } else {
+            rankz++;
+        }
+        if(y0 > w0) {
+            ranky++;
+        } else {
+            rankw++;
+        }
+        if(z0 > w0) {
+            rankz++;
+        } else {
+            rankw++;
+        }
+        int i1, j1, k1, l1; // The integer offsets for the second simplex corner
+        int i2, j2, k2, l2; // The integer offsets for the third simplex corner
+        int i3, j3, k3, l3; // The integer offsets for the fourth simplex corner
+        // simplex[c] is a 4-vector with the numbers 0, 1, 2 and 3 in some
+        // order.
+        // Many values of c will never occur, since e.g. x>y>z>w makes x<z, y<w
+        // and x<w
+        // impossible. Only the 24 indices which have non-zero entries make any
+        // sense.
+        // We use a thresholding to set the coordinates in turn from the largest
+        // magnitude.
+        // Rank 3 denotes the largest coordinate.
+        i1 = rankx >= 3 ? 1 : 0;
+        j1 = ranky >= 3 ? 1 : 0;
+        k1 = rankz >= 3 ? 1 : 0;
+        l1 = rankw >= 3 ? 1 : 0;
+        // Rank 2 denotes the second largest coordinate.
+        i2 = rankx >= 2 ? 1 : 0;
+        j2 = ranky >= 2 ? 1 : 0;
+        k2 = rankz >= 2 ? 1 : 0;
+        l2 = rankw >= 2 ? 1 : 0;
+        // Rank 1 denotes the second smallest coordinate.
+        i3 = rankx >= 1 ? 1 : 0;
+        j3 = ranky >= 1 ? 1 : 0;
+        k3 = rankz >= 1 ? 1 : 0;
+        l3 = rankw >= 1 ? 1 : 0;
+        // The fifth corner has all coordinate offsets = 1, so no need to
+        // compute that.
+        double x1 = x0 - i1 + G4; // Offsets for second corner in (x,y,z,w)
+                                  // coords
+        double y1 = y0 - j1 + G4;
+        double z1 = z0 - k1 + G4;
+        double w1 = w0 - l1 + G4;
+        double x2 = x0 - i2 + 2.0 * G4; // Offsets for third corner in (x,y,z,w)
+                                        // coords
+        double y2 = y0 - j2 + 2.0 * G4;
+        double z2 = z0 - k2 + 2.0 * G4;
+        double w2 = w0 - l2 + 2.0 * G4;
+        double x3 = x0 - i3 + 3.0 * G4; // Offsets for fourth corner in
+                                        // (x,y,z,w) coords
+        double y3 = y0 - j3 + 3.0 * G4;
+        double z3 = z0 - k3 + 3.0 * G4;
+        double w3 = w0 - l3 + 3.0 * G4;
+        double x4 = x0 - 1.0 + 4.0 * G4; // Offsets for last corner in (x,y,z,w)
+                                         // coords
+        double y4 = y0 - 1.0 + 4.0 * G4;
+        double z4 = z0 - 1.0 + 4.0 * G4;
+        double w4 = w0 - 1.0 + 4.0 * G4;
+        // Work out the hashed gradient indices of the five simplex corners
+        int ii = i & 255;
+        int jj = j & 255;
+        int kk = k & 255;
+        int ll = l & 255;
+        int gi0 = perm[ii + perm[jj + perm[kk + perm[ll]]]] % 32;
+        int gi1 = perm[ii + i1 + perm[jj + j1 + perm[kk + k1 + perm[ll + l1]]]] % 32;
+        int gi2 = perm[ii + i2 + perm[jj + j2 + perm[kk + k2 + perm[ll + l2]]]] % 32;
+        int gi3 = perm[ii + i3 + perm[jj + j3 + perm[kk + k3 + perm[ll + l3]]]] % 32;
+        int gi4 = perm[ii + 1 + perm[jj + 1 + perm[kk + 1 + perm[ll + 1]]]] % 32;
+        // Calculate the contribution from the five corners
+        double t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0 - w0 * w0;
+        if(t0 < 0) {
+            n0 = 0.0;
+        } else {
+            t0 *= t0;
+            n0 = t0 * t0 * dot(grad4[gi0], x0, y0, z0, w0);
+        }
+        double t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1 - w1 * w1;
+        if(t1 < 0) {
+            n1 = 0.0;
+        } else {
+            t1 *= t1;
+            n1 = t1 * t1 * dot(grad4[gi1], x1, y1, z1, w1);
+        }
+        double t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2 - w2 * w2;
+        if(t2 < 0) {
+            n2 = 0.0;
+        } else {
+            t2 *= t2;
+            n2 = t2 * t2 * dot(grad4[gi2], x2, y2, z2, w2);
+        }
+        double t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3 - w3 * w3;
+        if(t3 < 0) {
+            n3 = 0.0;
+        } else {
+            t3 *= t3;
+            n3 = t3 * t3 * dot(grad4[gi3], x3, y3, z3, w3);
+        }
+        double t4 = 0.6 - x4 * x4 - y4 * y4 - z4 * z4 - w4 * w4;
+        if(t4 < 0) {
+            n4 = 0.0;
+        } else {
+            t4 *= t4;
+            n4 = t4 * t4 * dot(grad4[gi4], x4, y4, z4, w4);
+        }
+        // Sum up and scale the result to cover the range [-1,1]
+        return 27.0 * (n0 + n1 + n2 + n3 + n4);
+    }
+
+    private SimplexNoise() {}
+    
+    // Inner class to speed upp gradient computations
+    // (array access is a lot slower than member access)
+    private static class Grad {
+        double x, y, z, w;
+
+        Grad(double x, double y, double z) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        Grad(double x, double y, double z, double w) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+    }
+}

--- a/megamek/src/megamek/common/util/generator/ElevationGenerator.java
+++ b/megamek/src/megamek/common/util/generator/ElevationGenerator.java
@@ -1,0 +1,32 @@
+/*
+ * MegaMek - Copyright (C) 2000-2016 Ben Mazur (bmazur@sev.org)
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ *  for more details.
+ */
+package megamek.common.util.generator;
+
+public interface ElevationGenerator {
+    /** @return translatable string for the generator name */
+    String getName();
+    
+    /** @return translatable string for the tooltip / description */
+    String getTolltip();
+    
+    /**
+     * Generate a map of given width and height and put it into the supplied elevation map
+     * 
+     * @param hilliness 1-100
+     * @param width width of the map, in hexes
+     * @param height height of the map, in hexes
+     * @param elevationMap the target elevation map, indexed as <tt>elevationMap[width][height]</tt>
+     */
+    void generate(int hilliness, int width, int height, int elevationMap[][]);
+}

--- a/megamek/src/megamek/common/util/generator/ElevationGenerator.java
+++ b/megamek/src/megamek/common/util/generator/ElevationGenerator.java
@@ -18,7 +18,7 @@ public interface ElevationGenerator {
     String getName();
     
     /** @return translatable string for the tooltip / description */
-    String getTolltip();
+    String getTooltip();
     
     /**
      * Generate a map of given width and height and put it into the supplied elevation map

--- a/megamek/src/megamek/common/util/generator/SimplexGenerator.java
+++ b/megamek/src/megamek/common/util/generator/SimplexGenerator.java
@@ -1,0 +1,73 @@
+/*
+ * MegaMek - Copyright (C) 2000-2016 Ben Mazur (bmazur@sev.org)
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ *  for more details.
+ */
+package megamek.common.util.generator;
+
+import java.util.Random;
+
+import megamek.common.util.SimplexNoise;
+
+public class SimplexGenerator implements ElevationGenerator {
+    /** Horizontal distance component between hexagons (compared to total width of a hexagon = 1.0) */
+    private static final double DIST_H = 0.75;
+    /** Vertical distance between hexagons */
+    private static final double DIST_V = Math.sqrt(3) / 2.0;
+    
+    private Random rnd;
+    
+    public SimplexGenerator() {
+        this(new Random());
+    }
+    
+    public SimplexGenerator(Random rnd) {
+        this.rnd = rnd;
+    }
+    
+    @Override
+    public String getName() {
+        return "Generator.Simplex"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getTolltip() {
+        return "Generator.Simplex.toolTip"; //$NON-NLS-1$
+    }
+
+    @Override public void generate(int hilliness, int width, int height, int[][] elevationMap) {
+        double noiseStartX = rnd.nextDouble() * 1000000;
+        double noiseStartY = rnd.nextDouble() * 1000000;
+        double noiseScale = (200.0 + rnd.nextDouble() * 30.0) / (4.0 + hilliness / 5.0);
+        hilliness = Math.max(hilliness, 1);
+        
+        for(int w = 0; w < width; ++ w) {
+            for(int h = 0; h < height; ++ h) {
+                double x = DIST_H * w;
+                double y = DIST_V * (2 * h + (w & 1)) / 2.0;
+                // SimplexNoise.noiseOctaves(..., 6) is between -6 and +6, most values are in the [-2, 2] range
+                double val = SimplexNoise.noiseOctaves(
+                        x / noiseScale + noiseStartX,
+                        y / noiseScale + noiseStartY, 6) + 0.5;
+                if(val < 0) {
+                    // Flatten out the bottom part
+                    // TODO: Make this configurable?
+                    val = 0;
+                } else {
+                    // Hilliness - make the hilltops more extreme thus the lower values more common
+                    val = Math.pow(val / 7.0, 10.0 / hilliness + 1.0) * 7.0; 
+                }
+                // Give the map scaler enough value range to work with
+                elevationMap[w][h] = (int) (val * 1000);
+            }
+        }
+    }
+}

--- a/megamek/src/megamek/common/util/generator/SimplexGenerator.java
+++ b/megamek/src/megamek/common/util/generator/SimplexGenerator.java
@@ -39,7 +39,7 @@ public class SimplexGenerator implements ElevationGenerator {
     }
 
     @Override
-    public String getTolltip() {
+    public String getTooltip() {
         return "Generator.Simplex.toolTip"; //$NON-NLS-1$
     }
 


### PR DESCRIPTION
This adds a Simplex-based landscape elevation generator to the list (with the ID 3).

The SImplex implementation is a public domain one by Stefan Gustavson and Peter Eastman (see the file for the credits), slightly amended to generate "proper" [-1, 1] ranges for the 2D and 3D case.

The elevation generator is added to the BoardUtilities class as an instance of the (new) ElevationGenerator instance, which will simplify adding or changing them in the future. The actual addition as well as the tooltip are currently still hardcoded though. If there's any interest, I can also replace the current numeric entry with a dropdown menu and transform the three hardcoded generators into ElevationGenerator instances as well, but I guess that's beyond the simple PR.

Submitted as PR for discussion and review.
