### PR TITLE
Errata: Terrain

### DIFF
--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -2724,7 +2724,7 @@ public class MoveStep implements Serializable {
 
         // Infantry (except mechanized) pay 1 less MP to enter woods and Jungle
         if (isInfantry && !isMechanizedInfantry
-                && (destHex.containsTerrain(Terrains.WOODS) || destHex.containsTerrain(Terrains.JUNGLE))
+                && destHex.containsTerrain(Terrains.WOODS)
                 && !isPavementStep) {
             mp--;
         }

--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -313,8 +313,7 @@ public class Terrain implements ITerrain, Serializable {
             }
             break;
         case Terrains.MUD:
-            if ((moveMode != EntityMovementMode.BIPED) && (moveMode != EntityMovementMode.QUAD)
-                    && (moveMode != EntityMovementMode.HOVER) && (moveMode != EntityMovementMode.WIGE)) {
+            if ((moveMode != EntityMovementMode.HOVER) && (moveMode != EntityMovementMode.WIGE)) {
                 roll.addModifier(1, "Mud");
             }
             break;
@@ -416,8 +415,7 @@ public class Terrain implements ITerrain, Serializable {
             }
             return 0;
         case Terrains.MUD:
-            if ((moveMode == EntityMovementMode.BIPED) || (moveMode == EntityMovementMode.QUAD)
-                    || (moveMode == EntityMovementMode.HOVER) || (moveMode == EntityMovementMode.WIGE)) {
+            if ((moveMode == EntityMovementMode.HOVER) || (moveMode == EntityMovementMode.WIGE)) {
                 return 0;
             }
             return 1;
@@ -517,9 +515,6 @@ public class Terrain implements ITerrain, Serializable {
             }
             return TargetRoll.AUTOMATIC_SUCCESS;
         case (Terrains.MUD):
-            if ((moveMode == EntityMovementMode.BIPED) || (moveMode == EntityMovementMode.QUAD)) {
-                return TargetRoll.AUTOMATIC_SUCCESS;
-            }
             return -1;
         case (Terrains.TUNDRA):
             return -1;


### PR DESCRIPTION
Fixed two items.

First, an incorrect assumption I made last year about infantry and jungle movement. The example that showed infantry paid one less MP to move through Jungle was incorrect. The example was corrected in the 2016 errata release.

Second, Mud was changed so Mechs no longer ignore the affects of mud.