### PR TITLE
Fix/#426 loading bombs

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
@@ -44,16 +44,30 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
     private int maxPoints = 0;
     private int maxSize = 0;
     private int maxRows = (int) Math.ceil(BombType.B_NUM / 2.0);
+    
+    //Variable for MekHQ functionality
+    private int[] typeMax;
 
     //private BombChoicePanel m_bombs;
     //private JPanel panBombs = new JPanel();
 
-    @SuppressWarnings("unchecked")
     public BombChoicePanel(IBomber bomber, boolean at2Nukes, boolean allowAdvancedAmmo) {
         this.bomber = bomber;
         this.at2Nukes = at2Nukes;
         this.allowAdvancedAmmo = allowAdvancedAmmo;
-
+        initPanel();
+    }
+    //Constructor to call from MekHQ to pass in typeMax
+    public BombChoicePanel(IBomber bomber, boolean at2Nukes, boolean allowAdvancedAmmo, int[] typeMax) {
+        this.bomber = bomber;
+        this.at2Nukes = at2Nukes;
+        this.allowAdvancedAmmo = allowAdvancedAmmo;
+        this.typeMax = typeMax;
+        initPanel();
+    }
+    
+    @SuppressWarnings("unchecked")
+    private void initPanel() {
         maxPoints = bomber.getMaxBombPoints();
         maxSize = bomber.getMaxBombSize();
         int[] bombChoices = bomber.getBombChoices();
@@ -82,6 +96,11 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
             if (BombType.getBombCost(type) > maxSize) {
                 maxNumBombs = 0;
             }
+            
+            if(typeMax != null) {
+                if (maxNumBombs > 0 && maxNumBombs > typeMax[type]) maxNumBombs = typeMax[type];
+            }
+            
             for (int x = 0; x <= maxNumBombs; x++) {
                 b_choices[type].addItem(Integer.toString(x));
             }
@@ -90,12 +109,10 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
             b_labels[type].setText(BombType.getBombName(type));
             b_choices[type].addItemListener(this);
 
-            if ((type == BombType.B_ALAMO)
-                && !at2Nukes) {
+            if ((type == BombType.B_ALAMO) && !at2Nukes) {
                 b_choices[type].setEnabled(false);
             }
-            if ((type > BombType.B_TAG)
-                && !allowAdvancedAmmo) {
+            if ((type > BombType.B_TAG) && !allowAdvancedAmmo) {
                 b_choices[type].setEnabled(false);
             }
             if ((type == BombType.B_ASEW) || (type == BombType.B_ALAMO)) {
@@ -140,6 +157,9 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
             int maxNumBombs = Math.round(availBombPoints
                     / BombType.getBombCost(type))
                     + current[type];
+            if(typeMax != null) {
+                if (maxNumBombs > 0 && maxNumBombs > typeMax[type]) maxNumBombs = typeMax[type];
+            }
             for (int x = 0; x <= maxNumBombs; x++) {
                 b_choices[type].addItem(Integer.toString(x));
             }
@@ -155,17 +175,21 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
         }
 
         bomber.setBombChoices(choices);
-
+    }
+    public int[] getChoice() {
+        int[] choices = new int[BombType.B_NUM];
+        for (int type = 0; type < BombType.B_NUM; type++) {
+            choices[type] = b_choices[type].getSelectedIndex();
+        }
+        return choices;
     }
 
     @Override
     public void setEnabled(boolean enabled) {
         for (int type = 0; type < BombType.B_NUM; type++) {
-            if ((type == BombType.B_ALAMO)
-                && !at2Nukes) {
+            if ((type == BombType.B_ALAMO) && !at2Nukes) {
                 b_choices[type].setEnabled(false);
-            } else if ((type > BombType.B_TAG)
-                       && !allowAdvancedAmmo) {
+            } else if ((type > BombType.B_TAG) && !allowAdvancedAmmo) {
                 b_choices[type].setEnabled(false);
             } else if ((type == BombType.B_ASEW)
                        || (type == BombType.B_ALAMO)

--- a/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
@@ -46,7 +46,7 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
     private int maxRows = (int) Math.ceil(BombType.B_NUM / 2.0);
     
     //Variable for MekHQ functionality
-    private int[] typeMax;
+    private int[] typeMax = null;
 
     //private BombChoicePanel m_bombs;
     //private JPanel panBombs = new JPanel();
@@ -187,9 +187,11 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
     @Override
     public void setEnabled(boolean enabled) {
         for (int type = 0; type < BombType.B_NUM; type++) {
-            if ((type == BombType.B_ALAMO) && !at2Nukes) {
+            if ((type == BombType.B_ALAMO) 
+                    && !at2Nukes) {
                 b_choices[type].setEnabled(false);
-            } else if ((type > BombType.B_TAG) && !allowAdvancedAmmo) {
+            } else if ((type > BombType.B_TAG) 
+                    && !allowAdvancedAmmo) {
                 b_choices[type].setEnabled(false);
             } else if ((type == BombType.B_ASEW)
                        || (type == BombType.B_ALAMO)

--- a/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
@@ -187,11 +187,11 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
     @Override
     public void setEnabled(boolean enabled) {
         for (int type = 0; type < BombType.B_NUM; type++) {
-            if ((type == BombType.B_ALAMO) 
-                    && !at2Nukes) {
+            if ((type == BombType.B_ALAMO)
+                && !at2Nukes) {
                 b_choices[type].setEnabled(false);
-            } else if ((type > BombType.B_TAG) 
-                    && !allowAdvancedAmmo) {
+            } else if ((type > BombType.B_TAG)
+                       && !allowAdvancedAmmo) {
                 b_choices[type].setEnabled(false);
             } else if ((type == BombType.B_ASEW)
                        || (type == BombType.B_ALAMO)

--- a/megamek/src/megamek/common/IBomber.java
+++ b/megamek/src/megamek/common/IBomber.java
@@ -91,6 +91,8 @@ public interface IBomber {
         IGame game = ((Entity)this).getGame();
         int gameTL = TechConstants.getSimpleLevel(game.getOptions()
                 .stringOption("techlevel"));
+        //Exit method if bombs have already been loaded
+        if(getBombPoints() > 0) return;
         Integer[] sorted = new Integer[BombType.B_NUM];
         // Apply the largest bombs first because we need to fit larger bombs into a single location
         // in LAMs.

--- a/megamek/src/megamek/common/IBomber.java
+++ b/megamek/src/megamek/common/IBomber.java
@@ -91,8 +91,6 @@ public interface IBomber {
         IGame game = ((Entity)this).getGame();
         int gameTL = TechConstants.getSimpleLevel(game.getOptions()
                 .stringOption("techlevel"));
-        //Exit method if bombs have already been loaded
-        if(getBombPoints() > 0) return;
         Integer[] sorted = new Integer[BombType.B_NUM];
         // Apply the largest bombs first because we need to fit larger bombs into a single location
         // in LAMs.


### PR DESCRIPTION
Changed MM/BombChoicePanel and MekHQ/BombsDialog so loading and unloading bombs will change the spares in the warehouse.

There is a matching pull request in MekHQ, both work together. https://github.com/MegaMek/mekhq/pull/427