### PR TITLE
Display distance info in the tooltip

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -220,6 +220,11 @@ BoardView1.Tooltip.ArtilleryAttack1=Artillery: {0} in 1 turn<BR><FONT SIZE=-2>&n
 BoardView1.Tooltip.ArtilleryAttackN=Artillery: {0} in {2} turns<BR><FONT SIZE=-2>&nbsp;&nbsp;Ammo: {1}</FONT>
 BoardView1.Tooltip.SeenBy=Seen by: {0}
 BoardView1.Tooltip.Sensors=Sensor: {0}
+BoardView1.Tooltip.Distance1=Distance from the selected unit: 1 Hex
+BoardView1.Tooltip.DistanceN=Distance from the selected unit: {0} Hexes
+BoardView1.Tooltip.DistanceMove1=<I>Distance from the movement end point: 1 Hex</I>
+BoardView1.Tooltip.DistanceMoveN=<I>Distance from the movement end point: {0} Hexes</I>
+
 
 BoardView1.Tooltip.Hex=Hex: {0} - Level: {1}
 BoardView1.Tooltip.Building={1} <BR>Height: {0}, CF: {2}<BR>Armor: {3}; Basement: {4}

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -465,7 +465,12 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     private Point2D oldCenter = new Point2D.Double();
     private long waitTimer;
     /** Speed of soft centering of the board, less is faster */
-    private static final int SOFT_CENTER_SPEED = 8; 
+    private static final int SOFT_CENTER_SPEED = 8;
+    
+    // Tooltip Info ---
+    /** Holds the final Coords for a planned movement. Set by MovementDisplay,
+     *  used to display the distance in the board tooltip. */ 
+    private Coords movementTarget;
 
 
     /**
@@ -3628,6 +3633,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
 
         // Nothing to do if we don't have a MovePath
         if (md == null) {
+            movementTarget = null;
             return;
         }
         // need to update the movement sprites based on the move path for this
@@ -3661,6 +3667,9 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                             "AdvancedMoveDefaultColor");
                     break;
             }
+            movementTarget = md.getLastStep().getPosition();
+        } else {
+            movementTarget = null;
         }
 
         refreshMoveVectors(entity, md, col);
@@ -3697,6 +3706,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
      */
     public void clearMovementData() {
         pathSprites = new ArrayList<StepSprite>();
+        movementTarget = null;
         checkFoVHexImageCacheClear();
         repaint();
         refreshMoveVectors();
@@ -5168,6 +5178,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             mhex = game.getBoard().getHex(mcoords);
 
         txt.append("<html>"); //$NON-NLS-1$
+        
 
         // Hex Terrain
         if (GUIPreferences.getInstance().getShowMapHexPopup() && (mhex != null)) {
@@ -5197,6 +5208,34 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 }
             }
             txt.append("</TD></TR></TABLE>"); //$NON-NLS-1$
+            
+            // Distance from the selected unit and a planned movement end point
+            if ((selectedEntity != null) && 
+                    (selectedEntity.getPosition() != null)) {
+                int distance = selectedEntity
+                        .getPosition()
+                        .distance(mcoords);
+                txt.append("<TABLE BORDER=0 BGCOLOR=#FFDDDD width=100%><TR><TD>"); //$NON-NLS-1$
+                if (distance == 1) {
+                    txt.append(Messages.getString("BoardView1.Tooltip.Distance1")); //$NON-NLS-1$
+                } else {
+                    txt.append(Messages.getString("BoardView1.Tooltip.DistanceN", //$NON-NLS-1$
+                            new Object[] { distance }));
+                }
+                
+                if ((game.getPhase() == Phase.PHASE_MOVEMENT) && 
+                        (movementTarget != null)) {
+                    txt.append("<BR>");
+                    int disPM = movementTarget.distance(mcoords);
+                    if (disPM == 1) {
+                        txt.append(Messages.getString("BoardView1.Tooltip.DistanceMove1")); //$NON-NLS-1$
+                    } else {
+                        txt.append(Messages.getString("BoardView1.Tooltip.DistanceMoveN", //$NON-NLS-1$
+                                new Object[] { disPM }));
+                    }
+                }
+                txt.append("</TD></TR></TABLE>"); //$NON-NLS-1$
+            }
             
             // Fuel Tank
             if (mhex.containsTerrain(Terrains.FUEL_TANK)) {


### PR DESCRIPTION
Changes: 
- If there is a selected unit, the board tooltip will display the distance to that unit. The selected unit is the active unit of a player, not necessarily the one viewed in the unitdisplay.
- In the movement phase, when a planned movement is shown, the distance to the endpoint of that is also shown.

I thought that especially when planning movement, this is basically what we are always looking for (or counting in the case of tabletop...). It's more direct and less of a visual obstruction than the firing arcs. Ideas, comments?

In the screenshot, the mouse was on the hex below the "6" of the movepath.

![tt_1](https://cloud.githubusercontent.com/assets/17069663/14172312/c0a0ed0e-f737-11e5-8062-9d373a7f0eb7.png)
