### PR TITLE
Removes <omni> tag from Clan second-line ASFs

### DIFF
--- a/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Ammon 2.blk
+++ b/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Ammon 2.blk
@@ -64,10 +64,6 @@ Aerodyne
 2
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 104
 86

--- a/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Chaeronea 2.blk
+++ b/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Chaeronea 2.blk
@@ -64,10 +64,6 @@ Aerodyne
 2
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 22
 20

--- a/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Chaeronea 3.blk
+++ b/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Chaeronea 3.blk
@@ -56,10 +56,6 @@ Aerodyne
 2
 </engine_type>
 
-<omni>
-1
-</omni>
-
 <armor>
 14
 12

--- a/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Chaeronea 4.blk
+++ b/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Chaeronea 4.blk
@@ -56,10 +56,6 @@ Aerodyne
 0
 </engine_type>
 
-<omni>
-1
-</omni>
-
 <armor>
 14
 12

--- a/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Hydaspes 2.blk
+++ b/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Hydaspes 2.blk
@@ -64,10 +64,6 @@ Aerodyne
 2
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 138
 106

--- a/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Issus 2.blk
+++ b/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Issus 2.blk
@@ -64,10 +64,6 @@ Aerodyne
 2
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 28
 23

--- a/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Issus 3.blk
+++ b/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Issus 3.blk
@@ -64,10 +64,6 @@ Aerodyne
 6
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 28
 23

--- a/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Xerxes 2.blk
+++ b/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Xerxes 2.blk
@@ -64,10 +64,6 @@ Aerodyne
 2
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 45
 43

--- a/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Xerxes 3.blk
+++ b/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Xerxes 3.blk
@@ -64,10 +64,6 @@ Aerodyne
 2
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 45
 43

--- a/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Xerxes.blk
+++ b/megamek/data/mechfiles/fighters/3067 Unabridged/Clan Aerospace/Xerxes.blk
@@ -64,10 +64,6 @@ Aerodyne
 2
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 45
 43

--- a/megamek/data/mechfiles/fighters/ProtoTypes/Hydaspes 3.blk
+++ b/megamek/data/mechfiles/fighters/ProtoTypes/Hydaspes 3.blk
@@ -64,10 +64,6 @@ Aerodyne
 6
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 100
 80

--- a/megamek/data/mechfiles/fighters/TRO3067/Clan/Ammon.blk
+++ b/megamek/data/mechfiles/fighters/TRO3067/Clan/Ammon.blk
@@ -56,10 +56,6 @@ Aerodyne
 0
 </engine_type>
 
-<omni>
-1
-</omni>
-
 <armor>
 70
 60

--- a/megamek/data/mechfiles/fighters/TRO3067/Clan/Chaeronea.blk
+++ b/megamek/data/mechfiles/fighters/TRO3067/Clan/Chaeronea.blk
@@ -56,10 +56,6 @@ Aerodyne
 0
 </engine_type>
 
-<omni>
-1
-</omni>
-
 <armor>
 14
 12

--- a/megamek/data/mechfiles/fighters/TRO3067/Clan/Hydaspes.blk
+++ b/megamek/data/mechfiles/fighters/TRO3067/Clan/Hydaspes.blk
@@ -64,10 +64,6 @@ Aerodyne
 2
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 138
 106

--- a/megamek/data/mechfiles/fighters/TRO3067/Clan/Issus.blk
+++ b/megamek/data/mechfiles/fighters/TRO3067/Clan/Issus.blk
@@ -64,10 +64,6 @@ Aerodyne
 2
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 28
 23

--- a/megamek/data/mechfiles/fighters/TRO3067/Clan/Tyre 2.blk
+++ b/megamek/data/mechfiles/fighters/TRO3067/Clan/Tyre 2.blk
@@ -56,10 +56,6 @@ Aerodyne
 0
 </engine_type>
 
-<omni>
-1
-</omni>
-
 <armor>
 35
 30

--- a/megamek/data/mechfiles/fighters/TRO3067/Clan/Tyre.blk
+++ b/megamek/data/mechfiles/fighters/TRO3067/Clan/Tyre.blk
@@ -56,10 +56,6 @@ Aerodyne
 0
 </engine_type>
 
-<omni>
-1
-</omni>
-
 <armor>
 35
 30

--- a/megamek/data/mechfiles/fighters/TRO3067/IS/Eisensturm EST-R3.blk
+++ b/megamek/data/mechfiles/fighters/TRO3067/IS/Eisensturm EST-R3.blk
@@ -64,10 +64,6 @@ Aerodyne
 -1
 </armor_tech>
 
-<omni>
-1
-</omni>
-
 <armor>
 110
 85


### PR DESCRIPTION
I noticed that all the Clan ASFs in TRO:3067 (and one from TRO:P) are tagged as omnis, as is the fixed-configuration Eisensturm EST-R3.