### PR TITLE
Fixed another logic error in Terrain.java

### DIFF
--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -315,9 +315,9 @@ public class Terrain implements ITerrain, Serializable {
             break;
         case Terrains.MUD:
             if ((moveMode != EntityMovementMode.BIPED)
-                    || (moveMode != EntityMovementMode.QUAD)
-                    || (moveMode != EntityMovementMode.HOVER)
-                    || (moveMode != EntityMovementMode.WIGE)) {
+                    && (moveMode != EntityMovementMode.QUAD)
+                    && (moveMode != EntityMovementMode.HOVER)
+                    && (moveMode != EntityMovementMode.WIGE)) {
                 roll.addModifier(1, "Mud");
             }
             break;


### PR DESCRIPTION
After updating the fix for the +4 on ice issue, I noticed that
the logic for the Terrains.MUD modifier suffered from the same
logic error.