### PR TITLE
Replacing Coords.hashCode() with something suitable for a PRNG

### DIFF
--- a/megamek/src/megamek/client/ui/swing/HexTileset.java
+++ b/megamek/src/megamek/client/ui/swing/HexTileset.java
@@ -540,13 +540,7 @@ public class HexTileset {
                 loadImage(comp);
             }
             if (images.size() > 1) {
-                // Use a "seed" for determining which
-                // Image to use from the tileset. Normally the seed is the
-                // hashcode of the hex coordinates.
-                // Coords.Hashcode() is always a multiple of 4. So mess with the
-                // seed a little.
-                int betterSeed = (seed >> 3) + (seed);
-                int rand = (betterSeed % images.size());
+                int rand = (seed % images.size());
                 return images.elementAt(rand);
             }
             return images.firstElement();

--- a/megamek/src/megamek/common/Coords.java
+++ b/megamek/src/megamek/common/Coords.java
@@ -17,6 +17,8 @@ package megamek.common;
 import java.io.Serializable;
 import java.util.ArrayList;
 
+import megamek.common.util.HashCodeUtil;
+
 /**
  * Coords stores x and y values. Since these are hexes, coordinates with odd x
  * values are a half-hex down. Directions work clockwise around the hex,
@@ -58,6 +60,7 @@ public class Coords implements Serializable {
 
     private final int x;
     private final int y;
+    private final int hash;
 
     /**
      * Constructs a new coordinate pair at (x, y).
@@ -65,6 +68,8 @@ public class Coords implements Serializable {
     public Coords(int x, int y) {
         this.x = x;
         this.y = y;
+        // Make sure the hash is positive
+        this.hash = HashCodeUtil.hash1(x << SHIFT + y) & 0x7FFFFFFF;
     }
 
     /**
@@ -307,41 +312,7 @@ public class Coords implements Serializable {
      */
     @Override
     public int hashCode() {
-        // Record the signs of X and Y separately from their values.
-        boolean negy = (getY() < 0);
-        boolean negx = (getX() < 0);
-        int signbits = 0;
-        int absx = getX();
-        int absy = getY();
-        if (negy) {
-            signbits += 0x1;
-            absy = -getY();
-        }
-        if (negx) {
-            signbits += 0x2;
-            absx = -getX();
-        }
-        return (((absx << Coords.SHIFT) ^ absy) << 2) + signbits;
-    }
-
-    /**
-     * Get the coordinates object for a given hash code.
-     * 
-     * @param hash - the hash code for the desired object.
-     * @return the <code>Coords</code> that match the hash code.
-     */
-    public static Coords getFromHashCode(int hash) {
-        // The signs of X and Y are recorded separately from their values.
-        boolean negy = (hash & 0x1) > 0;
-        boolean negx = (hash & 0x2) > 0;
-        int signless = hash >>> 2;
-        int hashy = (signless & Coords.MASK);
-        int hashx = (signless ^ hashy) >>> Coords.SHIFT;
-        if (negx)
-            hashx = -hashx;
-        if (negy)
-            hashy = -hashy;
-        return new Coords(hashx, hashy);
+        return hash;
     }
 
     @Override

--- a/megamek/src/megamek/common/Coords.java
+++ b/megamek/src/megamek/common/Coords.java
@@ -69,7 +69,7 @@ public class Coords implements Serializable {
         this.x = x;
         this.y = y;
         // Make sure the hash is positive
-        this.hash = HashCodeUtil.hash1(x << SHIFT + y) & 0x7FFFFFFF;
+        this.hash = (HashCodeUtil.hash1(x + 1337) ^ HashCodeUtil.hash1(y + 97331)) & 0x7FFFFFFF;
     }
 
     /**

--- a/megamek/src/megamek/common/Targetable.java
+++ b/megamek/src/megamek/common/Targetable.java
@@ -99,4 +99,11 @@ public interface Targetable extends Serializable {
      * Not used for aerospace units, see {@link Targetable#isAirborne()}
      */
     public boolean isAirborneVTOLorWIGE();
+    
+    // Make sure Targetable implements both
+    @Override
+    boolean equals(Object obj);
+    
+    @Override
+    int hashCode();
 }

--- a/megamek/src/megamek/common/util/HashCodeUtil.java
+++ b/megamek/src/megamek/common/util/HashCodeUtil.java
@@ -1,102 +1,17 @@
 package megamek.common.util;
 
-import java.lang.reflect.Array;
-
 /**
- * Collected methods which allow easy implementation of <tt>hashCode</tt>. This
- * code is public domain and originated from
- * http://www.javapractices.com/topic/TopicAction.do?Id=28.
- * 
- * Example use case:
- * 
- * <pre>
- * public int hashCode() {
- *     int result = HashCodeUtil.SEED;
- *     // collect the contributions of various fields
- *     result = HashCodeUtil.hash(result, fPrimitive);
- *     result = HashCodeUtil.hash(result, fObject);
- *     result = HashCodeUtil.hash(result, fArray);
- *     return result;
- * }
- * </pre>
+ * Specialized hash code implementations suitable for PRNG initialisation
  */
 public final class HashCodeUtil {
-
-    /**
-     * An initial value for a <tt>hashCode</tt>, to which is added contributions
-     * from fields. Using a non-zero value decreases collisons of
-     * <tt>hashCode</tt> values.
-     */
-    public static final int SEED = 23;
-
-    /** booleans. */
-    public static int hash(int aSeed, boolean aBoolean) {
-        return firstTerm(aSeed) + (aBoolean ? 1 : 0);
-    }
-
-    /*** chars. */
-    public static int hash(int aSeed, char aChar) {
-        return firstTerm(aSeed) + (int) aChar;
-    }
-
-    /** ints. */
-    public static int hash(int aSeed, int aInt) {
-        /*
-         * Implementation Note Note that byte and short are handled by this
-         * method, through implicit conversion.
-         */
-        return firstTerm(aSeed) + aInt;
-    }
-
-    /** longs. */
-    public static int hash(int aSeed, long aLong) {
-        return firstTerm(aSeed) + (int) (aLong ^ (aLong >>> 32));
-    }
-
-    /** floats. */
-    public static int hash(int aSeed, float aFloat) {
-        return hash(aSeed, Float.floatToIntBits(aFloat));
-    }
-
-    /** doubles. */
-    public static int hash(int aSeed, double aDouble) {
-        return hash(aSeed, Double.doubleToLongBits(aDouble));
-    }
-
-    /**
-     * <tt>aObject</tt> is a possibly-null object field, and possibly an array.
-     * 
-     * If <tt>aObject</tt> is an array, then each element may be a primitive or
-     * a possibly-null object.
-     */
-    public static int hash(int aSeed, Object aObject) {
-        int result = aSeed;
-        if (aObject == null) {
-            result = hash(result, 0);
-        } else if (!isArray(aObject)) {
-            result = hash(result, aObject.hashCode());
-        } else {
-            int length = Array.getLength(aObject);
-            for (int idx = 0; idx < length; ++idx) {
-                Object item = Array.get(aObject, idx);
-                // if item in array references the array itself, prevent
-                // infinite looping
-                if (!(item == aObject))
-                    // recursive call!
-                    result = hash(result, item);
-            }
-        }
-        return result;
-    }
-
-    // PRIVATE
-    private static final int fODD_PRIME_NUMBER = 37;
-
-    private static int firstTerm(int aSeed) {
-        return fODD_PRIME_NUMBER * aSeed;
-    }
-
-    private static boolean isArray(Object aObject) {
-        return aObject.getClass().isArray();
+    // Source: http://burtleburtle.net/bob/hash/integer.html
+    public static int hash1(int val) {
+        val = (val + 0x7ed55d16) + (val << 12);
+        val = (val ^ 0xc761c23c) ^ (val >> 19);
+        val = (val + 0x165667b1) + (val << 5);
+        val = (val + 0xd3a2646c) ^ (val << 9);
+        val = (val + 0xfd7046c5) + (val << 3);
+        val = (val ^ 0xb55a4f09) ^ (val >> 16);
+        return val;
     }
 }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -51,6 +51,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -60,6 +61,8 @@ import java.util.Vector;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+
+import com.thoughtworks.xstream.XStream;
 
 import megamek.MegaMek;
 import megamek.client.ui.swing.util.PlayerColors;
@@ -209,7 +212,6 @@ import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.BoardUtilities;
-import megamek.common.util.HashCodeUtil;
 import megamek.common.util.StringUtil;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestAero;
@@ -260,8 +262,6 @@ import megamek.server.commands.VictoryCommand;
 import megamek.server.commands.WhoCommand;
 import megamek.server.victory.Victory;
 
-import com.thoughtworks.xstream.XStream;
-
 /**
  * @author Ben Mazur
  */
@@ -279,21 +279,19 @@ public class Server implements Runnable {
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof EntityTargetPair)) {
+            if(this == o) {
+                return true;
+            }
+            if((null == o) || (getClass() != o.getClass())) {
                 return false;
             }
-            EntityTargetPair other = (EntityTargetPair)o;
-            return ent.equals(other.ent)
-                    && (((target != null) && target.equals(other.target))
-                            || ((target == null) && (other.target == null)));
+            final EntityTargetPair other = (EntityTargetPair) o;
+            return Objects.equals(ent, other.ent) && Objects.equals(target, other.target);
         }
 
         @Override
         public int hashCode() {
-            int hashCode = HashCodeUtil.SEED;
-            hashCode = HashCodeUtil.hash(hashCode, ent.getId());
-            hashCode = HashCodeUtil.hash(hashCode, target);
-            return hashCode;
+            return Objects.hash(ent, target);
         }
 
     }

--- a/megamek/src/megamek/test/TestCoords.java
+++ b/megamek/src/megamek/test/TestCoords.java
@@ -23,42 +23,32 @@ import megamek.common.Coords;
  * TODO: integrate JUnit into this class.
  */
 public class TestCoords {
-
+    private static final String OUTFORMAT = "The hash of %s is 0x%08X"; //$NON-NLS-1$
+    
     public static void main(String[] args) {
 
-        System.out.println("The maximum board height: "
-                + Coords.MAX_BOARD_HEIGHT);
+        System.out.println("The maximum board height: " + Coords.MAX_BOARD_HEIGHT); //$NON-NLS-1$
 
-        System.out
-                .println("The maximum board width: " + Coords.MAX_BOARD_WIDTH);
+        System.out.println("The maximum board width: " + Coords.MAX_BOARD_WIDTH); //$NON-NLS-1$
 
-        Coords coords = new Coords(1, 2);
-        System.out.println("The hash of " + coords + " is: "
-                + coords.hashCode());
-
-        System.out.println("The coords for a hash of 2056 is: "
-                + Coords.getFromHashCode(2056));
+        for(int x = 1; x < 10; ++ x) {
+            Coords coords = new Coords(x, 2);
+            System.out.println(String.format(OUTFORMAT, coords, coords.hashCode()));
+        }
+        
+        for(int y = 10; y < 19; ++ y) {
+            Coords coords = new Coords(1, y);
+            System.out.println(String.format(OUTFORMAT, coords, coords.hashCode()));
+        }
 
         Coords neg_coords = new Coords(-11, -22);
-        System.out.println("The hash of " + neg_coords + " is: "
-                + neg_coords.hashCode());
-
-        System.out.println("The coords for a hash of 22619 is: "
-                + Coords.getFromHashCode(22619));
+        System.out.println(String.format(OUTFORMAT, neg_coords, neg_coords.hashCode()));
 
         neg_coords = new Coords(42, -68);
-        System.out.println("The hash of " + neg_coords + " is: "
-                + neg_coords.hashCode());
-
-        System.out.println("The coords for a hash of 86289 is: "
-                + Coords.getFromHashCode(86289));
+        System.out.println(String.format(OUTFORMAT, neg_coords, neg_coords.hashCode()));
 
         neg_coords = new Coords(-668, 42);
-        System.out.println("The hash of " + neg_coords + " is: "
-                + neg_coords.hashCode());
-
-        System.out.println("The coords for a hash of 1368234 is: "
-                + Coords.getFromHashCode(1368234));
+        System.out.println(String.format(OUTFORMAT, neg_coords, neg_coords.hashCode()));
     }
 
 }


### PR DESCRIPTION
This is a proposed bugfix for Bug #120 

This repurposes the HashCodeUtil class to have a central place for specialised hashes. To do so cleanly, the following trivial changes had to be made:

* Server.EntityTargetPair's hashCode() and equals() changed to use the standard Objects.hash() and Objects.equals() methods
* The Targetable interface made to require both methods, since it's used in the class above

Also, the TestCoords class (which seems otherwise unused) was cleaned up and the "get coordinates from hash code" method in Coords removed, since it didn't make much sense to begin with.