### PR TITLE
Quirk NPEs fix

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -1,4 +1,4 @@
-VERSION HISTORY:
+﻿VERSION HISTORY:
 ----------------
 v0.43.5-git
 + Tech Progression Fixes.
@@ -14,6 +14,7 @@ v0.43.5-git
 + PR #693: Show unit roles in summary view.
 + Bug: Infantry weights calculated wrong, due to double adding of AntiMek training. 
 	Fixing unit files to include standard Foot infantry and AntiMek Trained one.
++ PR #706: Fixed several quirk-related NPEs. Implemented display of partial repairs on unit info card.
 
 v0.43.4 (2017-10-01 11:00 UTC)
 + Issue #573: Jumping through buildings.

--- a/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
@@ -63,8 +63,7 @@ public class GeneralInfoMapSet implements DisplayMapSet {
     private PMSimpleLabel statusR, pilotR, playerR, teamR, weightR, bvR, mpR0,
             mpR1, mpR2, mpR3, mpR4, curMoveR, heatR, movementTypeR, ejectR,
             elevationR, fuelR, curSensorsR, visualRangeR;
-    private PMSimpleLabel[] quirksR;
-    private PMSimpleLabel[] partRepsR;
+    private PMMultiLineLabel quirksAndPartReps;
     private Vector<BackGroundDrawer> bgDrawers = new Vector<BackGroundDrawer>();
     private static final Font FONT_VALUE = new Font(
             "SansSerif", Font.PLAIN, GUIPreferences.getInstance().getInt("AdvancedMechDisplayLargeFontSize")); //$NON-NLS-1$
@@ -248,20 +247,11 @@ public class GeneralInfoMapSet implements DisplayMapSet {
                 visualRangeL.getSize().width + 10, getYCoord());
         content.addArea(visualRangeR);
 
-        quirksR = new PMSimpleLabel[40];
-        for (int i = 0; i < quirksR.length; i++) {
-            quirksR[i] = createLabel(new Integer(i).toString(), fm, 0,
-                    getNewYCoord());
-            content.addArea(quirksR[i]);
-        }
-
-        partRepsR = new PMSimpleLabel[20];
-        for (int i = 0; i < partRepsR.length; i++) {
-            partRepsR[i] = createLabel(new Integer(i).toString(), fm, 0,
-                    getNewYCoord());
-            content.addArea(partRepsR[i]);
-        }
-
+        getNewYCoord(); // skip a line for readability
+        
+        quirksAndPartReps = new PMMultiLineLabel(fm, Color.white);
+        quirksAndPartReps.moveTo(0, getNewYCoord());
+        content.addArea(quirksAndPartReps);
     }
 
     /**
@@ -349,25 +339,19 @@ public class GeneralInfoMapSet implements DisplayMapSet {
                     .getString("GeneralInfoMapSet.elevationL"));
         }
 
-        for (PMSimpleLabel element : quirksR) {
-            element.setString(""); //$NON-NLS-1$
-        }
-        for (PMSimpleLabel element : partRepsR) {
-            element.setString(""); //$NON-NLS-1$
-        }
+        quirksAndPartReps.clear();
 
         if ((null != en.getGame())
                 && en.getGame().getOptions().booleanOption(OptionsConstants.ADVANCED_STRATOPS_QUIRKS)) {
-            addOptionsToList(en.getQuirks(), quirksR);
+            addOptionsToList(en.getQuirks(), quirksAndPartReps);
         }
         
-        // Note that, due to the fact that the quirks display is hardcoded to 40 labels in height,
-        // unless you're running at 1024x12000 resolution, you're never going to see partial repairs on the unit info card.
-        // That fix will require changing the data types of partRepsR and quirksR to a dynamically allocated list,
-        // which is not a very simple change, so I'm leaving it for another time.
         if ((null != en.getGame())
                 && en.getGame().getOptions().booleanOption(OptionsConstants.ADVANCED_STRATOPS_PARTIALREPAIRS)) {
-            addOptionsToList(en.getPartialRepairs(), partRepsR);
+            // skip a line for readability
+            quirksAndPartReps.addString("");
+                        
+            addOptionsToList(en.getPartialRepairs(), quirksAndPartReps);
         }
 
         if (en.mpUsed > 0) {
@@ -581,24 +565,16 @@ public class GeneralInfoMapSet implements DisplayMapSet {
      * @param optionsInstance IOptions instance
      * @param labels label array
      */
-    public void addOptionsToList(IOptions optionsInstance, PMSimpleLabel[] labels) {
-        int index = 0;
-        
+    public void addOptionsToList(IOptions optionsInstance, PMMultiLineLabel quirksAndPartReps) {
         for (Enumeration<IOptionGroup> optionGroups = optionsInstance.getGroups(); optionGroups.hasMoreElements();) {
             IOptionGroup group = optionGroups.nextElement();
             if (optionsInstance.count(group.getKey()) > 0) {
-                labels[index++].setString(group.getDisplayableName());
+                quirksAndPartReps.addString(group.getDisplayableName());
                 
                 for (Enumeration<IOption> options = group.getOptions(); options.hasMoreElements();) {
-                    // safety feature: because the labels are fixed-length arrays
-                    // we should not add more options than there are elements in the array.
-                    if(index >= labels.length) {
-                        return;
-                    }
-                    
                     IOption option = options.nextElement();
                     if (option != null && option.booleanValue()) {
-                        labels[index++].setString("  " + option.getDisplayableNameWithValue());
+                        quirksAndPartReps.addString("  " + option.getDisplayableNameWithValue());
                     }
                 }
             }

--- a/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
@@ -40,6 +40,7 @@ import megamek.common.Mech;
 import megamek.common.QuadVee;
 import megamek.common.Tank;
 import megamek.common.Warship;
+import megamek.common.options.AbstractOptions;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.OptionsConstants;
@@ -358,36 +359,12 @@ public class GeneralInfoMapSet implements DisplayMapSet {
         int i = 0;
         if ((null != en.getGame())
                 && en.getGame().getOptions().booleanOption(OptionsConstants.ADVANCED_STRATOPS_QUIRKS)) {
-            for (Enumeration<IOptionGroup> qGroups = en.getQuirks().getGroups(); qGroups
-                    .hasMoreElements();) {
-                IOptionGroup qGroup = qGroups.nextElement();
-                if (en.countQuirks(qGroup.getKey()) > 0) {
-                    quirksR[i++].setString(qGroup.getDisplayableName());
-                    for (Enumeration<IOption> quirks = qGroup.getOptions(); quirks
-                            .hasMoreElements();) {
-                        IOption quirk = quirks.nextElement();
-                        if (quirk != null && quirk.booleanValue()) {
-                            quirksR[i++].setString("  "
-                                    + quirk.getDisplayableNameWithValue());
-                        }
-                    }
-                }
-            }
+            addOptionsToList(i, en.getQuirks(), quirksR);
         }
-        for (Enumeration<IOptionGroup> repGroups = en.getPartialRepairs()
-                .getGroups(); repGroups.hasMoreElements();) {
-            IOptionGroup repGroup = repGroups.nextElement();
-            if (en.countPartialRepairs() > 0) {
-                partRepsR[i++].setString(repGroup.getDisplayableName());
-                for (Enumeration<IOption> partreps = repGroup.getOptions(); partreps
-                        .hasMoreElements();) {
-                    IOption partrep = partreps.nextElement();
-                    if (partrep.booleanValue()) {
-                        partRepsR[i++].setString("  "
-                                + partrep.getDisplayableNameWithValue());
-                    }
-                }
-            }
+        
+        if ((null != en.getGame())
+                && en.getGame().getOptions().booleanOption(OptionsConstants.ADVANCED_STRATOPS_PARTIALREPAIRS)) {
+            addOptionsToList(i, en.getPartialRepairs(), partRepsR);
         }
 
         if (en.mpUsed > 0) {
@@ -596,6 +573,22 @@ public class GeneralInfoMapSet implements DisplayMapSet {
 
     }
 
+    public void addOptionsToList(int index, AbstractOptions optionsInstance, PMSimpleLabel[] labels) {
+        for (Enumeration<IOptionGroup> optionGroups = optionsInstance.getGroups(); optionGroups.hasMoreElements();) {
+            IOptionGroup group = optionGroups.nextElement();
+            if (optionsInstance.count(group.getKey()) > 0) {
+                labels[index++].setString(group.getDisplayableName());
+                
+                for (Enumeration<IOption> options = group.getOptions(); options.hasMoreElements();) {
+                    IOption option = options.nextElement();
+                    if (option != null && option.booleanValue()) {
+                        labels[index++].setString("  " + option.getDisplayableNameWithValue());
+                    }
+                }
+            }
+        }
+    }
+    
     public PMAreasGroup getContentGroup() {
         return content;
     }

--- a/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
@@ -366,7 +366,7 @@ public class GeneralInfoMapSet implements DisplayMapSet {
                     for (Enumeration<IOption> quirks = qGroup.getOptions(); quirks
                             .hasMoreElements();) {
                         IOption quirk = quirks.nextElement();
-                        if (quirk.booleanValue()) {
+                        if (quirk != null && quirk.booleanValue()) {
                             quirksR[i++].setString("  "
                                     + quirk.getDisplayableNameWithValue());
                         }

--- a/megamek/src/megamek/client/ui/swing/widget/PMMultiLineLabel.java
+++ b/megamek/src/megamek/client/ui/swing/widget/PMMultiLineLabel.java
@@ -1,0 +1,74 @@
+package megamek.client.ui.swing.widget;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is a label that can stretch across multiple lines
+ * @author NickAragua
+ *
+ */
+public class PMMultiLineLabel extends PMSimpleLabel {
+    private List<String> labels = new ArrayList<>();
+    
+    /**
+     * Constructs a new multi-line label
+     * @param fm Font metrics object
+     * @param c Color for the text on this label
+     */
+    public PMMultiLineLabel(FontMetrics fm, Color c) {
+        super("", fm, c);
+    }
+    
+    /**
+     * Clear the contents of this multi-line label
+     */
+    public void clear() {
+        labels.clear();
+        height = 0;
+        width = 0;
+    }
+    
+    /**
+     * Add a string to this multi-line label
+     * @param s The string to add
+     */
+    public void addString(String s) {
+        labels.add(s);
+        
+        int newWidth = fm.stringWidth(s);
+        if(newWidth > width) {
+            width = newWidth;
+        }
+        
+        height += fm.getHeight();
+    }
+    
+    /*
+     * Draw the label.
+     */
+    @Override
+    public void drawInto(Graphics g) {
+        if (!visible)
+            return;
+        Font font = g.getFont();
+        Color temp = g.getColor();
+        g.setColor(color);
+        g.setFont(fm.getFont());
+        
+        int currentY = y;
+
+        for(String s : labels) {
+            g.drawString(s, x, currentY);
+            currentY += fm.getHeight();
+        }
+        
+        g.setColor(temp);
+        g.setFont(font);
+    }
+    
+}

--- a/megamek/src/megamek/common/Crew.java
+++ b/megamek/src/megamek/common/Crew.java
@@ -692,42 +692,11 @@ public class Crew implements Serializable {
     }
 
     public int countOptions() {
-        int count = 0;
-
-        for (Enumeration<IOptionGroup> i = options.getGroups(); i.hasMoreElements(); ) {
-            IOptionGroup group = i.nextElement();
-            for (Enumeration<IOption> j = group.getOptions(); j.hasMoreElements(); ) {
-                IOption option = j.nextElement();
-
-                if (option.booleanValue()) {
-                    count++;
-                }
-            }
-        }
-
-        return count;
+        return options.count();
     }
 
     public int countOptions(String grpKey) {
-        int count = 0;
-
-        for (Enumeration<IOptionGroup> i = options.getGroups(); i.hasMoreElements(); ) {
-            IOptionGroup group = i.nextElement();
-
-            if (!group.getKey().equalsIgnoreCase(grpKey)) {
-                continue;
-            }
-
-            for (Enumeration<IOption> j = group.getOptions(); j.hasMoreElements(); ) {
-                IOption option = j.nextElement();
-
-                if (option != null && option.booleanValue()) {
-                    count++;
-                }
-            }
-        }
-
-        return count;
+        return options.count(grpKey);
     }
 
     /**
@@ -751,34 +720,7 @@ public class Crew implements Serializable {
      * group, using sep as the separator
      */
     public String getOptionList(String sep, String grpKey) {
-        StringBuffer adv = new StringBuffer();
-
-        if (null == sep) {
-            sep = "";
-        }
-
-        for (Enumeration<IOptionGroup> i = options.getGroups(); i.hasMoreElements(); ) {
-            IOptionGroup group = i.nextElement();
-            if (!group.getKey().equalsIgnoreCase(grpKey)) {
-                continue;
-            }
-            for (Enumeration<IOption> j = group.getOptions(); j.hasMoreElements(); ) {
-                IOption option = j.nextElement();
-
-                if ((option != null) && option.booleanValue()) {
-                    if (adv.length() > 0) {
-                        adv.append(sep);
-                    }
-
-                    adv.append(option.getName());
-                    if ((option.getType() == IOption.STRING) || (option.getType() == IOption.CHOICE) || (option.getType() == IOption.INTEGER)) {
-                        adv.append(" ").append(option.stringValue());
-                    }
-                }
-            }
-        }
-
-        return adv.toString();
+        return options.getOptionListString(sep, grpKey);
     }
 
     // Helper function to reverse getAdvantageList() above

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3405,6 +3405,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             throws LocationFullException {
         mounted.setLocation(loc, rearMounted);
         equipmentList.add(mounted);
+        
         compositeTechLevel.addComponent(mounted.getType());
         if (mounted.isArmored()) {
             compositeTechLevel.addComponent(TA_ARMORED_COMPONENT);
@@ -12490,7 +12491,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                     .hasMoreElements(); ) {
                 IOption quirk = j.nextElement();
 
-                if (quirk.booleanValue()) {
+                if (quirk != null && quirk.booleanValue()) {
                     count++;
                 }
             }
@@ -12582,7 +12583,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             for (Enumeration<IOption> j = group.getOptions(); j
                     .hasMoreElements(); ) {
                 IOption quirk = j.nextElement();
-                if (quirk.booleanValue()) {
+                if (quirk != null && quirk.booleanValue()) {
                     if (qrk.length() > 0) {
                         qrk.append(sep);
                     }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -12477,27 +12477,12 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * count all the quirks for this unit, positive and negative
      */
     public int countQuirks() {
-        int count = 0;
-
         if ((null == game)
             || !game.getOptions().booleanOption(OptionsConstants.ADVANCED_STRATOPS_QUIRKS)) {
-            return count;
+            return 0;
         }
 
-        for (Enumeration<IOptionGroup> i = quirks.getGroups(); i
-                .hasMoreElements(); ) {
-            IOptionGroup group = i.nextElement();
-            for (Enumeration<IOption> j = group.getOptions(); j
-                    .hasMoreElements(); ) {
-                IOption quirk = j.nextElement();
-
-                if (quirk != null && quirk.booleanValue()) {
-                    count++;
-                }
-            }
-        }
-
-        return count;
+        return quirks.count();
     }
     
     public int countWeaponQuirks() {
@@ -12515,50 +12500,24 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     }
 
     public int countPartialRepairs() {
-        int count = 0;
-        for (Enumeration<IOptionGroup> i = partReps.getGroups(); i
-                .hasMoreElements(); ) {
-            IOptionGroup group = i.nextElement();
-            for (Enumeration<IOption> j = group.getOptions(); j
-                    .hasMoreElements(); ) {
-                IOption partRep = j.nextElement();
-
-                if (partRep != null && partRep.booleanValue()) {
-                    count++;
-                }
-            }
+        if((null == game) ||
+                !game.getOptions().booleanOption(OptionsConstants.ADVANCED_STRATOPS_PARTIALREPAIRS)) {
+            return 0;
         }
-        return count;
+        
+        return partReps.count();
     }
 
     /**
      * count the quirks for this unit, for a given group name
      */
     public int countQuirks(String grpKey) {
-        int count = 0;
-
         if ((null == game)
             || !game.getOptions().booleanOption(OptionsConstants.ADVANCED_STRATOPS_QUIRKS)) {
-            return count;
+            return 0;
         }
 
-        for (Enumeration<IOptionGroup> i = quirks.getGroups(); i
-                .hasMoreElements(); ) {
-            IOptionGroup group = i.nextElement();
-            if (!group.getKey().equalsIgnoreCase(grpKey)) {
-                continue;
-            }
-            for (Enumeration<IOption> j = group.getOptions(); j
-                    .hasMoreElements(); ) {
-                IOption quirk = j.nextElement();
-
-                if (null != quirk && quirk.booleanValue()) {
-                    count++;
-                }
-            }
-        }
-
-        return count;
+        return quirks.count(grpKey);
     }
 
     /**
@@ -12566,37 +12525,12 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * the separator
      */
     public String getQuirkList(String sep) {
-        StringBuffer qrk = new StringBuffer();
-
         if ((null == game)
             || !game.getOptions().booleanOption(OptionsConstants.ADVANCED_STRATOPS_QUIRKS)) {
-            return qrk.toString();
+            return "";
         }
 
-        if (null == sep) {
-            sep = "";
-        }
-
-        for (Enumeration<IOptionGroup> i = quirks.getGroups(); i
-                .hasMoreElements(); ) {
-            IOptionGroup group = i.nextElement();
-            for (Enumeration<IOption> j = group.getOptions(); j
-                    .hasMoreElements(); ) {
-                IOption quirk = j.nextElement();
-                if (quirk != null && quirk.booleanValue()) {
-                    if (qrk.length() > 0) {
-                        qrk.append(sep);
-                    }
-                    qrk.append(quirk.getName());
-                    if ((quirk.getType() == IOption.STRING)
-                        || (quirk.getType() == IOption.CHOICE)
-                        || (quirk.getType() == IOption.INTEGER)) {
-                        qrk.append(" ").append(quirk.stringValue());
-                    }
-                }
-            }
-        }
-        return qrk.toString();
+        return quirks.getOptionList(sep);
     }
 
     /**

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1608,7 +1608,7 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
             for (Enumeration<IOption> j = group.getOptions(); j
                     .hasMoreElements();) {
                 IOption quirk = j.nextElement();
-                if (quirk.booleanValue()) {
+                if (quirk != null && quirk.booleanValue()) {
                     count++;
                 }
             }
@@ -1639,7 +1639,7 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
             for (Enumeration<IOption> j = group.getOptions(); j
                     .hasMoreElements();) {
                 IOption quirk = j.nextElement();
-                if (quirk.booleanValue()) {
+                if (quirk != null && quirk.booleanValue()) {
                     if (qrk.length() > 0) {
                         qrk.append(sep);
                     }

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1592,29 +1592,15 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
     }
 
     /**
-     * count all the quirks for this unit, positive and negative
+     * Count all the quirks for this "mounted" object, positive and negative
      */
     public int countQuirks() {
-        int count = 0;
-
         if ((null == entity) || (null == entity.game)
                 || !entity.game.getOptions().booleanOption(OptionsConstants.ADVANCED_STRATOPS_QUIRKS)) {
-            return count;
+            return 0;
         }
 
-        for (Enumeration<IOptionGroup> i = quirks.getGroups(); i
-                .hasMoreElements();) {
-            IOptionGroup group = i.nextElement();
-            for (Enumeration<IOption> j = group.getOptions(); j
-                    .hasMoreElements();) {
-                IOption quirk = j.nextElement();
-                if (quirk != null && quirk.booleanValue()) {
-                    count++;
-                }
-            }
-        }
-
-        return count;
+        return quirks.count();
     }
 
     /**
@@ -1622,37 +1608,12 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
      * the separator
      */
     public String getQuirkList(String sep) {
-        StringBuffer qrk = new StringBuffer();
-
         if ((null == entity) || (null == entity.game)
                 || !entity.game.getOptions().booleanOption(OptionsConstants.ADVANCED_STRATOPS_QUIRKS)) {
-            return qrk.toString();
+            return "";
         }
 
-        if (null == sep) {
-            sep = "";
-        }
-
-        for (Enumeration<IOptionGroup> i = quirks.getGroups(); i
-                .hasMoreElements();) {
-            IOptionGroup group = i.nextElement();
-            for (Enumeration<IOption> j = group.getOptions(); j
-                    .hasMoreElements();) {
-                IOption quirk = j.nextElement();
-                if (quirk != null && quirk.booleanValue()) {
-                    if (qrk.length() > 0) {
-                        qrk.append(sep);
-                    }
-                    qrk.append(quirk.getName());
-                    if ((quirk.getType() == IOption.STRING)
-                            || (quirk.getType() == IOption.CHOICE)
-                            || (quirk.getType() == IOption.INTEGER)) {
-                        qrk.append(" ").append(quirk.stringValue());
-                    }
-                }
-            }
-        }
-        return qrk.toString();
+        return quirks.getOptionList(sep);
     }
 
     public CalledShot getCalledShot() {

--- a/megamek/src/megamek/common/options/AbstractOptions.java
+++ b/megamek/src/megamek/common/options/AbstractOptions.java
@@ -39,6 +39,89 @@ public abstract class AbstractOptions implements IOptions, Serializable {
 
     protected abstract void initialize();
 
+    /**
+     * Returns a count of all options in this object.
+     * @return Option count.
+     */
+    public int count() { 
+        return count(null);
+    }
+    
+    /**
+     * Returns a count of all options in this object with the given group key.
+     * @param groupKey the group key to filter on. Null signifies to return all options indiscriminately.
+     * @return Option count.
+     */
+    public int count(String groupKey) {
+        int count = 0;
+        
+        for (Enumeration<IOptionGroup> i = getGroups(); i
+                .hasMoreElements(); ) {
+            IOptionGroup group = i.nextElement();
+            if ((groupKey != null) && !group.getKey().equalsIgnoreCase(groupKey)) {
+                continue;
+            }
+            for (Enumeration<IOption> j = group.getOptions(); j
+                    .hasMoreElements(); ) {
+                IOption option = j.nextElement();
+
+                if (null != option && option.booleanValue()) {
+                    count++;
+                }
+            }
+        }
+        
+        return count;
+    }
+    
+    /**
+     * Returns a string of all the quirk "codes" for this entity, using sep as
+     * the separator
+     * @param separator The separator to insert between codes, in addition to a space
+     */
+    public String getOptionList(String separator) {
+        return getOptionListString(separator, null);
+    }
+    
+    /**
+     * Returns a string of all the quirk "codes" for this entity, using sep as
+     * the separator, filtering on a specific group key.
+     * @param separator The separator to insert between codes, in addition to a space
+     * @param groupKey The group key to use to filter options. Null signifies to return all options indiscriminately.
+     */
+    public String getOptionListString(String separator, String groupKey) {
+        StringBuffer listBuilder = new StringBuffer();
+        
+        if (null == separator) {
+            separator = "";
+        }
+
+        for (Enumeration<IOptionGroup> i = getGroups(); i.hasMoreElements();) {
+            IOptionGroup group = i.nextElement();
+            
+            if ((groupKey != null) && !group.getKey().equalsIgnoreCase(groupKey)) {
+                continue;
+            }
+            
+            for (Enumeration<IOption> j = group.getOptions(); j
+                    .hasMoreElements();) {
+                IOption option = j.nextElement();
+                if (option != null && option.booleanValue()) {
+                    if (listBuilder.length() > 0) {
+                        listBuilder.append(separator);
+                    }
+                    listBuilder.append(option.getName());
+                    if ((option.getType() == IOption.STRING)
+                            || (option.getType() == IOption.CHOICE)
+                            || (option.getType() == IOption.INTEGER)) {
+                        listBuilder.append(" ").append(option.stringValue());
+                    }
+                }
+            }
+        }
+        return listBuilder.toString();
+    }
+    
     public Enumeration<IOptionGroup> getGroups() {
         return new GroupsEnumeration();
     }

--- a/megamek/src/megamek/common/options/IOptions.java
+++ b/megamek/src/megamek/common/options/IOptions.java
@@ -86,4 +86,17 @@ public interface IOptions {
      * @return the value of the desired option as the <code>String</code>
      */
     public abstract String stringOption(String name);
+    
+    /**
+     * Returns a count of all options in the current IOptions instance.
+     * @return Option count.
+     */
+    public abstract int count();
+    
+    /**
+     * Returns a count of all options in the current IOptions instance with the given group key
+     * @param groupKey The key to look for.
+     * @return Option count.
+     */
+    public abstract int count(String groupKey);
 }

--- a/megamek/src/megamek/common/options/Quirks.java
+++ b/megamek/src/megamek/common/options/Quirks.java
@@ -15,6 +15,8 @@
 package megamek.common.options;
 
 
+import java.util.Enumeration;
+
 import megamek.common.Aero;
 import megamek.common.BattleArmor;
 import megamek.common.Dropship;

--- a/megamek/src/megamek/common/options/Quirks.java
+++ b/megamek/src/megamek/common/options/Quirks.java
@@ -15,8 +15,6 @@
 package megamek.common.options;
 
 
-import java.util.Enumeration;
-
 import megamek.common.Aero;
 import megamek.common.BattleArmor;
 import megamek.common.Dropship;


### PR DESCRIPTION
This fixes several NPEs that result in game hang/UI display failures. Mostly, the situations where I encountered this were when loading a saved game from a previous version of Megamek (I upgraded because I needed a fix for the "mech can't punch" bug). The units involved had quirks that must have been replaced, and so the quirks were loading as null. As I finished that game, I uncovered more of these issues.

Then I did a text search for what kept causing the NPEs and bulletproofed those as well.

Then I noticed that a lot of this code is identical so I pulled it up to separate methods.