### PR TITLE
The recent change to the MMLogger interface breaks FakeLogger.  This …

### DIFF
--- a/megamek/unittests/megamek/common/logging/FakeLogger.java
+++ b/megamek/unittests/megamek/common/logging/FakeLogger.java
@@ -21,17 +21,17 @@ public class FakeLogger implements MMLogger {
     }
 
     @Override
-    public <T extends Throwable> T log(Class callingClass, String methodName, T throwable) {
+    public <T extends Throwable> T log(Class<?> callingClass, String methodName, T throwable) {
         return null;
     }
 
     @Override
-    public <T extends Throwable> T log(Class callingClass, String methodName, LogLevel logLevel, T throwable) {
+    public <T extends Throwable> T log(Class<?> callingClass, String methodName, LogLevel logLevel, T throwable) {
         return null;
     }
 
     @Override
-    public <T extends Throwable> T log(Class callingClass, String methodName, LogLevel level, String message, T throwable) {
+    public <T extends Throwable> T log(Class<?> callingClass, String methodName, LogLevel level, String message, T throwable) {
         return null;
     }
 


### PR DESCRIPTION
…fix brings FakeLogger back into compliance with the interface.