### PR TITLE
Fix for MHQ Bug#3.

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -6177,8 +6177,9 @@ public class Compute {
 
     // Taken from MekHQ, assumptions are whatever Taharqa made for there - Dylan
     public static int getTotalDriverNeeds(Entity entity) {
+        //Fix for MHQ Bug #3. Space stations have as much need for pilots as jumpships do.
         if (entity instanceof SpaceStation) {
-            return 0;
+            return 2;
         }
         if (entity instanceof SmallCraft || entity instanceof Jumpship) {
             //its not at all clear how many pilots dropships and jumpships 


### PR DESCRIPTION
Space stations really ought to have pilots, since they have station keeping drives. If they have neither pilots nor gunners, MHQ treats the station as having a missing crew and never creates an engineer from all the vessel crewmembers.