### PR TITLE
Added feature request for Issue 479

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -10,6 +10,7 @@ v0.43.4-git
 + Bug: gyro hits require PSR for tracked mechs and QuadVees in vee mode instead of the other way around.
 + Issue #542: Megamek can't exit attack phase using fighter squadrons 0.43.1
 + Enhancement #581: Implement Log4J
++ Feature #479: Added BV listing to unit tooltip.
 
 v0.43.3 (2017-07-18 18:30 UTC)
 + Added support for specifying # of marines, BA & other for large craft

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -289,7 +289,7 @@ BoardView1.Tooltip.Distance1=Distance from the selected unit: 1 Hex
 BoardView1.Tooltip.DistanceN=Distance from the selected unit: {0} Hexes
 BoardView1.Tooltip.DistanceMove1=<I>Distance from the movement end point: 1 Hex</I>
 BoardView1.Tooltip.DistanceMoveN=<I>Distance from the movement end point: {0} Hexes</I>
-BoardView1.Tooltip.BV=BV: {0}/{1} ({2}%)
+BoardView1.Tooltip.BV=BV: {0}/{1} ({2, number, percent})
 
 
 BoardView1.Tooltip.Hex=Hex: {0} - Level: {1}

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -289,6 +289,7 @@ BoardView1.Tooltip.Distance1=Distance from the selected unit: 1 Hex
 BoardView1.Tooltip.DistanceN=Distance from the selected unit: {0} Hexes
 BoardView1.Tooltip.DistanceMove1=<I>Distance from the movement end point: 1 Hex</I>
 BoardView1.Tooltip.DistanceMoveN=<I>Distance from the movement end point: {0} Hexes</I>
+BoardView1.Tooltip.BV=BV: {0}/{1} ({2}%)
 
 
 BoardView1.Tooltip.Hex=Hex: {0} - Level: {1}

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -780,12 +780,19 @@ class EntitySprite extends Sprite {
         addToTT("ArmorInternals", BR, entity.getTotalArmor(),
                 entity.getTotalInternal());
 
-        // BV info
-        int currentBV = entity.calculateBattleValue(false, false);
-        int initialBV = currentBV;
-        double percentage = ((double)currentBV / initialBV) * 100;
+        // BV Info
+        // Only show this if we aren't in double blind and hide enemy bv isn't selected.
+        // Should always see this on your own Entities.
+        boolean suppressEnemyBV = bv.game.getOptions().booleanOption(OptionsConstants.ADVANCED_SUPPRESS_DB_BV) &&
+                bv.game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND);
 
-        addToTT("BV", BR, currentBV, initialBV, percentage);
+        if (!(suppressEnemyBV && !trackThisEntitiesVisibilityInfo(entity))) {
+            int currentBV = entity.calculateBattleValue(false, false);
+            int initialBV = entity.getInitialBV();
+            double percentage = (double) currentBV / initialBV;
+
+            addToTT("BV", BR, currentBV, initialBV, percentage);
+        }
 
         // Heat, not shown for units with 999 heat sinks (vehicles)
         if (entity.getHeatCapacity() != 999) {

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -780,6 +780,13 @@ class EntitySprite extends Sprite {
         addToTT("ArmorInternals", BR, entity.getTotalArmor(),
                 entity.getTotalInternal());
 
+        // BV info
+        int currentBV = entity.calculateBattleValue(false, false);
+        int initialBV = currentBV;
+        double percentage = ((double)currentBV / initialBV) * 100;
+
+        addToTT("BV", BR, currentBV, initialBV, percentage);
+
         // Heat, not shown for units with 999 heat sinks (vehicles)
         if (entity.getHeatCapacity() != 999) {
             if (entity.heat == 0) 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -217,6 +217,9 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     protected boolean useManualBV = false;
     protected int manualBV = -1;
 
+    protected int initialBV = -1;
+    protected boolean initialBVSet = false;
+
     protected String displayName = null;
     protected String shortName = null;
     public int duplicateMarker = 1;
@@ -12300,6 +12303,18 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     public void setManualBV(int bv) {
         manualBV = bv;
     }
+
+    public int getInitialBV() {
+        return initialBV;
+    }
+
+    public void setInitialBV(int bv) {
+        if (!initialBVSet) {
+            initialBV = bv;
+            initialBVSet = true;
+        }
+    }
+
 
     /**
      * produce an int array of the number of bombs of each type based on the

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -218,7 +218,6 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     protected int manualBV = -1;
 
     protected int initialBV = -1;
-    protected boolean initialBVSet = false;
 
     protected String displayName = null;
     protected String shortName = null;
@@ -12309,9 +12308,8 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     }
 
     public void setInitialBV(int bv) {
-        if (!initialBVSet) {
+        if (initialBV < 0) {
             initialBV = bv;
-            initialBVSet = true;
         }
     }
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -12303,10 +12303,22 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         manualBV = bv;
     }
 
+    /**
+     * Gets the initial BV of a unit.
+     *
+     * Useful for comparisons with the current BV.
+     * @return The initial BV of a unit.
+     */
     public int getInitialBV() {
         return initialBV;
     }
 
+    /**
+     * Sets the initial BV for a unit.
+     *
+     * Called when the game is initialized.
+     * @param bv The initial BV of a unit.
+     */
     public void setInitialBV(int bv) {
         if (initialBV < 0) {
             initialBV = bv;

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -1338,6 +1338,8 @@ public class Game implements Serializable, IGame {
             ((Mech) entity).setCondEjectHeadshot(true);
         }
 
+        entity.setInitialBV(entity.calculateBattleValue(false, false));
+
         assert (entities.size() == entityIds.size()) : "Add Entity failed";
         if (genEvent) {
             processGameEvent(new GameEntityNewEvent(this, entity));


### PR DESCRIPTION
Adds a feature requested in issue #479. This allows a user to quickly see the current battle value of a unit in game, without having to view the unit. The listing shows the current bv, the initial bv, and the percentage of bv remaining. If playing with double blind and the "Hide Battle Value report" option is selected, the bv listings will not be visible on enemy units, but will be visible on your units.