### PR TITLE
Infantry damage for combat within buildings

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -13,6 +13,7 @@ v0.41.22-git
 + Issue #303: Reporting issues with misses on units in buildings
 + Feature: Non-Infantry Weapon Damage Against Infantry changes now reported
 + Bug [#4186]: Combat within building damage for infantry now correct
++ Adjusted building floor names during deployment; starts with ground floor
 
 v0.41.21 (2016-07-31 10:00 UTC)
 + Feature: Added "Swarmed" entry to unit tooltips

--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -11,6 +11,8 @@ v0.41.22-git
 + Issue #70: Terrain Factor Damage for Engine Explosions and Ammo Explosions
 + Issue #300: Ground to Air fire Causing Accidental Fire Check
 + Issue #303: Reporting issues with misses on units in buildings
++ Feature: Non-Infantry Weapon Damage Against Infantry changes now reported
++ Bug [#4186]: Combat within building damage for infantry now correct
 
 v0.41.21 (2016-07-31 10:00 UTC)
 + Feature: Added "Swarmed" entry to unit tooltips

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -863,6 +863,7 @@ DeploymentDisplay.Deploy=Deploy
 DeploymentDisplay.floor=Floor \#
 DeploymentDisplay.floorsDialog.message=What floor should {0} be placed on?
 DeploymentDisplay.floorsDialog.title=What floor?
+DeploymentDisplay.ground=Ground floor
 DeploymentDisplay.belowbridge=Below the bridge
 DeploymentDisplay.topbridge=On top of the bridge
 DeploymentDisplay.bridgeDialog.message=Where should {0} be placed?

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -1072,3 +1072,4 @@
 9973=Missile weapon against infantry, damage reduced from <data> to <data>
 9974=Burst-fire weapon against infantry, damage changed from <data> to <data>
 9975=Burst-fire weapon against infantry in building, damage changed from <data> to <data>
+9976=Building provides no protection when units are on the same level!

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -1065,3 +1065,10 @@
 9960=<data> (<data>) detects a hidden unit in hex <data>!
 9961=Hidden unit <data> (<data>) prevents <data> (<data>) from entering hex <data>!
 9962=<data> (<data>) was unable to enter hex <data> because it would create a stacking violation with a hidden unit, movement ended!
+
+9970=Direct fire weapon against infantry,  damage reduced from <data> to <data>
+9971=Ballistic cluster weapon against infantry,  damage reduced from <data> to <data>
+9972=Pulse weapon against infantry, damage reduced from <data> to <data>
+9973=Missile weapon against infantry, damage reduced from <data> to <data>
+9974=Burst-fire weapon against infantry, damage changed from <data> to <data>
+9975=Burst-fire weapon against infantry in building, damage changed from <data> to <data>

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -785,7 +785,7 @@
 6430=<font color='C00000'><data> (<data>) takes an additional critical hit, because it was hit by anti-TSM missiles this round.</font>
 6435=The building in the hex absorbs <data> damage from the bombs!
 6440=<data> takes no damage.
-6445=Infantry receives no damage.
+6445=<data> receives no damage.
 6450=<data> damage is passed on to <data>.
 6455=<data> is hit by falling debris for <data> damage.
 6460=<newline><data> collapses due to damage.

--- a/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
@@ -566,10 +566,15 @@ public class DeploymentDisplay extends StatusBarPhaseDisplay {
         ArrayList<String> floorNames = new ArrayList<>(height + 1);
         ArrayList<Integer> floorValues = new ArrayList<>(height + 1);
 
-        for (int loop = 0; loop < height; loop++) {
+        if (Compute.stackingViolation(game, ce(), 0, moveto, null) == null) {
+            floorNames.add(Messages.getString("DeploymentDisplay.ground"));
+            floorValues.add(0);
+        }
+
+        for (int loop = 1; loop < height; loop++) {
             if (Compute.stackingViolation(game, ce(), loop, moveto, null) == null) {
                 floorNames.add(Messages.getString("DeploymentDisplay.floor")
-                        + Integer.toString(loop + 1));
+                        + Integer.toString(loop));
                 floorValues.add(loop);
             }
         }

--- a/megamek/src/megamek/common/Building.java
+++ b/megamek/src/megamek/common/Building.java
@@ -849,6 +849,27 @@ public class Building implements Serializable {
         return (int) Math.ceil(getPhaseCF(pos) / 10.0);
     }
 
+    /**
+     * Returns the percentage of damage done to the building for attacks against
+     * infantry in the building from other units within the building.  TW pg175.
+     *
+     * @param pos
+     * @return
+     */
+    public double getInfDmgFromInside() {
+         switch (getType()) {
+            case Building.LIGHT:
+            case Building.MEDIUM:
+                return 0.0;
+            case Building.HEAVY:
+                return 0.5;
+            case Building.HARDENED:
+                return 0.75;
+            default:
+                return 0;
+        }
+    }
+
     public BasementType getBasement(Coords coords) {
         return basement.get(coords);
     }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -5325,6 +5325,14 @@ public class Compute {
         return (int) damage;
     }
 
+    public static int directBlowInfantryDamage(double damage, int mos,
+            int damageType, boolean isNonInfantryAgainstMechanized,
+            boolean isAttackThruBuilding) {
+        return directBlowInfantryDamage(damage, mos, damageType,
+                isNonInfantryAgainstMechanized, isAttackThruBuilding,
+                Entity.NONE, null);
+    }
+
     /**
      * Method replicates the Non-Conventional Damage against Infantry damage
      * table as well as shifting for direct blows. also adjust for non-infantry
@@ -5337,83 +5345,108 @@ public class Compute {
      */
     public static int directBlowInfantryDamage(double damage, int mos,
             int damageType, boolean isNonInfantryAgainstMechanized,
-            boolean isAttackThruBuilding) {
+            boolean isAttackThruBuilding, int attackerId, Vector<Report> vReport) {
 
         damageType += mos;
 
+        double origDamage = damage;
+        int repNum = 9970;
         switch (damageType) {
             case WeaponType.WEAPON_DIRECT_FIRE:
                 damage /= 10;
+                repNum = 9970;
                 break;
             case WeaponType.WEAPON_CLUSTER_BALLISTIC:
                 damage /= 10;
                 damage++;
+                repNum = 9971;
                 break;
             case WeaponType.WEAPON_PULSE:
                 damage /= 10;
                 damage += 2;
+                repNum = 9972;
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE:
                 damage /= 5;
+                repNum = 9973;
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_1D6:
                 damage /= 5;
                 damage += Compute.d6();
+                repNum = 9973;
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_2D6:
                 damage /= 5;
                 damage += Compute.d6(2);
+                repNum = 9973;
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_3D6:
                 damage /= 5;
                 damage += Compute.d6(3);
+                repNum = 9973;
                 break;
             case WeaponType.WEAPON_BURST_HALFD6:
                 damage = Compute.d6() / 2.0;
+                repNum = 9974;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
+                    repNum = 9975;
                 }
                 break;
             case WeaponType.WEAPON_BURST_1D6:
                 damage = Compute.d6();
+                repNum = 9974;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
+                    repNum = 9975;
                 }
                 break;
             case WeaponType.WEAPON_BURST_2D6:
                 damage = Compute.d6(2);
+                repNum = 9974;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
+                    repNum = 9975;
                 }
                 break;
             case WeaponType.WEAPON_BURST_3D6:
                 damage = Compute.d6(3);
+                repNum = 9974;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
+                    repNum = 9975;
                 }
                 break;
             case WeaponType.WEAPON_BURST_4D6:
                 damage = Compute.d6(4);
+                repNum = 9974;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
+                    repNum = 9975;
                 }
                 break;
             case WeaponType.WEAPON_BURST_5D6:
                 damage = Compute.d6(5);
+                repNum = 9974;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
+                    repNum = 9975;
                 }
                 break;
             case WeaponType.WEAPON_BURST_6D6:
                 damage = Compute.d6(6);
+                repNum = 9974;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
+                    repNum = 9975;
                 }
                 break;
             case WeaponType.WEAPON_BURST_7D6:
                 damage = Compute.d6(7);
+                repNum = 9974;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
+                    repNum = 9975;
                 }
                 break;
         }
@@ -5429,6 +5462,15 @@ public class Compute {
             } else {
                 damage /= 2;
             }
+        }
+        
+        if (vReport != null) {
+            Report r = new Report(repNum);
+            r.subject = attackerId;
+            r.indent(2);
+            r.add((int)origDamage);
+            r.add((int)damage);
+            vReport.addElement(r);
         }
         return (int) damage;
     }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2945,7 +2945,7 @@ public class Compute {
             && !(g.getEntity(waa.getTargetId()) instanceof BattleArmor)) {
             fDamage = directBlowInfantryDamage(fDamage, 0,
                     wt.getInfantryDamageClass(), ((Infantry) (g.getEntity(waa
-                            .getTargetId()))).isMechanized());
+                            .getTargetId()))).isMechanized(), false);
         }
 
         fDamage *= fChance;
@@ -5336,7 +5336,8 @@ public class Compute {
      * @return
      */
     public static int directBlowInfantryDamage(double damage, int mos,
-                                               int damageType, boolean isNonInfantryAgainstMechanized) {
+            int damageType, boolean isNonInfantryAgainstMechanized,
+            boolean isAttackThruBuilding) {
 
         damageType += mos;
 
@@ -5369,35 +5370,58 @@ public class Compute {
                 break;
             case WeaponType.WEAPON_BURST_HALFD6:
                 damage = Compute.d6() / 2.0;
+                if (isAttackThruBuilding) {
+                    damage *= 0.5;
+                }
                 break;
             case WeaponType.WEAPON_BURST_1D6:
                 damage = Compute.d6();
+                if (isAttackThruBuilding) {
+                    damage *= 0.5;
+                }
                 break;
             case WeaponType.WEAPON_BURST_2D6:
                 damage = Compute.d6(2);
+                if (isAttackThruBuilding) {
+                    damage *= 0.5;
+                }
                 break;
             case WeaponType.WEAPON_BURST_3D6:
                 damage = Compute.d6(3);
+                if (isAttackThruBuilding) {
+                    damage *= 0.5;
+                }
                 break;
             case WeaponType.WEAPON_BURST_4D6:
                 damage = Compute.d6(4);
+                if (isAttackThruBuilding) {
+                    damage *= 0.5;
+                }
                 break;
             case WeaponType.WEAPON_BURST_5D6:
                 damage = Compute.d6(5);
+                if (isAttackThruBuilding) {
+                    damage *= 0.5;
+                }
                 break;
             case WeaponType.WEAPON_BURST_6D6:
                 damage = Compute.d6(6);
+                if (isAttackThruBuilding) {
+                    damage *= 0.5;
+                }
                 break;
             case WeaponType.WEAPON_BURST_7D6:
                 damage = Compute.d6(7);
+                if (isAttackThruBuilding) {
+                    damage *= 0.5;
+                }
                 break;
         }
         damage = Math.ceil(damage);
 
         // according to the following ruling, the half damage that mechanized
-        // inf
-        // get against burst fire should trump the double damage they get from
-        // non-infantry rather than cancel it out
+        // inf get against burst fire should trump the double damage they get
+        // from non-infantry rather than cancel it out
         // http://bg.battletech.com/forums/index.php/topic,23928.0.html
         if (isNonInfantryAgainstMechanized) {
             if (damageType < WeaponType.WEAPON_BURST_HALFD6) {

--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -792,7 +792,9 @@ public class LosEffects {
                         ai.attackPos)) {
             los.setThruBldg(game.getBoard().getBuildingAt(in.get(0)));
             //elevation differences count as building hexes passed through
-            los.buildingLevelsOrHexes += (Math.abs((ai.attackAbsHeight-ai.attackHeight) - (ai.targetAbsHeight-ai.targetHeight)));
+            los.buildingLevelsOrHexes += (Math
+                    .abs((ai.attackAbsHeight - ai.attackHeight)
+                            - (ai.targetAbsHeight - ai.targetHeight)));
         }
 
         // add non-divided line segments
@@ -807,6 +809,11 @@ public class LosEffects {
 
         // if blocked already, return that
         if (los.losModifiers(game).getValue() == TargetRoll.IMPOSSIBLE) {
+            return los;
+        }
+
+        // If there src & dst hexes are the same, nothing to do
+        if (in.size() < 2) {
             return los;
         }
 

--- a/megamek/src/megamek/common/ToHitData.java
+++ b/megamek/src/megamek/common/ToHitData.java
@@ -102,6 +102,14 @@ public class ToHitData extends TargetRoll {
     Coords coverLocSecondary = null;
 
     /**
+     * Keeps track of the <code>LosEffects</code> thruBldg value, which tracks
+     * if combat within a building is happening.  That is, if LoS from the
+     * attacker to target is traced  through a single building, then this value
+     * will be non-null.
+     */
+    Building thruBldg = null;
+
+    /**
      * Construct default.
      */
     public ToHitData() {
@@ -310,6 +318,14 @@ public class ToHitData extends TargetRoll {
 
     public void setCoverLocSecondary(Coords coverLoc) {
         coverLocSecondary = coverLoc;
+    }
+
+    public Building getThruBldg() {
+        return thruBldg;
+    }
+
+    public void setThruBldg(Building b) {
+        thruBldg = b;
     }
 
 }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1492,6 +1492,9 @@ public class WeaponAttackAction extends AbstractAttackAction implements
                     "Targeting adjacent building.");
         }
 
+        // Store the thruBldg state, for later processing
+        toHit.setThruBldg(los.getThruBldg());
+
         // Attacks against buildings from inside automatically hit.
         if ((null != los.getThruBldg())
                 && ((target.getTargetType() == Targetable.TYPE_BUILDING)

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1505,8 +1505,12 @@ public class WeaponAttackAction extends AbstractAttackAction implements
                     "Targeting building from inside (are you SURE this is a good idea?).");
         }
 
-        // add range mods
-        toHit.append(Compute.getRangeMods(game, ae, weaponId, target));
+        // Add range mods - If the attacker and target are in the same building
+        // & hex, range mods don't apply (and will cause the shot to fail)
+        if ((los.getThruBldg() == null)
+                || !los.getTargetPosition().equals(ae.getPosition())) {
+            toHit.append(Compute.getRangeMods(game, ae, weaponId, target));
+        }
 
         if (ae.hasQuirk(OptionsConstants.QUIRK_POS_ANTI_AIR)
                 && (target instanceof Entity)) {
@@ -3907,6 +3911,13 @@ public class WeaponAttackAction extends AbstractAttackAction implements
             }
 
             losMods = los.losModifiers(game, underWater);
+        }
+
+        // If the attacker and target are in the same building & hex, they can
+        // always attack each other, TW pg 175.
+        if ((los.getThruBldg() != null)
+                && los.getTargetPosition().equals(ae.getPosition())) {
+            return null;
         }
 
         if (multiPurposeelevationHack) {

--- a/megamek/src/megamek/common/weapons/ACAPHandler.java
+++ b/megamek/src/megamek/common/weapons/ACAPHandler.java
@@ -99,6 +99,12 @@ public class ACAPHandler extends ACWeaponHandler {
             hit.makeDirectBlow(toHit.getMoS() / 3);
         }
 
+        // Report calcDmgPerHitReports here
+        if (calcDmgPerHitReport.size() > 0) {
+            vPhaseReport.addAll(calcDmgPerHitReport);
+        }
+
+
         // A building may be damaged, even if the squad is not.
         if (bldgAbsorbs > 0) {
             int toBldg = Math.min(bldgAbsorbs, nDamage);

--- a/megamek/src/megamek/common/weapons/ACAPHandler.java
+++ b/megamek/src/megamek/common/weapons/ACAPHandler.java
@@ -116,6 +116,13 @@ public class ACAPHandler extends ACWeaponHandler {
                 report.subject = subjectId;
             }
             vPhaseReport.addAll(buildingReport);
+        // Units on same level, report building absorbs no damage
+        } else if (bldgAbsorbs == Integer.MIN_VALUE) {
+            Report.addNewline(vPhaseReport);
+            r = new Report(9976);
+            r.subject = ae.getId();
+            r.indent(2);
+            vPhaseReport.add(r);
         // Cases where absorbed damage doesn't reduce incoming damage
         } else if (bldgAbsorbs < 0) {
             int toBldg = -bldgAbsorbs;

--- a/megamek/src/megamek/common/weapons/ACAPHandler.java
+++ b/megamek/src/megamek/common/weapons/ACAPHandler.java
@@ -27,18 +27,16 @@ import megamek.common.Entity;
 import megamek.common.HitData;
 import megamek.common.IGame;
 import megamek.common.Infantry;
-import megamek.common.RangeType;
 import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
-import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 import megamek.server.Server.DamageType;
 
 /**
  * @author Andrew Hunter
  */
-public class ACAPHandler extends AmmoWeaponHandler {
+public class ACAPHandler extends ACWeaponHandler {
     /**
      *
      */
@@ -54,46 +52,6 @@ public class ACAPHandler extends AmmoWeaponHandler {
         generalDamageType = HitData.DAMAGE_ARMOR_PIERCING;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see megamek.common.weapons.WeaponHandler#calcDamagePerHit()
-     */
-    @Override
-    protected int calcDamagePerHit() {
-        double toReturn = wtype.getDamage();
-        // during a swarm, all damage gets applied as one block to one
-        // location
-        if ((ae instanceof BattleArmor)
-            && (weapon.getLocation() == BattleArmor.LOC_SQUAD)
-            && !(weapon.isSquadSupportWeapon())
-            && (ae.getSwarmTargetId() == target.getTargetId())) {
-            toReturn *= ((BattleArmor) ae).getShootingStrength();
-        }
-        // we default to direct fire weapons for anti-infantry damage
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
-            toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() / 3 : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
-        } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
-        }
-
-        if (bGlancing) {
-            toReturn = (int) Math.floor(toReturn / 2.0);
-        }
-        if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_RANGE)
-            && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG])) {
-            toReturn = (int) Math.floor(toReturn * .75);
-        }
-        if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_LOS_RANGE)
-                && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_EXTREME])) {
-            toReturn = (int) Math.floor(toReturn * .5);
-        }
-
-        return (int) toReturn;
-    }
 
     /*
      * (non-Javadoc)
@@ -147,7 +105,7 @@ public class ACAPHandler extends AmmoWeaponHandler {
             nDamage -= toBldg;
             Report.addNewline(vPhaseReport);
             Vector<Report> buildingReport = server.damageBuilding(bldg, toBldg,
-                                                                  entityTarget.getPosition());
+                    entityTarget.getPosition());
             for (Report report : buildingReport) {
                 report.subject = subjectId;
             }
@@ -181,10 +139,10 @@ public class ACAPHandler extends AmmoWeaponHandler {
             hit.makeArmorPiercing(atype, critModifer);
             vPhaseReport
                     .addAll(server.damageEntity(entityTarget, hit, nDamage,
-                                                false, ae.getSwarmTargetId() == entityTarget
+                            false, ae.getSwarmTargetId() == entityTarget
                                     .getId() ? DamageType.IGNORE_PASSENGER
-                                             : damageType, false, false, throughFront,
-                                                underWater));
+                                    : damageType, false, false, throughFront,
+                            underWater));
         }
     }
 }

--- a/megamek/src/megamek/common/weapons/ACAPHandler.java
+++ b/megamek/src/megamek/common/weapons/ACAPHandler.java
@@ -110,6 +110,16 @@ public class ACAPHandler extends ACWeaponHandler {
                 report.subject = subjectId;
             }
             vPhaseReport.addAll(buildingReport);
+        // Cases where absorbed damage doesn't reduce incoming damage
+        } else if (bldgAbsorbs < 0) {
+            int toBldg = -bldgAbsorbs;
+            Report.addNewline(vPhaseReport);
+            Vector<Report> buildingReport = server.damageBuilding(bldg, toBldg,
+                    entityTarget.getPosition());
+            for (Report report : buildingReport) {
+                report.subject = subjectId;
+            }
+            vPhaseReport.addAll(buildingReport);
         }
 
         nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);

--- a/megamek/src/megamek/common/weapons/ACIncendiaryHandler.java
+++ b/megamek/src/megamek/common/weapons/ACIncendiaryHandler.java
@@ -17,21 +17,16 @@
  */
 package megamek.common.weapons;
 
-import megamek.common.BattleArmor;
-import megamek.common.Compute;
 import megamek.common.IGame;
-import megamek.common.Infantry;
-import megamek.common.RangeType;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
-import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 import megamek.server.Server.DamageType;
 
 /**
  * @author Sebastian Brocks
  */
-public class ACIncendiaryHandler extends AmmoWeaponHandler {
+public class ACIncendiaryHandler extends ACWeaponHandler {
     /**
      *
      */
@@ -46,46 +41,6 @@ public class ACIncendiaryHandler extends AmmoWeaponHandler {
                                Server s) {
         super(t, w, g, s);
         damageType = DamageType.INCENDIARY;
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see megamek.common.weapons.WeaponHandler#calcDamagePerHit()
-     */
-    @Override
-    protected int calcDamagePerHit() {
-        double toReturn = wtype.getDamage();
-        // during a swarm, all damage gets applied as one block to one
-        // location
-        if ((ae instanceof BattleArmor)
-            && (weapon.getLocation() == BattleArmor.LOC_SQUAD)
-            && !(weapon.isSquadSupportWeapon())
-            && (ae.getSwarmTargetId() == target.getTargetId())) {
-            toReturn *= ((BattleArmor) ae).getShootingStrength();
-        }
-        // we default to direct fire weapons for anti-infantry damage
-        if (target instanceof Infantry && !(target instanceof BattleArmor)) {
-            toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
-        } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
-        }
-        if (bGlancing) {
-            toReturn = (int) Math.floor(toReturn / 2.0);
-        }
-        if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_RANGE)
-            && nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG]) {
-            toReturn = (int) Math.floor(toReturn * .75);
-        }
-        if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_LOS_RANGE)
-                && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_EXTREME])) {
-            toReturn = (int) Math.floor(toReturn * .5);
-        }        
-
-        return (int) toReturn;
     }
 
 }

--- a/megamek/src/megamek/common/weapons/ACTracerHandler.java
+++ b/megamek/src/megamek/common/weapons/ACTracerHandler.java
@@ -13,20 +13,15 @@
  */
 package megamek.common.weapons;
 
-import megamek.common.BattleArmor;
-import megamek.common.Compute;
 import megamek.common.IGame;
-import megamek.common.Infantry;
-import megamek.common.RangeType;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
-import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 
 /**
  * @author Sebastian Brocks
  */
-public class ACTracerHandler extends AmmoWeaponHandler {
+public class ACTracerHandler extends ACWeaponHandler {
 
     /**
      *
@@ -50,36 +45,7 @@ public class ACTracerHandler extends AmmoWeaponHandler {
      */
     @Override
     protected int calcDamagePerHit() {
-        double toReturn = wtype.getDamage();
-        // during a swarm, all damage gets applied as one block to one
-        // location
-        if ((ae instanceof BattleArmor)
-            && (weapon.getLocation() == BattleArmor.LOC_SQUAD)
-            && !(weapon.isSquadSupportWeapon())
-            && (ae.getSwarmTargetId() == target.getTargetId())) {
-            toReturn *= ((BattleArmor) ae).getShootingStrength();
-        }
-        // we default to direct fire weapons for anti-infantry damage
-        if (target instanceof Infantry && !(target instanceof BattleArmor)) {
-            toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
-        } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
-        }
-        if (bGlancing) {
-            toReturn = (int) Math.floor(toReturn / 2.0);
-        }
-        if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_RANGE)
-            && nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG]) {
-            toReturn = (int) Math.floor(toReturn * .75);
-        }
-        if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_LOS_RANGE)
-                && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_EXTREME])) {
-            toReturn = (int) Math.floor(toReturn * .5);
-        }        
-
+        double toReturn = super.calcDamagePerHit();
         return (int) toReturn - 1;
     }
 

--- a/megamek/src/megamek/common/weapons/ACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ACWeaponHandler.java
@@ -62,9 +62,10 @@ public class ACWeaponHandler extends AmmoWeaponHandler {
         // we default to direct fire weapons for anti-infantry damage
         if (target instanceof Infantry && !(target instanceof BattleArmor)) {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
+                    bDirect ? toHit.getMoS() / 3 : 0,
+                    wtype.getInfantryDamageClass(),
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/ACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ACWeaponHandler.java
@@ -65,7 +65,8 @@ public class ACWeaponHandler extends AmmoWeaponHandler {
                     bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null,
+                    ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/ATMHandler.java
+++ b/megamek/src/megamek/common/weapons/ATMHandler.java
@@ -77,10 +77,11 @@ public class ATMHandler extends MissileWeaponHandler {
             toReturn = 2;
         }
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
-            toReturn = Compute.directBlowInfantryDamage(wtype.getRackSize()
-                    * toReturn, bDirect ? toHit.getMoS() / 3 : 0,
+            toReturn = Compute.directBlowInfantryDamage(
+                    wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/ATMHandler.java
+++ b/megamek/src/megamek/common/weapons/ATMHandler.java
@@ -81,7 +81,7 @@ public class ATMHandler extends MissileWeaponHandler {
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BayWeaponHandler.java
@@ -314,11 +314,32 @@ public class BayWeaponHandler extends WeaponHandler {
             }
             bSalvo = true;
 
-            // The building shields all units from a certain amount of damage.
-            // The amount is based upon the building's CF at the phase's start.
+            // Buildings shield all units from a certain amount of damage.
+            // Amount is based upon the building's CF at the phase's start.
             int bldgAbsorbs = 0;
-            if (targetInBuilding && (bldg != null)) {
+            if (targetInBuilding && (bldg != null)
+                    && (toHit.getThruBldg() == null)) {
                 bldgAbsorbs = bldg.getAbsorbtion(target.getPosition());
+            }
+            
+            // Attacking infantry in buildings from same building
+            if (targetInBuilding && (bldg != null)
+                    && (toHit.getThruBldg() != null)
+                    && (entityTarget instanceof Infantry)) {
+                int dmgClass = wtype.getInfantryDamageClass();
+                int nDamage;
+                if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
+                    nDamage = nDamPerHit * Math.min(nCluster, hits);
+                } else {
+                    // Need to indicate to handleEntityDamage that the
+                    // absorbed damage shouldn't reduce incoming damage,
+                    // since the incoming damage was reduced in
+                    // Compute.directBlowInfantryDamage
+                    nDamage = -wtype.getDamage(nRange)
+                            * Math.min(nCluster, hits);
+                }
+                bldgAbsorbs = (int) Math.round(nDamage
+                        * bldg.getInfDmgFromInside()); 
             }
 
             handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,

--- a/megamek/src/megamek/common/weapons/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BayWeaponHandler.java
@@ -326,20 +326,26 @@ public class BayWeaponHandler extends WeaponHandler {
             if (targetInBuilding && (bldg != null)
                     && (toHit.getThruBldg() != null)
                     && (entityTarget instanceof Infantry)) {
-                int dmgClass = wtype.getInfantryDamageClass();
-                int nDamage;
-                if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
-                    nDamage = nDamPerHit * Math.min(nCluster, hits);
+                // If elevation is the same, building doesn't absorb
+                if (ae.getElevation() != entityTarget.getElevation()) {
+                    int dmgClass = wtype.getInfantryDamageClass();
+                    int nDamage;
+                    if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
+                        nDamage = nDamPerHit * Math.min(nCluster, hits);
+                    } else {
+                        // Need to indicate to handleEntityDamage that the
+                        // absorbed damage shouldn't reduce incoming damage,
+                        // since the incoming damage was reduced in
+                        // Compute.directBlowInfantryDamage
+                        nDamage = -wtype.getDamage(nRange)
+                                * Math.min(nCluster, hits);
+                    }
+                    bldgAbsorbs = (int) Math.round(nDamage
+                            * bldg.getInfDmgFromInside());
                 } else {
-                    // Need to indicate to handleEntityDamage that the
-                    // absorbed damage shouldn't reduce incoming damage,
-                    // since the incoming damage was reduced in
-                    // Compute.directBlowInfantryDamage
-                    nDamage = -wtype.getDamage(nRange)
-                            * Math.min(nCluster, hits);
+                    // Used later to indicate a special report
+                    bldgAbsorbs = Integer.MIN_VALUE;
                 }
-                bldgAbsorbs = (int) Math.round(nDamage
-                        * bldg.getInfDmgFromInside()); 
             }
 
             handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,

--- a/megamek/src/megamek/common/weapons/BombastLaserWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BombastLaserWeaponHandler.java
@@ -13,18 +13,13 @@
  */
 package megamek.common.weapons;
 
-import megamek.common.BattleArmor;
-import megamek.common.Compute;
 import megamek.common.HitData;
 import megamek.common.IGame;
-import megamek.common.Infantry;
-import megamek.common.RangeType;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
-import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 
-public class BombastLaserWeaponHandler extends WeaponHandler {
+public class BombastLaserWeaponHandler extends EnergyWeaponHandler {
     /**
      *
      */
@@ -36,61 +31,9 @@ public class BombastLaserWeaponHandler extends WeaponHandler {
      * @param g
      */
     public BombastLaserWeaponHandler(ToHitData toHit, WeaponAttackAction waa,
-                                     IGame g, Server s) {
+            IGame g, Server s) {
         super(toHit, waa, g, s);
         generalDamageType = HitData.DAMAGE_ENERGY;
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see megamek.common.weapons.WeaponHandler#calcDamagePerHit()
-     */
-    @Override
-    protected int calcDamagePerHit() {
-        double toReturn = wtype.getDamage(nRange);
-
-        toReturn = Compute.dialDownDamage(weapon, wtype, nRange);
-        // during a swarm, all damage gets applied as one block to one location
-        if ((ae instanceof BattleArmor)
-            && (weapon.getLocation() == BattleArmor.LOC_SQUAD)
-            && !(weapon.isSquadSupportWeapon())
-            && (ae.getSwarmTargetId() == target.getTargetId())) {
-            toReturn *= ((BattleArmor) ae).getShootingStrength();
-        }
-        // Check for Altered Damage from Energy Weapons (TacOp, pg.83)
-        if (game.getOptions().booleanOption("tacops_altdmg")) {
-            if (nRange <= 1) {
-                toReturn++;
-            } else if (nRange <= wtype.getMediumRange()) {
-                // Do Nothing for Short and Medium Range
-            } else if (nRange <= wtype.getLongRange()) {
-                toReturn--;
-            }
-        }
-
-        if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_RANGE)
-            && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG])) {
-            toReturn -= 1;
-        }
-        if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_LOS_RANGE)
-                && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_EXTREME])) {
-            toReturn = (int) Math.floor(toReturn * .75);
-        }
-
-        if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
-            toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() / 3 : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
-        } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
-        }
-        if (bGlancing) {
-            toReturn = (int) Math.floor(toReturn / 2.0);
-        }
-
-        return (int) Math.ceil(toReturn);
     }
 
 }

--- a/megamek/src/megamek/common/weapons/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/CLIATMHandler.java
@@ -94,7 +94,7 @@ public class CLIATMHandler extends ATMHandler {
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2; // Is this correct for partial streak missiles??
                 // it seems as if this only affects infantry -

--- a/megamek/src/megamek/common/weapons/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/CLIATMHandler.java
@@ -824,20 +824,26 @@ public class CLIATMHandler extends ATMHandler {
             if (targetInBuilding && (bldg != null)
                     && (toHit.getThruBldg() != null)
                     && (entityTarget instanceof Infantry)) {
-                int dmgClass = wtype.getInfantryDamageClass();
-                int nDamage;
-                if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
-                    nDamage = nDamPerHit * Math.min(nCluster, hits);
+                // If elevation is the same, building doesn't absorb
+                if (ae.getElevation() != entityTarget.getElevation()) {
+                    int dmgClass = wtype.getInfantryDamageClass();
+                    int nDamage;
+                    if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
+                        nDamage = nDamPerHit * Math.min(nCluster, hits);
+                    } else {
+                        // Need to indicate to handleEntityDamage that the
+                        // absorbed damage shouldn't reduce incoming damage,
+                        // since the incoming damage was reduced in
+                        // Compute.directBlowInfantryDamage
+                        nDamage = -wtype.getDamage(nRange)
+                                * Math.min(nCluster, hits);
+                    }
+                    bldgAbsorbs = (int) Math.round(nDamage
+                            * bldg.getInfDmgFromInside());
                 } else {
-                    // Need to indicate to handleEntityDamage that the
-                    // absorbed damage shouldn't reduce incoming damage,
-                    // since the incoming damage was reduced in
-                    // Compute.directBlowInfantryDamage
-                    nDamage = -wtype.getDamage(nRange)
-                            * Math.min(nCluster, hits);
+                    // Used later to indicate a special report
+                    bldgAbsorbs = Integer.MIN_VALUE;
                 }
-                bldgAbsorbs = (int) Math.round(nDamage
-                        * bldg.getInfDmgFromInside()); 
             }
 
             // Make sure the player knows when his attack causes no damage.

--- a/megamek/src/megamek/common/weapons/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/CLIATMHandler.java
@@ -90,10 +90,11 @@ public class CLIATMHandler extends ATMHandler {
         }
 
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
-            toReturn = Compute.directBlowInfantryDamage(wtype.getRackSize()
-                                                        * toReturn, bDirect ? toHit.getMoS() / 3 : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
+            toReturn = Compute.directBlowInfantryDamage(
+                    wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
+                    wtype.getInfantryDamageClass(),
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2; // Is this correct for partial streak missiles??
                 // it seems as if this only affects infantry -
@@ -205,8 +206,7 @@ public class CLIATMHandler extends ATMHandler {
         // Only apply if not all shots hit. IATM IMP have HE ranges and thus
         // suffer from spread too
         if (((atype.getMunitionType() == AmmoType.M_HIGH_EXPLOSIVE) || (atype
-                                                                                .getMunitionType() == AmmoType
-                                                                                .M_IATM_IMP))
+                .getMunitionType() == AmmoType.M_IATM_IMP))
             && tacopscluster
             && !allShotsHit()) {
             if (nRange <= 1) {
@@ -263,18 +263,18 @@ public class CLIATMHandler extends ATMHandler {
                 missilesHit = wtype.getRackSize();
             } else {
                 missilesHit = Compute.missilesHit(wtype.getRackSize(), amsMod,
-                                                  weapon.isHotLoaded(), allShotsHit(), isAdvancedAMS());
+                        weapon.isHotLoaded(), allShotsHit(), isAdvancedAMS());
             }
         } else {
             if (ae instanceof BattleArmor) {
                 missilesHit = Compute.missilesHit(wtype.getRackSize()
-                                                  * ((BattleArmor) ae).getShootingStrength(),
-                                                  nMissilesModifier, weapon.isHotLoaded(), false,
-                                                  isAdvancedAMS());
+                        * ((BattleArmor) ae).getShootingStrength(),
+                        nMissilesModifier, weapon.isHotLoaded(), false,
+                        isAdvancedAMS());
             } else {
                 missilesHit = Compute.missilesHit(wtype.getRackSize(),
-                                                  nMissilesModifier, weapon.isHotLoaded(), false,
-                                                  isAdvancedAMS());
+                        nMissilesModifier, weapon.isHotLoaded(), false,
+                        isAdvancedAMS());
             }
         }
 
@@ -324,7 +324,7 @@ public class CLIATMHandler extends ATMHandler {
             while (minefields.hasMoreElements()) {
                 Minefield mf = minefields.nextElement();
                 if (server.clearMinefield(mf, ae,
-                                          Minefield.CLEAR_NUMBER_WEAPON, vPhaseReport)) {
+                        Minefield.CLEAR_NUMBER_WEAPON, vPhaseReport)) {
                     mfRemoved.add(mf);
                 }
             }
@@ -786,7 +786,7 @@ public class CLIATMHandler extends ATMHandler {
                         bSalvo = true;
                         if (nweapons > 1) {
                             nweaponsHit = Compute.missilesHit(nweapons,
-                                                              ((Aero) ae).getClusterMods());
+                                    ((Aero) ae).getClusterMods());
                             r = new Report(3325);
                             r.subject = subjectId;
                             r.add(nweaponsHit);

--- a/megamek/src/megamek/common/weapons/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/CLIATMHandler.java
@@ -812,11 +812,32 @@ public class CLIATMHandler extends ATMHandler {
 
             } // End missed-target
 
-            // The building shields all units from a certain amount of damage.
-            // The amount is based upon the building's CF at the phase's start.
+            // Buildings shield all units from a certain amount of damage.
+            // Amount is based upon the building's CF at the phase's start.
             int bldgAbsorbs = 0;
-            if (targetInBuilding && (bldg != null)) {
+            if (targetInBuilding && (bldg != null)
+                    && (toHit.getThruBldg() == null)) {
                 bldgAbsorbs = bldg.getAbsorbtion(target.getPosition());
+            }
+            
+            // Attacking infantry in buildings from same building
+            if (targetInBuilding && (bldg != null)
+                    && (toHit.getThruBldg() != null)
+                    && (entityTarget instanceof Infantry)) {
+                int dmgClass = wtype.getInfantryDamageClass();
+                int nDamage;
+                if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
+                    nDamage = nDamPerHit * Math.min(nCluster, hits);
+                } else {
+                    // Need to indicate to handleEntityDamage that the
+                    // absorbed damage shouldn't reduce incoming damage,
+                    // since the incoming damage was reduced in
+                    // Compute.directBlowInfantryDamage
+                    nDamage = -wtype.getDamage(nRange)
+                            * Math.min(nCluster, hits);
+                }
+                bldgAbsorbs = (int) Math.round(nDamage
+                        * bldg.getInfDmgFromInside()); 
             }
 
             // Make sure the player knows when his attack causes no damage.
@@ -858,10 +879,10 @@ public class CLIATMHandler extends ATMHandler {
                     firstHit = false;
                     // do IMP stuff here!
                     if ((entityTarget instanceof Mech)
-                        || (entityTarget instanceof Aero)
-                        || (entityTarget instanceof Tank)) {
-                        entityTarget
-                                .addIMPHits(Math.max(0, hits - bldgAbsorbs));
+                            || (entityTarget instanceof Aero)
+                            || (entityTarget instanceof Tank)) {
+                        entityTarget.addIMPHits(Math.max(0,
+                                hits - Math.max(0, bldgAbsorbs)));
                     }
                 }
             } // Handle the next cluster.

--- a/megamek/src/megamek/common/weapons/ChemicalLaserHandler.java
+++ b/megamek/src/megamek/common/weapons/ChemicalLaserHandler.java
@@ -81,7 +81,7 @@ public class ChemicalLaserHandler extends AmmoWeaponHandler {
 
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
             toReturn = Compute.directBlowInfantryDamage(
-                    wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
+                    toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null);

--- a/megamek/src/megamek/common/weapons/ChemicalLaserHandler.java
+++ b/megamek/src/megamek/common/weapons/ChemicalLaserHandler.java
@@ -37,7 +37,7 @@ public class ChemicalLaserHandler extends AmmoWeaponHandler {
      * @param g
      */
     public ChemicalLaserHandler(ToHitData toHit, WeaponAttackAction waa,
-                                IGame g, Server s) {
+            IGame g, Server s) {
         super(toHit, waa, g, s);
         generalDamageType = HitData.DAMAGE_ENERGY;
     }
@@ -80,10 +80,11 @@ public class ChemicalLaserHandler extends AmmoWeaponHandler {
         }        
 
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
-            toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() / 3 : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
+            toReturn = Compute.directBlowInfantryDamage(
+                    wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
+                    wtype.getInfantryDamageClass(),
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/ChemicalLaserHandler.java
+++ b/megamek/src/megamek/common/weapons/ChemicalLaserHandler.java
@@ -84,7 +84,7 @@ public class ChemicalLaserHandler extends AmmoWeaponHandler {
                     toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/EnergyWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/EnergyWeaponHandler.java
@@ -85,7 +85,7 @@ public class EnergyWeaponHandler extends WeaponHandler {
 
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
             toReturn = Compute.directBlowInfantryDamage(
-                    wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
+                    toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null);

--- a/megamek/src/megamek/common/weapons/EnergyWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/EnergyWeaponHandler.java
@@ -88,7 +88,7 @@ public class EnergyWeaponHandler extends WeaponHandler {
                     toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/EnergyWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/EnergyWeaponHandler.java
@@ -20,6 +20,7 @@ import megamek.common.IGame;
 import megamek.common.Infantry;
 import megamek.common.RangeType;
 import megamek.common.ToHitData;
+import megamek.common.WeaponType;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
@@ -50,8 +51,8 @@ public class EnergyWeaponHandler extends WeaponHandler {
     protected int calcDamagePerHit() {
         double toReturn = wtype.getDamage(nRange);
 
-        if (game.getOptions().booleanOption("tacops_energy_weapons")
-            && wtype.hasModes()) {
+        if ((game.getOptions().booleanOption("tacops_energy_weapons")
+            && wtype.hasModes()) || wtype.hasFlag(WeaponType.F_BOMBAST_LASER)) {
             toReturn = Compute.dialDownDamage(weapon, wtype, nRange);
         }
         // during a swarm, all damage gets applied as one block to one location
@@ -83,10 +84,11 @@ public class EnergyWeaponHandler extends WeaponHandler {
         
 
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
-            toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() / 3 : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
+            toReturn = Compute.directBlowInfantryDamage(
+                    wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
+                    wtype.getInfantryDamageClass(),
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/FluidGunCoolHandler.java
+++ b/megamek/src/megamek/common/weapons/FluidGunCoolHandler.java
@@ -62,7 +62,8 @@ public class FluidGunCoolHandler extends AmmoWeaponHandler {
             nDamPerHit = Compute.directBlowInfantryDamage(1,
                     bDirect ? toHit.getMoS() / 3 : 0,
                     WeaponType.WEAPON_DIRECT_FIRE,
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
                     nCluster, bldgAbsorbs);
         }

--- a/megamek/src/megamek/common/weapons/GRHandler.java
+++ b/megamek/src/megamek/common/weapons/GRHandler.java
@@ -67,7 +67,7 @@ public class GRHandler extends AmmoWeaponHandler {
 
         if (target instanceof Infantry && !(target instanceof BattleArmor)) {
             toReturn = Compute.directBlowInfantryDamage(
-                    wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
+                    toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null);

--- a/megamek/src/megamek/common/weapons/GRHandler.java
+++ b/megamek/src/megamek/common/weapons/GRHandler.java
@@ -66,10 +66,11 @@ public class GRHandler extends AmmoWeaponHandler {
         }
 
         if (target instanceof Infantry && !(target instanceof BattleArmor)) {
-            toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() / 3 : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
+            toReturn = Compute.directBlowInfantryDamage(
+                    wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
+                    wtype.getInfantryDamageClass(),
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/GRHandler.java
+++ b/megamek/src/megamek/common/weapons/GRHandler.java
@@ -70,7 +70,7 @@ public class GRHandler extends AmmoWeaponHandler {
                     toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/HAGWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/HAGWeaponHandler.java
@@ -66,10 +66,11 @@ public class HAGWeaponHandler extends AmmoWeaponHandler {
     protected int calcDamagePerHit() {
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
             double toReturn = wtype.getRackSize();
-            toReturn = Compute.directBlowInfantryDamage(toReturn,
-                    bDirect ? toHit.getMoS() / 3 : 0,
+            toReturn = Compute.directBlowInfantryDamage(
+                    wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/HAGWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/HAGWeaponHandler.java
@@ -70,7 +70,7 @@ public class HAGWeaponHandler extends AmmoWeaponHandler {
                     toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/HAGWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/HAGWeaponHandler.java
@@ -67,7 +67,7 @@ public class HAGWeaponHandler extends AmmoWeaponHandler {
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
             double toReturn = wtype.getRackSize();
             toReturn = Compute.directBlowInfantryDamage(
-                    wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
+                    toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null);

--- a/megamek/src/megamek/common/weapons/LBXHandler.java
+++ b/megamek/src/megamek/common/weapons/LBXHandler.java
@@ -64,7 +64,7 @@ public class LBXHandler extends AmmoWeaponHandler {
                     wtype.getDamage(), bDirect ? toHit.getMoS() / 3 : 0,
                     WeaponType.WEAPON_CLUSTER_BALLISTIC,
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/LBXHandler.java
+++ b/megamek/src/megamek/common/weapons/LBXHandler.java
@@ -63,7 +63,8 @@ public class LBXHandler extends AmmoWeaponHandler {
             double toReturn = Compute.directBlowInfantryDamage(
                     wtype.getDamage(), bDirect ? toHit.getMoS() / 3 : 0,
                     WeaponType.WEAPON_CLUSTER_BALLISTIC,
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -317,7 +317,8 @@ public class LRMSwarmHandler extends LRMHandler {
             double toReturn = Compute.directBlowInfantryDamage(
                     missiles, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -210,20 +210,26 @@ public class LRMSwarmHandler extends LRMHandler {
         if (targetInBuilding && (bldg != null)
                 && (toHit.getThruBldg() != null)
                 && (entityTarget instanceof Infantry)) {
-            int dmgClass = wtype.getInfantryDamageClass();
-            int nDamage;
-            if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
-                nDamage = nDamPerHit * Math.min(nCluster, hits);
+            // If elevation is the same, building doesn't absorb
+            if (ae.getElevation() != entityTarget.getElevation()) {
+                int dmgClass = wtype.getInfantryDamageClass();
+                int nDamage;
+                if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
+                    nDamage = nDamPerHit * Math.min(nCluster, hits);
+                } else {
+                    // Need to indicate to handleEntityDamage that the
+                    // absorbed damage shouldn't reduce incoming damage,
+                    // since the incoming damage was reduced in
+                    // Compute.directBlowInfantryDamage
+                    nDamage = -wtype.getDamage(nRange)
+                            * Math.min(nCluster, hits);
+                }
+                bldgAbsorbs = (int) Math.round(nDamage
+                        * bldg.getInfDmgFromInside());
             } else {
-                // Need to indicate to handleEntityDamage that the
-                // absorbed damage shouldn't reduce incoming damage,
-                // since the incoming damage was reduced in
-                // Compute.directBlowInfantryDamage
-                nDamage = -wtype.getDamage(nRange)
-                        * Math.min(nCluster, hits);
+                // Used later to indicate a special report
+                bldgAbsorbs = Integer.MIN_VALUE;
             }
-            bldgAbsorbs = (int) Math.round(nDamage
-                    * bldg.getInfDmgFromInside()); 
         }
 
         // Make sure the player knows when his attack causes no damage.

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -340,7 +340,7 @@ public class LRMSwarmHandler extends LRMHandler {
                     missiles, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -27,6 +27,7 @@ import megamek.common.Report;
 import megamek.common.TargetRoll;
 import megamek.common.Targetable;
 import megamek.common.ToHitData;
+import megamek.common.WeaponType;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.server.Server;
 
@@ -197,11 +198,32 @@ public class LRMSwarmHandler extends LRMHandler {
 
         } // End missed-target
 
-        // The building shields all units from a certain amount of damage.
-        // The amount is based upon the building's CF at the phase's start.
+        // Buildings shield all units from a certain amount of damage.
+        // Amount is based upon the building's CF at the phase's start.
         int bldgAbsorbs = 0;
-        if (targetInBuilding && (bldg != null)) {
+        if (targetInBuilding && (bldg != null)
+                && (toHit.getThruBldg() == null)) {
             bldgAbsorbs = bldg.getAbsorbtion(target.getPosition());
+        }
+        
+        // Attacking infantry in buildings from same building
+        if (targetInBuilding && (bldg != null)
+                && (toHit.getThruBldg() != null)
+                && (entityTarget instanceof Infantry)) {
+            int dmgClass = wtype.getInfantryDamageClass();
+            int nDamage;
+            if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
+                nDamage = nDamPerHit * Math.min(nCluster, hits);
+            } else {
+                // Need to indicate to handleEntityDamage that the
+                // absorbed damage shouldn't reduce incoming damage,
+                // since the incoming damage was reduced in
+                // Compute.directBlowInfantryDamage
+                nDamage = -wtype.getDamage(nRange)
+                        * Math.min(nCluster, hits);
+            }
+            bldgAbsorbs = (int) Math.round(nDamage
+                    * bldg.getInfDmgFromInside()); 
         }
 
         // Make sure the player knows when his attack causes no damage.

--- a/megamek/src/megamek/common/weapons/MGAWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MGAWeaponHandler.java
@@ -184,7 +184,18 @@ public class MGAWeaponHandler extends MGHandler {
                 report.subject = subjectId;
             }
             vPhaseReport.addAll(buildingReport);
+        // Cases where absorbed damage doesn't reduce incoming damage
+        } else if (bldgAbsorbs < 0) {
+            int toBldg = -bldgAbsorbs;
+            Report.addNewline(vPhaseReport);
+            Vector<Report> buildingReport = server.damageBuilding(bldg, toBldg,
+                    entityTarget.getPosition());
+            for (Report report : buildingReport) {
+                report.subject = subjectId;
+            }
+            vPhaseReport.addAll(buildingReport);
         }
+
 
         nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);
 

--- a/megamek/src/megamek/common/weapons/MGAWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MGAWeaponHandler.java
@@ -189,6 +189,13 @@ public class MGAWeaponHandler extends MGHandler {
                 report.subject = subjectId;
             }
             vPhaseReport.addAll(buildingReport);
+        // Units on same level, report building absorbs no damage
+        } else if (bldgAbsorbs == Integer.MIN_VALUE) {
+            Report.addNewline(vPhaseReport);
+            Report r = new Report(9976);
+            r.subject = ae.getId();
+            r.indent(2);
+            vPhaseReport.add(r);            
         // Cases where absorbed damage doesn't reduce incoming damage
         } else if (bldgAbsorbs < 0) {
             int toBldg = -bldgAbsorbs;

--- a/megamek/src/megamek/common/weapons/MGAWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MGAWeaponHandler.java
@@ -173,6 +173,11 @@ public class MGAWeaponHandler extends MGHandler {
         // Resolve damage normally.
         nDamage = nDamPerHit * Math.min(nCluster, hits);
 
+        // Report calcDmgPerHitReports here
+        if (calcDmgPerHitReport.size() > 0) {
+            vPhaseReport.addAll(calcDmgPerHitReport);
+        }
+
         // A building may be damaged, even if the squad is not.
         if (bldgAbsorbs > 0) {
             int toBldg = Math.min(bldgAbsorbs, nDamage);

--- a/megamek/src/megamek/common/weapons/MGHandler.java
+++ b/megamek/src/megamek/common/weapons/MGHandler.java
@@ -79,10 +79,10 @@ public class MGHandler extends AmmoWeaponHandler {
             if ((target instanceof Infantry)
                     && !(target instanceof BattleArmor)) {
                 toReturn = Compute.directBlowInfantryDamage(
-                        toReturn, bDirect ? toHit.getMoS() / 3 : 0,
+                        wtype.getDamage(), bDirect ? toHit.getMoS() / 3 : 0,
                         wtype.getInfantryDamageClass(),
                         ((Infantry) target).isMechanized(),
-                        toHit.getThruBldg() != null);
+                        toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
                 if (bGlancing) {
                     toReturn = (int) Math.floor(toReturn / 2.0);
                 }

--- a/megamek/src/megamek/common/weapons/MGHandler.java
+++ b/megamek/src/megamek/common/weapons/MGHandler.java
@@ -79,7 +79,7 @@ public class MGHandler extends AmmoWeaponHandler {
             if ((target instanceof Infantry)
                     && !(target instanceof BattleArmor)) {
                 toReturn = Compute.directBlowInfantryDamage(
-                        wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
+                        toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                         wtype.getInfantryDamageClass(),
                         ((Infantry) target).isMechanized(),
                         toHit.getThruBldg() != null);

--- a/megamek/src/megamek/common/weapons/MGHandler.java
+++ b/megamek/src/megamek/common/weapons/MGHandler.java
@@ -77,11 +77,12 @@ public class MGHandler extends AmmoWeaponHandler {
             }
         } else {
             if ((target instanceof Infantry)
-                && !(target instanceof BattleArmor)) {
-                toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                            bDirect ? toHit.getMoS() / 3 : 0,
-                                                            wtype.getInfantryDamageClass(),
-                                                            ((Infantry) target).isMechanized());
+                    && !(target instanceof BattleArmor)) {
+                toReturn = Compute.directBlowInfantryDamage(
+                        wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
+                        wtype.getInfantryDamageClass(),
+                        ((Infantry) target).isMechanized(),
+                        toHit.getThruBldg() != null);
                 if (bGlancing) {
                     toReturn = (int) Math.floor(toReturn / 2.0);
                 }

--- a/megamek/src/megamek/common/weapons/MekMortarHandler.java
+++ b/megamek/src/megamek/common/weapons/MekMortarHandler.java
@@ -120,7 +120,8 @@ public class MekMortarHandler extends AmmoWeaponHandler {
             double toReturn = Compute.directBlowInfantryDamage(
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/MekMortarHandler.java
+++ b/megamek/src/megamek/common/weapons/MekMortarHandler.java
@@ -121,7 +121,7 @@ public class MekMortarHandler extends AmmoWeaponHandler {
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -769,20 +769,26 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
             if (targetInBuilding && (bldg != null)
                     && (toHit.getThruBldg() != null)
                     && (entityTarget instanceof Infantry)) {
-                int dmgClass = wtype.getInfantryDamageClass();
-                int nDamage;
-                if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
-                    nDamage = nDamPerHit * Math.min(nCluster, hits);
+                // If elevation is the same, building doesn't absorb
+                if (ae.getElevation() != entityTarget.getElevation()) {
+                    int dmgClass = wtype.getInfantryDamageClass();
+                    int nDamage;
+                    if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
+                        nDamage = nDamPerHit * Math.min(nCluster, hits);
+                    } else {
+                        // Need to indicate to handleEntityDamage that the
+                        // absorbed damage shouldn't reduce incoming damage,
+                        // since the incoming damage was reduced in
+                        // Compute.directBlowInfantryDamage
+                        nDamage = -wtype.getDamage(nRange)
+                                * Math.min(nCluster, hits);
+                    }
+                    bldgAbsorbs = (int) Math.round(nDamage
+                            * bldg.getInfDmgFromInside());
                 } else {
-                    // Need to indicate to handleEntityDamage that the
-                    // absorbed damage shouldn't reduce incoming damage,
-                    // since the incoming damage was reduced in
-                    // Compute.directBlowInfantryDamage
-                    nDamage = -wtype.getDamage(nRange)
-                            * Math.min(nCluster, hits);
+                    // Used later to indicate a special report
+                    bldgAbsorbs = Integer.MIN_VALUE;
                 }
-                bldgAbsorbs = (int) Math.round(nDamage
-                        * bldg.getInfDmgFromInside()); 
             }
 
             // Make sure the player knows when his attack causes no damage.

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -283,7 +283,8 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
             double toReturn = Compute.directBlowInfantryDamage(
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -757,11 +757,32 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         }
 
         if (!bMissed){
-            // The building shields all units from a certain amount of damage.
-            // The amount is based upon the building's CF at the phase's start.
+            // Buildings shield all units from a certain amount of damage.
+            // Amount is based upon the building's CF at the phase's start.
             int bldgAbsorbs = 0;
-            if (targetInBuilding && (bldg != null)) {
+            if (targetInBuilding && (bldg != null)
+                    && (toHit.getThruBldg() == null)) {
                 bldgAbsorbs = bldg.getAbsorbtion(target.getPosition());
+            }
+            
+            // Attacking infantry in buildings from same building
+            if (targetInBuilding && (bldg != null)
+                    && (toHit.getThruBldg() != null)
+                    && (entityTarget instanceof Infantry)) {
+                int dmgClass = wtype.getInfantryDamageClass();
+                int nDamage;
+                if (dmgClass < WeaponType.WEAPON_BURST_1D6) {
+                    nDamage = nDamPerHit * Math.min(nCluster, hits);
+                } else {
+                    // Need to indicate to handleEntityDamage that the
+                    // absorbed damage shouldn't reduce incoming damage,
+                    // since the incoming damage was reduced in
+                    // Compute.directBlowInfantryDamage
+                    nDamage = -wtype.getDamage(nRange)
+                            * Math.min(nCluster, hits);
+                }
+                bldgAbsorbs = (int) Math.round(nDamage
+                        * bldg.getInfDmgFromInside()); 
             }
 
             // Make sure the player knows when his attack causes no damage.

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -284,7 +284,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/NarcExplosiveHandler.java
+++ b/megamek/src/megamek/common/weapons/NarcExplosiveHandler.java
@@ -130,7 +130,7 @@ public class NarcExplosiveHandler extends MissileWeaponHandler {
                     bDirect ? toHit.getMoS() / 3 : 0,
                     WeaponType.WEAPON_DIRECT_FIRE,
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             toReturn = Math.ceil(toReturn);
         }
         if (bGlancing) {

--- a/megamek/src/megamek/common/weapons/NarcExplosiveHandler.java
+++ b/megamek/src/megamek/common/weapons/NarcExplosiveHandler.java
@@ -129,7 +129,8 @@ public class NarcExplosiveHandler extends MissileWeaponHandler {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
                     bDirect ? toHit.getMoS() / 3 : 0,
                     WeaponType.WEAPON_DIRECT_FIRE,
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             toReturn = Math.ceil(toReturn);
         }
         if (bGlancing) {

--- a/megamek/src/megamek/common/weapons/PPCHandler.java
+++ b/megamek/src/megamek/common/weapons/PPCHandler.java
@@ -124,7 +124,7 @@ public class PPCHandler extends EnergyWeaponHandler {
                     bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/PPCHandler.java
+++ b/megamek/src/megamek/common/weapons/PPCHandler.java
@@ -78,7 +78,7 @@ public class PPCHandler extends EnergyWeaponHandler {
         float toReturn = wtype.getDamage(nRange);
 
         if (game.getOptions().booleanOption("tacops_energy_weapons")
-            && wtype.hasModes()) {
+                && wtype.hasModes()) {
             toReturn = Compute.dialDownDamage(weapon, wtype, nRange);
         }
 
@@ -87,9 +87,9 @@ public class PPCHandler extends EnergyWeaponHandler {
         }
         // during a swarm, all damage gets applied as one block to one location
         if ((ae instanceof BattleArmor)
-            && (weapon.getLocation() == BattleArmor.LOC_SQUAD)
-            && !(weapon.isSquadSupportWeapon())
-            && (ae.getSwarmTargetId() == target.getTargetId())) {
+                && (weapon.getLocation() == BattleArmor.LOC_SQUAD)
+                && !(weapon.isSquadSupportWeapon())
+                && (ae.getSwarmTargetId() == target.getTargetId())) {
             toReturn *= ((BattleArmor) ae).getShootingStrength();
         }
 
@@ -105,24 +105,26 @@ public class PPCHandler extends EnergyWeaponHandler {
         }
 
         if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_RANGE)
-            && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG])) {
+                && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG])) {
             toReturn -= 1;
         }
-        if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_LOS_RANGE)
+        if (game.getOptions().booleanOption(
+                OptionsConstants.AC_TAC_OPS_LOS_RANGE)
                 && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_EXTREME])) {
             toReturn = (int) Math.floor(toReturn * .75);
-        }        
+        }
 
         if ((target instanceof Entity)
-            && ((Entity) target).hasActiveBlueShield()) {
+                && ((Entity) target).hasActiveBlueShield()) {
             toReturn = (int) Math.max(Math.floor(toReturn / 2.0), 1);
         }
 
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() / 3 : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
+                    bDirect ? toHit.getMoS() / 3 : 0,
+                    wtype.getInfantryDamageClass(),
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }
@@ -142,8 +144,8 @@ public class PPCHandler extends EnergyWeaponHandler {
     protected boolean doChecks(Vector<Report> vPhaseReport) {
         // Resolve roll for disengaged field inhibitors on PPCs, if needed
         if (game.getOptions().booleanOption("tacops_ppc_inhibitors")
-            && wtype.hasModes()
-            && weapon.curMode().equals("Field Inhibitor OFF")) {
+                && wtype.hasModes()
+                && weapon.curMode().equals("Field Inhibitor OFF")) {
             int rollTarget = 0;
             int dieRoll = Compute.d6(2);
             int distance = Compute.effectiveDistance(game, ae, target);
@@ -173,9 +175,9 @@ public class PPCHandler extends EnergyWeaponHandler {
                 // Destroy the first unmarked critical for the PPC
                 for (int i = 0; i < ae.getNumberOfCriticals(wlocation); i++) {
                     CriticalSlot slot1 = ae.getCritical(wlocation, i);
-                    if ((slot1 == null) ||
-                        (slot1.getType() == CriticalSlot.TYPE_SYSTEM) ||
-                        slot1.isHit()) {
+                    if ((slot1 == null)
+                            || (slot1.getType() == CriticalSlot.TYPE_SYSTEM)
+                            || slot1.isHit()) {
                         continue;
                     }
                     Mounted mounted = slot1.getMount();
@@ -189,8 +191,9 @@ public class PPCHandler extends EnergyWeaponHandler {
                 r.choose(false);
                 r.indent(2);
                 vPhaseReport.addElement(r);
-                Vector<Report> newReports = server.damageEntity(ae, new HitData(
-                        wlocation), 10, false, DamageType.NONE, true);
+                Vector<Report> newReports = server.damageEntity(ae,
+                        new HitData(wlocation), 10, false, DamageType.NONE,
+                        true);
                 for (Report rep : newReports) {
                     rep.indent(2);
                 }
@@ -218,7 +221,7 @@ public class PPCHandler extends EnergyWeaponHandler {
                 for (int i = 0; i < ae.getNumberOfCriticals(wlocation); i++) {
                     CriticalSlot slot = ae.getCritical(wlocation, i);
                     if ((slot == null)
-                        || (slot.getType() == CriticalSlot.TYPE_SYSTEM)) {
+                            || (slot.getType() == CriticalSlot.TYPE_SYSTEM)) {
                         continue;
                     }
                     // Only one Crit needs to be damaged.

--- a/megamek/src/megamek/common/weapons/PulseLaserWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/PulseLaserWeaponHandler.java
@@ -82,9 +82,10 @@ public class PulseLaserWeaponHandler extends EnergyWeaponHandler {
 
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() / 3 : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
+                    bDirect ? toHit.getMoS() / 3 : 0,
+                    wtype.getInfantryDamageClass(),
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/PulseLaserWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/PulseLaserWeaponHandler.java
@@ -85,7 +85,7 @@ public class PulseLaserWeaponHandler extends EnergyWeaponHandler {
                     bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
@@ -49,7 +49,7 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
      * @param s
      */
     public RifleWeaponHandler(ToHitData t, WeaponAttackAction w, IGame g,
-                              Server s) {
+            Server s) {
         super(t, w, g, s);
     }
 
@@ -65,9 +65,10 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
         // we default to direct fire weapons for anti-infantry damage
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
+                    bDirect ? toHit.getMoS() : 0,
+                    wtype.getInfantryDamageClass(),
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }
@@ -75,13 +76,13 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
         if (target instanceof Entity) {
             te = (Entity) target;
             hit = te.rollHitLocation(toHit.getHitTable(), toHit.getSideTable(),
-                                     waa.getAimedLocation(), waa.getAimingMode(),
-                                     toHit.getCover());
+                    waa.getAimedLocation(), waa.getAimingMode(),
+                    toHit.getCover());
             hit.setAttackerId(getAttackerId());
             if (!(te instanceof BattleArmor)
-                && !(te instanceof Infantry)
-                && (!te.hasBARArmor(hit.getLocation()) || (te
-                                                                   .getBARRating(hit.getLocation()) >= 8))) {
+                    && !(te instanceof Infantry)
+                    && (!te.hasBARArmor(hit.getLocation()) || (te
+                            .getBARRating(hit.getLocation()) >= 8))) {
                 toReturn = Math.max(0, toReturn - 3);
             }
         }
@@ -147,7 +148,7 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
             nDamage -= toBldg;
             Report.addNewline(vPhaseReport);
             Vector<Report> buildingReport = server.damageBuilding(bldg, toBldg,
-                                                                  entityTarget.getPosition());
+                    entityTarget.getPosition());
             for (Report report : buildingReport) {
                 report.subject = subjectId;
             }
@@ -177,10 +178,10 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
             }
             vPhaseReport
                     .addAll(server.damageEntity(entityTarget, hit, nDamage,
-                                                false, ae.getSwarmTargetId() == entityTarget
+                            false, ae.getSwarmTargetId() == entityTarget
                                     .getId() ? DamageType.IGNORE_PASSENGER
-                                             : damageType, false, false, throughFront,
-                                                underWater, nukeS2S));
+                                    : damageType, false, false, throughFront,
+                            underWater, nukeS2S));
         }
     }
 }

--- a/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
@@ -160,6 +160,13 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
                 report.subject = subjectId;
             }
             vPhaseReport.addAll(buildingReport);
+        // Units on same level, report building absorbs no damage
+        } else if (bldgAbsorbs == Integer.MIN_VALUE) {
+            Report.addNewline(vPhaseReport);
+            r = new Report(9976);
+            r.subject = ae.getId();
+            r.indent(2);
+            vPhaseReport.add(r);
         // Cases where absorbed damage doesn't reduce incoming damage
         } else if (bldgAbsorbs < 0) {
             int toBldg = -bldgAbsorbs;

--- a/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
@@ -105,8 +105,8 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
 
     @Override
     protected void handleEntityDamage(Entity entityTarget,
-                                      Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
-                                      int bldgAbsorbs) {
+            Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
+            int bldgAbsorbs) {
         int nDamage;
         missed = false;
 
@@ -118,7 +118,7 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
                 .getCalledShot().getCall()))) {
             // Weapon strikes Partial Cover.
             handlePartialCoverHit(entityTarget, vPhaseReport, hit, bldg, hits,
-                                  nCluster, bldgAbsorbs);
+                    nCluster, bldgAbsorbs);
             return;
         }
 
@@ -153,7 +153,18 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
                 report.subject = subjectId;
             }
             vPhaseReport.addAll(buildingReport);
+        // Cases where absorbed damage doesn't reduce incoming damage
+        } else if (bldgAbsorbs < 0) {
+            int toBldg = -bldgAbsorbs;
+            Report.addNewline(vPhaseReport);
+            Vector<Report> buildingReport = server.damageBuilding(bldg, toBldg,
+                    entityTarget.getPosition());
+            for (Report report : buildingReport) {
+                report.subject = subjectId;
+            }
+            vPhaseReport.addAll(buildingReport);
         }
+
 
         nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);
 

--- a/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
@@ -68,7 +68,7 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
                     bDirect ? toHit.getMoS() : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }
@@ -142,6 +142,13 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
         if (bDirect) {
             hit.makeDirectBlow(toHit.getMoS() / 3);
         }
+
+        // Report calcDmgPerHitReports here
+        if (calcDmgPerHitReport.size() > 0) {
+            vPhaseReport.addAll(calcDmgPerHitReport);
+        }
+
+
         // A building may be damaged, even if the squad is not.
         if (bldgAbsorbs > 0) {
             int toBldg = Math.min(bldgAbsorbs, nDamage);

--- a/megamek/src/megamek/common/weapons/SRMDeadFireHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMDeadFireHandler.java
@@ -65,7 +65,7 @@ public class SRMDeadFireHandler extends SRMHandler {
                     wtype.getRackSize() * 3, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/SRMDeadFireHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMDeadFireHandler.java
@@ -64,7 +64,8 @@ public class SRMDeadFireHandler extends SRMHandler {
             double toReturn = Compute.directBlowInfantryDamage(
                     wtype.getRackSize() * 3, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/SRMHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMHandler.java
@@ -59,7 +59,7 @@ public class SRMHandler extends MissileWeaponHandler {
                     wtype.getRackSize() * 2, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/SRMHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMHandler.java
@@ -58,7 +58,8 @@ public class SRMHandler extends MissileWeaponHandler {
             double toReturn = Compute.directBlowInfantryDamage(
                     wtype.getRackSize() * 2, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
@@ -104,7 +104,18 @@ public class SRMTandemChargeHandler extends SRMHandler {
                 report.subject = subjectId;
             }
             vPhaseReport.addAll(buildingReport);
+        // Cases where absorbed damage doesn't reduce incoming damage
+        } else if (bldgAbsorbs < 0) {
+            int toBldg = -bldgAbsorbs;
+            Report.addNewline(vPhaseReport);
+            Vector<Report> buildingReport = server.damageBuilding(bldg, toBldg,
+                    entityTarget.getPosition());
+            for (Report report : buildingReport) {
+                report.subject = subjectId;
+            }
+            vPhaseReport.addAll(buildingReport);
         }
+
 
         nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);
 

--- a/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
@@ -169,7 +169,8 @@ public class SRMTandemChargeHandler extends SRMHandler {
             double toReturn = Compute.directBlowInfantryDamage(
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
@@ -110,6 +110,13 @@ public class SRMTandemChargeHandler extends SRMHandler {
                 report.subject = subjectId;
             }
             vPhaseReport.addAll(buildingReport);
+        // Units on same level, report building absorbs no damage
+        } else if (bldgAbsorbs == Integer.MIN_VALUE) {
+            Report.addNewline(vPhaseReport);
+            Report r = new Report(9976);
+            r.subject = ae.getId();
+            r.indent(2);
+            vPhaseReport.add(r);
         // Cases where absorbed damage doesn't reduce incoming damage
         } else if (bldgAbsorbs < 0) {
             int toBldg = -bldgAbsorbs;

--- a/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
@@ -93,6 +93,12 @@ public class SRMTandemChargeHandler extends SRMHandler {
         // Resolve damage normally.
         nDamage = nDamPerHit * Math.min(nCluster, hits);
 
+        // Report calcDmgPerHitReports here
+        if (calcDmgPerHitReport.size() > 0) {
+            vPhaseReport.addAll(calcDmgPerHitReport);
+        }
+
+
         // A building may be damaged, even if the squad is not.
         if (bldgAbsorbs > 0) {
             int toBldg = Math.min(bldgAbsorbs, nDamage);
@@ -181,7 +187,7 @@ public class SRMTandemChargeHandler extends SRMHandler {
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/StreakHandler.java
+++ b/megamek/src/megamek/common/weapons/StreakHandler.java
@@ -63,7 +63,7 @@ public class StreakHandler extends MissileWeaponHandler {
                     wtype.getRackSize() * 2, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             return toReturn;
         }
         return 2;

--- a/megamek/src/megamek/common/weapons/StreakHandler.java
+++ b/megamek/src/megamek/common/weapons/StreakHandler.java
@@ -62,7 +62,8 @@ public class StreakHandler extends MissileWeaponHandler {
             int toReturn = Compute.directBlowInfantryDamage(
                     wtype.getRackSize() * 2, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             return toReturn;
         }
         return 2;

--- a/megamek/src/megamek/common/weapons/StreakLRMHandler.java
+++ b/megamek/src/megamek/common/weapons/StreakLRMHandler.java
@@ -58,7 +58,8 @@ public class StreakLRMHandler extends StreakHandler {
             int toReturn = Compute.directBlowInfantryDamage(
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             return toReturn;
         }
         return 1;

--- a/megamek/src/megamek/common/weapons/StreakLRMHandler.java
+++ b/megamek/src/megamek/common/weapons/StreakLRMHandler.java
@@ -59,7 +59,7 @@ public class StreakLRMHandler extends StreakHandler {
                     wtype.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             return toReturn;
         }
         return 1;

--- a/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
@@ -70,7 +70,8 @@ public class ThunderBoltWeaponHandler extends MissileWeaponHandler {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
                     bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
@@ -71,7 +71,7 @@ public class ThunderBoltWeaponHandler extends MissileWeaponHandler {
                     bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
@@ -188,7 +188,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
                         bDirect ? toHit.getMoS() / 3 : 0,
                         wtype.getInfantryDamageClass(),
                         ((Infantry) target).isMechanized(),
-                        toHit.getThruBldg() != null);
+                        toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             }
             // plus 1 for cluster
             toReturn++;

--- a/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
@@ -42,8 +42,9 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
     private static final long serialVersionUID = 7551194199079004134L;
     int howManyShots;
     private final boolean twoRollsUltra; // Tracks whether or not this is an
-        // ultra AC using the unofficial "two rolls" rule. Can be final because
-        // this isn't really going to change over the course of a game.
+
+    // ultra AC using the unofficial "two rolls" rule. Can be final because
+    // this isn't really going to change over the course of a game.
 
     /**
      * @param t
@@ -51,11 +52,11 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
      * @param g
      */
     public UltraWeaponHandler(ToHitData t, WeaponAttackAction w, IGame g,
-                              Server s) {
+            Server s) {
         super(t, w, g, s);
         twoRollsUltra = game.getOptions().booleanOption("uac_tworolls")
-                && ((wtype.getAmmoType() == AmmoType.T_AC_ULTRA)
-                    || (wtype.getAmmoType() == AmmoType.T_AC_ULTRA_THB));
+                && ((wtype.getAmmoType() == AmmoType.T_AC_ULTRA) || (wtype
+                        .getAmmoType() == AmmoType.T_AC_ULTRA_THB));
     }
 
     /*
@@ -89,7 +90,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
             ammo = weapon.getLinked();
             // that fired one, do we need to fire another?
             ammo.setShotsLeft(ammo.getBaseShotsLeft()
-                              - ((howManyShots == 2) ? 1 : 0));
+                    - ((howManyShots == 2) ? 1 : 0));
         } else {
             ammo.setShotsLeft(ammo.getBaseShotsLeft() - howManyShots);
         }
@@ -161,7 +162,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
             weapon.setJammed(true);
             isJammed = true;
             if ((wtype.getAmmoType() == AmmoType.T_AC_ULTRA)
-                || (wtype.getAmmoType() == AmmoType.T_AC_ULTRA_THB)) {
+                    || (wtype.getAmmoType() == AmmoType.T_AC_ULTRA_THB)) {
                 r.messageId = 3160;
             } else {
                 r.messageId = 3170;
@@ -184,15 +185,16 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
             toReturn = 0;
             for (int i = 0; i < howManyShots; i++) {
                 toReturn += Compute.directBlowInfantryDamage(wtype.getDamage(),
-                                                             bDirect ? toHit.getMoS() / 3 : 0,
-                                                             wtype.getInfantryDamageClass(),
-                                                             ((Infantry) target).isMechanized());
+                        bDirect ? toHit.getMoS() / 3 : 0,
+                        wtype.getInfantryDamageClass(),
+                        ((Infantry) target).isMechanized(),
+                        toHit.getThruBldg() != null);
             }
             // plus 1 for cluster
             toReturn++;
-            
-        // Cluster bonuses or penalties can't apply to "two rolls" UACs, so
-        // if we have one, modify the damage per hit directly.
+
+            // Cluster bonuses or penalties can't apply to "two rolls" UACs, so
+            // if we have one, modify the damage per hit directly.
         } else if (bDirect && (howManyShots == 1 || twoRollsUltra)) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }
@@ -202,10 +204,11 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
         }
 
         if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_RANGE)
-            && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG])) {
+                && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_LONG])) {
             toReturn = (int) Math.floor(toReturn * .75);
         }
-        if (game.getOptions().booleanOption(OptionsConstants.AC_TAC_OPS_LOS_RANGE)
+        if (game.getOptions().booleanOption(
+                OptionsConstants.AC_TAC_OPS_LOS_RANGE)
                 && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_EXTREME])) {
             toReturn = (int) Math.floor(toReturn * .5);
         }
@@ -220,7 +223,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
     @Override
     protected int calcnClusterAero(Entity entityTarget) {
         if (usesClusterTable() && !ae.isCapitalFighter()
-            && (entityTarget != null) && !entityTarget.isCapitalScale()) {
+                && (entityTarget != null) && !entityTarget.isCapitalScale()) {
             return (int) Math.ceil(attackValue / 2.0);
         } else {
             return 1;

--- a/megamek/src/megamek/common/weapons/VGLWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/VGLWeaponHandler.java
@@ -165,7 +165,8 @@ public class VGLWeaponHandler extends AmmoWeaponHandler {
                             && !(entTarget instanceof BattleArmor)) {
                         int infDmg = Compute.directBlowInfantryDamage(0, 0,
                                 WeaponType.WEAPON_BURST_2D6,
-                                ((Infantry) entTarget).isMechanized());
+                                ((Infantry) entTarget).isMechanized(),
+                                toHit.getThruBldg() != null);
                         dmgReports = 
                                 server.damageEntity(entTarget, hit, infDmg);
                     } else if (inBuilding && (entTarget instanceof Infantry) 

--- a/megamek/src/megamek/common/weapons/VariableSpeedPulseLaserWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/VariableSpeedPulseLaserWeaponHandler.java
@@ -70,7 +70,7 @@ public class VariableSpeedPulseLaserWeaponHandler extends EnergyWeaponHandler {
                     bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (nRange <= nRanges[RangeType.RANGE_SHORT]) {
                 toReturn += 3;
             } else if (nRange <= nRanges[RangeType.RANGE_MEDIUM]) {

--- a/megamek/src/megamek/common/weapons/VariableSpeedPulseLaserWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/VariableSpeedPulseLaserWeaponHandler.java
@@ -35,7 +35,7 @@ public class VariableSpeedPulseLaserWeaponHandler extends EnergyWeaponHandler {
      * @param g
      */
     public VariableSpeedPulseLaserWeaponHandler(ToHitData toHit,
-                                                WeaponAttackAction waa, IGame g, Server s) {
+            WeaponAttackAction waa, IGame g, Server s) {
         super(toHit, waa, g, s);
     }
 
@@ -67,9 +67,10 @@ public class VariableSpeedPulseLaserWeaponHandler extends EnergyWeaponHandler {
 
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
-                                                        bDirect ? toHit.getMoS() / 3 : 0,
-                                                        wtype.getInfantryDamageClass(),
-                                                        ((Infantry) target).isMechanized());
+                    bDirect ? toHit.getMoS() / 3 : 0,
+                    wtype.getInfantryDamageClass(),
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (nRange <= nRanges[RangeType.RANGE_SHORT]) {
                 toReturn += 3;
             } else if (nRange <= nRanges[RangeType.RANGE_MEDIUM]) {

--- a/megamek/src/megamek/common/weapons/VehicleFlamerCoolHandler.java
+++ b/megamek/src/megamek/common/weapons/VehicleFlamerCoolHandler.java
@@ -62,7 +62,8 @@ public class VehicleFlamerCoolHandler extends AmmoWeaponHandler {
             nDamPerHit = Compute.directBlowInfantryDamage(1,
                     bDirect ? toHit.getMoS() / 3 : 0,
                     WeaponType.WEAPON_DIRECT_FIRE,
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
                     nCluster, bldgAbsorbs);
         }

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -527,8 +527,20 @@ public class WeaponHandler implements AttackHandler, Serializable {
                 // Buildings shield all units from a certain amount of damage.
                 // Amount is based upon the building's CF at the phase's start.
                 int bldgAbsorbs = 0;
-                if (targetInBuilding && (bldg != null)) {
+                if (targetInBuilding && (bldg != null)
+                        && (toHit.getThruBldg() == null)) {
                     bldgAbsorbs = bldg.getAbsorbtion(target.getPosition());
+                }
+                
+                // Attacks infantry in buildings
+                if (targetInBuilding && (bldg != null)
+                        && (toHit.getThruBldg() != null)
+                        && (entityTarget instanceof Infantry)) {
+                    //Vector<Report> buildingReport = server.damageBuilding(bldg, toBldg,
+                     //       entityTarget.getPosition());
+                    //for (Report report : buildingReport) {
+                    //    report.subject = subjectId;
+                    //}
                 }
 
                 // Make sure the player knows when his attack causes no damage.
@@ -667,7 +679,8 @@ public class WeaponHandler implements AttackHandler, Serializable {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
                     bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }
@@ -1112,9 +1125,11 @@ public class WeaponHandler implements AttackHandler, Serializable {
         }
         vPhaseReport.addAll(buildingReport);
 
-        // Damage any infantry in the hex.
-        vPhaseReport.addAll(server.damageInfantryIn(bldg, nDamage, coords,
-                wtype.getInfantryDamageClass()));
+        // Damage any infantry in hex, unless attack between units in same bldg
+        if (toHit.getThruBldg() == null) {
+            vPhaseReport.addAll(server.damageInfantryIn(bldg, nDamage, coords,
+                    wtype.getInfantryDamageClass()));
+        }
     }
 
     protected boolean allShotsHit() {

--- a/megamek/src/megamek/common/weapons/battlearmor/BALBXHandler.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/BALBXHandler.java
@@ -49,7 +49,8 @@ public class BALBXHandler extends WeaponHandler {
             double toReturn = Compute.directBlowInfantryDamage(
                     wtype.getRackSize() * 2, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
-                    ((Infantry) target).isMechanized());
+                    ((Infantry) target).isMechanized(),
+                    toHit.getThruBldg() != null);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/common/weapons/battlearmor/BALBXHandler.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/BALBXHandler.java
@@ -50,7 +50,7 @@ public class BALBXHandler extends WeaponHandler {
                     wtype.getRackSize() * 2, bDirect ? toHit.getMoS() / 3 : 0,
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
-                    toHit.getThruBldg() != null);
+                    toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
             if (bGlancing) {
                 toReturn /= 2;
             }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -31156,14 +31156,14 @@ public class Server implements Runnable {
      * @return a <code>Report</code> to be shown to the players.
      */
     public Vector<Report> damageBuilding(Building bldg, int damage, String why,
-                                         Coords coords) {
+            Coords coords) {
         Vector<Report> vPhaseReport = new Vector<Report>();
         Report r = new Report(1210, Report.PUBLIC);
 
         // Do nothing if no building or no damage was passed.
         if ((bldg != null) && (damage > 0)) {
             r.messageId = 3435;
-            r.add(bldg.getName());
+            r.add(bldg.toString());
             r.add(why);
             r.add(damage);
             vPhaseReport.add(r);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -17272,12 +17272,12 @@ public class Server implements Runnable {
      * Handle a charge's damage
      */
     private void resolveChargeDamage(Entity ae, Entity te, ToHitData toHit,
-                                     int direction) {
+            int direction) {
         resolveChargeDamage(ae, te, toHit, direction, false, true);
     }
 
     private void resolveChargeDamage(Entity ae, Entity te, ToHitData toHit,
-                                     int direction, boolean glancing, boolean throughFront) {
+            int direction, boolean glancing, boolean throughFront) {
 
         // we hit...
 
@@ -17289,8 +17289,7 @@ public class Server implements Runnable {
 
         // Damage To Target
         int damage = ChargeAttackAction.getDamageFor(ae, te, game.getOptions()
-                                                                 .booleanOption("tacops_charge_damage"),
-                                                     toHit.getMoS());
+                .booleanOption("tacops_charge_damage"), toHit.getMoS());
 
         // Damage to Attacker
         int damageTaken = ChargeAttackAction.getDamageTakenBy(ae, te, game
@@ -17374,7 +17373,7 @@ public class Server implements Runnable {
                 spikeDamage += 2;
             }
             addReport(damageEntity(ae, hit, cluster, false, DamageType.NONE,
-                                   false, false, throughFront));
+                    false, false, throughFront));
             damageTaken -= cluster;
         }
 

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -29770,9 +29770,11 @@ public class Server implements Runnable {
     /**
      * Process a packet from a connection.
      *
-     * @param connId - the <code>int</code> ID the connection that received the
-     *               packet.
-     * @param packet - the <code>Packet</code> to be processed.
+     * @param connId
+     *            - the <code>int</code> ID the connection that received the
+     *            packet.
+     * @param packet
+     *            - the <code>Packet</code> to be processed.
      */
     protected void handle(int connId, Packet packet) {
         IPlayer player = game.getPlayer(connId);
@@ -29907,16 +29909,17 @@ public class Server implements Runnable {
                 break;
             case Packet.COMMAND_ENTITY_WORDER_UPDATE:
                 Object data[] = packet.getData();
-                Entity ent = game.getEntity((Integer)data[0]);
+                Entity ent = game.getEntity((Integer) data[0]);
                 if (ent != null) {
-                    Entity.WeaponSortOrder order =
-                        (Entity.WeaponSortOrder)data[1];
+                    Entity.WeaponSortOrder order = (Entity.WeaponSortOrder) data[1];
                     ent.setWeaponSortOrder(order);
                     // Used by the client but is set in setWeaponSortOrder
                     ent.setWeapOrderChanged(false);
                     if (order == Entity.WeaponSortOrder.CUSTOM) {
-                        @SuppressWarnings("unchecked") // Unchecked cause of limitations in Java when casting to a collection
-                        Map<Integer, Integer> customWeapOrder = (Map<Integer, Integer>)data[2];
+                        @SuppressWarnings("unchecked")
+                        // Unchecked cause of limitations in Java when casting
+                        // to a collection
+                        Map<Integer, Integer> customWeapOrder = (Map<Integer, Integer>) data[2];
                         ent.setCustomWeaponOrder(customWeapOrder);
                     }
                 }
@@ -29934,19 +29937,22 @@ public class Server implements Runnable {
                     MapSettings newSettings = (MapSettings) packet.getObject(0);
                     if (!mapSettings.equalMapGenParameters(newSettings)) {
                         sendServerChat("Player " + player.getName()
-                                       + " changed map settings");
+                                + " changed map settings");
                     }
                     mapSettings = newSettings;
-                    mapSettings.setBoardsAvailableVector(scanForBoards(new BoardDimensions(
-                            mapSettings.getBoardWidth(),
-                            mapSettings.getBoardHeight())));
+                    mapSettings
+                            .setBoardsAvailableVector(scanForBoards(new BoardDimensions(
+                                    mapSettings.getBoardWidth(), mapSettings
+                                            .getBoardHeight())));
                     mapSettings.removeUnavailable();
                     mapSettings.setNullBoards(DEFAULT_BOARD);
-                    mapSettings.replaceBoardWithRandom(MapSettings.BOARD_RANDOM);
+                    mapSettings
+                            .replaceBoardWithRandom(MapSettings.BOARD_RANDOM);
                     mapSettings.removeUnavailable();
                     // if still only nulls left, use BOARD_GENERATED
                     if (mapSettings.getBoardsSelected().next() == null) {
-                        mapSettings.setNullBoards((MapSettings.BOARD_GENERATED));
+                        mapSettings
+                                .setNullBoards((MapSettings.BOARD_GENERATED));
                     }
                     newSettings = null;
                     resetPlayersDone();
@@ -29959,20 +29965,23 @@ public class Server implements Runnable {
                     MapSettings newSettings = (MapSettings) packet.getObject(0);
                     if (!mapSettings.equalMapGenParameters(newSettings)) {
                         sendServerChat("Player " + player.getName()
-                                       + " changed map dimensions");
+                                + " changed map dimensions");
                     }
                     mapSettings = newSettings;
                     newSettings = null;
-                    mapSettings.setBoardsAvailableVector(scanForBoards(new BoardDimensions(
-                            mapSettings.getBoardWidth(),
-                            mapSettings.getBoardHeight())));
+                    mapSettings
+                            .setBoardsAvailableVector(scanForBoards(new BoardDimensions(
+                                    mapSettings.getBoardWidth(), mapSettings
+                                            .getBoardHeight())));
                     mapSettings.removeUnavailable();
                     mapSettings.setNullBoards(DEFAULT_BOARD);
-                    mapSettings.replaceBoardWithRandom(MapSettings.BOARD_RANDOM);
+                    mapSettings
+                            .replaceBoardWithRandom(MapSettings.BOARD_RANDOM);
                     mapSettings.removeUnavailable();
                     // if still only nulls left, use BOARD_GENERATED
                     if (mapSettings.getBoardsSelected().next() == null) {
-                        mapSettings.setNullBoards((MapSettings.BOARD_GENERATED));
+                        mapSettings
+                                .setNullBoards((MapSettings.BOARD_GENERATED));
                     }
                     resetPlayersDone();
                     transmitAllPlayerDones();
@@ -29985,7 +29994,7 @@ public class Server implements Runnable {
                     PlanetaryConditions conditions = (PlanetaryConditions) packet
                             .getObject(0);
                     sendServerChat("Player " + player.getName()
-                                   + " changed planetary conditions");
+                            + " changed planetary conditions");
                     game.setPlanetaryConditions(conditions);
                     resetPlayersDone();
                     transmitAllPlayerDones();
@@ -30006,13 +30015,14 @@ public class Server implements Runnable {
             case Packet.COMMAND_LOAD_GAME:
                 try {
                     sendServerChat(getPlayer(connId).getName()
-                                   + " loaded a new game.");
+                            + " loaded a new game.");
                     setGame((IGame) packet.getObject(0));
                     for (IConnection conn : connections) {
                         sendCurrentInfo(conn.getId());
                     }
                 } catch (Exception e) {
-                    System.out.println("Error loading savegame sent from client");
+                    System.out
+                            .println("Error loading savegame sent from client");
                 }
                 break;
             case Packet.COMMAND_SQUADRON_ADD:
@@ -30030,8 +30040,9 @@ public class Server implements Runnable {
                 sendSpecialHexDisplayPackets();
                 break;
             case Packet.COMMAND_SPECIAL_HEX_DISPLAY_APPEND:
-                game.getBoard().addSpecialHexDisplay((Coords) packet.getObject(0),
-                                                     (SpecialHexDisplay) packet.getObject(1));
+                game.getBoard().addSpecialHexDisplay(
+                        (Coords) packet.getObject(0),
+                        (SpecialHexDisplay) packet.getObject(1));
                 sendSpecialHexDisplayPackets();
                 break;
         }
@@ -30093,8 +30104,9 @@ public class Server implements Runnable {
      * Makes one slot of inferno ammo, determined by certain rules, explode on a
      * mech.
      *
-     * @param entity The <code>Entity</code> that should suffer an inferno ammo
-     *               explosion.
+     * @param entity
+     *            The <code>Entity</code> that should suffer an inferno ammo
+     *            explosion.
      */
     private Vector<Report> explodeInfernoAmmoFromHeat(Entity entity) {
         int damage = 0;
@@ -30110,7 +30122,7 @@ public class Server implements Runnable {
                 CriticalSlot cs = entity.getCritical(j, k);
                 // Ignore empty, destroyed, hit, and structure slots.
                 if ((cs == null) || cs.isDestroyed() || cs.isHit()
-                    || (cs.getType() != CriticalSlot.TYPE_EQUIPMENT)) {
+                        || (cs.getType() != CriticalSlot.TYPE_EQUIPMENT)) {
                     continue;
                 }
                 // Ignore everything but weapons slots.
@@ -30121,9 +30133,8 @@ public class Server implements Runnable {
                 // Ignore everything but Inferno ammo.
                 AmmoType atype = (AmmoType) mounted.getType();
                 if (!atype.isExplosive(mounted)
-                    || ((atype.getMunitionType() != AmmoType.M_INFERNO) && (atype
-                                                                                    .getMunitionType() != AmmoType
-                                                                                    .M_IATM_IIW))) {
+                        || ((atype.getMunitionType() != AmmoType.M_INFERNO) && (atype
+                                .getMunitionType() != AmmoType.M_IATM_IIW))) {
                     continue;
                 }
 
@@ -30139,14 +30150,14 @@ public class Server implements Runnable {
                 int newDamage = mounted.getExplosionDamage();
                 Mounted mount2 = cs.getMount2();
                 if ((mount2 != null) && (mount2.getType() instanceof AmmoType)
-                    && (mount2.getHittableShotsLeft() > 0)) {
+                        && (mount2.getHittableShotsLeft() > 0)) {
                     // must be for same weapontype, so racksize stays
                     atype = (AmmoType) mount2.getType();
                     newRack += atype.getDamagePerShot() * atype.getRackSize();
                     newDamage += mount2.getExplosionDamage();
                 }
                 if (!mounted.isHit()
-                    && ((rack < newRack) || ((rack == newRack) && (damage < newDamage)))) {
+                        && ((rack < newRack) || ((rack == newRack) && (damage < newDamage)))) {
                     rack = newRack;
                     damage = newDamage;
                     boomloc = j;
@@ -30252,18 +30263,18 @@ public class Server implements Runnable {
                         damage = Compute.d6(2);
                     }
                     HitData hit = en.rollHitLocation(ToHitData.HIT_NORMAL,
-                                                     ToHitData.SIDE_FRONT);
+                            ToHitData.SIDE_FRONT);
                     if (en instanceof BattleArmor) {
                         // ugly - I have to apply damage to each trooper
                         // separately
                         for (int loc = 0; loc < en.locations(); loc++) {
                             if ((IArmorState.ARMOR_NA != en.getInternal(loc))
-                                && (IArmorState.ARMOR_DESTROYED != en
-                                    .getInternal(loc))
-                                && (IArmorState.ARMOR_DOOMED != en
-                                    .getInternal(loc))) {
+                                    && (IArmorState.ARMOR_DESTROYED != en
+                                            .getInternal(loc))
+                                    && (IArmorState.ARMOR_DOOMED != en
+                                            .getInternal(loc))) {
                                 vDesc.addAll(damageEntity(en, new HitData(loc),
-                                                          damage));
+                                        damage));
                             }
                         }
                     } else {
@@ -30273,7 +30284,7 @@ public class Server implements Runnable {
                         // lets pretend that the infernos came from the entity
                         // itself (should give us side_front)
                         vDesc.addAll(deliverInfernoMissiles(en, en,
-                                                            Compute.d6(2)));
+                                Compute.d6(2)));
                     }
                 }
             }
@@ -30294,22 +30305,30 @@ public class Server implements Runnable {
      * Tank enters a building, leaves a building, or travels from one hex to
      * another inside a multi-hex building.
      *
-     * @param entity    - the <code>Entity</code> that passed through a wall. Don't
-     *                  pass <code>Infantry</code> units to this method.
-     * @param bldg      - the <code>Building</code> the entity is passing through.
-     * @param lastPos   - the <code>Coords</code> of the hex the entity is exiting.
-     * @param curPos    - the <code>Coords</code> of the hex the entity is entering
-     * @param distance  - the <code>int</code> number of hexes the entity has moved
-     *                  already this phase.
-     * @param why       - the <code>String</code> explanation for this action.
-     * @param backwards - the <code>boolean</code> indicating if the entity is
-     *                  entering the hex backwards
-     * @param entering  - a <code>boolean</code> if the entity is entering or exiting
-     *                  a building
+     * @param entity
+     *            - the <code>Entity</code> that passed through a wall. Don't
+     *            pass <code>Infantry</code> units to this method.
+     * @param bldg
+     *            - the <code>Building</code> the entity is passing through.
+     * @param lastPos
+     *            - the <code>Coords</code> of the hex the entity is exiting.
+     * @param curPos
+     *            - the <code>Coords</code> of the hex the entity is entering
+     * @param distance
+     *            - the <code>int</code> number of hexes the entity has moved
+     *            already this phase.
+     * @param why
+     *            - the <code>String</code> explanation for this action.
+     * @param backwards
+     *            - the <code>boolean</code> indicating if the entity is
+     *            entering the hex backwards
+     * @param entering
+     *            - a <code>boolean</code> if the entity is entering or exiting
+     *            a building
      */
     private void passBuildingWall(Entity entity, Building bldg, Coords lastPos,
-                                  Coords curPos, int distance, String why, boolean backwards,
-                                  EntityMovementType overallMoveType, boolean entering) {
+            Coords curPos, int distance, String why, boolean backwards,
+            EntityMovementType overallMoveType, boolean entering) {
 
         Report r;
 
@@ -30322,16 +30341,16 @@ public class Server implements Runnable {
         } else {
             // Need to roll based on building type.
             PilotingRollData psr = entity.rollMovementInBuilding(bldg,
-                                                                 distance, why, overallMoveType);
+                    distance, why, overallMoveType);
 
             // Did the entity make the roll?
             if (0 < doSkillCheckWhileMoving(entity, entity.getElevation(),
-                                            lastPos, curPos, psr, false)) {
+                    lastPos, curPos, psr, false)) {
 
                 // Divide the building's current CF by 10, round up.
                 int damage = (int) Math.floor(bldg.getDamageFromScale()
-                                              * Math.ceil(bldg.getCurrentCF(entering ? curPos
-                                                                                     : lastPos) / 10.0));
+                        * Math.ceil(bldg.getCurrentCF(entering ? curPos
+                                : lastPos) / 10.0));
 
                 // Infantry and Battle armor take different amounts of damage
                 // then Meks and vehicles.
@@ -30353,7 +30372,7 @@ public class Server implements Runnable {
                         side = ToHitData.SIDE_REAR;
                     }
                     HitData hit = entity.rollHitLocation(ToHitData.HIT_NORMAL,
-                                                         side);
+                            side);
                     hit.setGeneralDamageType(HitData.DAMAGE_PHYSICAL);
                     addReport(damageEntity(entity, hit, damage));
                 }
@@ -30365,7 +30384,7 @@ public class Server implements Runnable {
             }
             // Damage the building. The CF can never drop below 0.
             int toBldg = (int) Math.floor(bldg.getDamageToScale()
-                                          * Math.ceil(entity.getWeight() / 10.0));
+                    * Math.ceil(entity.getWeight() / 10.0));
             int curCF = bldg.getCurrentCF(entering ? curPos : lastPos);
             curCF -= Math.min(curCF, toBldg);
             bldg.setCurrentCF(curCF, entering ? curPos : lastPos);
@@ -30374,20 +30393,23 @@ public class Server implements Runnable {
             // ASSUMPTION: We inflict toBldg damage to infantry and
             // not the amount to bring building to 0 CF.
             addReport(damageInfantryIn(bldg, toBldg, entering ? curPos
-                                                              : lastPos));
+                    : lastPos));
         }
     }
 
     /**
      * check if a building collapes because of a moving entity
      *
-     * @param bldg   the <code>Building</code>
-     * @param entity the <code>Entity</code>
-     * @param curPos the <coode>Coords</code> of the position of the entity
+     * @param bldg
+     *            the <code>Building</code>
+     * @param entity
+     *            the <code>Entity</code>
+     * @param curPos
+     *            the <coode>Coords</code> of the position of the entity
      * @return a <code>boolean</code> value indicating if the building collapses
      */
     private boolean checkBuildingCollapseWhileMoving(Building bldg,
-                                                     Entity entity, Coords curPos) {
+            Entity entity, Coords curPos) {
         Coords oldPos = entity.getPosition();
         // Count the moving entity in its current position, not
         // its pre-move postition. Be sure to handle nulls.
@@ -30398,7 +30420,7 @@ public class Server implements Runnable {
 
         // Check for collapse of this building due to overloading, and return.
         boolean rv = checkForCollapse(bldg, positionMap, curPos, true,
-                                      vPhaseReport);
+                vPhaseReport);
 
         // If the entity was not displaced and didnt fall, move it back where it
         // was
@@ -30409,20 +30431,20 @@ public class Server implements Runnable {
     }
 
     public Vector<Report> damageInfantryIn(Building bldg, int damage,
-                                           Coords hexCoords) {
+            Coords hexCoords) {
         return damageInfantryIn(bldg, damage, hexCoords, WeaponType.WEAPON_NA);
     }
 
     /**
      * Apply the correct amount of damage that passes on to any infantry unit in
      * the given building, based upon the amount of damage the building just
-     * sustained. This amount is a percentage dictated by pg. 52 of BMRr.
+     * sustained. This amount is a percentage dictated by pg. 172 of TW.
      *
      * @param bldg   - the <code>Building</code> that sustained the damage.
      * @param damage - the <code>int</code> amount of damage.
      */
     public Vector<Report> damageInfantryIn(Building bldg, int damage,
-                                           Coords hexCoords, int infDamageClass) {
+            Coords hexCoords, int infDamageClass) {
 
         Vector<Report> vDesc = new Vector<Report>();
 

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -30507,8 +30507,10 @@ public class Server implements Runnable {
                         // TW page 217 says left over damage gets treated as
                         // direct fire ballistic damage
                         if (!(entity instanceof BattleArmor)) {
-                            toInf = Compute.directBlowInfantryDamage(toInf, 0,
-                                    WeaponType.WEAPON_DIRECT_FIRE, false);
+                            toInf = Compute
+                                    .directBlowInfantryDamage(toInf, 0,
+                                            WeaponType.WEAPON_DIRECT_FIRE,
+                                            false, false);
                         }
                         int remaining = toInf;
                         int cluster = toInf;

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -30491,23 +30491,24 @@ public class Server implements Runnable {
                     // Report if the infantry receive no points of damage.
                     if (toInf == 0) {
                         r = new Report(6445);
+                        r.indent(3);
                         r.subject = entity.getId();
+                        r.add(entity.getDisplayName());
                         vDesc.addElement(r);
                     } else {
                         // Yup. Damage the entity.
                         r = new Report(6450);
-                        r.indent(2);
+                        r.indent(3);
                         r.subject = entity.getId();
                         r.add(toInf);
                         r.add(entity.getDisplayName());
                         vDesc.addElement(r);
                         // need to adjust damage to conventional infantry
                         // TW page 217 says left over damage gets treated as
-                        // direct
-                        // fire ballistic damage
+                        // direct fire ballistic damage
                         if (!(entity instanceof BattleArmor)) {
                             toInf = Compute.directBlowInfantryDamage(toInf, 0,
-                                                                     WeaponType.WEAPON_DIRECT_FIRE, false);
+                                    WeaponType.WEAPON_DIRECT_FIRE, false);
                         }
                         int remaining = toInf;
                         int cluster = toInf;

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -30548,23 +30548,26 @@ public class Server implements Runnable {
      * crash through its floor into its basement. Again, apply appropriate
      * damage.
      *
-     * @param bldg        - the <code>Building</code> being checked. This value should
-     *                    not be <code>null</code>.
-     * @param positionMap - a <code>Hashtable</code> that maps the <code>Coords</code>
-     *                    positions or each unit in the game to a <code>Vector</code> of
-     *                    <code>Entity</code>s at that position. This value should not
-     *                    be <code>null</code>.
-     * @param coords      - the <code>Coords</code> of the building hex to be checked
+     * @param bldg
+     *            - the <code>Building</code> being checked. This value should
+     *            not be <code>null</code>.
+     * @param positionMap
+     *            - a <code>Hashtable</code> that maps the <code>Coords</code>
+     *            positions or each unit in the game to a <code>Vector</code> of
+     *            <code>Entity</code>s at that position. This value should not
+     *            be <code>null</code>.
+     * @param coords
+     *            - the <code>Coords</code> of the building hex to be checked
      * @return <code>true</code> if the building collapsed.
      */
     public boolean checkForCollapse(Building bldg,
-                                    Hashtable<Coords, Vector<Entity>> positionMap, Coords coords,
-                                    boolean checkBecauseOfDamage, Vector<Report> vPhaseReport) {
+            Hashtable<Coords, Vector<Entity>> positionMap, Coords coords,
+            boolean checkBecauseOfDamage, Vector<Report> vPhaseReport) {
 
         // If the input is meaningless, do nothing and throw no exception.
         if ((bldg == null) || (positionMap == null) || positionMap.isEmpty()
-            || (coords == null) || !bldg.isIn(coords)
-            || !bldg.hasCFIn(coords)) {
+                || (coords == null) || !bldg.isIn(coords)
+                || !bldg.hasCFIn(coords)) {
             return false;
         }
 
@@ -30592,7 +30595,7 @@ public class Server implements Runnable {
             // How many levels does this building have in this hex?
             final IHex curHex = game.getBoard().getHex(coords);
             final int numFloors = Math.max(0,
-                                           curHex.terrainLevel(Terrains.BLDG_ELEV));
+                    curHex.terrainLevel(Terrains.BLDG_ELEV));
             final int bridgeEl = curHex.terrainLevel(Terrains.BRIDGE_ELEV);
             int numLoads = numFloors;
             if (bridgeEl != ITerrain.LEVEL_NONE) {
@@ -30600,7 +30603,7 @@ public class Server implements Runnable {
             }
             if (numLoads < 1) {
                 System.err.println("Check for collapse: hex "
-                                   + coords.toString() + " has no bridge or building");
+                        + coords.toString() + " has no bridge or building");
                 return false;
             }
 
@@ -30636,9 +30639,9 @@ public class Server implements Runnable {
                     }
 
                     if ((entity.getMovementMode() == EntityMovementMode.HYDROFOIL)
-                        || (entity.getMovementMode() == EntityMovementMode.NAVAL)
-                        || (entity.getMovementMode() == EntityMovementMode.SUBMARINE)
-                        || (entity.getMovementMode() == EntityMovementMode.INF_UMU)) {
+                            || (entity.getMovementMode() == EntityMovementMode.NAVAL)
+                            || (entity.getMovementMode() == EntityMovementMode.SUBMARINE)
+                            || (entity.getMovementMode() == EntityMovementMode.INF_UMU)) {
                         continue; // under the bridge even at same level
                     }
 
@@ -30683,8 +30686,8 @@ public class Server implements Runnable {
 
             // did anyone fall into the basement?
             if (!basementMap.isEmpty()
-                && (bldg.getBasement(coords) != BasementType.NONE)
-                && !collapse) {
+                    && (bldg.getBasement(coords) != BasementType.NONE)
+                    && !collapse) {
 
                 collapseBasement(bldg, basementMap, coords, vPhaseReport);
                 if (currentCF == 0) {
@@ -30719,8 +30722,8 @@ public class Server implements Runnable {
     } // End private boolean checkForCollapse( Building, Hashtable )
 
     public void collapseBuilding(Building bldg,
-                                 Hashtable<Coords, Vector<Entity>> positionMap, Coords coords,
-                                 Vector<Report> vPhaseReport) {
+            Hashtable<Coords, Vector<Entity>> positionMap, Coords coords,
+            Vector<Report> vPhaseReport) {
         collapseBuilding(bldg, positionMap, coords, true, vPhaseReport);
     }
 


### PR DESCRIPTION
Fixes SF Bug [[#4186]](https://sourceforge.net/p/megamek/bugs/4186/).  For combat within a building, the infantry damage was off.  If a unit is outside of a building and wants to shoot at infantry in a building, they cannot.  Instead, the unit must shoot at the building, and some of the damage to the building is transfered to the infantry.

For combat within a building, the infantry can be targeted directly,  however the building can still absorb damage (although a smaller amount).  However, since the infantry themselves are targeted, the same mechanisms used in the previous case don't work.