### PR TITLE
Right-Click Scrolling and the MapMenu 

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -28,6 +28,7 @@ import java.util.Vector;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
+import javax.swing.UIManager;
 
 import megamek.client.Client;
 import megamek.client.ui.Messages;
@@ -94,6 +95,9 @@ public class MapMenu extends JPopupMenu {
         selectedEntity = myEntity = game.getEntity(gui.getSelectedEntityNum());
 
         hasMenu = createMenu();
+        // make this popup not consume mouse events outside it
+        // so board dragging can start correctly when it's open
+        UIManager.put("PopupMenu.consumeEventOnClose", false);
     }
 
     private boolean canSelectEntities() {
@@ -110,7 +114,7 @@ public class MapMenu extends JPopupMenu {
                    || (currentPanel instanceof PhysicalDisplay)
                    || (currentPanel instanceof TargetingPhaseDisplay));
     }
-
+    
     private boolean createMenu() {
         removeAll();
         int itemCount = 0;

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -95,8 +95,8 @@ public class MapMenu extends JPopupMenu {
         selectedEntity = myEntity = game.getEntity(gui.getSelectedEntityNum());
 
         hasMenu = createMenu();
-        // make this popup not consume mouse events outside it
-        // so board dragging can start correctly when it's open
+        // make popups not consume mouse events outside them
+        // so board dragging can start correctly when this menu is open
         UIManager.put("PopupMenu.consumeEventOnClose", false);
     }
 
@@ -114,7 +114,7 @@ public class MapMenu extends JPopupMenu {
                    || (currentPanel instanceof PhysicalDisplay)
                    || (currentPanel instanceof TargetingPhaseDisplay));
     }
-    
+
     private boolean createMenu() {
         removeAll();
         int itemCount = 0;

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -240,7 +240,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     private int scrollYDifference = 0;
     // are we drag-scrolling?
     private boolean dragging = false;
-    // should we scroll when the mouse is dragged?
+    /** True when the right mouse button was pressed to start a drag */
     private boolean shouldScroll = false;
 
     // entity sprites


### PR DESCRIPTION
With this UIManager change the board context menu will no longer consume mouse clicks outside it so right mouse button scrolling isn't blocked by it.

Will merge it if no one stops me.