### PR TITLE
Disable direct draw for Windows draw issue

### DIFF
--- a/megamek/packaging_utils/megamek.l4j.ini
+++ b/megamek/packaging_utils/megamek.l4j.ini
@@ -1,3 +1,4 @@
 # Launch4j runtime config
 #you can add arguments here that will be processed by the JVM at runtime
 -Xmx1024m
+-Dsun.java2d.d3d=false


### PR DESCRIPTION
A problem with Java 8. Perhaps future Java versions will fix this and
the command line option can be removed.

Closes MegaMek/megamek#647

*See issue for more details.*