### PR TITLE
Errata: Mechs should not become stuck in mud

### DIFF
--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -544,6 +544,9 @@ public class Terrain implements ITerrain, Serializable {
             }
             return TargetRoll.AUTOMATIC_SUCCESS;
         case (Terrains.MUD):
+            if ((moveMode == EntityMovementMode.BIPED) || (moveMode == EntityMovementMode.QUAD)) {
+                return TargetRoll.AUTOMATIC_SUCCESS;
+            }
             return -1;
         case (Terrains.TUNDRA):
             return -1;


### PR DESCRIPTION
When I fixed the cost for mechs moving in mud I didn't even notice this as I don't often fight in mud. Now all of the mud changes should be up to date.