### PR TITLE
Mouse Button 4 will hide/show the Minimap and UnitDisplay

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -142,7 +142,7 @@ public class BoardEditor extends JComponent implements ItemListener,
     public BoardEditor(MegaMekController c) {
         controller = c;
         try {
-            bv = new BoardView1(game, controller);
+            bv = new BoardView1(game, controller, null);
             bvc = bv.getComponent(true);
         } catch (IOException e) {
             JOptionPane

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1226,6 +1226,20 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
             bv.showPopup(popup, c);
         }
     }
+    
+    /** Switches the Minimap and the MechDisplay an and off together.
+     *  If the MechDisplay is active, both will be hidden, else 
+     *  both will be shown.
+     */
+    public void toggleMMUDDisplays() {
+        if (mechW.isVisible()) {
+            setDisplayVisible(false);
+            setMapVisible(false);
+        } else {
+            setDisplayVisible(true);
+            setMapVisible(true);
+        }
+    }
 
     /**
      * Toggles the entity display window
@@ -1241,6 +1255,21 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
      * Sets the visibility of the entity display window
      */
     public void setDisplayVisible(boolean visible) {
+        // If no unit is displayed, select a unit so the display can be safely shown
+        // This can happen when using mouse button 4
+        if ((mechD.getCurrentEntity() == null) &&
+                (getClient() != null) && 
+                (getClient().getGame() != null)) {
+            List<Entity> es = getClient().getGame().getEntitiesVector();
+            if ((es != null) && (es.size() > 0)) {
+                mechD.displayEntity(es.get(0));
+            } else {
+                return;
+            }
+        } else {
+            return;
+        }
+
         mechW.setVisible(visible);
         if (visible) {
             frame.requestFocus();

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -380,7 +380,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         try {
             client.getGame().addGameListener(gameListener);
             // Create the board viewer.
-            bv = new BoardView1(client.getGame(), controller);
+            bv = new BoardView1(client.getGame(), controller, this);
             bv.setPreferredSize(getSize());
             bvc = bv.getComponent();
             bvc.setName("BoardView");
@@ -1230,7 +1230,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
     /**
      * Toggles the entity display window
      */
-    private void toggleDisplay() {
+    public void toggleDisplay() {
         mechW.setVisible(!mechW.isVisible());
         if (mechW.isVisible()) {
             frame.requestFocus();
@@ -1247,7 +1247,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         }
     }
 
-    private void toggleUnitOverview() {
+    public void toggleUnitOverview() {
         uo.setVisible(!uo.isVisible());
         GUIPreferences.getInstance().setShowUnitOverview(uo.isVisible());
         bv.refreshDisplayables();
@@ -1256,7 +1256,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
     /**
      * Toggles the minimap window Also, toggles the minimap enabled setting
      */
-    private void toggleMap() {
+    public void toggleMap() {
         if (minimapW.isVisible()) {
             GUIPreferences.getInstance().setMinimapEnabled(false);
         } else {

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1257,17 +1257,18 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
     public void setDisplayVisible(boolean visible) {
         // If no unit is displayed, select a unit so the display can be safely shown
         // This can happen when using mouse button 4
-        if ((mechD.getCurrentEntity() == null) &&
-                (getClient() != null) && 
-                (getClient().getGame() != null)) {
-            List<Entity> es = getClient().getGame().getEntitiesVector();
-            if ((es != null) && (es.size() > 0)) {
-                mechD.displayEntity(es.get(0));
+        if (mechD.getCurrentEntity() == null) {
+            if ((getClient() != null) && 
+                    (getClient().getGame() != null)) {
+                List<Entity> es = getClient().getGame().getEntitiesVector();
+                if ((es != null) && (es.size() > 0)) {
+                    mechD.displayEntity(es.get(0));
+                } else {
+                    return;
+                }
             } else {
                 return;
             }
-        } else {
-            return;
         }
 
         mechW.setVisible(visible);

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1244,7 +1244,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
     /**
      * Toggles the entity display window
      */
-    public void toggleDisplay() {
+    private void toggleDisplay() {
         mechW.setVisible(!mechW.isVisible());
         if (mechW.isVisible()) {
             frame.requestFocus();
@@ -1276,7 +1276,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         }
     }
 
-    public void toggleUnitOverview() {
+    private void toggleUnitOverview() {
         uo.setVisible(!uo.isVisible());
         GUIPreferences.getInstance().setShowUnitOverview(uo.isVisible());
         bv.refreshDisplayables();
@@ -1285,7 +1285,7 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
     /**
      * Toggles the minimap window Also, toggles the minimap enabled setting
      */
-    public void toggleMap() {
+    private void toggleMap() {
         if (minimapW.isVisible()) {
             GUIPreferences.getInstance().setMinimapEnabled(false);
         } else {

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -94,6 +94,7 @@ import megamek.client.ui.IDisplayable;
 import megamek.client.ui.Messages;
 import megamek.client.ui.SharedUtility;
 import megamek.client.ui.swing.ChatterBox2;
+import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.MovementDisplay;
 import megamek.client.ui.swing.TilesetManager;
@@ -228,6 +229,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     private Font font_minefield = FONT_12;
 
     IGame game;
+    ClientGUI clientgui;
 
     private Dimension boardSize;
     private Dimension preferredSize = new Dimension(0, 0);
@@ -471,9 +473,10 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     /**
      * Construct a new board view for the specified game
      */
-    public BoardView1(final IGame game, final MegaMekController controller)
+    public BoardView1(final IGame game, final MegaMekController controller, ClientGUI clientgui)
             throws java.io.IOException {
         this.game = game;
+        this.clientgui = clientgui;
 
         hexImageCache = new ImageCache<Coords, HexImageCacheEntry>();
 
@@ -4413,6 +4416,13 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         if (null == point) {
             return;
         }
+        
+        // Button 4: Hide/Show the minimap and unitDisplay
+        if (me.getButton() == 4) {
+            clientgui.toggleDisplay();
+            clientgui.toggleMap();
+        }
+        
         // we clicked the right mouse button,
         // remember the position if we start to scroll
         // if we drag, we should scroll

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -4419,8 +4419,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         
         // Button 4: Hide/Show the minimap and unitDisplay
         if (me.getButton() == 4) {
-            clientgui.toggleDisplay();
-            clientgui.toggleMap();
+            clientgui.toggleMMUDDisplays();
         }
         
         // we clicked the right mouse button,

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -4419,7 +4419,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         
         // Button 4: Hide/Show the minimap and unitDisplay
         if (me.getButton() == 4) {
-            clientgui.toggleMMUDDisplays();
+            if (clientgui != null) clientgui.toggleMMUDDisplays();
         }
         
         // we clicked the right mouse button,


### PR DESCRIPTION
For me, the displays tend to be in the way when they're present and I miss their info when they're not. Therefore I wanted a quick way to show/hide them both and as far as I can see, MB4 has not been used by MegaMek so far.

Since I can't show a screenshot for this and it should only add functionality, not remove or change any, I will merge this in.