### PR TITLE
Fixes #513 Infantry killed by Inferno ammo not giving kill credit

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -10291,6 +10291,7 @@ public class Server implements Runnable {
                         vPhaseReport.add(r);
                     } else {
                         vPhaseReport.addAll(destroyEntity(te, "damage", false));
+                        creditKill(te, ae);
                         Report.addNewline(vPhaseReport);
                     }
                 } else {


### PR DESCRIPTION
Took longer than expected to find, but I believe it is now fixed. 