### PR TITLE
Fix for HQ bug #2 Space Stations show in the hangar as unit type Jumpship

### DIFF
--- a/megamek/src/megamek/common/UnitType.java
+++ b/megamek/src/megamek/common/UnitType.java
@@ -68,6 +68,8 @@ public class UnitType {
             return PROTOMEK;
         } else if (e instanceof Warship) {
             return WARSHIP;
+        } else if (e instanceof SpaceStation) {
+            return SPACE_STATION;
         } else if (e instanceof Jumpship) {
             return JUMPSHIP;
         } else if (e instanceof Dropship) {


### PR DESCRIPTION
determineUnitTypeCode() missing Space Station entity.
This was causing MekHQ from properly displaying the correct entity type in the Hangar tab.