### PR TITLE
Fix for soft lock when firing missiles at buildings

### DIFF
--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -901,7 +901,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         CounterAV = getCounterAV();
         
         //This is for firing ATM/LRM/MML/MRM/SRMs at a dropship
-        if (entityTarget.usesWeaponBays()) {
+        if (entityTarget != null && entityTarget.usesWeaponBays()) {
             nDamPerHit = attackValue;
         } else {
             //This is for all other targets in atmosphere
@@ -929,9 +929,10 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         int nCluster = calcnCluster();
         int id = vPhaseReport.size();
         int hits;
-        if (target.isAirborne() 
-                || game.getBoard().inSpace() 
-                || (entityTarget.usesWeaponBays() && !game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_IND_WEAPONS_GROUNDED_DROPPER))) {
+        if (target.isAirborne() || 
+            game.getBoard().inSpace() || 
+            (entityTarget != null && entityTarget.usesWeaponBays() &&
+                    !game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_IND_WEAPONS_GROUNDED_DROPPER))) {
             // Ensures AMS state is properly updated
             getAMSHitsMod(new Vector<Report>());
             int[] aeroResults = calcAeroDamage(entityTarget, vPhaseReport);


### PR DESCRIPTION
Nothing complicated here, just a couple of null checks. Fixes the behavior where, if you fire missiles of any kind at a building, the game locks up while resolving weapons fire. Buildings aren't entities, so entityTarget was being calculated as null. I suspect the same issue would be happening if you were to shoot missiles at the dirt.