### PR TITLE
Show % BV remaining in round reports

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -847,7 +847,7 @@
 7005=Winner is: the Chicago Cubs!!!<newline>
 7010=Winner is: <data><newline>
 7015=Winner is: TEAM #<data><newline>
-7016=<data>: <data> BV remaining (from <data> initially) <data> BV fled
+7016=<data>: <data> BV remaining (from <data> initially) (<data>%) <data> BV fled
 7020=<newline>Survivors are:
 7025=<data> (<data>)
 7030=Pilot :

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1873,6 +1873,7 @@ public class Server implements Runnable {
             r.add(Server.getColorForPlayer(player));
             r.add(player.getBV());
             r.add(player.getInitialBV());
+            r.add(Double.toString(Math.round((double) player.getBV() / player.getInitialBV() * 10000) / 100));
             r.add(player.getFledBV());
             addReport(r);
         }
@@ -2546,6 +2547,7 @@ public class Server implements Runnable {
                     r.add(Server.getColorForPlayer(player));
                     r.add(player.getBV());
                     r.add(player.getInitialBV());
+                    r.add(Double.toString(Math.round((double) player.getBV() / player.getInitialBV() * 10000) / 100));
                     r.add(player.getFledBV());
                     addReport(r);
                 }


### PR DESCRIPTION
Mostly for AtB play. Typing `/checkbv` every turn isn't exactly fun. 😉 