### PR TITLE
StratOps/NATO Symbols in the Minimap

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -635,6 +635,7 @@ CommonSettingsDialog.AOHexSHadows=Show ambient-occlusion-like hex shadows at the
 CommonSettingsDialog.useShadowMap=Show terrain and building shadows
 CommonSettingsDialog.levelHighlight=Level highlighting (thick borders at level changes)
 CommonSettingsDialog.floatingIso=Floating isometric (no hex sides in isometric mode)
+CommonSettingsDialog.mmSymbol=Use StratOps unit symbols in the Minimap
 ConfirmDialog.dontBother=Do not bother me again
 
 CustomBattleArmorDialog.title=Build your Battle Armor...

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -164,6 +164,7 @@ public class CommonSettingsDialog extends ClientDialog implements
     private JCheckBox showMapsheets;
     private JCheckBox aOHexShadows;
     private JCheckBox floatingIso;
+    private JCheckBox mmSymbol;
     private JCheckBox levelhighlight;
     private JCheckBox shadowMap;
     private JCheckBox mouseWheelZoom;
@@ -680,6 +681,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         showDamageLevel.setSelected(gs.getShowDamageLevel());
         aOHexShadows.setSelected(gs.getAOHexShadows());
         floatingIso.setSelected(gs.getFloatingIso());
+        mmSymbol.setSelected(gs.getMmSymbol());
         levelhighlight.setSelected(gs.getLevelHighlight());
         shadowMap.setSelected(gs.getShadowMap());
 
@@ -804,6 +806,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         gs.setShowMapsheets(showMapsheets.isSelected());
         gs.setAOHexShadows(aOHexShadows.isSelected());
         gs.setFloatingIso(floatingIso.isSelected());
+        gs.setMmSymbol(mmSymbol.isSelected());
         gs.setLevelHighlight(levelhighlight.isSelected());
         gs.setShadowMap(shadowMap.isSelected());
 
@@ -1066,8 +1069,13 @@ public class CommonSettingsDialog extends ClientDialog implements
                 clientgui.bv.clearHexImageCache();
                 clientgui.bv.repaint();
             }
-        }
+        } else if (source.equals(mmSymbol)) {
+            guip.setMmSymbol(mmSymbol.isSelected());
+            if ((clientgui != null) && (clientgui.minimap != null)) {
+                clientgui.minimap.drawMap();
+            }
 
+        }
     }
 
     public void focusGained(FocusEvent e) {
@@ -1163,7 +1171,15 @@ public class CommonSettingsDialog extends ClientDialog implements
         floatingIso.addItemListener(this);
         row.add(floatingIso);
         comps.add(row);
-        
+
+        // Type of symbol used on the minimap 
+        mmSymbol = new JCheckBox(Messages.getString("CommonSettingsDialog.mmSymbol")); //$NON-NLS-1$
+        row = new ArrayList<>();
+        mmSymbol.addItemListener(this);
+        row.add(mmSymbol);
+        comps.add(row);
+
+
         // Skin
         skinFiles = new JComboBox<String>();
         skinFiles.setMaximumSize(new Dimension(400,skinFiles.getMaximumSize().height));

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -90,6 +90,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String AOHEXSHADOWS = "AoHexShadows";
     public static final String LEVELHIGHLIGHT = "LevelHighlight";
     public static final String FLOATINGISO = "FloatingIsometric";
+    public static final String MMSYMBOL = "MmSymbol";
     public static final String AUTO_END_FIRING = "AutoEndFiring";
     public static final String AUTO_DECLARE_SEARCHLIGHT = "AutoDeclareSearchlight";
     public static final String CHAT_LOUNGE_TABS = "ChatLoungeTabs";
@@ -366,6 +367,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
     
     public boolean getFloatingIso() {
         return store.getBoolean(FLOATINGISO);
+    }
+    
+    public boolean getMmSymbol() {
+        return store.getBoolean(MMSYMBOL);
     }
 
     public boolean getShadowMap() {
@@ -737,11 +742,15 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setFloatingIso(boolean state){
         store.setValue(FLOATINGISO, state);
     }
-    
+
+    public void setMmSymbol(boolean state){
+        store.setValue(MMSYMBOL, state);
+    }
+
     public void setLevelHighlight(boolean state){
         store.setValue(LEVELHIGHLIGHT, state);
     }
-    
+
     public boolean getShowDamageLevel(){
         return store.getBoolean(SHOW_DAMAGE_LEVEL);
     }


### PR DESCRIPTION
OK, as requested the alternate minimap symbols according to part of StratOps pp 340/341 (more or less NATO standard). Theres a checkbox in the Client settings to switch between these and the normal ones. Completely optional.
Opinions?
![minim_strat_1](https://cloud.githubusercontent.com/assets/17069663/14061541/9f958dbc-f382-11e5-9f85-a0e737149850.png)
![minim_strat_2](https://cloud.githubusercontent.com/assets/17069663/14061542/a39e1438-f382-11e5-863f-9eac337e3fc0.png)
![minim_strat_3](https://cloud.githubusercontent.com/assets/17069663/14061543/a6cea64a-f382-11e5-8b89-97f020a55f7f.png)


