### PR TITLE
Fix for #418: Graphical anomalis  with FlyOverSprite

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -3192,7 +3192,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         return p;
     }
 
-    private Point getCentreHexLocation(Coords c) {
+    public Point getCentreHexLocation(Coords c) {
         return getCentreHexLocation(c.getX(), c.getY());
     }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -3145,11 +3145,11 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
      * Returns the absolute position of the upper-left hand corner of the hex
      * graphic
      */
-    private Point getHexLocation(int x, int y) {
+    private Point getHexLocation(int x, int y, boolean ignoreElevation) {
         float elevationAdjust = 0.0f;
 
         IHex hex = game.getBoard().getHex(x, y);
-        if ((hex != null) && useIsometric()) {
+        if ((hex != null) && useIsometric() && !ignoreElevation) {
             int level = hex.getLevel();
             if (level != 0) {
                 elevationAdjust = level * HEX_ELEV * scale * -1.0f;
@@ -3179,21 +3179,25 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     }
 
     Point getHexLocation(Coords c) {
-        return getHexLocation(c.getX(), c.getY());
+        return getHexLocation(c.getX(), c.getY(), false);
     }
     
      /**
      * Returns the absolute position of the centre of the hex graphic
      */
-    private Point getCentreHexLocation(int x, int y) {
-        Point p = getHexLocation(x, y);
+    private Point getCentreHexLocation(int x, int y, boolean ignoreElevation) {
+        Point p = getHexLocation(x, y, ignoreElevation);
         p.x += ((HEX_W / 2) * scale);
         p.y += ((HEX_H / 2) * scale);
         return p;
     }
 
     public Point getCentreHexLocation(Coords c) {
-        return getCentreHexLocation(c.getX(), c.getY());
+        return getCentreHexLocation(c.getX(), c.getY(), false);
+    }
+
+    public Point getCentreHexLocation(Coords c, boolean ignoreElevation) {
+        return getCentreHexLocation(c.getX(), c.getY(), ignoreElevation);
     }
 
     public void drawRuler(Coords s, Coords e, Color sc, Color ec) {

--- a/megamek/src/megamek/client/ui/swing/boardview/FlyOverSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlyOverSprite.java
@@ -116,8 +116,9 @@ class FlyOverSprite extends Sprite {
         final double lw = bv.scale * BoardView1.FLY_OVER_LINE_WIDTH;
         int numPassedThrough = en.getPassedThrough().size();
         double angle;
+        double xDiff, yDiff;
         Coords prev, curr, next;
-        Point currPoint;
+        Point currPoint, nextPoint;
 
         // Handle First Coords
         curr = en.getPassedThrough().get(0);
@@ -135,19 +136,45 @@ class FlyOverSprite extends Sprite {
             addPolyPoint(curr, next, prev, true);
         }
 
-        // Handle Last Coords
+        // Handle Last Coords - only draw to the hex edge
         curr = en.getPassedThrough().get(numPassedThrough - 1);
         next = en.getPassedThrough().get(numPassedThrough - 2);
         currPoint = bv.getCentreHexLocation(curr, true);
+        nextPoint = bv.getCentreHexLocation(next, true);
+        if (bv.useIsometric()) {
+            xDiff = Math.sqrt(Math.pow(currPoint.x - nextPoint.x, 2));
+            yDiff = Math.sqrt(Math.pow(currPoint.y - nextPoint.y, 2));
+            if (nextPoint.x > currPoint.x) {
+                xDiff *= -1;
+            }
+            if (nextPoint.y >= currPoint.y) {
+                yDiff *= -1;
+            }
+            currPoint.x = (int) (currPoint.x - xDiff / 2 + 0.5);
+            currPoint.y = (int) (currPoint.y - yDiff / 2 + 0.5);
+        }
         angle = (curr.radian(next) + Math.PI) % (2 * Math.PI);
         flyOverPoly.addPoint(currPoint.x + (int) (Math.cos(angle) * lw + 0.5),
                 currPoint.y + (int) (Math.sin(angle) * lw + 0.5));
 
         // Now go in reverse order - to add second half of points
-        // Handle Last Coords
+        // Handle Last Coords - only draw to the hex edge
         curr = en.getPassedThrough().get(numPassedThrough - 1);
         next = en.getPassedThrough().get(numPassedThrough - 2);
         currPoint = bv.getCentreHexLocation(curr, true);
+        nextPoint = bv.getCentreHexLocation(next, true);
+        if (bv.useIsometric()) {
+            xDiff = Math.sqrt(Math.pow(currPoint.x - nextPoint.x, 2));
+            yDiff = Math.sqrt(Math.pow(currPoint.y - nextPoint.y, 2));
+            if (nextPoint.x > currPoint.x) {
+                xDiff *= -1;
+            }
+            if (nextPoint.y >= currPoint.y) {
+                yDiff *= -1;
+            }
+            currPoint.x = (int) (currPoint.x - xDiff / 2 + 0.5);
+            currPoint.y = (int) (currPoint.y - yDiff / 2 + 0.5);
+        }
         angle = curr.radian(next);
         flyOverPoly.addPoint(currPoint.x + (int) (Math.cos(angle) * lw + 0.5),
                 currPoint.y + (int) (Math.sin(angle) * lw + 0.5));
@@ -171,7 +198,7 @@ class FlyOverSprite extends Sprite {
 
     @Override
     public Rectangle getBounds() {
-        if (flyOverPoly == null) {
+        if (true) {
             makePoly();
         }
         // set bounds

--- a/megamek/src/megamek/client/ui/swing/boardview/FlyOverSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlyOverSprite.java
@@ -47,7 +47,7 @@ class FlyOverSprite extends Sprite {
         double nextAngle = curr.radian(next);
         double prevAngle = prev.radian(curr);
 
-        Point currPoint = this.bv.getCentreHexLocation(curr);
+        Point currPoint = this.bv.getCentreHexLocation(curr, true);
         final double lw = bv.scale * BoardView1.FLY_OVER_LINE_WIDTH;
 
         // This is a bend
@@ -122,7 +122,7 @@ class FlyOverSprite extends Sprite {
         // Handle First Coords
         curr = en.getPassedThrough().get(0);
         next = en.getPassedThrough().get(1);
-        currPoint = bv.getCentreHexLocation(curr);
+        currPoint = bv.getCentreHexLocation(curr, true);
         angle = curr.radian(next);
         flyOverPoly.addPoint(currPoint.x + (int) (Math.cos(angle) * lw + 0.5),
                 currPoint.y + (int) (Math.sin(angle) * lw + 0.5));
@@ -138,7 +138,7 @@ class FlyOverSprite extends Sprite {
         // Handle Last Coords
         curr = en.getPassedThrough().get(numPassedThrough - 1);
         next = en.getPassedThrough().get(numPassedThrough - 2);
-        currPoint = bv.getCentreHexLocation(curr);
+        currPoint = bv.getCentreHexLocation(curr, true);
         angle = (curr.radian(next) + Math.PI) % (2 * Math.PI);
         flyOverPoly.addPoint(currPoint.x + (int) (Math.cos(angle) * lw + 0.5),
                 currPoint.y + (int) (Math.sin(angle) * lw + 0.5));
@@ -147,7 +147,7 @@ class FlyOverSprite extends Sprite {
         // Handle Last Coords
         curr = en.getPassedThrough().get(numPassedThrough - 1);
         next = en.getPassedThrough().get(numPassedThrough - 2);
-        currPoint = bv.getCentreHexLocation(curr);
+        currPoint = bv.getCentreHexLocation(curr, true);
         angle = curr.radian(next);
         flyOverPoly.addPoint(currPoint.x + (int) (Math.cos(angle) * lw + 0.5),
                 currPoint.y + (int) (Math.sin(angle) * lw + 0.5));
@@ -163,7 +163,7 @@ class FlyOverSprite extends Sprite {
         // Handle First Coords
         curr = en.getPassedThrough().get(0);
         prev = en.getPassedThrough().get(1);
-        currPoint = bv.getCentreHexLocation(curr);
+        currPoint = bv.getCentreHexLocation(curr, true);
         angle = prev.radian(curr);
         flyOverPoly.addPoint(currPoint.x + (int) (Math.cos(angle) * lw + 0.5),
                 currPoint.y + (int) (Math.sin(angle) * lw + 0.5));

--- a/megamek/src/megamek/client/ui/swing/boardview/FlyOverSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlyOverSprite.java
@@ -15,12 +15,12 @@ import megamek.common.Coords;
 import megamek.common.Entity;
 
 /**
- * Sprite and info for an aero flyover route. Does not actually use the
- * image buffer as this can be horribly inefficient for long diagonal lines.
+ * Sprite and info for an aero flyover route. Does not actually use the image
+ * buffer as this can be horribly inefficient for long diagonal lines.
  */
 class FlyOverSprite extends Sprite {
 
-    private Polygon flyOverPoly;
+    private Polygon flyOverPoly = null;
 
     protected Entity en;
 
@@ -30,157 +30,173 @@ class FlyOverSprite extends Sprite {
         super(boardView1);
         en = e;
         spriteColor = PlayerColors.getColor(e.getOwner().getColorIndex());
-
-        if ((e.getPosition() == null) || (e.getPassedThrough().size() < 2)) {
-            flyOverPoly = new Polygon();
-            flyOverPoly.addPoint(0, 0);
-            flyOverPoly.addPoint(1, 0);
-            flyOverPoly.addPoint(0, 1);
-            bounds = new Rectangle(flyOverPoly.getBounds());
-            bounds.setSize(bounds.getSize().width + 1,
-                    bounds.getSize().height + 1);
-            image = null;
-            return;
-        }
-
-        makePoly();
-
-        // set bounds
-        bounds = new Rectangle(flyOverPoly.getBounds());
-        bounds.setSize(bounds.getSize().width + 1,
-                bounds.getSize().height + 1);
-
-        // move poly to upper right of image
-        flyOverPoly.translate(-bounds.getLocation().x,
-                -bounds.getLocation().y);
-
-        // set names & stuff
-
-        // nullify image
         image = null;
+        prepare();
     }
 
     @Override
     public void prepare() {
+        makePoly();
+        getBounds();
     }
 
-    private void makePoly() {
-        // make a polygon
-        flyOverPoly = new Polygon();
-        for (Coords c : en.getPassedThrough()) {
-            Coords prev = en.passedThroughPrevious(c);
-            if (prev.equals(c)) {
-                continue;
+    private void addPolyPoint(Coords curr, Coords next, Coords prev,
+            boolean forward) {
+        int newX, newY;
+        int prevX, prevY, nextX, nextY;
+        double nextAngle = curr.radian(next);
+        double prevAngle = prev.radian(curr);
+
+        Point currPoint = this.bv.getCentreHexLocation(curr);
+        final double lw = bv.scale * BoardView1.FLY_OVER_LINE_WIDTH;
+
+        // This is a bend
+        double diff;
+        if (forward) {
+            diff = nextAngle - prevAngle;
+        } else {
+            diff = prevAngle - nextAngle;
+        }
+        diff = nextAngle - prevAngle;
+        if (Math.abs(diff) > 0.001) {
+            // Inside Corner - Add one point
+            double bendAngle = (Math.PI + diff);
+            if (bendAngle > (2 * Math.PI)) {
+                bendAngle -= 2 * Math.PI;
+            } else if (bendAngle < 0) {
+                bendAngle += 2 * Math.PI;
             }
-            Point a = this.bv.getHexLocation(prev);
-            Point t = this.bv.getHexLocation(c);
+            // Outside Corner
+            if (bendAngle < Math.PI) {
+                newX = currPoint.x + (int) (Math.cos(prevAngle) * lw + 0.5);
+                newY = currPoint.y + (int) (Math.sin(prevAngle) * lw + 0.5);
+                flyOverPoly.addPoint(newX, newY);
+                newX = currPoint.x + (int) (Math.cos(nextAngle) * lw + 0.5);
+                newY = currPoint.y + (int) (Math.sin(nextAngle) * lw + 0.5);
+                flyOverPoly.addPoint(newX, newY);
+            } else { // Inside corner
+                prevX = currPoint.x + (int) (Math.cos(prevAngle) * lw + 0.5);
+                prevY = currPoint.y + (int) (Math.sin(prevAngle) * lw + 0.5);
+                nextX = currPoint.x + (int) (Math.cos(nextAngle) * lw + 0.5);
+                nextY = currPoint.y + (int) (Math.sin(nextAngle) * lw + 0.5);
+                int d = prevX - nextX;
+                if ((prevY < nextY && prevX < nextX)
+                        || (prevY > nextY && prevX > nextX)) {
+                    d *= -1;
+                }
+                flyOverPoly.addPoint(nextX + d, nextY);
+                flyOverPoly.addPoint(prevX + d, prevY);
+            }
+        } else { // Not a bend
+            // Only need to add one
+            newX = currPoint.x + (int) (Math.cos(nextAngle) * lw + 0.5);
+            newY = currPoint.y + (int) (Math.sin(nextAngle) * lw + 0.5);
+            flyOverPoly.addPoint(newX, newY);
+        }
+    }
 
-            final double an = (prev.radian(c) + (Math.PI * 1.5))
-                    % (Math.PI * 2); // angle
-            final double lw = this.bv.scale * BoardView1.FLY_OVER_LINE_WIDTH; // line width
+    /**
+     * Creates the flyover polygon, which is essentially a wide line from the
+     * part of the fly path to the end.
+     */
+    private void makePoly() {
+        // make polygon
+        flyOverPoly = new Polygon();
 
-            flyOverPoly.addPoint(
-                    a.x
-                            + (int) ((this.bv.scale * (BoardView1.HEX_W / 2)) - (int) Math
-                                    .round(Math.sin(an) * lw)),
-                    a.y
-                            + (int) ((this.bv.scale * (BoardView1.HEX_H / 2)) + (int) Math
-                                    .round(Math.cos(an) * lw)));
-            // flyOverPoly.addPoint(
-            // a.x + (int) (scale * (HEX_W / 2) + (int)
-            // Math.round(Math.sin(an) * lw)), a.y
-            // + (int) (scale * (HEX_H / 2) - (int) Math.round(Math.cos(an)
-            // * lw)));
-            // flyOverPoly.addPoint(
-            // t.x + (int) (scale * (HEX_W / 2) + (int)
-            // Math.round(Math.sin(an) * lw)), t.y
-            // + (int) (scale * (HEX_H / 2) - (int) Math.round(Math.cos(an)
-            // * lw)));
-            flyOverPoly.addPoint(
-                    t.x
-                            + (int) ((this.bv.scale * (BoardView1.HEX_W / 2)) - (int) Math
-                                    .round(Math.sin(an) * lw)),
-                    t.y
-                            + (int) ((this.bv.scale * (BoardView1.HEX_H / 2)) + (int) Math
-                                    .round(Math.cos(an) * lw)));
-
+        // Check for degenerate case
+        if ((en.getPosition() == null) || (en.getPassedThrough().size() < 2)) {
+            flyOverPoly = new Polygon();
+            flyOverPoly.addPoint(0, 0);
+            flyOverPoly.addPoint(1, 0);
+            flyOverPoly.addPoint(0, 1);
+            return;
         }
 
-        // now loop through backwards
-        for (int i = (en.getPassedThrough().size() - 1); i > 0; i--) {
-            Coords c = en.getPassedThrough().elementAt(i);
-            Coords next = en.getPassedThrough().elementAt(i - 1);
-            Point a = this.bv.getHexLocation(c);
-            Point t = this.bv.getHexLocation(next);
+        // line width
+        final double lw = bv.scale * BoardView1.FLY_OVER_LINE_WIDTH;
+        int numPassedThrough = en.getPassedThrough().size();
+        double angle;
+        Coords prev, curr, next;
+        Point currPoint;
 
-            final double an = (c.radian(next) + (Math.PI * 1.5))
-                    % (Math.PI * 2); // angle
-            final double lw = this.bv.scale * BoardView1.FLY_OVER_LINE_WIDTH; // line width
-            // flyOverPoly.addPoint(
-            // a.x + (int) (scale * (HEX_W / 2) + (int)
-            // Math.round(Math.sin(an) * lw)), a.y
-            // + (int) (scale * (HEX_H / 2) - (int) Math.round(Math.cos(an)
-            // * lw)));
-            // flyOverPoly.addPoint(
-            // t.x + (int) (scale * (HEX_W / 2) + (int)
-            // Math.round(Math.sin(an) * lw)), t.y
-            // + (int) (scale * (HEX_H / 2) - (int) Math.round(Math.cos(an)
-            // * lw)));
+        // Handle First Coords
+        curr = en.getPassedThrough().get(0);
+        next = en.getPassedThrough().get(1);
+        currPoint = bv.getCentreHexLocation(curr);
+        angle = curr.radian(next);
+        flyOverPoly.addPoint(currPoint.x + (int) (Math.cos(angle) * lw + 0.5),
+                currPoint.y + (int) (Math.sin(angle) * lw + 0.5));
 
-            flyOverPoly.addPoint(
-                    a.x
-                            + (int) ((this.bv.scale * (BoardView1.HEX_W / 2)) - (int) Math
-                                    .round(Math.sin(an) * lw)),
-                    a.y
-                            + (int) ((this.bv.scale * (BoardView1.HEX_H / 2)) + (int) Math
-                                    .round(Math.cos(an) * lw)));
-            flyOverPoly.addPoint(
-                    t.x
-                            + (int) ((this.bv.scale * (BoardView1.HEX_W / 2)) - (int) Math
-                                    .round(Math.sin(an) * lw)),
-                    t.y
-                            + (int) ((this.bv.scale * (BoardView1.HEX_H / 2)) + (int) Math
-                                    .round(Math.cos(an) * lw)));
-
+        // Handle Middle Coords
+        for (int i = 1; i < (numPassedThrough - 1); i++) {
+            prev = en.getPassedThrough().get(i - 1);
+            curr = en.getPassedThrough().get(i);
+            next = en.getPassedThrough().get(i + 1);
+            addPolyPoint(curr, next, prev, true);
         }
 
+        // Handle Last Coords
+        curr = en.getPassedThrough().get(numPassedThrough - 1);
+        next = en.getPassedThrough().get(numPassedThrough - 2);
+        currPoint = bv.getCentreHexLocation(curr);
+        angle = (curr.radian(next) + Math.PI) % (2 * Math.PI);
+        flyOverPoly.addPoint(currPoint.x + (int) (Math.cos(angle) * lw + 0.5),
+                currPoint.y + (int) (Math.sin(angle) * lw + 0.5));
+
+        // Now go in reverse order - to add second half of points
+        // Handle Last Coords
+        curr = en.getPassedThrough().get(numPassedThrough - 1);
+        next = en.getPassedThrough().get(numPassedThrough - 2);
+        currPoint = bv.getCentreHexLocation(curr);
+        angle = curr.radian(next);
+        flyOverPoly.addPoint(currPoint.x + (int) (Math.cos(angle) * lw + 0.5),
+                currPoint.y + (int) (Math.sin(angle) * lw + 0.5));
+
+        // Handle Middle Coords (in reverse)
+        for (int i = (numPassedThrough - 2); i > 0; i--) {
+            prev = en.getPassedThrough().get(i + 1);
+            curr = en.getPassedThrough().get(i);
+            next = en.getPassedThrough().get(i - 1);
+            addPolyPoint(curr, next, prev, false);
+        }
+
+        // Handle First Coords
+        curr = en.getPassedThrough().get(0);
+        prev = en.getPassedThrough().get(1);
+        currPoint = bv.getCentreHexLocation(curr);
+        angle = prev.radian(curr);
+        flyOverPoly.addPoint(currPoint.x + (int) (Math.cos(angle) * lw + 0.5),
+                currPoint.y + (int) (Math.sin(angle) * lw + 0.5));
     }
 
     @Override
     public Rectangle getBounds() {
-        makePoly();
+        if (flyOverPoly == null) {
+            makePoly();
+        }
         // set bounds
         bounds = new Rectangle(flyOverPoly.getBounds());
-        bounds.setSize(bounds.getSize().width + 1,
-                bounds.getSize().height + 1);
-
-        // move poly to upper right of image
-        flyOverPoly.translate(-bounds.getLocation().x,
-                -bounds.getLocation().y);
-        image = null;
-
+        bounds.setSize(bounds.getSize().width + 1, bounds.getSize().height + 1);
         return bounds;
     }
 
     @Override
     public boolean isReady() {
-        return true;
+        return flyOverPoly != null;
     }
 
     public int getEntityId() {
         return en.getId();
     }
-    
+
     public Entity getEntity() {
         return en;
     }
 
     @Override
     public void drawOnto(Graphics g, int x, int y, ImageObserver observer) {
-
-        Polygon drawPoly = new Polygon(flyOverPoly.xpoints,
-                flyOverPoly.ypoints, flyOverPoly.npoints);
-        drawPoly.translate(x, y);
+        Polygon drawPoly = new Polygon(flyOverPoly.xpoints, flyOverPoly.ypoints,
+                flyOverPoly.npoints);
 
         g.setColor(spriteColor);
         g.fillPolygon(drawPoly);


### PR DESCRIPTION
I changed how FlyOverSprite computes its polygon.  It now has slightly rounded bends without the little spurs.  I also made it so the polygon is only computed once, not every time the bounds are retrieved.  I also made it so the path ignores elevation in isometric mode.  Additionally, the path ends at the edge of the last hex in isometric mode, to prevent issues with the path drawing over the icon.