### PR TITLE
Visibility of minimap unit icons

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MiniMap.java
+++ b/megamek/src/megamek/client/ui/swing/MiniMap.java
@@ -1097,15 +1097,25 @@ public class MiniMap extends JPanel {
         g.setColor(pColor);
         
         // Fill the interior of the unit marker
-        if (!entity.isSelectableThisTurn()) {
-            // entity has moved (or whatever) already
-            g.setColor(g.getColor().darker());
-        }
         g.fillPolygon(xPoints, yPoints, xPoints.length);
-
+        
         // Create a colored border according to the done() status
         Entity se = clientgui == null ? null : m_game.getEntity(clientgui
                 .getSelectedEntityNum());
+        if (entity == se) {
+            g.setColor(GUIPreferences.getInstance().getColor(
+                    GUIPreferences.ADVANCED_UNITOVERVIEW_SELECTED_COLOR));
+        } else if (entity.isSelectableThisTurn()) {
+            // entity has moved (or whatever) already
+//            g.setColor(g.getColor().darker());
+            g.setColor(GUIPreferences.getInstance().getColor(
+                    GUIPreferences.ADVANCED_UNITOVERVIEW_VALID_COLOR));
+            
+        } else {
+            g.setColor(Color.BLACK);
+        }
+        g.drawPolygon(xPoints, yPoints, xPoints.length);
+/*
         if (entity == se) {
             Color w = new Color(255, 255, 255);
             Color b = new Color(0, 0, 0);
@@ -1114,12 +1124,13 @@ public class MiniMap extends JPanel {
             g.setColor(w);
             g.drawRect(baseX, baseY, 1, 1);
         }
+        
         if (border) {
             Color oldColor = g.getColor();
             g.setColor(oldColor.darker().darker().darker());
             g.drawPolygon(xPoints, yPoints, xPoints.length);
             g.setColor(oldColor);
-        }
+        }*/
     }
     
     /** Returns a non-transparent, saturated form of Color c or Black if passed Black. */

--- a/megamek/src/megamek/client/ui/swing/MiniMap.java
+++ b/megamek/src/megamek/client/ui/swing/MiniMap.java
@@ -1103,29 +1103,32 @@ public class MiniMap extends JPanel {
         g.drawPolygon(xPoints, yPoints, xPoints.length);
         
         // Fill the icon according to the player color
-        Color pColor = new Color(PlayerColors.getColorRGB(entity.getOwner().getColorIndex()));
+        Color pColor = new Color(
+                PlayerColors.getColorRGB(entity.getOwner().getColorIndex()));
         g.setColor(pColor);
         g.fillPolygon(xPoints, yPoints, xPoints.length);
         
-        // Create a colored circle for the selected unit
-        ((Graphics2D)g).setStroke(new BasicStroke(unitBorder[zoom]+1));
+        // Draw a white border to better show the player color
+        // maybe useful later: if (!entity.isSelectableThisTurn()) {
+        ((Graphics2D)g).setStroke(new BasicStroke(unitBorder[zoom]));
+        g.setColor(Color.WHITE);
+        g.drawPolygon(xPoints, yPoints, xPoints.length);
+
+        // Create a colored circle if this is the selected unit
         Entity se = (clientgui == null) ? null : 
             m_game.getEntity(clientgui.getSelectedEntityNum());
+        
         if (entity == se) {
+            ((Graphics2D)g).setStroke(new BasicStroke(unitBorder[zoom]+1));
             g.setColor(GUIPreferences.getInstance().getColor(
                     GUIPreferences.ADVANCED_UNITOVERVIEW_SELECTED_COLOR));
             int rad = unitSize*2-1;
             g.drawOval(baseX-rad, baseY-rad, rad*2, rad*2);
         }
         
-        // Draw a white border to better show the player color
-        ((Graphics2D)g).setStroke(new BasicStroke(unitBorder[zoom]));
-        g.setColor(Color.WHITE);
-        g.drawPolygon(xPoints, yPoints, xPoints.length);
-        
         ((Graphics2D)g).setStroke(svStroke);
     }
-    
+
     private void paintRoads(Graphics g) {
         int exits = 0;
         int baseX, baseY, x, y;

--- a/megamek/src/megamek/client/ui/swing/MiniMap.java
+++ b/megamek/src/megamek/client/ui/swing/MiniMap.java
@@ -1091,13 +1091,19 @@ public class MiniMap extends JPanel {
             yPoints[3] = baseY;
         }
 
-        g.setColor(PlayerColors.getColor(entity.getOwner().getColorIndex()));
+        // set the fill color according to the player color
+        Color pColor = PlayerColors.getColor(entity.getOwner().getColorIndex());
+        pColor = saturateColor(pColor);
+        g.setColor(pColor);
+        
+        // Fill the interior of the unit marker
         if (!entity.isSelectableThisTurn()) {
             // entity has moved (or whatever) already
             g.setColor(g.getColor().darker());
         }
         g.fillPolygon(xPoints, yPoints, xPoints.length);
 
+        // Create a colored border according to the done() status
         Entity se = clientgui == null ? null : m_game.getEntity(clientgui
                 .getSelectedEntityNum());
         if (entity == se) {
@@ -1114,6 +1120,24 @@ public class MiniMap extends JPanel {
             g.drawPolygon(xPoints, yPoints, xPoints.length);
             g.setColor(oldColor);
         }
+    }
+    
+    /** Returns a non-transparent, saturated form of Color c or Black if passed Black. */
+    private Color saturateColor(Color c) {
+        // find the highest component
+        int r = c.getRed();
+        int g = c.getGreen();
+        int b = c.getBlue();
+        int maxC = Math.max(r, Math.max(g, b));
+        
+        // When the highest component is 0, Black was passed as a parameter
+        if (maxC == 0) return Color.BLACK;
+        
+        // Otherwise, increase all components so that the highest become 255 
+        r = r * 255/maxC;
+        g = g * 255/maxC;
+        b = b * 255/maxC;
+        return new Color(r, g, b);
     }
 
     private void paintRoads(Graphics g) {


### PR DESCRIPTION
This will make the tiny tiny unit icons on the minimap much more obvious (I believe):
The selected unit gets a circle in the color that is set in the advanced settings (its not in the screenshot). I have tried to include the color for !done() units but even with the minimap at largest zoom this makes the colors barely distinguishable so I deleted that again. Maybe I have a good idea how to do it in the future.
Opinions welcome.

![minimap](https://cloud.githubusercontent.com/assets/17069663/14003522/b680f7fe-f153-11e5-9551-487493756d4f.png)
