### PR TITLE
Add support for user data directory

### DIFF
--- a/megamek/.gitignore
+++ b/megamek/.gitignore
@@ -19,3 +19,4 @@
 /classes/
 /mechs.csv
 /*.ps
+/userdata/

--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -50,6 +50,7 @@ import megamek.common.Tank;
 import megamek.common.TechConstants;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.AbstractCommandLineParser;
+import megamek.common.util.MegaMekFile;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestBattleArmor;
@@ -604,8 +605,8 @@ public class MegaMek {
                         System.err
                                 .println("Validating Entity: " + entity.getShortNameRaw()); //$NON-NLS-1$
                         EntityVerifier entityVerifier = EntityVerifier.getInstance(
-                                new File(Configuration.unitsDir(),
-                                        EntityVerifier.CONFIG_FILENAME));
+                                new MegaMekFile(Configuration.unitsDir(),
+                                        EntityVerifier.CONFIG_FILENAME).getFile());
                         MechView mechView = new MechView(entity, false);
                         StringBuffer sb = new StringBuffer(
                                 mechView.getMechReadout());

--- a/megamek/src/megamek/client/RandomNameGenerator.java
+++ b/megamek/src/megamek/client/RandomNameGenerator.java
@@ -29,6 +29,7 @@ import java.util.Vector;
 
 import megamek.common.Compute;
 import megamek.common.Configuration;
+import megamek.common.util.MegaMekFile;
 
 /** 
  * This class sets up a random name generator that can then
@@ -130,7 +131,7 @@ public class RandomNameGenerator implements Serializable {
         }
 
         // READ IN MALE FIRST NAMES
-        File male_firstnames_path = new File(Configuration.namesDir(), FILENAME_FIRSTNAMES_MALE);
+        File male_firstnames_path = new MegaMekFile(Configuration.namesDir(), FILENAME_FIRSTNAMES_MALE).getFile();
         try(Scanner input = new Scanner(new FileInputStream(male_firstnames_path), "UTF-8")) { //$NON-NLS-1$
             int linen = 0;
             while (input.hasNextLine()) {
@@ -166,7 +167,7 @@ public class RandomNameGenerator implements Serializable {
         }
 
         // READ IN FEMALE FIRST NAMES
-        File female_firstnames_path = new File(Configuration.namesDir(), FILENAME_FIRSTNAMES_FEMALE);
+        File female_firstnames_path = new MegaMekFile(Configuration.namesDir(), FILENAME_FIRSTNAMES_FEMALE).getFile();
         try(Scanner input = new Scanner(new FileInputStream(female_firstnames_path), "UTF-8")) { //$NON-NLS-1$
             int linen = 0;
             while (input.hasNextLine()) {
@@ -202,7 +203,7 @@ public class RandomNameGenerator implements Serializable {
         }
 
         // READ IN SURNAMES
-        File surnames_path = new File(Configuration.namesDir(), FILENAME_SURNAMES);
+        File surnames_path = new MegaMekFile(Configuration.namesDir(), FILENAME_SURNAMES).getFile();
         try(Scanner input = new Scanner(new FileInputStream(surnames_path), "UTF-8")) { //$NON-NLS-1$
             int linen = 0;
             while (input.hasNextLine()) {
@@ -239,7 +240,7 @@ public class RandomNameGenerator implements Serializable {
 
         // READ IN FACTION FILES
         // all faction files should be in the faction directory
-        File factions_dir_path = new File(Configuration.namesDir(), DIR_NAME_FACTIONS);
+        File factions_dir_path = new MegaMekFile(Configuration.namesDir(), DIR_NAME_FACTIONS).getFile();
         String[] filenames = factions_dir_path.list();
         if (null == filenames) {
             return;
@@ -252,7 +253,7 @@ public class RandomNameGenerator implements Serializable {
             }
             factionLast.put(key, new Vector<String>());
             factionFirst.put(key, new HashMap<String, Vector<String>>());
-            File ff = new File(factions_dir_path, filename);
+            File ff = new MegaMekFile(factions_dir_path, filename).getFile();
             try(Scanner factionInput = new Scanner(new FileInputStream(ff), "UTF-8")) { //$NON-NLS-1$
                 Map<String, Vector<String>> hash = new HashMap<String, Vector<String>>();
                 while (factionInput.hasNextLine()) {

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -41,6 +41,7 @@ import megamek.common.EntityMovementMode;
 import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
 import megamek.common.UnitType;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Generates a random assignment table (RAT) dynamically based on a variety of criteria,
@@ -752,7 +753,7 @@ public class RATGenerator {
 	}
 	
 	private void loadFactions() {
-		File file = new File(Configuration.forceGeneratorDir(), "factions.xml");
+		File file = new MegaMekFile(Configuration.forceGeneratorDir(), "factions.xml").getFile();
 		FileInputStream fis = null;
 		try {
 			fis = new FileInputStream(file);
@@ -795,7 +796,7 @@ public class RATGenerator {
 		}
 		chassisIndex.put(era, new HashMap<String,HashMap<String,AvailabilityRating>>());
 		modelIndex.put(era, new HashMap<String,HashMap<String,AvailabilityRating>>());
-		File file = new File(Configuration.forceGeneratorDir(), era + ".xml");
+		File file = new MegaMekFile(Configuration.forceGeneratorDir(), era + ".xml").getFile();
 		FileInputStream fis = null;
 		try {
 			fis = new FileInputStream(file);

--- a/megamek/src/megamek/client/ui/swing/AbstractPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/AbstractPhaseDisplay.java
@@ -55,6 +55,7 @@ import megamek.common.event.GameTurnChangeEvent;
 import megamek.common.event.GameVictoryEvent;
 import megamek.common.util.Distractable;
 import megamek.common.util.DistractableAdapter;
+import megamek.common.util.MegaMekFile;
 
 public abstract class AbstractPhaseDisplay extends JPanel implements 
         BoardViewListener, GameListener, Distractable {
@@ -86,8 +87,8 @@ public abstract class AbstractPhaseDisplay extends JPanel implements
 
         try {
             if (pdSkinSpec.backgrounds.size() > 0){
-                File file = new File(Configuration.widgetsDir(), 
-                        pdSkinSpec.backgrounds.get(0));
+                File file = new MegaMekFile(Configuration.widgetsDir(), 
+                        pdSkinSpec.backgrounds.get(0)).getFile();
                 URI imgURL = file.toURI();
                 if (!file.exists()){
                     System.err.println("PhaseDisplay Error: icon doesn't exist: "

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -140,6 +140,7 @@ import megamek.common.options.PilotOptions;
 import megamek.common.options.Quirks;
 import megamek.common.util.BoardUtilities;
 import megamek.common.util.DirectoryItems;
+import megamek.common.util.MegaMekFile;
 
 public class ChatLounge extends AbstractPhaseDisplay implements ActionListener,
         ItemListener, ListSelectionListener, MouseListener,
@@ -1227,7 +1228,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener,
         String boardName = lisBoardsAvailable.getSelectedValue();
         if (lisBoardsAvailable.getSelectedIndex() > 2) {
             IBoard board = new Board(16, 17);
-            board.load(new File(Configuration.boardsDir(), boardName + ".board"));
+            board.load(new MegaMekFile(Configuration.boardsDir(), boardName + ".board").getFile());
             if (chkRotateBoard.isSelected()) {
                 BoardUtilities.flip(board, true, true);
             }
@@ -1257,8 +1258,8 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener,
                     || (temp.getMedium() == MapSettings.MEDIUM_SPACE)) {
                 sheetBoards[i] = BoardUtilities.generateRandom(temp);
             } else {
-                sheetBoards[i].load(new File(Configuration.boardsDir(), name
-                        + ".board"));
+                sheetBoards[i].load(new MegaMekFile(Configuration.boardsDir(), name
+                        + ".board").getFile());
                 BoardUtilities.flip(sheetBoards[i], isRotated, isRotated);
             }
             rotateBoard.add(isRotated);
@@ -3525,7 +3526,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener,
                             clearImage();
                         } else {
                             Image image = getToolkit().getImage(
-                                    new File(Configuration.miscImagesDir(),
+                                    new MegaMekFile(Configuration.miscImagesDir(),
                                             FILENAME_UNKNOWN_UNIT).toString());
                             image = image.getScaledInstance(-1, 72,
                                     Image.SCALE_DEFAULT);
@@ -3536,7 +3537,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener,
                             clearImage();
                         } else {
                             Image image = getToolkit().getImage(
-                                    new File(Configuration.portraitImagesDir(),
+                                    new MegaMekFile(Configuration.portraitImagesDir(),
                                             FILENAME_PORTRAIT_DEFAULT)
                                             .toString());
                             image = image.getScaledInstance(-1, 50,

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -38,7 +38,6 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/megamek/src/megamek/client/ui/swing/ChatterBox2.java
+++ b/megamek/src/megamek/client/ui/swing/ChatterBox2.java
@@ -29,7 +29,6 @@ import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-import java.io.File;
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Vector;
@@ -48,6 +47,7 @@ import megamek.common.event.GameEntityNewEvent;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GamePlayerChatEvent;
 import megamek.common.preference.PreferenceManager;
+import megamek.common.util.MegaMekFile;
 import megamek.common.util.StringUtil;
 
 /**
@@ -156,19 +156,19 @@ public class ChatterBox2 implements KeyListener, IDisplayable {
         fm = bv.getFontMetrics(FONT_CHAT);
 
         Toolkit toolkit = bv.getToolkit();
-        upbutton = toolkit.getImage(new File(Configuration.widgetsDir(), 
+        upbutton = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), 
                 FILENAME_BUTTON_UP).toString());
         PMUtil.setImage(upbutton, client);
-        downbutton = toolkit.getImage(new File(Configuration.widgetsDir(), 
+        downbutton = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), 
                 FILENAME_BUTTON_DOWN).toString());
         PMUtil.setImage(downbutton, client);
-        minbutton = toolkit.getImage(new File(Configuration.widgetsDir(), 
+        minbutton = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), 
                 FILENAME_BUTTON_MINIMISE).toString());
         PMUtil.setImage(minbutton, client);
-        maxbutton = toolkit.getImage(new File(Configuration.widgetsDir(), 
+        maxbutton = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), 
                 FILENAME_BUTTON_MAXIMISE).toString());
         PMUtil.setImage(maxbutton, client);
-        resizebutton = toolkit.getImage(new File(Configuration.widgetsDir(), 
+        resizebutton = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), 
                 FILENAME_BUTTON_RESIZE).toString());
         PMUtil.setImage(resizebutton, client);
 

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -107,6 +107,7 @@ import megamek.common.net.Packet;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.AddBotUtil;
 import megamek.common.util.Distractable;
+import megamek.common.util.MegaMekFile;
 import megamek.common.util.StringUtil;
 
 public class ClientGUI extends JPanel implements WindowListener, BoardViewListener, ActionListener, ComponentListener {
@@ -347,16 +348,16 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         frame.setForeground(SystemColor.menuText);
         List<Image> iconList = new ArrayList<Image>();
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_16X16).toString()
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_16X16).toString()
         ));
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_32X32).toString()
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_32X32).toString()
         ));
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_48X48).toString()
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_48X48).toString()
         ));
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_256X256).toString()
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_256X256).toString()
         ));
         frame.setIconImages(iconList);
     }

--- a/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
@@ -27,7 +27,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.io.File;
 import java.util.Date;
 
 import javax.swing.ImageIcon;
@@ -39,6 +38,7 @@ import javax.swing.JTextArea;
 
 import megamek.client.ui.Messages;
 import megamek.common.Configuration;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Every about dialog in MegaMek should have an identical look-and-feel.
@@ -66,7 +66,7 @@ public class CommonAboutDialog extends JDialog {
         if (imgTitleImage == null) {
             // Nope. Load it.
             Image image = frame.getToolkit().getImage(
-                    new File(Configuration.miscImagesDir(), FILENAME_MEGAMEK_SPLASH2).toString()
+                    new MegaMekFile(Configuration.miscImagesDir(), FILENAME_MEGAMEK_SPLASH2).toString()
             );
             MediaTracker tracker = new MediaTracker(frame);
             tracker.addImage(image, 0);

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -713,7 +713,7 @@ public class CommonSettingsDialog extends ClientDialog implements
             }
         });
         tileSetChoice.removeAllItems();
-        for (int i = 0; i < tileSets.length; i++) {
+        for (int i = 0; (tileSets != null) && i < tileSets.length; i++) {
             String name = tileSets[i].getName();
             tileSetChoice.addItem(name.substring(0, name.length() - 8));
             if (name.equals(cs.getMapTileset())) {
@@ -728,7 +728,7 @@ public class CommonSettingsDialog extends ClientDialog implements
                 return name.endsWith(".tileset");
             }
         });
-        for (int i = 0; i < tileSets.length; i++) {
+        for (int i = 0; (tileSets != null) && i < tileSets.length; i++) {
             String name = tileSets[i].getName();
             tileSetChoice.addItem(name.substring(0, name.length() - 8));
             if (name.equals(cs.getMapTileset())) {
@@ -743,12 +743,15 @@ public class CommonSettingsDialog extends ClientDialog implements
                         return fileName.endsWith(".xml");
                     }
                 }));
-        xmlFiles.addAll(Arrays.asList(new File(Configuration.userdataDir(),
-                Configuration.skinsDir().toString()).list(new FilenameFilter() {
+        String[] files = new File(Configuration.userdataDir(), Configuration.skinsDir().toString())
+                .list(new FilenameFilter() {
                     public boolean accept(File directory, String fileName) {
                         return fileName.endsWith(".xml");
                     }
-                })));
+                });
+        if (files != null) {
+            xmlFiles.addAll(Arrays.asList(files));
+        }
         Collections.sort(xmlFiles);
         for (String file : xmlFiles) {
             if (SkinXMLHandler.validSkinSpecFile(file)) {

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -36,7 +36,9 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.swing.Box;
@@ -704,8 +706,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         entityOwnerColor.setSelected(gs.getEntityOwnerLabelColor());
 
 
-        File dir = new File("data" + File.separator + "images" + File.separator
-                + "hexes" + File.separator);
+        File dir = Configuration.hexesDir();
         tileSets = dir.listFiles(new FilenameFilter() {
             public boolean accept(File direc, String name) {
                 return name.endsWith(".tileset");
@@ -719,20 +720,39 @@ public class CommonSettingsDialog extends ClientDialog implements
                 tileSetChoice.setSelectedIndex(i);
             }
         }
+        
+        dir = new File(Configuration.userdataDir(),
+                Configuration.hexesDir().toString());
+        tileSets = dir.listFiles(new FilenameFilter() {
+            public boolean accept(File direc, String name) {
+                return name.endsWith(".tileset");
+            }
+        });
+        for (int i = 0; i < tileSets.length; i++) {
+            String name = tileSets[i].getName();
+            tileSetChoice.addItem(name.substring(0, name.length() - 8));
+            if (name.equals(cs.getMapTileset())) {
+                tileSetChoice.setSelectedIndex(i);
+            }
+        }
 
         skinFiles.removeAllItems();
-        String[] xmlFiles = 
-            Configuration.skinsDir().list(new FilenameFilter() {
-                public boolean accept(File directory, String fileName) {
-                    return fileName.endsWith(".xml");
-                } 
-            });
-        if (xmlFiles != null) {
-            Arrays.sort(xmlFiles);
-            for (String file : xmlFiles) {
-                if (SkinXMLHandler.validSkinSpecFile(file)) {
-                    skinFiles.addItem(file);
-                }
+        List<String> xmlFiles = Arrays
+                .asList(Configuration.skinsDir().list(new FilenameFilter() {
+                    public boolean accept(File directory, String fileName) {
+                        return fileName.endsWith(".xml");
+                    }
+                }));
+        xmlFiles.addAll(Arrays.asList(new File(Configuration.userdataDir(),
+                Configuration.skinsDir().toString()).list(new FilenameFilter() {
+                    public boolean accept(File directory, String fileName) {
+                        return fileName.endsWith(".xml");
+                    }
+                })));
+        Collections.sort(xmlFiles);
+        for (String file : xmlFiles) {
+            if (SkinXMLHandler.validSkinSpecFile(file)) {
+                skinFiles.addItem(file);
             }
         }
         // Select the default file first

--- a/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
@@ -31,7 +31,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;

--- a/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
@@ -83,6 +83,7 @@ import megamek.common.options.PilotOptions;
 import megamek.common.options.Quirks;
 import megamek.common.options.WeaponQuirks;
 import megamek.common.preference.PreferenceManager;
+import megamek.common.util.MegaMekFile;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestBattleArmor;
@@ -1353,8 +1354,8 @@ public class CustomMechDialog extends ClientDialog implements ActionListener,
 
         // Check validity of units after customization
         for (Entity entity : entities) {
-            EntityVerifier verifier = EntityVerifier.getInstance(new File(
-                    Configuration.unitsDir(), EntityVerifier.CONFIG_FILENAME));
+            EntityVerifier verifier = EntityVerifier.getInstance(new MegaMekFile(
+                    Configuration.unitsDir(), EntityVerifier.CONFIG_FILENAME).getFile());
             TestEntity testEntity = null;
             if (entity instanceof Mech) {
                 testEntity = new TestMech((Mech) entity, verifier.mechOption,

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -62,6 +62,7 @@ import megamek.common.TechConstants;
 import megamek.common.WeaponType;
 import megamek.common.options.IOptions;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestBattleArmor;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -235,8 +236,8 @@ public class EquipChoicePanel extends JPanel implements Serializable {
             //  pick legal combinations of manipulators
             BattleArmor ba = (BattleArmor) entity;
             EntityVerifier verifier = EntityVerifier.getInstance(
-                    new File(Configuration.unitsDir(),
-                            EntityVerifier.CONFIG_FILENAME));
+                    new MegaMekFile(Configuration.unitsDir(),
+                            EntityVerifier.CONFIG_FILENAME).getFile());
             TestBattleArmor testBA = new TestBattleArmor(ba, 
                     verifier.baOption, null);
             double maxTrooperWeight = 0;

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -18,7 +18,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/megamek/src/megamek/client/ui/swing/HexTileset.java
+++ b/megamek/src/megamek/client/ui/swing/HexTileset.java
@@ -44,6 +44,7 @@ import megamek.common.IHex;
 import megamek.common.ITerrain;
 import megamek.common.Terrains;
 import megamek.common.util.ImageUtil;
+import megamek.common.util.MegaMekFile;
 import megamek.common.util.StringUtil;
 
 /**
@@ -250,7 +251,7 @@ public class HexTileset {
     public void loadFromFile(String filename) throws IOException {
         // make input stream for board
         Reader r = new BufferedReader(new FileReader(
-                new File(Configuration.hexesDir(), filename)
+                new MegaMekFile(Configuration.hexesDir(), filename).getFile()
         ));
         // read board, looking for "size"
         StreamTokenizer st = new StreamTokenizer(r);
@@ -584,7 +585,7 @@ public class HexTileset {
             images = new Vector<Image>();
             for (int i = 0; i < filenames.size(); i++) {
                 String filename = filenames.elementAt(i);
-                File imgFile = new File(Configuration.hexesDir(), filename);
+                File imgFile = new MegaMekFile(Configuration.hexesDir(), filename).getFile();
                 Image image = ImageUtil.loadImageFromFile(imgFile.toString(), comp.getToolkit());
                 if(null != image) {
                     images.add(image);

--- a/megamek/src/megamek/client/ui/swing/MechTileset.java
+++ b/megamek/src/megamek/client/ui/swing/MechTileset.java
@@ -50,6 +50,7 @@ import megamek.common.TeleMissile;
 import megamek.common.TripodMech;
 import megamek.common.Warship;
 import megamek.common.util.ImageUtil;
+import megamek.common.util.MegaMekFile;
 
 /**
  * MechTileset is a misleading name, as this matches any unit, not just mechs
@@ -388,7 +389,7 @@ public class MechTileset {
 
     public void loadFromFile(String filename) throws IOException {
         // make inpustream for board
-        Reader r = new BufferedReader(new FileReader(new File(dir, filename)));
+        Reader r = new BufferedReader(new FileReader(new MegaMekFile(dir, filename).getFile()));
         // read board, looking for "size"
         StreamTokenizer st = new StreamTokenizer(r);
         st.eolIsSignificant(true);
@@ -505,7 +506,7 @@ public class MechTileset {
 
         public void loadImage(Component comp) {
             // System.out.println("loading mech image...");
-            File fin = new File(dir, imageFile);
+            File fin = new MegaMekFile(dir, imageFile).getFile();
             if (!fin.exists()) {
                 System.out.println("Warning: MechTileSet is trying to " +
                         "load a file that doesn't exist: "

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -75,6 +75,7 @@ import megamek.common.options.GameOptions;
 import megamek.common.options.IBasicOption;
 import megamek.common.options.IOption;
 import megamek.common.preference.PreferenceManager;
+import megamek.common.util.MegaMekFile;
 import megamek.server.ScenarioLoader;
 import megamek.server.Server;
 
@@ -137,16 +138,16 @@ public class MegaMekGUI implements IMegaMekGUI {
         frame.setForeground(SystemColor.menuText);
         List<Image> iconList = new ArrayList<Image>();
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_16X16)
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_16X16)
                         .toString()));
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_32X32)
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_32X32)
                         .toString()));
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_48X48)
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_48X48)
                         .toString()));
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_256X256)
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_256X256)
                         .toString()));
         frame.setIconImages(iconList);
         CommonMenuBar menuBar = new CommonMenuBar();
@@ -232,7 +233,7 @@ public class MegaMekGUI implements IMegaMekGUI {
         // initialize splash image
         Image imgSplash = frame.getToolkit()
                 .getImage(
-                        new File(Configuration.miscImagesDir(),
+                        new MegaMekFile(Configuration.miscImagesDir(),
                                 FILENAME_MEGAMEK_SPLASH).toString());
 
         // wait for splash image to load completely

--- a/megamek/src/megamek/client/ui/swing/MiniMap.java
+++ b/megamek/src/megamek/client/ui/swing/MiniMap.java
@@ -97,6 +97,7 @@ import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Displays all the mapsheets in a scaled-down size. TBD refactorings: -make a
@@ -438,9 +439,9 @@ public class MiniMap extends JPanel {
         int green;
         int blue;
 
-        File coloursFile = new File(
+        File coloursFile = new MegaMekFile(
                 Configuration.hexesDir(), GUIPreferences.getInstance().getMinimapColours()
-        );
+        ).getFile();
 
         // only while the defaults are hard-coded!
         if (!coloursFile.exists()) {

--- a/megamek/src/megamek/client/ui/swing/TilesetManager.java
+++ b/megamek/src/megamek/client/ui/swing/TilesetManager.java
@@ -64,6 +64,7 @@ import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.DirectoryItems;
 import megamek.common.util.ImageUtil;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Handles loading and manipulating images from both the mech tileset and the
@@ -100,7 +101,7 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
     // mech images
     private MechTileset mechTileset = new MechTileset(Configuration.unitImagesDir());
     private MechTileset wreckTileset = new MechTileset(
-            new File(Configuration.unitImagesDir(), DIR_NAME_WRECKS));
+            new MegaMekFile(Configuration.unitImagesDir(), DIR_NAME_WRECKS).getFile());
     private ArrayList<EntityImage> mechImageList = new ArrayList<EntityImage>();
     private HashMap<ArrayList<Integer>, EntityImage> mechImages = new HashMap<ArrayList<Integer>, EntityImage>();
 
@@ -148,7 +149,7 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
             System.out.println("Error loading tileset, "
                     + "reverting to default hexset! " + "Could not find file: "
                     + PreferenceManager.getClientPreferences().getMapTileset());
-            if (!new File(Configuration.hexesDir(), FILENAME_DEFAULT_HEX_SET).exists()){
+            if (!new MegaMekFile(Configuration.hexesDir(), FILENAME_DEFAULT_HEX_SET).getFile().exists()){
                 createDefaultHexSet();
             }
             hexTileset.loadFromFile(FILENAME_DEFAULT_HEX_SET);
@@ -403,23 +404,23 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
         }
 
         // load minefield sign
-        minefieldSign = boardview.getToolkit().getImage(new File(Configuration.hexesDir(), Minefield.FILENAME_IMAGE).toString());
+        minefieldSign = boardview.getToolkit().getImage(new MegaMekFile(Configuration.hexesDir(), Minefield.FILENAME_IMAGE).toString());
 
         // load night overlay
-        nightFog = boardview.getToolkit().getImage(new File(Configuration.hexesDir(), FILENAME_NIGHT_IMAGE).toString());
+        nightFog = boardview.getToolkit().getImage(new MegaMekFile(Configuration.hexesDir(), FILENAME_NIGHT_IMAGE).toString());
         
         // load the hexMask
-        hexMask = boardview.getToolkit().getImage(new File(Configuration.hexesDir(), FILENAME_HEX_MASK).toString());
+        hexMask = boardview.getToolkit().getImage(new MegaMekFile(Configuration.hexesDir(), FILENAME_HEX_MASK).toString());
 
         // load artillery targets
         artilleryAutohit = boardview.getToolkit().getImage(
-                new File(Configuration.hexesDir(), FILENAME_ARTILLERY_AUTOHIT_IMAGE).toString()
+                new MegaMekFile(Configuration.hexesDir(), FILENAME_ARTILLERY_AUTOHIT_IMAGE).toString()
         );
         artilleryAdjusted = boardview.getToolkit().getImage(
-                new File(Configuration.hexesDir(), FILENAME_ARTILLERY_ADJUSTED_IMAGE).toString()
+                new MegaMekFile(Configuration.hexesDir(), FILENAME_ARTILLERY_ADJUSTED_IMAGE).toString()
         );
         artilleryIncoming = boardview.getToolkit().getImage(
-                new File(Configuration.hexesDir(), FILENAME_ARTILLERY_INCOMING_IMAGE).toString()
+                new MegaMekFile(Configuration.hexesDir(), FILENAME_ARTILLERY_INCOMING_IMAGE).toString()
         );
 
         started = true;
@@ -794,7 +795,7 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
 
     public static void createDefaultHexSet(){
         try {
-            FileOutputStream fos = new FileOutputStream(new File(Configuration.hexesDir(), FILENAME_DEFAULT_HEX_SET));
+            FileOutputStream fos = new FileOutputStream(new MegaMekFile(Configuration.hexesDir(), FILENAME_DEFAULT_HEX_SET).getFile());
             PrintStream p = new PrintStream(fos);
 
             p.println("# suggested hex tileset");

--- a/megamek/src/megamek/client/ui/swing/UnitOverview.java
+++ b/megamek/src/megamek/client/ui/swing/UnitOverview.java
@@ -24,7 +24,6 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Vector;
 

--- a/megamek/src/megamek/client/ui/swing/UnitOverview.java
+++ b/megamek/src/megamek/client/ui/swing/UnitOverview.java
@@ -45,6 +45,7 @@ import megamek.common.Mech;
 import megamek.common.Protomech;
 import megamek.common.Tank;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 import megamek.common.util.StringUtil;
 
 public class UnitOverview implements IDisplayable {
@@ -86,13 +87,13 @@ public class UnitOverview implements IDisplayable {
         fm = clientgui.getFontMetrics(FONT);
 
         Toolkit toolkit = clientgui.getToolkit();
-        scrollUp = toolkit.getImage(new File(Configuration.widgetsDir(), "scrollUp.gif").toString()); //$NON-NLS-1$
+        scrollUp = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "scrollUp.gif").toString()); //$NON-NLS-1$
         PMUtil.setImage(scrollUp, clientgui);
-        scrollDown = toolkit.getImage(new File(Configuration.widgetsDir(), "scrollDown.gif").toString()); //$NON-NLS-1$
+        scrollDown = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "scrollDown.gif").toString()); //$NON-NLS-1$
         PMUtil.setImage(scrollDown, clientgui);
-        pageUp = toolkit.getImage(new File(Configuration.widgetsDir(), "pageUp.gif").toString()); //$NON-NLS-1$
+        pageUp = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "pageUp.gif").toString()); //$NON-NLS-1$
         PMUtil.setImage(pageUp, clientgui);
-        pageDown = toolkit.getImage(new File(Configuration.widgetsDir(), "pageDown.gif").toString()); //$NON-NLS-1$
+        pageDown = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "pageDown.gif").toString()); //$NON-NLS-1$
         PMUtil.setImage(pageDown, clientgui);
         
         visible = GUIPreferences.getInstance().getShowUnitOverview();

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -174,6 +174,7 @@ import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.ImageUtil;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Displays the board; lets the user scroll around and select points on it.
@@ -719,10 +720,10 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         fovHighlightingAndDarkening = new FovHighlightingAndDarkening(this);
 
         flareImage = getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_FLARE_IMAGE)
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_FLARE_IMAGE)
                         .toString());
         radarBlipImage = getToolkit().getImage(
-                new File(Configuration.miscImagesDir(),
+                new MegaMekFile(Configuration.miscImagesDir(),
                         FILENAME_RADAR_BLIP_IMAGE).toString());
     }
 
@@ -5874,8 +5875,8 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         try {
             File file;
             if (bvSkinSpec.backgrounds.size() > 0) {
-                file = new File(Configuration.widgetsDir(),
-                                bvSkinSpec.backgrounds.get(0));
+                file = new MegaMekFile(Configuration.widgetsDir(),
+                                bvSkinSpec.backgrounds.get(0)).getFile();
                 if (!file.exists()) {
                     System.err.println("BoardView1 Error: icon doesn't exist: "
                                        + file.getAbsolutePath());
@@ -5887,8 +5888,8 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 }
             }
             if (bvSkinSpec.backgrounds.size() > 1) {
-                file = new File(Configuration.widgetsDir(),
-                                bvSkinSpec.backgrounds.get(1));
+                file = new MegaMekFile(Configuration.widgetsDir(),
+                                bvSkinSpec.backgrounds.get(1)).getFile();
                 if (!file.exists()) {
                     System.err.println("BoardView1 Error: icon doesn't exist: "
                                        + file.getAbsolutePath());

--- a/megamek/src/megamek/client/ui/swing/skinEditor/SkinEditorMainGUI.java
+++ b/megamek/src/megamek/client/ui/swing/skinEditor/SkinEditorMainGUI.java
@@ -81,6 +81,7 @@ import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.util.Distractable;
+import megamek.common.util.MegaMekFile;
 
 public class SkinEditorMainGUI extends JPanel implements WindowListener,
         BoardViewListener, ActionListener, ComponentListener {
@@ -221,16 +222,16 @@ public class SkinEditorMainGUI extends JPanel implements WindowListener,
         frame.setForeground(SystemColor.menuText);
         List<Image> iconList = new ArrayList<Image>();
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_16X16)
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_16X16)
                         .toString()));
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_32X32)
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_32X32)
                         .toString()));
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_48X48)
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_48X48)
                         .toString()));
         iconList.add(frame.getToolkit().getImage(
-                new File(Configuration.miscImagesDir(), FILENAME_ICON_256X256)
+                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_256X256)
                         .toString()));
         frame.setIconImages(iconList);
 

--- a/megamek/src/megamek/client/ui/swing/skinEditor/SkinEditorMainGUI.java
+++ b/megamek/src/megamek/client/ui/swing/skinEditor/SkinEditorMainGUI.java
@@ -32,7 +32,6 @@ import java.awt.event.ComponentListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
-import java.io.File;
 import java.io.IOException;
 import java.util.*;
 

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
@@ -46,6 +46,7 @@ import megamek.common.Mounted;
 import megamek.common.Sensor;
 import megamek.common.Tank;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 import megamek.common.weapons.TSEMPWeapon;
 
 /**
@@ -290,7 +291,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
 
         Image tile = getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, this);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -298,28 +299,28 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -327,7 +328,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -335,7 +336,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -344,7 +345,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -352,7 +353,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
@@ -10,7 +10,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.io.File;
 import java.util.Enumeration;
 
 import javax.swing.DefaultListModel;

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
@@ -11,7 +11,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.io.File;
 import java.util.Enumeration;
 import java.util.Vector;
 

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
@@ -52,6 +52,7 @@ import megamek.common.Protomech;
 import megamek.common.Tank;
 import megamek.common.WeaponType;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 
 /**
  * This class shows the critical hits and systems for a mech
@@ -709,7 +710,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
 
         Image tile = getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, this);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -717,28 +718,28 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString()); //$NON-NLS-1$
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString()); //$NON-NLS-1$
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -746,7 +747,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -754,7 +755,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -763,7 +764,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -771,7 +772,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -11,7 +11,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -70,6 +70,7 @@ import megamek.common.WeaponComparatorNum;
 import megamek.common.WeaponComparatorRange;
 import megamek.common.WeaponType;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 import megamek.common.weapons.BayWeapon;
 import megamek.common.weapons.HAGWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -857,7 +858,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
 
         Image tile = getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, this);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -865,28 +866,28 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -895,7 +896,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopLeftCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -903,7 +904,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -912,7 +913,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -920,7 +921,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
+++ b/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
@@ -26,6 +26,7 @@ import megamek.common.BattleArmor;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Tank;
+import megamek.common.util.MegaMekFile;
 
 /**
  * 
@@ -95,7 +96,7 @@ public class FluffImageHelper {
         }
 
         File fluff_image_file = findFluffImage(
-                new File(Configuration.fluffImagesDir(), dir), unit);
+                new MegaMekFile(Configuration.fluffImagesDir(), dir).getFile(), unit);
         if (fluff_image_file != null) {
             fluff = new ImageIcon(fluff_image_file.toString()).getImage();
         }
@@ -128,10 +129,10 @@ public class FluffImageHelper {
         String sanitizedModel = unit.getModel().replace("\"", "")
                 .replace("/", "");
         String[] basenames = {
-                new File(directory, sanitizedChassis + " " + sanitizedModel)
+                new MegaMekFile(directory, sanitizedChassis + " " + sanitizedModel)
                         .toString(),
-                new File(directory, sanitizedModel).toString(),
-                new File(directory, sanitizedChassis).toString(), };
+                new MegaMekFile(directory, sanitizedModel).toString(),
+                new MegaMekFile(directory, sanitizedChassis).toString(), };
 
         for (String basename : basenames) {
             for (String extension : EXTENSIONS_FLUFF_IMAGE_FORMATS) {

--- a/megamek/src/megamek/client/ui/swing/widget/AeroMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/AeroMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -32,6 +31,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.FixedWingSupport;
 import megamek.common.SmallCraft;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent ASF unit in
@@ -227,7 +227,7 @@ public class AeroMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -235,28 +235,28 @@ public class AeroMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -264,7 +264,7 @@ public class AeroMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -272,7 +272,7 @@ public class AeroMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -281,7 +281,7 @@ public class AeroMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -289,7 +289,7 @@ public class AeroMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/ArmlessMechMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/ArmlessMechMapSet.java
@@ -21,7 +21,6 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -33,6 +32,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Mech;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Very cumbersome class that handles set of polygonal areas and labels for
@@ -368,13 +368,13 @@ public class ArmlessMechMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getMechOutline())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
                         .toString());
         PMUtil.setImage(tile, comp);
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_CENTER

--- a/megamek/src/megamek/client/ui/swing/widget/BattleArmorMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/BattleArmorMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Image;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -30,6 +29,7 @@ import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.BattleArmor;
 import megamek.common.Configuration;
 import megamek.common.Entity;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Battle Armor unit in
@@ -74,7 +74,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
         FontMetrics fm = comp.getFontMetrics(FONT_VALUE);
 
         battleArmorImage = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), "battle_armor.gif").toString()); //$NON-NLS-1$
+                new MegaMekFile(Configuration.widgetsDir(), "battle_armor.gif").toString()); //$NON-NLS-1$
         PMUtil.setImage(battleArmorImage, comp);
         for (int i = 0; i < BattleArmor.BA_MAX_MEN; i++) {
             int shiftY = i * stepY;
@@ -146,7 +146,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -154,28 +154,28 @@ public class BattleArmorMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -183,7 +183,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -191,7 +191,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -200,7 +200,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -208,7 +208,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/CapitalFighterMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/CapitalFighterMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Image;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -30,6 +29,7 @@ import megamek.common.Aero;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Capital Fighter unit
@@ -160,50 +160,50 @@ public class CapitalFighterMapSet implements DisplayMapSet {
         UnitDisplaySkinSpecification udSpec = SkinXMLHandler.getUnitDisplaySkin();
 
         Image tile = comp.getToolkit()
-                .getImage(new File(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
+                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit()
-                .getImage(new File(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
+                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
-                .getImage(new File(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
+                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
     }

--- a/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
@@ -19,7 +19,6 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
-import java.io.File;
 import java.util.Enumeration;
 import java.util.Vector;
 
@@ -42,6 +41,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Set of elements to reperesent general unit information in MechDisplay
@@ -548,52 +548,52 @@ public class GeneralInfoMapSet implements DisplayMapSet {
         UnitDisplaySkinSpecification udSpec = SkinXMLHandler
                 .getUnitDisplaySkin();
 
-        Image tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString()); //$NON-NLS-1$
+        Image tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString()); //$NON-NLS-1$
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopLine()).toString()); //$NON-NLS-1$
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString()); //$NON-NLS-1$
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 

--- a/megamek/src/megamek/client/ui/swing/widget/GunEmplacementMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/GunEmplacementMapSet.java
@@ -18,13 +18,13 @@ package megamek.client.ui.swing.widget;
 
 
 import java.awt.Image;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
 
 import megamek.common.Configuration;
 import megamek.common.Entity;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent GunEmplacement unit
@@ -78,7 +78,7 @@ public class GunEmplacementMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -86,28 +86,28 @@ public class GunEmplacementMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -115,7 +115,7 @@ public class GunEmplacementMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -123,7 +123,7 @@ public class GunEmplacementMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -132,7 +132,7 @@ public class GunEmplacementMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -140,7 +140,7 @@ public class GunEmplacementMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/InfantryMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/InfantryMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -30,6 +29,7 @@ import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Infantry;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Set of areas for PicMap to represent infantry platoon in MechDisplay
@@ -90,7 +90,7 @@ public class InfantryMapSet implements DisplayMapSet {
     private void setAreas() {
         int stepX = 30;
         int stepY = 42;
-        infImage = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), "inf.gif").toString()); //$NON-NLS-1$
+        infImage = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), "inf.gif").toString()); //$NON-NLS-1$
         PMUtil.setImage(infImage, comp);
         for (int i = 0; i < Infantry.INF_PLT_MAX_MEN; i++) {
             int shiftX = (i % 5) * stepX;
@@ -124,7 +124,7 @@ public class InfantryMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -132,28 +132,28 @@ public class InfantryMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -161,7 +161,7 @@ public class InfantryMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -169,7 +169,7 @@ public class InfantryMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -178,7 +178,7 @@ public class InfantryMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -186,7 +186,7 @@ public class InfantryMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/JumpshipMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/JumpshipMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -30,6 +29,7 @@ import megamek.client.ui.swing.unitDisplay.UnitDisplay;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Jumpship;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to 
@@ -215,7 +215,7 @@ public class JumpshipMapSet implements DisplayMapSet{
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -223,28 +223,28 @@ public class JumpshipMapSet implements DisplayMapSet{
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -252,7 +252,7 @@ public class JumpshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -260,7 +260,7 @@ public class JumpshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -269,7 +269,7 @@ public class JumpshipMapSet implements DisplayMapSet{
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -277,7 +277,7 @@ public class JumpshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/LargeSupportTankMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/LargeSupportTankMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -32,6 +31,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.LargeSupportTank;
 import megamek.common.SupportTank;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Tank unit in
@@ -271,7 +271,7 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -279,28 +279,28 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -308,7 +308,7 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -316,7 +316,7 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -325,7 +325,7 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -333,7 +333,7 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/MechMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MechMapSet.java
@@ -21,7 +21,6 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -33,6 +32,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Mech;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Very cumbersome class that handles set of polygonal areas and labels for
@@ -415,13 +415,13 @@ public class MechMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getMechOutline())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
                         .toString());
         PMUtil.setImage(tile, comp);
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_CENTER

--- a/megamek/src/megamek/client/ui/swing/widget/MechPanelTabStrip.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MechPanelTabStrip.java
@@ -13,10 +13,9 @@ import java.awt.Polygon;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.File;
-
 import megamek.client.ui.swing.unitDisplay.UnitDisplay;
 import megamek.common.Configuration;
+import megamek.common.util.MegaMekFile;
 
 public class MechPanelTabStrip extends PicMap {
 
@@ -60,20 +59,20 @@ public class MechPanelTabStrip extends PicMap {
                 .getUnitDisplaySkin();
         MediaTracker mt = new MediaTracker(this);
         Toolkit tk = getToolkit();
-        idleImage[0] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getGeneralTabIdle()).toString());
-        idleImage[1] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getPilotTabIdle()).toString());
-        idleImage[2] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getArmorTabIdle()).toString());
-        idleImage[3] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getSystemsTabIdle()).toString());
-        idleImage[4] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getWeaponsTabIdle()).toString());
-        idleImage[5] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getExtrasTabIdle()).toString());
-        activeImage[0] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getGeneralTabActive()).toString());
-        activeImage[1] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getPilotTabActive()).toString());
-        activeImage[2] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getArmorTabActive()).toString());
-        activeImage[3] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getSystemsTabActive()).toString());
-        activeImage[4] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getWeaponsTabActive()).toString());
-        activeImage[5] = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getExtraTabActive()).toString());
-        idleCorner = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getCornerIdle()).toString());
-        selectedCorner = tk.getImage(new File(Configuration.widgetsDir(), udSpec.getCornerActive()).toString());
+        idleImage[0] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getGeneralTabIdle()).toString());
+        idleImage[1] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getPilotTabIdle()).toString());
+        idleImage[2] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getArmorTabIdle()).toString());
+        idleImage[3] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getSystemsTabIdle()).toString());
+        idleImage[4] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getWeaponsTabIdle()).toString());
+        idleImage[5] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getExtrasTabIdle()).toString());
+        activeImage[0] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getGeneralTabActive()).toString());
+        activeImage[1] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getPilotTabActive()).toString());
+        activeImage[2] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getArmorTabActive()).toString());
+        activeImage[3] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getSystemsTabActive()).toString());
+        activeImage[4] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getWeaponsTabActive()).toString());
+        activeImage[5] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getExtraTabActive()).toString());
+        idleCorner = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getCornerIdle()).toString());
+        selectedCorner = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getCornerActive()).toString());
 
         // If we don't flush, we might have stale data
         idleCorner.flush();

--- a/megamek/src/megamek/client/ui/swing/widget/MegamekBorder.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MegamekBorder.java
@@ -27,6 +27,7 @@ import javax.swing.ImageIcon;
 import javax.swing.border.EtchedBorder;
 
 import megamek.common.Configuration;
+import megamek.common.util.MegaMekFile;
 
 /**
  * A Border that has an image for each corner as well as images for the line
@@ -98,7 +99,7 @@ public class MegamekBorder extends EtchedBorder {
         java.net.URI imgURL;
         File file;
 
-        file = new File(Configuration.widgetsDir(), path);
+        file = new MegaMekFile(Configuration.widgetsDir(), path).getFile();
         imgURL = file.toURI();
         icon = new ImageIcon(imgURL.toURL());
         if (!file.exists()){
@@ -145,8 +146,8 @@ public class MegamekBorder extends EtchedBorder {
             leftLine = new ArrayList<ImageIcon>();
             leftShouldTile = new ArrayList<Boolean>();
             for (int i = 0; i < skin.leftEdge.size(); i++){
-                file = new File(Configuration.widgetsDir(),
-                        skin.leftEdge.get(i));
+                file = new MegaMekFile(Configuration.widgetsDir(),
+                        skin.leftEdge.get(i)).getFile();
                 imgURL = file.toURI();
                 if (!file.exists()){
                     System.err.println(
@@ -167,8 +168,8 @@ public class MegamekBorder extends EtchedBorder {
             rightLine = new ArrayList<ImageIcon>();
             rightShouldTile = new ArrayList<Boolean>();
             for (int i = 0; i < skin.rightEdge.size(); i++){
-                file = new File(Configuration.widgetsDir(),
-                        skin.rightEdge.get(i));
+                file = new MegaMekFile(Configuration.widgetsDir(),
+                        skin.rightEdge.get(i)).getFile();
                 imgURL = file.toURI();
                 if (!file.exists()){
                     System.err.println(
@@ -189,8 +190,8 @@ public class MegamekBorder extends EtchedBorder {
             topLine = new ArrayList<ImageIcon>();
             topShouldTile = new ArrayList<Boolean>();
             for (int i = 0; i < skin.topEdge.size(); i++){
-                file = new File(Configuration.widgetsDir(),
-                        skin.topEdge.get(i));
+                file = new MegaMekFile(Configuration.widgetsDir(),
+                        skin.topEdge.get(i)).getFile();
                 imgURL = file.toURI();
                 if (!file.exists()){
                     System.err.println(
@@ -211,8 +212,8 @@ public class MegamekBorder extends EtchedBorder {
             bottomLine = new ArrayList<ImageIcon>();
             bottomShouldTile = new ArrayList<Boolean>();
             for (int i = 0; i < skin.bottomEdge.size(); i++){
-                file = new File(Configuration.widgetsDir(),
-                        skin.bottomEdge.get(i));
+                file = new MegaMekFile(Configuration.widgetsDir(),
+                        skin.bottomEdge.get(i)).getFile();
                 imgURL = file.toURI();
                 if (!file.exists()){
                     System.err.println(

--- a/megamek/src/megamek/client/ui/swing/widget/MegamekButton.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MegamekButton.java
@@ -20,14 +20,13 @@ import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
-import java.io.File;
-
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.SwingConstants;
 
 import megamek.common.Configuration;
+import megamek.common.util.MegaMekFile;
 
 /**
  * A subclass of JButton that supports specifying the look and feel of the
@@ -179,11 +178,11 @@ public class MegamekButton extends JButton {
                         + "2 background images!");
                 iconsLoaded = false;
             }
-            java.net.URI imgURL = new File(Configuration.widgetsDir(),
-                    spec.backgrounds.get(0)).toURI();
+            java.net.URI imgURL = new MegaMekFile(Configuration.widgetsDir(),
+                    spec.backgrounds.get(0)).getFile().toURI();
             backgroundIcon = new ImageIcon(imgURL.toURL());
-            imgURL = new File(Configuration.widgetsDir(),
-                    spec.backgrounds.get(1)).toURI();
+            imgURL = new MegaMekFile(Configuration.widgetsDir(),
+                    spec.backgrounds.get(1)).getFile().toURI();
             backgroundPressedIcon = new ImageIcon(imgURL.toURL());
         } catch (Exception e) {
             System.out.println("Error: loading background icons for "

--- a/megamek/src/megamek/client/ui/swing/widget/PilotMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/PilotMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.util.Enumeration;
 import java.util.Vector;
 
@@ -37,6 +36,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.DirectoryItems;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Set of elements to reperesent pilot information in MechDisplay
@@ -260,50 +260,50 @@ public class PilotMapSet implements DisplayMapSet {
         UnitDisplaySkinSpecification udSpec = SkinXMLHandler.getUnitDisplaySkin();
 
         Image tile = comp.getToolkit()
-                .getImage(new File(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
+                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit()
-                .getImage(new File(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
+                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
-                .getImage(new File(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
+                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
     }

--- a/megamek/src/megamek/client/ui/swing/widget/ProtomechMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/ProtomechMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -30,6 +29,7 @@ import megamek.client.ui.swing.unitDisplay.UnitDisplay;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Protomech;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Protomech unit in
@@ -172,7 +172,7 @@ public class ProtomechMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -180,28 +180,28 @@ public class ProtomechMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -209,7 +209,7 @@ public class ProtomechMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -217,7 +217,7 @@ public class ProtomechMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -226,7 +226,7 @@ public class ProtomechMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -234,7 +234,7 @@ public class ProtomechMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/QuadMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/QuadMapSet.java
@@ -21,7 +21,6 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -33,6 +32,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Mech;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Very cumbersome class that handles set of polygonal areas and labels for
@@ -370,13 +370,13 @@ public class QuadMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getMechOutline())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
                         .toString());
         PMUtil.setImage(tile, comp);
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_CENTER

--- a/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
@@ -33,6 +33,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.widget.SkinSpecification.UIComponents;
 import megamek.common.Configuration;
+import megamek.common.util.MegaMekFile;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -143,7 +144,7 @@ public class SkinXMLHandler {
      * @return
      */
     public static boolean validSkinSpecFile(String fileName) {
-        File file = new File(Configuration.skinsDir(), fileName);
+        File file = new MegaMekFile(Configuration.skinsDir(), fileName).getFile();
         if (!file.exists() || !file.isFile()) {
             return false;
         }
@@ -188,7 +189,7 @@ public class SkinXMLHandler {
             return false;
         }
         
-        File file = new File(Configuration.skinsDir(), fileName);
+        File file = new MegaMekFile(Configuration.skinsDir(), fileName).getFile();
         if (!file.exists() || !file.isFile()) {
             System.out.println("ERROR: Bad skin specification file: " +
                     "file doesn't exist!  File name: " + fileName);
@@ -522,8 +523,8 @@ public class SkinXMLHandler {
      * @param filename
      */
     public static void writeSkinToFile(String filename) {
-        File filePath = new File(Configuration.skinsDir(),
-                filename);
+        File filePath = new MegaMekFile(Configuration.skinsDir(),
+                filename).getFile();
 
         try (Writer output = new BufferedWriter(new OutputStreamWriter(
                 new FileOutputStream(filePath)));){

--- a/megamek/src/megamek/client/ui/swing/widget/SpheroidMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SpheroidMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -31,6 +30,7 @@ import megamek.common.Aero;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.SmallCraft;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to 
@@ -204,7 +204,7 @@ public class SpheroidMapSet implements DisplayMapSet{
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -212,28 +212,28 @@ public class SpheroidMapSet implements DisplayMapSet{
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -241,7 +241,7 @@ public class SpheroidMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -249,7 +249,7 @@ public class SpheroidMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -258,7 +258,7 @@ public class SpheroidMapSet implements DisplayMapSet{
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -266,7 +266,7 @@ public class SpheroidMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/SquadronMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SquadronMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Image;
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
@@ -33,6 +32,7 @@ import megamek.common.Entity;
 import megamek.common.FighterSquadron;
 import megamek.common.IGame;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Capital Fighter unit
@@ -237,50 +237,50 @@ public class SquadronMapSet implements DisplayMapSet {
         UnitDisplaySkinSpecification udSpec = SkinXMLHandler.getUnitDisplaySkin();
 
         Image tile = comp.getToolkit()
-                .getImage(new File(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
+                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit()
-                .getImage(new File(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
+                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new File(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
+        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
-                .getImage(new File(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
+                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
     }

--- a/megamek/src/megamek/client/ui/swing/widget/SuperHeavyTankMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SuperHeavyTankMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -31,6 +30,7 @@ import megamek.client.ui.swing.unitDisplay.UnitDisplay;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.SuperHeavyTank;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Tank unit in
@@ -266,7 +266,7 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -274,28 +274,28 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -303,7 +303,7 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -311,7 +311,7 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -320,7 +320,7 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -328,7 +328,7 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/TankMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/TankMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -32,6 +31,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.SupportTank;
 import megamek.common.Tank;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Tank unit in
@@ -242,7 +242,7 @@ public class TankMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -250,28 +250,28 @@ public class TankMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -279,7 +279,7 @@ public class TankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -287,7 +287,7 @@ public class TankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -296,7 +296,7 @@ public class TankMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -304,7 +304,7 @@ public class TankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/TripodMechMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/TripodMechMapSet.java
@@ -21,7 +21,6 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -33,6 +32,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Mech;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Very cumbersome class that handles set of polygonal areas and labels for
@@ -424,13 +424,13 @@ public class TripodMechMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getMechOutline())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
                         .toString());
         PMUtil.setImage(tile, comp);
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_CENTER

--- a/megamek/src/megamek/client/ui/swing/widget/VTOLMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/VTOLMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -32,6 +31,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.SupportVTOL;
 import megamek.common.VTOL;
+import megamek.common.util.MegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Tank unit in
@@ -333,7 +333,7 @@ public class VTOLMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -341,28 +341,28 @@ public class VTOLMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -370,7 +370,7 @@ public class VTOLMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -378,7 +378,7 @@ public class VTOLMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -387,7 +387,7 @@ public class VTOLMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -395,7 +395,7 @@ public class VTOLMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/WarshipMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/WarshipMapSet.java
@@ -20,7 +20,6 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.Polygon;
-import java.io.File;
 import java.util.Vector;
 
 import javax.swing.JComponent;
@@ -30,6 +29,7 @@ import megamek.client.ui.swing.unitDisplay.UnitDisplay;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Jumpship;
+import megamek.common.util.MegaMekFile;
 /**
  * Class which keeps set of all areas required to 
  * represent ASF unit in MechDsiplay.ArmorPanel class.
@@ -207,7 +207,7 @@ public class WarshipMapSet implements DisplayMapSet{
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -215,28 +215,28 @@ public class WarshipMapSet implements DisplayMapSet{
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getRightLine())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -244,7 +244,7 @@ public class WarshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -252,7 +252,7 @@ public class WarshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -261,7 +261,7 @@ public class WarshipMapSet implements DisplayMapSet{
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new File(Configuration.widgetsDir(), udSpec
+                        new MegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -269,7 +269,7 @@ public class WarshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new File(Configuration.widgetsDir(), udSpec
+                new MegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -43,6 +43,7 @@ import java.util.Vector;
 import megamek.common.Building.BasementType;
 import megamek.common.event.BoardEvent;
 import megamek.common.event.BoardListener;
+import megamek.common.util.MegaMekFile;
 
 public class Board implements Serializable, IBoard {
     private static final long serialVersionUID = -5744058872091016636L;
@@ -772,7 +773,7 @@ public class Board implements Serializable, IBoard {
     @Override
     @Deprecated
     public void load(final String filename) {
-        load(new File(Configuration.boardsDir(), filename));
+        load(new MegaMekFile(Configuration.boardsDir(), filename).getFile());
     }
 
     /**
@@ -870,8 +871,8 @@ public class Board implements Serializable, IBoard {
                 } else if ((st.ttype == StreamTokenizer.TT_WORD)
                         && st.sval.equalsIgnoreCase("background")) {
                     st.nextToken();
-                    File bgFile = new File(Configuration.boardBackgroundsDir(),
-                            st.sval);
+                    File bgFile = new MegaMekFile(Configuration.boardBackgroundsDir(),
+                            st.sval).getFile();
                     if (bgFile.exists()) {
                         backgroundPaths.add(bgFile.getPath());
                     } else {

--- a/megamek/src/megamek/common/Configuration.java
+++ b/megamek/src/megamek/common/Configuration.java
@@ -39,6 +39,9 @@ public final class Configuration {
     // **************************************************************************
     // Directories normally at the top of the game hierarchy.
 
+    /** The default directory for user data */
+    private static final String DEFAULT_USER_DATA_DIR = "userdata";
+    
     /** The default configuration directory. */
     private static final String DEFAULT_DIR_NAME_CONFIG = "mmconf";
 
@@ -112,6 +115,20 @@ public final class Configuration {
 
     // **************************************************************************
     // Static methods for accessing and modifying configuration data.
+
+    /**
+     * Return the configured userdata directory.
+     * 
+     * @return {@link File} containing the path to the userdata directory.
+     */
+    public static File userdataDir() {
+        lock.readLock().lock();
+        try {
+            return userdata_dir;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
 
     /**
      * Return the configured configuration file directory.
@@ -558,6 +575,9 @@ public final class Configuration {
      * This is a little paranoid, but at least I know it will work...
      */
     private static ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    /** The configured configuration directory. */
+    private static File userdata_dir = new File(DEFAULT_USER_DATA_DIR);
 
     /** The configured configuration directory. */
     private static File config_dir = new File(DEFAULT_DIR_NAME_CONFIG);

--- a/megamek/src/megamek/common/KeyBindParser.java
+++ b/megamek/src/megamek/common/KeyBindParser.java
@@ -28,6 +28,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.client.ui.swing.util.MegaMekController;
+import megamek.common.util.MegaMekFile;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -57,7 +58,7 @@ public class KeyBindParser {
     
     public static void parseKeyBindings(MegaMekController controller){
         // Get the path to the default bindings file.
-        File file = new File(Configuration.configDir(), DEFAULT_BINDINGS_FILE);
+        File file = new MegaMekFile(Configuration.configDir(), DEFAULT_BINDINGS_FILE).getFile();
         if (!file.exists() || !file.isFile()) {
             registerDefaultKeyBinds(controller);
             return;
@@ -162,8 +163,8 @@ public class KeyBindParser {
     public static void writeKeyBindings(){
         try {
             Writer output = new BufferedWriter(new OutputStreamWriter(
-                    new FileOutputStream(new File(Configuration.configDir(), 
-                            DEFAULT_BINDINGS_FILE))));
+                    new FileOutputStream(new MegaMekFile(Configuration.configDir(), 
+                            DEFAULT_BINDINGS_FILE).getFile())));
             output.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
             output.write("<KeyBindings " +
                     "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +

--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -56,6 +56,7 @@ import megamek.common.loaders.MepFile;
 import megamek.common.loaders.MtfFile;
 import megamek.common.loaders.TdbFile;
 import megamek.common.util.BuildingBlock;
+import megamek.common.util.MegaMekFile;
 import megamek.common.weapons.CLERPPC;
 import megamek.common.weapons.ISERPPC;
 import megamek.common.weapons.ISHeavyPPC;
@@ -870,8 +871,8 @@ public class MechFileParser {
             if (canonUnitNames == null) {
                 canonUnitNames = new Vector<String>();
                 // init the list.
-                try(BufferedReader br = new BufferedReader(new FileReader(new File(
-                            Configuration.docsDir(), FILENAME_OFFICIAL_UNITS)))) {
+                try(BufferedReader br = new BufferedReader(new FileReader(new MegaMekFile(
+                            Configuration.docsDir(), FILENAME_OFFICIAL_UNITS).getFile()))) {
                     String s;
                     String name;
                     while ((s = br.readLine()) != null) {

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -246,6 +246,11 @@ public class MechSummaryCache {
         boolean bNeedsUpdate = loadMechsFromDirectory(vMechs, sKnownFiles,
                 lLastCheck, Configuration.unitsDir(), ignoreUnofficial);
 
+        File userDataUnits = new File(Configuration.userdataDir(), Configuration.unitsDir().toString());
+        if (userDataUnits.isDirectory()) {
+            bNeedsUpdate |= loadMechsFromDirectory(vMechs, sKnownFiles, lLastCheck, userDataUnits, ignoreUnofficial);
+        }
+
         // convert to array
         m_data = new MechSummary[vMechs.size()];
         vMechs.copyInto(m_data);

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -38,6 +38,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import megamek.common.loaders.EntityLoadingException;
+import megamek.common.util.MegaMekFile;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestBattleArmor;
@@ -324,7 +325,7 @@ public class MechSummaryCache {
 
     private void saveCache() throws Exception {
         loadReport.append("Saving unit cache.\n");
-        File unit_cache_path = new File(getUnitCacheDir(), FILENAME_UNITS_CACHE);
+        File unit_cache_path = new MegaMekFile(getUnitCacheDir(), FILENAME_UNITS_CACHE).getFile();
         ObjectOutputStream wr = new ObjectOutputStream(
                 new BufferedOutputStream(new FileOutputStream(unit_cache_path)));
         Integer length = new Integer(m_data.length);
@@ -498,8 +499,8 @@ public class MechSummaryCache {
                     done();
                     return false;
                 }
-                File f = new File(fDir, element);
-                if (f.equals(new File(getUnitCacheDir(), FILENAME_UNITS_CACHE))) {
+                File f = new MegaMekFile(fDir, element).getFile();
+                if (f.equals(new MegaMekFile(getUnitCacheDir(), FILENAME_UNITS_CACHE).getFile())) {
                     continue;
                 }
                 if (f.isDirectory()) {

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -189,8 +189,8 @@ public class MechSummaryCache {
         Vector<MechSummary> vMechs = new Vector<MechSummary>();
         Set<String> sKnownFiles = new HashSet<String>();
         long lLastCheck = 0;
-        entityVerifier = EntityVerifier.getInstance(new File(getUnitCacheDir(),
-                EntityVerifier.CONFIG_FILENAME));
+        entityVerifier = EntityVerifier.getInstance(new MegaMekFile(getUnitCacheDir(),
+                EntityVerifier.CONFIG_FILENAME).getFile());
         hFailedFiles = new HashMap<String, String>();
 
         EquipmentType.initializeTypes(); // load master equipment lists
@@ -199,8 +199,8 @@ public class MechSummaryCache {
         loadReport.append("Reading unit files:\n");
 
         if (!ignoreUnofficial) {
-            File unit_cache_path = new File(getUnitCacheDir(),
-                    FILENAME_UNITS_CACHE);
+            File unit_cache_path = new MegaMekFile(getUnitCacheDir(),
+                    FILENAME_UNITS_CACHE).getFile();
             // check the cache
             try {
                 if (unit_cache_path.exists()

--- a/megamek/src/megamek/common/SpecialHexDisplay.java
+++ b/megamek/src/megamek/common/SpecialHexDisplay.java
@@ -16,7 +16,6 @@ package megamek.common;
 
 import java.awt.Image;
 import java.awt.Toolkit;
-import java.io.File;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -33,7 +32,7 @@ public class SpecialHexDisplay implements Serializable {
     private static final long serialVersionUID = 27470795993329492L;
 
     public enum Type {
-        ARTILLERY_AUTOHIT(new File(Configuration.hexesDir(), 
+        ARTILLERY_AUTOHIT(new MegaMekFile(Configuration.hexesDir(), 
                 "artyauto.gif").toString()) { //$NON-NLS-1$
             @Override
             public boolean drawBefore() {

--- a/megamek/src/megamek/common/SpecialHexDisplay.java
+++ b/megamek/src/megamek/common/SpecialHexDisplay.java
@@ -20,6 +20,8 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.Objects;
 
+import megamek.common.util.MegaMekFile;
+
 /**
  * @author dirk
  */
@@ -43,7 +45,7 @@ public class SpecialHexDisplay implements Serializable {
                 return true;
             }
         },
-        ARTILLERY_ADJUSTED(new File(Configuration.hexesDir(), 
+        ARTILLERY_ADJUSTED(new MegaMekFile(Configuration.hexesDir(), 
                 "artyadj.gif").toString()) { //$NON-NLS-1$
             @Override
             public boolean drawBefore() {
@@ -55,23 +57,23 @@ public class SpecialHexDisplay implements Serializable {
                 return true;
             }
         },
-        ARTILLERY_INCOMING(new File(Configuration.hexesDir(), 
+        ARTILLERY_INCOMING(new MegaMekFile(Configuration.hexesDir(), 
                 "artyinc.gif").toString()), //$NON-NLS-1$
-        ARTILLERY_TARGET(new File(Configuration.hexesDir(), 
+        ARTILLERY_TARGET(new MegaMekFile(Configuration.hexesDir(), 
                 "artytarget.gif").toString()) { //$NON-NLS-1$
             @Override
             public boolean drawBefore() {
                 return false;
             }
         },
-        ARTILLERY_HIT(new File(Configuration.hexesDir(), 
+        ARTILLERY_HIT(new MegaMekFile(Configuration.hexesDir(), 
                 "artyhit.gif").toString()) { //$NON-NLS-1$
             @Override
             public boolean drawBefore() {
                 return false;
             }
         },
-        PLAYER_NOTE(new File(Configuration.hexesDir(), 
+        PLAYER_NOTE(new MegaMekFile(Configuration.hexesDir(), 
                 "note.png").toString()) { //$NON-NLS-1$
             @Override
             public boolean drawBefore() {

--- a/megamek/src/megamek/common/WeaponOrderHandler.java
+++ b/megamek/src/megamek/common/WeaponOrderHandler.java
@@ -30,6 +30,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import megamek.common.Entity.WeaponSortOrder;
 import megamek.common.annotations.Nullable;
+import megamek.common.util.MegaMekFile;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -95,7 +97,7 @@ public class WeaponOrderHandler {
         }
         
         String path = CUSTOM_WEAPON_ORDER_FILENAME;
-        File file = new File(Configuration.configDir(), path);
+        File file = new MegaMekFile(Configuration.configDir(), path).getFile();
         if (file.exists() && !file.canWrite()) {
             System.err.println("WARN: Could not save custom weapon orders " +
                     "from " + path);
@@ -178,7 +180,7 @@ public class WeaponOrderHandler {
         Map<String, WeaponOrder> weapOrderMap = new HashMap<>();
 
         String path = CUSTOM_WEAPON_ORDER_FILENAME;
-        File file = new File(Configuration.configDir(), path);
+        File file = new MegaMekFile(Configuration.configDir(), path).getFile();
         if (!file.exists() || !file.isFile()) {
             System.err.println("WARN: Could not load custom weapon orders " +
                     "from " + path);

--- a/megamek/src/megamek/common/preference/PreferenceManager.java
+++ b/megamek/src/megamek/common/preference/PreferenceManager.java
@@ -39,6 +39,7 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 
 import megamek.common.Configuration;
+import megamek.common.util.MegaMekFile;
 
 public class PreferenceManager {
 
@@ -82,7 +83,7 @@ public class PreferenceManager {
         clientPreferenceStore = new PreferenceStore();
         String cfgName = System.getProperty(
                 CFG_FILE_OPTION_NAME,
-                new File(Configuration.configDir(), DEFAULT_CFG_FILE_NAME).toString()
+                new MegaMekFile(Configuration.configDir(), DEFAULT_CFG_FILE_NAME).toString()
         );
         load(cfgName);
         clientPreferences = new ClientPreferences(clientPreferenceStore);
@@ -122,7 +123,7 @@ public class PreferenceManager {
     }
 
     public void save() {
-        save(new File(Configuration.configDir(), DEFAULT_CFG_FILE_NAME));
+        save(new MegaMekFile(Configuration.configDir(), DEFAULT_CFG_FILE_NAME).getFile());
     }
     
     public void save(final File file) {

--- a/megamek/src/megamek/common/util/MegaMekFile.java
+++ b/megamek/src/megamek/common/util/MegaMekFile.java
@@ -1,0 +1,43 @@
+package megamek.common.util;
+
+import java.io.File;
+
+import megamek.common.Configuration;
+
+/**
+ * This is a local MegaMek version of java.io.File and is designed to support
+ * having files that could exist in two locations: the MM install location and
+ * a userdata directory.  When a file is opened, the path is first checked to
+ * see if it exists within the userdata directory, and if it does, that file is
+ * opened.  However, if it doesn't exist, then the file is opened from MM's
+ * install directory instead.
+ * 
+ * @author arlith
+ *
+ */
+public class MegaMekFile {
+    
+    File file;
+    
+    public MegaMekFile(File parent, String child) {
+        this(new File(parent, child).toString());
+    }
+    
+    public MegaMekFile(String pathname) {
+        File userdataVersion = new File(Configuration.userdataDir(), pathname);
+        if (userdataVersion.exists()) {
+            file = userdataVersion;
+        } else {
+            file = new File(pathname);
+        }
+    }
+    
+    public File getFile() {
+        return file;
+    }
+    
+    public String toString() {
+        return file.toString();
+    }
+    
+}

--- a/megamek/src/megamek/server/ScenarioLoader.java
+++ b/megamek/src/megamek/server/ScenarioLoader.java
@@ -72,6 +72,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.BoardUtilities;
 import megamek.common.util.DirectoryItems;
+import megamek.common.util.MegaMekFile;
 
 public class ScenarioLoader {
     private static final String COMMENT_MARK = "#"; //$NON-NLS-1$
@@ -404,7 +405,7 @@ public class ScenarioLoader {
         if (optionFile == null) {
             g.getOptions().loadOptions();
         } else {
-            g.getOptions().loadOptions(new File(scenarioFile.getParentFile(), optionFile), true);
+            g.getOptions().loadOptions(new MegaMekFile(scenarioFile.getParentFile(), optionFile).getFile(), true);
         }
 
         // set wind
@@ -873,12 +874,12 @@ public class ScenarioLoader {
                 } else {
                     sBoardFile = board + FILE_SUFFIX_BOARD;
                 }
-                File fBoard = new File(Configuration.boardsDir(), sBoardFile);
+                File fBoard = new MegaMekFile(Configuration.boardsDir(), sBoardFile).getFile();
                 if (!fBoard.exists()) {
                     throw new ScenarioLoaderException("nonexistantBoard", board); //$NON-NLS-1$
                 }
                 ba[n] = new Board();
-                ba[n].load(new File(Configuration.boardsDir(), sBoardFile));
+                ba[n].load(new MegaMekFile(Configuration.boardsDir(), sBoardFile).getFile());
                 if(cf > 0) {
                     ba[n].setBridgeCF(cf);
                 }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -27850,6 +27850,10 @@ public class Server implements Runnable {
         if (boards_dir.isDirectory()) {
             getBoardSizesInDir(boards_dir, board_sizes);
         }
+        boards_dir = new File(Configuration.userdataDir(), Configuration.boardsDir().toString());
+        if (boards_dir.isDirectory()) {
+            getBoardSizesInDir(boards_dir, board_sizes);
+        }
 
         return board_sizes;
     }
@@ -27875,6 +27879,11 @@ public class Server implements Runnable {
         ArrayList<String> tempList = new ArrayList<String>();
         Comparator<String> sortComp = StringUtil.stringComparator();
         scanForBoardsInDir(boardDir, "", dimensions, tempList);
+        // Check boards in userData dir
+        boardDir = new File(Configuration.userdataDir(), Configuration.boardsDir().toString());
+        if (boardDir.isDirectory()) {
+            scanForBoardsInDir(boardDir, "", dimensions, tempList);
+        }
         // if there are any boards, add these:
         if (tempList.size() > 0) {
             boards.add(MapSettings.BOARD_RANDOM);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -218,6 +218,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.BoardUtilities;
+import megamek.common.util.MegaMekFile;
 import megamek.common.util.StringUtil;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestAero;
@@ -3467,8 +3468,8 @@ public class Server implements Runnable {
                     || (mapSettings.getMedium() == MapSettings.MEDIUM_SPACE)) {
                 sheetBoards[i] = BoardUtilities.generateRandom(mapSettings);
             } else {
-                sheetBoards[i].load(new File(Configuration.boardsDir(), name
-                        + ".board"));
+                sheetBoards[i].load(new MegaMekFile(Configuration.boardsDir(), name
+                        + ".board").getFile());
                 BoardUtilities.flip(sheetBoards[i], isRotated, isRotated);
             }
             rotateBoard.add(isRotated);
@@ -27776,9 +27777,9 @@ public class Server implements Runnable {
 
         String fileList[] = boardDir.list();
         for (String filename : fileList) {
-            File filepath = new File(boardDir, filename);
+            File filepath = new MegaMekFile(boardDir, filename).getFile();
             if (filepath.isDirectory()) {
-                scanForBoardsInDir(new File(boardDir, filename), basePath
+                scanForBoardsInDir(new MegaMekFile(boardDir, filename).getFile(), basePath
                         .concat(File.separator).concat(filename), dimensions,
                         boards);
             } else {
@@ -28546,9 +28547,9 @@ public class Server implements Runnable {
 
             // Verify the entity's design
             if (Server.entityVerifier == null) {
-                Server.entityVerifier = EntityVerifier.getInstance(new File(
+                Server.entityVerifier = EntityVerifier.getInstance(new MegaMekFile(
                         Configuration.unitsDir(),
-                        EntityVerifier.CONFIG_FILENAME));
+                        EntityVerifier.CONFIG_FILENAME).getFile());
             }
 
             // Create a TestEntity instance for supported unit types


### PR DESCRIPTION
The purpose of this PR is to add the ability for users to specify their configuration data for MM that is redundant with the configuration data for the MM release.

This is implemented by creating a new `MegaMekFile` class that wraps a `java.io.File`.  It has similar constructors, which it uses to create an internal `File` instance, however the way it works is when a path is specified, it checks to see if that path exists in the `Configuration.userData()` directory first, and if it does, points the `File` to that directory instead.  What this allows is for users to have files in a user data directory that can override files within MegaMek.

This means that users could have something like `userdata/mmconf/clientsettings.xml`, or `userdata/data/mechfiles/customunits` and this whole userdata directory could be copied forward with a new MegaMek release, making the process of migrating to new versions much easier.

A large portion of this PR is replacing `new File` instances with `new MegaMekFile(...).getFile()`.

I have ensured that this works for mechfiles, boards, tilesets, and skins.  I've done a bit of testing, but nothing thorough yet.