### PR TITLE
Small fix for better keyscrolling smoothness

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -808,7 +808,16 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     public void performAction() {
                         controller.stopRepeating(KeyCommandBind.SCROLL_SOUTH);
                         vbar.setValue((int) (vbar.getValue() - (HEX_H * scale)));
+                    }
+                    
+                    @Override
+                    public void releaseAction() {
                         pingMinimap();
+                    }
+                    
+                    @Override
+                    public boolean hasReleaseAction() {
+                        return true;
                     }
 
                 });
@@ -830,7 +839,16 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     public void performAction() {
                         controller.stopRepeating(KeyCommandBind.SCROLL_NORTH);
                         vbar.setValue((int) (vbar.getValue() + (HEX_H * scale)));
+                    }
+                    
+                    @Override
+                    public void releaseAction() {
                         pingMinimap();
+                    }
+                    
+                    @Override
+                    public boolean hasReleaseAction() {
+                        return true;
                     }
 
                 });
@@ -852,7 +870,16 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     public void performAction() {
                         controller.stopRepeating(KeyCommandBind.SCROLL_WEST);
                         hbar.setValue((int) (hbar.getValue() + (HEX_W * scale)));
+                    }
+                    
+                    @Override
+                    public void releaseAction() {
                         pingMinimap();
+                    }
+                    
+                    @Override
+                    public boolean hasReleaseAction() {
+                        return true;
                     }
 
                 });
@@ -874,7 +901,16 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                     public void performAction() {
                         controller.stopRepeating(KeyCommandBind.SCROLL_EAST);
                         hbar.setValue((int) (hbar.getValue() - (HEX_W * scale)));
+                    }
+                    
+                    @Override
+                    public void releaseAction() {
                         pingMinimap();
+                    }
+                    
+                    @Override
+                    public boolean hasReleaseAction() {
+                        return true;
                     }
 
                 });


### PR DESCRIPTION
Im actually responsible for the problem. At the time I was playing around with the minimap I couldn't find a good way to access the minimap from the boardview. The one Im using is probably silly and certainly slow, good enough for using once in a while but not 40 times a second. I dont use key scrolling so I never noticed.

If anyone knows a sensible way to access the minimap from bv or what would be best practice to do it please let me know.