### PR TITLE
Board soft centering

### DIFF
--- a/megamek/src/megamek/client/ui/IBoardView.java
+++ b/megamek/src/megamek/client/ui/IBoardView.java
@@ -69,6 +69,8 @@ public interface IBoardView extends MechDisplayListener {
     public void centerOnHex(Coords position);
     public void centerOnPointRel(double xrel, double yrel);
     public double[] getVisibleArea();
+    
+    public void stopSoftCentering();
 
     // it's a hack that the popup is Object, but we use this interface
     // for both AWT and swing, and AWT's PopupMenu and Swing's JPopupMenu

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -543,7 +543,7 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
             refreshAll();
         }
         
-        if ((ce() != null) &&ce().isWeapOrderChanged()) {
+        if ((ce() != null) && ce().isWeapOrderChanged()) {
             clientgui.getClient().sendEntityWeaponOrderUpdate(ce());
         }
         
@@ -603,9 +603,6 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
             refreshAll();
             cacheVisibleTargets();
 
-            if (!clientgui.bv.isMovingUnits() && !ce().isOffBoard()) {
-                clientgui.bv.centerOnHex(ce().getPosition());
-            }
 
             // Update the menu bar.
             clientgui.getMenuBar().setEntity(ce());
@@ -621,6 +618,10 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
             updateClearTurret();
             updateClearWeaponJam();
             updateStrafe();
+            
+            if (!ce().isOffBoard()) {
+                clientgui.bv.centerOnHex(ce().getPosition());
+            }
         } else {
             System.err.println("FiringDisplay: tried to " + //$NON-NLS-1$
                     "select non-existant entity: " + en); //$NON-NLS-1$

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -603,6 +603,9 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
             refreshAll();
             cacheVisibleTargets();
 
+            if (!ce().isOffBoard()) {
+                clientgui.bv.centerOnHex(ce().getPosition());
+            }
 
             // Update the menu bar.
             clientgui.getMenuBar().setEntity(ce());
@@ -618,10 +621,6 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
             updateClearTurret();
             updateClearWeaponJam();
             updateStrafe();
-            
-            if (!ce().isOffBoard()) {
-                clientgui.bv.centerOnHex(ce().getPosition());
-            }
         } else {
             System.err.println("FiringDisplay: tried to " + //$NON-NLS-1$
                     "select non-existant entity: " + en); //$NON-NLS-1$

--- a/megamek/src/megamek/client/ui/swing/MiniMap.java
+++ b/megamek/src/megamek/client/ui/swing/MiniMap.java
@@ -661,6 +661,8 @@ public class MiniMap extends JPanel {
             return;
         }
         double[] relSize = m_bview.getVisibleArea();
+        for (int i=0;i<4;i++) relSize[i] = Math.min(1, Math.max(0,relSize[i]));
+        
         Color sc = g.getColor();
         Stroke sbs = ((Graphics2D) g).getStroke();
         

--- a/megamek/src/megamek/client/ui/swing/MiniMap.java
+++ b/megamek/src/megamek/client/ui/swing/MiniMap.java
@@ -1439,8 +1439,8 @@ public class MiniMap extends JPanel {
                 m_bview.centerOnPointRel(
                         ((double)(x - leftMargin))/(double)((hexSideBySin30[zoom] + hexSide[zoom])*m_board.getWidth()),
                         ((double)(y - topMargin))/(double)(2 * hexSideByCos30[zoom]*m_board.getHeight()));
+                m_bview.stopSoftCentering();
                 repaint();
-                //drawMap(); MUCH SLOWER
             }
         }
     }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -447,10 +447,11 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     // Soft Centering ---
     
     /** True when the board is in the process of centering to a spot. */
-    boolean isSoftCentering = false;
+    private boolean isSoftCentering = false;
     /** The final position of a soft centering relative to board size (x, y=0...1). */
-    double[] softCenterTarget = new double[2];
-    double[] oldCenter = new double[2];
+    private double[] softCenterTarget = new double[2];
+    private double[] oldCenter = new double[2];
+    private long waitTimer;
     /** Speed of soft centering of the board, less is faster */
     private static final int SOFT_CENTER_SPEED = 8; 
 
@@ -3293,7 +3294,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         double minY = (h/2-HEX_H)/bh;
         double maxX = (bw+HEX_W-w/2)/bw;
         double maxY = (bh+HEX_H-h/2)/bh;
-        // adjust the position because the board can't 
+        // adjust the target point because the board can't 
         // center on points too close to an edge
         softCenterTarget[0] = Math.max(softCenterTarget[0], minX);
         softCenterTarget[1] = Math.max(softCenterTarget[1], minY);
@@ -3309,8 +3310,6 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         waitTimer = 0;
         isSoftCentering = true;
     }
-    
-    long waitTimer;
     
     /** Moves the board one step towards the final 
      * position in during soft centering.

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -806,6 +806,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         controller.stopRepeating(KeyCommandBind.SCROLL_SOUTH);
                         vbar.setValue((int) (vbar.getValue() - (HEX_H * scale)));
                         pingMinimap();
+                        isSoftCentering = false;
                     }
 
                 });
@@ -828,6 +829,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         controller.stopRepeating(KeyCommandBind.SCROLL_NORTH);
                         vbar.setValue((int) (vbar.getValue() + (HEX_H * scale)));
                         pingMinimap();
+                        isSoftCentering = false;
                     }
 
                 });
@@ -850,6 +852,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         controller.stopRepeating(KeyCommandBind.SCROLL_WEST);
                         hbar.setValue((int) (hbar.getValue() + (HEX_W * scale)));
                         pingMinimap();
+                        isSoftCentering = false;
                     }
 
                 });
@@ -872,6 +875,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         controller.stopRepeating(KeyCommandBind.SCROLL_EAST);
                         hbar.setValue((int) (hbar.getValue() - (HEX_W * scale)));
                         pingMinimap();
+                        isSoftCentering = false;
                     }
 
                 });
@@ -3278,6 +3282,23 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         Point p = getCentreHexLocation(c);
         softCenterTarget[0] = (double)p.x/boardSize.getWidth();
         softCenterTarget[1] = (double)p.y/boardSize.getHeight();
+        
+        double w = scrollpane.getViewport().getWidth();
+        double h = scrollpane.getViewport().getHeight();
+        double bw = boardSize.getWidth();
+        double bh = boardSize.getHeight();
+        
+        double minX = (w/2-HEX_W)/bw;
+        double minY = (h/2-HEX_H)/bh;
+        double maxX = (bw+HEX_W-w/2)/bw;
+        double maxY = (bh+HEX_H-h/2)/bh;
+        // adjust the position because the board can't 
+        // center on points too close to an edge
+        softCenterTarget[0] = Math.max(softCenterTarget[0], minX);
+        softCenterTarget[1] = Math.max(softCenterTarget[1], minY);
+        
+        softCenterTarget[0] = Math.min(softCenterTarget[0], maxX);
+        softCenterTarget[1] = Math.min(softCenterTarget[1], maxY);
 
         // get the current board center point
         double[] v = getVisibleArea();

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -807,7 +807,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         controller.stopRepeating(KeyCommandBind.SCROLL_SOUTH);
                         vbar.setValue((int) (vbar.getValue() - (HEX_H * scale)));
                         pingMinimap();
-                        isSoftCentering = false;
+                        stopSoftCentering();
                     }
 
                 });
@@ -830,7 +830,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         controller.stopRepeating(KeyCommandBind.SCROLL_NORTH);
                         vbar.setValue((int) (vbar.getValue() + (HEX_H * scale)));
                         pingMinimap();
-                        isSoftCentering = false;
+                        stopSoftCentering();
                     }
 
                 });
@@ -853,7 +853,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         controller.stopRepeating(KeyCommandBind.SCROLL_WEST);
                         hbar.setValue((int) (hbar.getValue() + (HEX_W * scale)));
                         pingMinimap();
-                        isSoftCentering = false;
+                        stopSoftCentering();
                     }
 
                 });
@@ -876,7 +876,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                         controller.stopRepeating(KeyCommandBind.SCROLL_EAST);
                         hbar.setValue((int) (hbar.getValue() - (HEX_W * scale)));
                         pingMinimap();
-                        isSoftCentering = false;
+                        stopSoftCentering();
                     }
 
                 });
@@ -3302,14 +3302,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         softCenterTarget[1] = Math.min(softCenterTarget[1], maxY);
 
         // get the current board center point
-        double[] v = new double[4];
-        double x = scrollpane.getViewport().getViewPosition().getX()-HEX_W;
-        double y = scrollpane.getViewport().getViewPosition().getY()-HEX_H;
-        
-        v[0] = x/bw;
-        v[1] = y/bh;
-        v[2] = (x+w)/bw;
-        v[3] = (y+h)/bh;
+        double[] v = getVisibleArea();
         oldCenter[0] = (v[0]+v[2])/2; 
         oldCenter[1] = (v[1]+v[3])/2;
         
@@ -3338,7 +3331,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             if ((Math.abs(vec[0]) < 0.0005) && (Math.abs(vec[1]) < 0.0005)) {
                 // very close to the final position -> stop the motion
                 centerOnPointRel(softCenterTarget[0], softCenterTarget[1]);
-                isSoftCentering = false; 
+                stopSoftCentering();
                 pingMinimap();
             } else {
                 centerOnPointRel(oldCenter[0], oldCenter[1]);
@@ -3346,6 +3339,10 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 oldCenter[1] = newC[1];
             }
         }
+    }
+    
+    public void stopSoftCentering() {
+        isSoftCentering = false;
     }
     
     private void adjustVisiblePosition(Coords c, Point dispPoint, double ihdx, double ihdy) {
@@ -3398,17 +3395,17 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
      */
     public double[] getVisibleArea() {
         double[] values = new double[4];
-        double x = scrollpane.getViewport().getViewPosition().getX()-HEX_W;
-        double y = scrollpane.getViewport().getViewPosition().getY()-HEX_H;
+        double x = scrollpane.getViewport().getViewPosition().getX();
+        double y = scrollpane.getViewport().getViewPosition().getY();
         double w = scrollpane.getViewport().getWidth();
         double h = scrollpane.getViewport().getHeight();
         double bw = boardSize.getWidth();
         double bh = boardSize.getHeight();
         
-        values[0] = x/bw;
-        values[1] = y/bh;
-        values[2] = (x+w)/bw;
-        values[3] = (y+h)/bh;
+        values[0] = (x-HEX_W)/bw;
+        values[1] = (y-HEX_H)/bh;
+        values[2] = (x-HEX_W+w)/bw;
+        values[3] = (y-HEX_H+h)/bh;
         
         return values;
     }
@@ -4203,7 +4200,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     //
     public void mousePressed(MouseEvent me) {
         requestFocusInWindow();
-        isSoftCentering = false;
+        stopSoftCentering();
         Point point = me.getPoint();
         if (null == point) {
             return;


### PR DESCRIPTION
Makes the board center in a smooth motion on wherever it wants go (next unit, next target) instead of jumping there. (Clicking the minimap is unchanged and acts instantly).

Much easier on the eye for me. I also feel that it makes it easier to spot the selected unit while the board moves towards it. Of course, theres no need to wait it out, clicking the board, minimap, scrolling with the keys will stop the motion and selecting another unit will immediately start centering on that.

The centering speed can be adjusted by changing the SOFT_CENTERING_SPEED. I wasn't playing, just testing so maybe a little faster (a value of 7 or 6) would be better. Of course, there's no need to wait it out, clicking the board, minimap or scrolling with the keys will stop the motion and selecting another unit will immediately start centering on that.