### PR TITLE
Update so non-direct kills count for kill victory

### DIFF
--- a/megamek/src/megamek/server/victory/KillCountVictory.java
+++ b/megamek/src/megamek/server/victory/KillCountVictory.java
@@ -17,6 +17,7 @@ import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.List;
 
 import megamek.common.Entity;
 import megamek.common.IGame;
@@ -101,9 +102,8 @@ public class KillCountVictory implements Victory, Serializable {
             Entity killer = game.getEntityFromAllSources(wreck.getKillerId());
             
             if (killer == null){
-                if (game.getNoOfTeams() == 2) {
-                    for (Enumeration<Team> e = game.getTeams(); e.hasMoreElements();) {
-                        Team team = e.nextElement();
+                if (game.getNoOfTeams() == 2 && wreck.getOwner().getTeam() != Player.TEAM_NONE) {
+                    for (Team team : game.getTeamsVector()) {
                         if (team.getId() != wreck.getOwner().getTeam()) {
                             Integer kills = teamKills.get(team.getId());
                             if (kills == null){

--- a/megamek/src/megamek/server/victory/KillCountVictory.java
+++ b/megamek/src/megamek/server/victory/KillCountVictory.java
@@ -23,6 +23,7 @@ import megamek.common.IGame;
 import megamek.common.IPlayer;
 import megamek.common.Player;
 import megamek.common.Report;
+import megamek.common.Team;
 
 /**
  * Implements a kill count victory condition.  Victory is achieved if a team (or
@@ -100,6 +101,20 @@ public class KillCountVictory implements Victory, Serializable {
             Entity killer = game.getEntityFromAllSources(wreck.getKillerId());
             
             if (killer == null){
+                if (game.getNoOfTeams() == 2) {
+                    for (Enumeration<Team> e = game.getTeams(); e.hasMoreElements();) {
+                        Team team = e.nextElement();
+                        if (team.getId() != wreck.getOwner().getTeam()) {
+                            Integer kills = teamKills.get(team.getId());
+                            if (kills == null){
+                                kills = 1;
+                            } else {
+                                kills++;
+                            }
+                            teamKills.put(team.getId(), kills);
+                        }
+                    }
+                }
                 continue;
             }            
             


### PR DESCRIPTION
Fixing https://github.com/MegaMek/megamek/issues/417

Before it would not count the kill if the unit did not have a 'killer' assigned. I changed it to award credit towards the kill count victory to the opposite team. Since this wouldn't work very well for more than 2 teams in that event the credit is skipped.