### PR TITLE
Movement Envelope & Walk-Jump-Toggle

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1020,6 +1020,8 @@ KeyBinds.cmdNames.udWeapons=Unit Display Weapon Tab
 KeyBinds.cmdDesc.udWeapons=Selects the Weapon tab on the unit display
 KeyBinds.cmdNames.udExtras=Unit Display Extras Tab
 KeyBinds.cmdDesc.udExtras=Selects the Extras tab on the unit display
+KeyBinds.cmdNames.toggleJump=Toggle Jumping/Walking
+KeyBinds.cmdDesc.toggleJump=Switches between walking and jumping movement modes
 
 LOSDialog.inFirstHex=In first hex:
 LOSDialog.InSecondHex=In second hex:

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -785,6 +785,8 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
             bv.refreshDisplayables();
         } else if (event.getActionCommand().equals(VIEW_MOVE_ENV)) {
             if (curPanel instanceof MovementDisplay){
+                GUIPreferences.getInstance().setMoveEnvelope(
+                        !GUIPreferences.getInstance().getMoveEnvelope());
                 ((MovementDisplay) curPanel).computeMovementEnvelope(mechD
                         .getCurrentEntity());
             }

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -94,7 +94,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
     private JCheckBoxMenuItem toggleFovHighlight;
     private JCheckBoxMenuItem toggleFovDarken;
     private JCheckBoxMenuItem toggleFiringSolutions;
-    private JMenuItem viewMovementEnvelope;
+    private JCheckBoxMenuItem viewMovementEnvelope;
     private JMenuItem viewMovModEnvelope;
     private JMenuItem viewChangeTheme;
     private JMenuItem viewLOSSetting;
@@ -402,8 +402,9 @@ public class CommonMenuBar extends JMenuBar implements ActionListener,
         toggleFiringSolutions.addActionListener(this);
         toggleFiringSolutions.setActionCommand(ClientGUI.VIEW_TOGGLE_FIRING_SOLUTIONS);
         menu.add(toggleFiringSolutions);
-        viewMovementEnvelope = new JMenuItem(Messages
+        viewMovementEnvelope = new JCheckBoxMenuItem(Messages
                 .getString("CommonMenuBar.movementEnvelope")); //$NON-NLS-1$
+        viewMovementEnvelope.setState(GUIPreferences.getInstance().getBoolean("MoveEnvelope")); //$NON-NLS-1$
         viewMovementEnvelope.addActionListener(this);
         viewMovementEnvelope.setActionCommand(ClientGUI.VIEW_MOVE_ENV);
         viewMovementEnvelope.setMnemonic(KeyEvent.VK_Q);

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -101,6 +101,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String GAME_OPTIONS_SIZE_HEIGHT = "GameOptionsSizeHeight";
     public static final String GAME_OPTIONS_SIZE_WIDTH = "GameOptionsSizeWidth";
     public static final String FIRING_SOLUTIONS = "FiringSolutions";
+    public static final String MOVE_ENVELOPE = "MoveEnvelope";
     public static final String FOV_HIGHLIGHT = "FovHighlight";
     public static final String FOV_HIGHLIGHT_ALPHA = "FovHighlightAlpha";
     //Rings' sizes (measured in distance to center) separated by whitespace.
@@ -417,6 +418,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public boolean getFiringSolutions() {
         return store.getBoolean(FIRING_SOLUTIONS);
+    }
+    
+    public boolean getMoveEnvelope() {
+        return store.getBoolean(MOVE_ENVELOPE);
     }
 
     public boolean getFovHighlight() {
@@ -784,6 +789,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setFiringSolutions(boolean state){
         store.setValue(FIRING_SOLUTIONS,state);
     }
+    
+    public void setMoveEnvelope(boolean state){
+        store.setValue(MOVE_ENVELOPE,state);
+    }   
 
     public void setFovHighlight(boolean state){
         store.setValue(FOV_HIGHLIGHT,state);

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -427,6 +427,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                     @Override
                     public void performAction() {
                         removeLastStep();
+                        computeMovementEnvelope(ce());
                     }
                 });
 
@@ -493,8 +494,14 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
 
                     @Override
                     public void performAction() {
-                        computeMovementEnvelope(clientgui.mechD
-                                .getCurrentEntity());
+                        GUIPreferences.getInstance().setMoveEnvelope(
+                                !GUIPreferences.getInstance().getMoveEnvelope());
+                        if (GUIPreferences.getInstance().getMoveEnvelope()) {
+                            computeMovementEnvelope(clientgui.mechD
+                                    .getCurrentEntity());
+                        } else {
+                            clientgui.bv.clearMovementEnvelope();
+                        }
                     }
                 });
 
@@ -516,8 +523,64 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                     @Override
                     public void performAction() {
                         clear();
+                        computeMovementEnvelope(ce());
                     }
                 });
+        
+        // Command to toggle between jumping and walk/run
+        controller.registerCommandAction(KeyCommandBind.TOGGLE_MOVEMODE.cmd,
+                new CommandAction() {
+
+                    @Override
+                    public boolean shouldPerformAction() {
+                        if (!clientgui.getClient().isMyTurn()
+                                || clientgui.bv.getChatterBoxActive()
+                                || !display.isVisible()
+                                || display.isIgnoringEvents()) {
+                            return false;
+                        } else {
+                            return true;
+                        }
+                    }
+
+                    @Override
+                    public void performAction() {
+                        final Entity ce = ce();
+                        boolean isAero = (ce instanceof Aero);
+                        // first check if jumping is available at all
+                        if (!isAero && !ce.isImmobile() && (ce.getJumpMP() > 0)
+                                && !(ce.isStuck() && !ce.canUnstickByJumping())) {
+                            if (gear != MovementDisplay.GEAR_JUMP) {
+                                if (!((cmd.getLastStep() != null)
+                                        && cmd.getLastStep().isFirstStep() 
+                                        && (cmd.getLastStep().getType() 
+                                                == MoveStepType.LAY_MINE))) {
+                                    clear();
+                                }
+                                if (!cmd.isJumping()) {
+                                    cmd.addStep(MoveStepType.START_JUMP);
+                                }
+                                gear = MovementDisplay.GEAR_JUMP;
+                                Color jumpColor = GUIPreferences.getInstance().getColor(
+                                        GUIPreferences.ADVANCED_MOVE_JUMP_COLOR);
+                                clientgui.getBoardView().setHighlightColor(jumpColor);
+                            } else {
+                                Color walkColor = GUIPreferences.getInstance().getColor(
+                                        GUIPreferences.ADVANCED_MOVE_DEFAULT_COLOR);
+                                clientgui.getBoardView().setHighlightColor(walkColor);
+                                gear = MovementDisplay.GEAR_LAND;
+                                clear();
+                            }
+                        } else {
+                            Color walkColor = GUIPreferences.getInstance().getColor(
+                                    GUIPreferences.ADVANCED_MOVE_DEFAULT_COLOR);
+                            clientgui.getBoardView().setHighlightColor(walkColor);
+                            gear = MovementDisplay.GEAR_LAND;
+                            clear();
+                        }
+                        computeMovementEnvelope(ce); 
+                    }
+        });
 
     }
 
@@ -621,14 +684,16 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
 
         cen = en;
         clientgui.setSelectedEntityNum(en);
+        gear = MovementDisplay.GEAR_LAND;
+        Color walkColor = GUIPreferences.getInstance().getColor(
+                GUIPreferences.ADVANCED_MOVE_DEFAULT_COLOR);
+        clientgui.getBoardView().setHighlightColor(walkColor);
         clear();
+        
         updateButtons();
         // Update the menu bar.
         clientgui.getMenuBar().setEntity(ce);
         clientgui.getBoardView().highlight(ce.getPosition());
-        Color walkColor = GUIPreferences.getInstance().getColor(
-                GUIPreferences.ADVANCED_MOVE_DEFAULT_COLOR);
-        clientgui.getBoardView().setHighlightColor(walkColor);
         clientgui.getBoardView().select(null);
         clientgui.getBoardView().cursor(null);
         clientgui.mechD.displayEntity(ce);
@@ -653,6 +718,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             setStatusBarText(yourTurnMsg);
         }
         clientgui.bv.clearFieldofF();
+        computeMovementEnvelope(ce);
     }
 
     private MegamekButton getBtn(MoveCommand c) {
@@ -954,11 +1020,15 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         cmd = new MovePath(clientgui.getClient().getGame(), ce);
         clientgui.bv.setWeaponFieldofFire(ce, cmd);
 
-        // set to "walk" or the equivalent
-        gear = MovementDisplay.GEAR_LAND;
-        Color walkColor = GUIPreferences.getInstance().getColor(
-                GUIPreferences.ADVANCED_MOVE_DEFAULT_COLOR);
-        clientgui.getBoardView().setHighlightColor(walkColor);
+        // set to "walk," or the equivalent
+        if (gear != MovementDisplay.GEAR_JUMP) {
+            gear = MovementDisplay.GEAR_LAND;
+            Color walkColor = GUIPreferences.getInstance().getColor(
+                    GUIPreferences.ADVANCED_MOVE_DEFAULT_COLOR);
+            clientgui.getBoardView().setHighlightColor(walkColor);
+        } else if (!cmd.isJumping()) {
+            cmd.addStep(MoveStepType.START_JUMP);
+        }
 
         // update some GUI elements
         clientgui.bv.clearMovementData();
@@ -1010,12 +1080,17 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             updateLoadButtons();
             butDone.setEnabled(true);
         }
+        
     }
 
     private void removeLastStep() {
         cmd.removeLastStep();
         if (cmd.length() == 0) {
             clear();
+            if ((gear == MovementDisplay.GEAR_JUMP) && 
+                    (!cmd.isJumping())) {
+                cmd.addStep(MoveStepType.START_JUMP);
+            }
         } else {
             clientgui.bv.drawMovementData(ce(), cmd);
             clientgui.bv.setWeaponFieldofFire(ce(), cmd);
@@ -1560,6 +1635,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                             Messages.getString("MovementDisplay.CantCharge"), //$NON-NLS-1$
                             Messages.getString("MovementDisplay.NoTarget")); //$NON-NLS-1$
                     clear();
+                    computeMovementEnvelope(ce);
                     return;
                 }
 
@@ -1628,6 +1704,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                         Messages.getString("MovementDisplay.CantCharge"), //$NON-NLS-1$
                         toHit.getDesc());
                 clear();
+                computeMovementEnvelope(ce);
                 return;
             } else if (gear == MovementDisplay.GEAR_DFA) {
                 // check if target is valid
@@ -1637,6 +1714,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                             Messages.getString("MovementDisplay.CantDFA"),
                             Messages.getString("MovementDisplay.NoTarget")); //$NON-NLS-1$ //$NON-NLS-2$
                     clear();
+                    computeMovementEnvelope(ce);
                     return;
                 }
 
@@ -3609,6 +3687,13 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
      * @param suggestion
      */
     public void computeMovementEnvelope(Entity suggestion) {
+        // dp nothing if deactivated in the settings
+        if (!GUIPreferences.getInstance()
+                .getBoolean(GUIPreferences.MOVE_ENVELOPE)) {
+            clientgui.bv.clearMovementEnvelope();
+            return;
+        }
+        
         Entity en = ce();
         int mvMode = gear;
         if ((en == null) && (suggestion == null)) {
@@ -3627,7 +3712,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         MovePath mp = new MovePath(clientgui.getClient().getGame(), en);
 
         int maxMP;
-        if (mvMode == GEAR_JUMP) {
+        if (mvMode == GEAR_JUMP || mvMode == GEAR_DFA) {
             maxMP = en.getJumpMP();
         } else if (mvMode == GEAR_BACKUP) {
             maxMP = en.getWalkMP();
@@ -3641,7 +3726,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         }
         MoveStepType stepType = (mvMode == GEAR_BACKUP) ? MoveStepType.BACKWARDS
                 : MoveStepType.FORWARDS;
-        if (mvMode == GEAR_JUMP) {
+        if (mvMode == GEAR_JUMP || mvMode == GEAR_DFA) {
             mp.addStep(MoveStepType.START_JUMP);
         }
 
@@ -3717,6 +3802,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             selectNextPlayer();
         } else if (actionCmd.equals(MoveCommand.MOVE_CANCEL.getCmd())) {
             clear();
+            computeMovementEnvelope(ce);
         } else if (ev.getSource().equals(getBtn(MoveCommand.MOVE_MORE))) {
             currentButtonGroup++;
             currentButtonGroup %= numButtonGroups;
@@ -3764,6 +3850,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                     GUIPreferences.ADVANCED_MOVE_DEFAULT_COLOR);
             clientgui.getBoardView().setHighlightColor(walkColor);
             gear = MovementDisplay.GEAR_LAND;
+            computeMovementEnvelope(ce);
         } else if (actionCmd.equals(MoveCommand.MOVE_JUMP.getCmd())) {
             if ((gear != MovementDisplay.GEAR_JUMP)
                     && !((cmd.getLastStep() != null)
@@ -3779,6 +3866,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             Color jumpColor = GUIPreferences.getInstance().getColor(
                     GUIPreferences.ADVANCED_MOVE_JUMP_COLOR);
             clientgui.getBoardView().setHighlightColor(jumpColor);
+            computeMovementEnvelope(ce);
         } else if (actionCmd.equals(MoveCommand.MOVE_SWIM.getCmd())) {
             if (gear != MovementDisplay.GEAR_SWIM) {
                 clear();
@@ -3797,6 +3885,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             Color backColor = GUIPreferences.getInstance().getColor(
                     GUIPreferences.ADVANCED_MOVE_BACK_COLOR);
             clientgui.getBoardView().setHighlightColor(backColor);
+            computeMovementEnvelope(ce);
         } else if (actionCmd.equals(MoveCommand.MOVE_LONGEST_RUN.getCmd())) {
             if (gear == MovementDisplay.GEAR_JUMP) {
                 clear();
@@ -3869,11 +3958,13 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 clear();
             }
             gear = MovementDisplay.GEAR_CHARGE;
+            computeMovementEnvelope(ce);
         } else if (actionCmd.equals(MoveCommand.MOVE_DFA.getCmd())) {
             if (gear != MovementDisplay.GEAR_JUMP) {
                 clear();
             }
             gear = MovementDisplay.GEAR_DFA;
+            computeMovementEnvelope(ce);
             if (!cmd.isJumping()) {
                 cmd.addStep(MoveStepType.START_JUMP);
             }
@@ -3882,6 +3973,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 clear();
             }
             gear = MovementDisplay.GEAR_RAM;
+            computeMovementEnvelope(ce);
         } else if (actionCmd.equals(MoveCommand.MOVE_GET_UP.getCmd())) {
             // if the unit has a hull down step
             // then don't clear the moves

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -3687,7 +3687,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
      * @param suggestion
      */
     public void computeMovementEnvelope(Entity suggestion) {
-        // dp nothing if deactivated in the settings
+        // do nothing if deactivated in the settings
         if (!GUIPreferences.getInstance()
                 .getBoolean(GUIPreferences.MOVE_ENVELOPE)) {
             clientgui.bv.clearMovementEnvelope();

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -3879,9 +3879,10 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             gear = MovementDisplay.GEAR_TURN;
         } else if (actionCmd.equals(MoveCommand.MOVE_BACK_UP.getCmd())) {
             if (gear == MovementDisplay.GEAR_JUMP) {
+                gear = MovementDisplay.GEAR_BACKUP; // on purpose...
                 clear();
             }
-            gear = MovementDisplay.GEAR_BACKUP;
+            gear = MovementDisplay.GEAR_BACKUP; // on purpose...
             Color backColor = GUIPreferences.getInstance().getColor(
                     GUIPreferences.ADVANCED_MOVE_BACK_COLOR);
             clientgui.getBoardView().setHighlightColor(backColor);

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -3741,7 +3741,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         for (Coords loc : mvEnvData.keySet()) {
             Color spriteColor = null;
             int mvType = -1;
-            if (gear == MovementDisplay.GEAR_JUMP) {
+            if (gear == MovementDisplay.GEAR_JUMP || gear == MovementDisplay.GEAR_DFA) {
                 if (mvEnvData.get(loc) <= jump) {
                     spriteColor = guip
                             .getColor(GUIPreferences.ADVANCED_MOVE_JUMP_COLOR);

--- a/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
+++ b/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
@@ -68,7 +68,7 @@ public enum KeyCommandBind {
     UD_SYSTEMS("udSystems", false, KeyEvent.VK_F4, 0), // Default: F4
     UD_WEAPONS("udWeapons", false, KeyEvent.VK_F5, 0), // Default: F5
     UD_EXTRAS("udExtras", false, KeyEvent.VK_F6, 0), // Default: F6
-    // Toggle between Jumping and Walk/Run (or other movement modes if there are any)
+    /** Toggles between Jumping and Walk/Run, also acts as a reset when a unit cannot jump */
     TOGGLE_MOVEMODE("toggleJump", false, KeyEvent.VK_J, 0); // Default: J
     
     /**

--- a/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
+++ b/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
@@ -67,7 +67,9 @@ public enum KeyCommandBind {
     UD_ARMOR("udArmor", false, KeyEvent.VK_F3, 0), // Default: F3
     UD_SYSTEMS("udSystems", false, KeyEvent.VK_F4, 0), // Default: F4
     UD_WEAPONS("udWeapons", false, KeyEvent.VK_F5, 0), // Default: F5
-    UD_EXTRAS("udExtras", false, KeyEvent.VK_F6, 0); // Default: F6
+    UD_EXTRAS("udExtras", false, KeyEvent.VK_F6, 0), // Default: F6
+    // Toggle between Jumping and Walk/Run (or other movement modes if there are any)
+    TOGGLE_MOVEMODE("toggleJump", false, KeyEvent.VK_J, 0); // Default: J
     
     /**
      * The command associated with this binding.


### PR DESCRIPTION
Up for discussion: 

- adds a keybind to switch between walk/run and jumping movement, default J;
- as before with the buttons, J will clear any planned movement;
- if the unit cannot jump J will still clear planned movement as if ESC was pressed (I found that easier than constantly moving my hand between J and ESC);
- if the unit can jump, pressing J twice will effectively act as ESC, removing planned moves and returning to the same move type;
- in addition, the movement envelope menu entry is now a toggle (like the FOV darkening) so that when activated it will always be there (I found constantly having to reactivate the movement envelope annoying and not useful and I could never see a reason for not having it there. Of course, it can still be deactivated by the keybind or in the menu.)

(Note: I do remember that throwing in several changes into one PR is not good style. I think I had a reason for doing it here but can't remember.
Second note: MovementDisplay seems like it would benefit from some cleanup. I might do something there but as a separate thing)