### PR TITLE
Issue #149: LOS range

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1033,9 +1033,9 @@ public class Compute {
                 }
             }
             // No Direct Fire Energy or Pulse with range < 7            
-            if (wtype.hasFlag(WeaponType.F_PULSE)
-                && (wtype.hasFlag(WeaponType.F_ENERGY)
-                    || wtype.hasFlag(WeaponType.F_DIRECT_FIRE))) {
+            if ((wtype.hasFlag(WeaponType.F_DIRECT_FIRE)
+                    && wtype.hasFlag(WeaponType.F_ENERGY))
+                || wtype.hasFlag(WeaponType.F_PULSE)) {
                 if (longRange < 7) {
                     range = RangeType.RANGE_OUT;
                 }

--- a/megamek/src/megamek/common/weapons/MGWeapon.java
+++ b/megamek/src/megamek/common/weapons/MGWeapon.java
@@ -37,7 +37,7 @@ public abstract class MGWeapon extends AmmoWeapon {
         super();
         ammoType = AmmoType.T_MG;
         flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON)
-                .or(F_BALLISTIC).or(F_MG).or(F_PROTO_WEAPON)
+                .or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_MG).or(F_PROTO_WEAPON)
                 .or(F_BURST_FIRE);
         atClass = CLASS_POINT_DEFENSE;
     }


### PR DESCRIPTION
**DO NOT USE, MGs still bugged**
_Applying the DIRECT_FIRE weapon type flag to MGs will make them work with TCs (which they shouldn't)_


Fix for both parts of issue #149 :
- LOS Range logic bug for non-pulse energy weapons
- Missing DIRECT_FIRE flag for MG weapons

