### PR TITLE
Large space craft ammo

### DIFF
--- a/megamek/data/mechfiles/dropships/Arondight Pocket Warship (RAF Mk II).blk
+++ b/megamek/data/mechfiles/dropships/Arondight Pocket Warship (RAF Mk II).blk
@@ -1,0 +1,207 @@
+#building block data file
+<BlockVersion>
+1
+</BlockVersion>
+
+#Write the version number just in case...
+<Version>
+MAM0
+</Version>
+
+<UnitType>
+Dropship
+</UnitType>
+
+<Name>
+Arondight Pocket Warship
+</Name>
+
+<Model>
+(RAF Mk II)
+</Model>
+
+<Tonnage>
+12000
+</Tonnage>
+
+<SafeThrust>
+5
+</SafeThrust>
+
+<Armor>
+352
+322
+322
+301
+</Armor>
+
+<Nose Equipment>
+Kraken
+Kraken Ammo:10
+ISERPPC
+ISERPPC
+ISGaussRifle
+ISGaussRifle
+ISGauss Ammo:80
+ISERMediumLaser
+ISERMediumLaser
+ISERMediumLaser
+ISERMediumLaser
+AMS
+AMS
+AMS
+ISAMS Ammo:72
+</Nose Equipment>
+
+<Left Side Equipment>
+AR10
+AR10
+AR10 Barracuda Ammo:7
+AR10 KillerWhale Ammo:9
+AR10 WhiteShark Ammo:5
+AR10 SantaAnna Ammo:0
+AR10 Peacemaker Ammo:0
+(B) Piranha
+Piranha
+Piranha Ammo:20
+ISERMediumLaser
+ISERMediumLaser
+CLLBXAC10
+CLLBXAC10
+CLLBXAC10 Ammo:60
+AMS
+AMS
+ISAMS Ammo:48
+(R) Piranha
+(R) Piranha
+(R) Piranha Ammo:20
+(R) CLLBXAC10
+(R) CLLBXAC10
+(R) CLLBXAC10 Ammo:60
+(R) ISERMediumLaser
+(R) ISERMediumLaser
+(R) ISERMediumLaser
+(R) AMS
+(R) AMS
+(R) AMS
+(R) ISAMS Ammo:72
+</Left Side Equipment>
+
+<Right Side Equipment> 
+AR10
+AR10
+AR10 Barracuda Ammo:7
+AR10 KillerWhale Ammo:9
+AR10 WhiteShark Ammo:5
+AR10 SantaAnna Ammo:0
+AR10 Peacemaker Ammo:0
+(B) Piranha
+Piranha
+Piranha Ammo:20
+ISERMediumLaser
+ISERMediumLaser
+CLLBXAC10
+CLLBXAC10
+CLLBXAC10 Ammo:60
+AMS
+AMS
+ISAMS Ammo:48
+(R) Piranha
+(R) Piranha
+(R) Piranha Ammo:20
+(R) CLLBXAC10
+(R) CLLBXAC10
+(R) CLLBXAC10 Ammo:60
+(R) ISERMediumLaser
+(R) ISERMediumLaser
+(R) ISERMediumLaser
+(R) AMS
+(R) AMS
+(R) AMS
+(R) ISAMS Ammo:72
+</Right Side Equipment>
+
+<Aft Equipment>
+Screen Launcher 
+Ammo Screen:10 
+ISGaussRifle
+ISGaussRifle
+ISGauss Ammo:80
+ISERMediumLaser
+ISERMediumLaser
+ISERMediumLaser
+ISERMediumLaser
+AMS
+AMS
+AMS
+ISAMS Ammo:72
+</Aft Equipment>
+
+<structural_integrity>
+20
+</structural_integrity>
+
+<heatsinks>
+200
+</heatsinks>
+
+<sink_type>
+1
+</sink_type>
+
+<fuel>
+7500
+</fuel>
+
+<type>
+IS Level 3
+</type>
+
+<year>
+3078
+</year>
+
+<source>
+TRO 3085 - Jihad
+</source>
+
+<internal_type>
+0
+</internal_type>
+
+<designtype>
+1
+</designtype>
+
+<armor_type>
+19
+</armor_type>
+
+<engine_type>
+0
+</engine_type>
+
+<motion_type>
+spheroid
+</motion_type>
+
+<transporters>
+CargoBay:429:2
+SmallCraftBay:2:2
+</transporters>
+
+<escape_pod>
+7
+</escape_pod>
+
+<life_boat>
+4
+</life_boat>
+
+<crew>
+45
+</crew>
+
+<passengers>
+0
+</passengers>

--- a/megamek/data/mechfiles/dropships/Arondight Pocket Warship (RAF Mk II).blk
+++ b/megamek/data/mechfiles/dropships/Arondight Pocket Warship (RAF Mk II).blk
@@ -59,8 +59,6 @@ AR10
 AR10 Barracuda Ammo:7
 AR10 KillerWhale Ammo:9
 AR10 WhiteShark Ammo:5
-AR10 SantaAnna Ammo:0
-AR10 Peacemaker Ammo:0
 (B) Piranha
 Piranha
 Piranha Ammo:20
@@ -93,8 +91,6 @@ AR10
 AR10 Barracuda Ammo:7
 AR10 KillerWhale Ammo:9
 AR10 WhiteShark Ammo:5
-AR10 SantaAnna Ammo:0
-AR10 Peacemaker Ammo:0
 (B) Piranha
 Piranha
 Piranha Ammo:20

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -398,7 +398,7 @@
 3470=<B><data></B> was hit by an ASEW missile!
 3471=<B><data></B> was hit by <data> ASEW missiles!
 3472=Attacks originating from the <data> suffer a +4 to-hit penalty until the end phase of the next turn!
-3473=Attacks originating from the <data> suffer a +4 to-hit penalty for <data> additional turns!
+3473=Attacks from this unit suffer a +4 to-hit penalty until the end phase of the next turn!
 3500=<newline><data> (<data>) lays a 10 point conventional minefield in hex <data>.
 3505=<newline><data> (<data>) lays a 10 point vibrabomb minefield in hex <data>.
 3510=<newline><data> (<data>) lays a 10 point active minefield in hex <data>.

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -395,6 +395,10 @@
 3455=<data> is illuminated by <data>'s searchlight.
 3460=<data> suffers no damage. (<data> behind cover)
 3465=<data> was providing cover and absorbs the damage.
+3470=<B><data></B> was hit by an ASEW missile!
+3471=<B><data></B> was hit by <data> ASEW missiles!
+3472=Attacks originating from the <data> suffer a +4 to-hit penalty until the end phase of the next turn!
+3473=Attacks originating from the <data> suffer a +4 to-hit penalty for <data> additional turns!
 3500=<newline><data> (<data>) lays a 10 point conventional minefield in hex <data>.
 3505=<newline><data> (<data>) lays a 10 point vibrabomb minefield in hex <data>.
 3510=<newline><data> (<data>) lays a 10 point active minefield in hex <data>.

--- a/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
@@ -115,9 +115,6 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
             if ((type > BombType.B_TAG) && !allowAdvancedAmmo) {
                 b_choices[type].setEnabled(false);
             }
-            if ((type == BombType.B_ASEW) || (type == BombType.B_ALAMO)) {
-                b_choices[type].setEnabled(false);
-            }
 
             if (row >= maxRows) {
                 row = 0;

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -119,6 +119,9 @@ public class EquipChoicePanel extends JPanel implements Serializable {
 
     private ArrayList<MineChoicePanel> m_vMines = new ArrayList<MineChoicePanel>();
     private JPanel panMines = new JPanel();
+    
+    private ArrayList<CapMissileChoicePanel> m_vCapMissile = new ArrayList<CapMissileChoicePanel>();
+    private JPanel panCapMissile = new JPanel();
 
     private ArrayList<SantaAnnaChoicePanel> m_vSantaAnna = new ArrayList<SantaAnnaChoicePanel>();
     private JPanel panSantaAnna = new JPanel();
@@ -368,6 +371,10 @@ public class EquipChoicePanel extends JPanel implements Serializable {
         // update mines setting
         for (final Object newVar : m_vMines) {
             ((MineChoicePanel) newVar).applyChoice();
+        }
+        // update Capital Missile setting
+        for (final Object newVar : m_vSantaAnna) {
+            ((CapMissileChoicePanel) newVar).applyChoice();
         }
         // update Santa Anna setting
         for (final Object newVar : m_vSantaAnna) {
@@ -627,19 +634,11 @@ public class EquipChoicePanel extends JPanel implements Serializable {
             }
 
             // don't allow ammo switching of most things for Aeros
-            // allow only MML, ATM, NARC, and capital missiles
+            // allow only MML, ATM, NARC
             if ((entity instanceof Aero)
                     && !((at.getAmmoType() == AmmoType.T_MML)
                             || (at.getAmmoType() == AmmoType.T_ATM)
-                            || (at.getAmmoType() == AmmoType.T_NARC)
-                            || (at.getAmmoType() == AmmoType.T_AR10)
-                            || (at.getAmmoType() == AmmoType.T_KILLER_WHALE)
-                            || (at.getAmmoType() == AmmoType.T_WHITE_SHARK)
-                            || (at.getAmmoType() == AmmoType.T_BARRACUDA)
-                            || (at.getAmmoType() == AmmoType.T_MANTA_RAY)
-                            || (at.getAmmoType() == AmmoType.T_STINGRAY)
-                            || (at.getAmmoType() == AmmoType.T_SWORDFISH)
-                            || (at.getAmmoType() == AmmoType.T_PIRANHA))) {
+                            || (at.getAmmoType() == AmmoType.T_NARC))) {
                 aeroShotsOnly = true;
             }
 
@@ -709,10 +708,17 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                             .booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_HOTLOAD)) { //$NON-NLS-1$
                 continue;
             }
-            MunitionChoicePanel mcp;
-            mcp = new MunitionChoicePanel(m, vTypes);
-            panMunitions.add(mcp, GBC.eol());
-            m_vMunitions.add(mcp);
+            if (at.hasFlag(AmmoType.F_CAP_MISSILE)) {
+                CapMissileChoicePanel cmcp;
+                cmcp = new CapMissileChoicePanel(m);
+                panCapMissile.add(cmcp, GBC.eol());
+                m_vCapMissile.add(cmcp);
+            } else {
+                MunitionChoicePanel mcp;
+                mcp = new MunitionChoicePanel(m, vTypes);
+                panMunitions.add(mcp, GBC.eol());
+                m_vMunitions.add(mcp);
+            }
         }
         }
 
@@ -1178,6 +1184,184 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 m_mounted.setShotsLeft(shots);
             }
         }
+        
+        class CapMissileChoicePanel extends JPanel {
+
+            private static final long serialVersionUID = 3401126035583995327L;
+
+            private ArrayList<AmmoType> m_vTypes;
+
+            private JLabel barracuda = new JLabel ("Barracuda Missiles: ");
+            private JLabel whiteshark = new JLabel ("White Shark Missiles: ");
+            private JLabel killerwhale = new JLabel ("Killer Whale Missiles: ");
+            private JLabel santaanna = new JLabel ("Santa Anna Missiles: ");
+            private JLabel peacemaker = new JLabel ("Peacemaker Missiles: ");
+
+            @SuppressWarnings("rawtypes")
+            private JComboBox b_num_shots;
+            private JComboBox w_num_shots;
+            private JComboBox k_num_shots;
+            private JComboBox s_num_shots;
+            private JComboBox p_num_shots;
+
+            private Mounted m_mounted;
+
+            JLabel labDump = new JLabel(
+                    Messages.getString("CustomMechDialog.labDump")); //$NON-NLS-1$
+
+            JCheckBox chDump = new JCheckBox();
+                       
+            @SuppressWarnings("unchecked")
+            CapMissileChoicePanel(Mounted m) {
+                m_mounted = m;
+                AmmoType curType = (AmmoType) m.getType();
+                if (m.getType().getName() == "Barracuda Ammo") {
+                    barracuda.setVisible(true);
+                    whiteshark.setVisible(false);
+                    killerwhale.setVisible(false);
+                    santaanna.setVisible(false);
+                    peacemaker.setVisible(false);
+                    //b_num_shots.setVisible(true);
+                    //w_num_shots.setVisible(false);
+                    //k_num_shots.setVisible(false);
+                    //s_num_shots.setVisible(false);
+                    //p_num_shots.setVisible(false);
+                } else if (m.getType().getName() == "White Shark Ammo") {                    
+                    whiteshark.setVisible(true);
+                    santaanna.setVisible(true);
+                    barracuda.setVisible(false);
+                    killerwhale.setVisible(false);                   
+                    peacemaker.setVisible(false);
+                    //w_num_shots.setVisible(true);
+                    //s_num_shots.setVisible(true);
+                    //b_num_shots.setVisible(false);
+                    //k_num_shots.setVisible(false);
+                    //p_num_shots.setVisible(false);
+                } else if (m.getType().getName() == "Killer Whale Ammo") {                    
+                    killerwhale.setVisible(true);                   
+                    peacemaker.setVisible(true);
+                    whiteshark.setVisible(false);
+                    santaanna.setVisible(false);
+                    barracuda.setVisible(false);
+                    //k_num_shots.setVisible(true);
+                    //p_num_shots.setVisible(true);
+                    //b_num_shots.setVisible(false);
+                    //w_num_shots.setVisible(false);
+                    //s_num_shots.setVisible(false);
+                } else if (m.getType().getName() == "Capital Missile Launcher (AR10 Launcher)") {                    
+                    killerwhale.setVisible(true);                   
+                    peacemaker.setVisible(true);
+                    whiteshark.setVisible(true);
+                    santaanna.setVisible(true);
+                    barracuda.setVisible(true);
+                    //k_num_shots.setVisible(true);
+                    //p_num_shots.setVisible(true);
+                    //b_num_shots.setVisible(true);
+                    //w_num_shots.setVisible(true);
+                    //s_num_shots.setVisible(true);
+                }
+                b_num_shots = new JComboBox<String>();
+                //w_num_shots = new JComboBox<String>();
+                //k_num_shots = new JComboBox<String>();
+                //s_num_shots = new JComboBox<String>();
+                //p_num_shots = new JComboBox<String>();
+                int shotsPerTon = 0;
+                if (entity.usesWeaponBays()) {
+                    shotsPerTon = m.getBaseShotsLeft();
+                } else {
+                    shotsPerTon = curType.getShots();
+                }
+                JLabel labAeroMunitionType = new JLabel(curType.getName() + " : "); //$NON-NLS-1$
+                int stepSize = 1;
+                
+                for (int i = 0; i <= shotsPerTon; i += stepSize){
+                    b_num_shots.addItem(i);
+                }
+                b_num_shots.setSelectedItem(m_mounted.getBaseShotsLeft());
+
+               /* m_choice.addItemListener(new ItemListener(){
+                @Override
+                public void itemStateChanged(ItemEvent evt) {
+                        int currShots = (Integer)b_num_shots.getSelectedItem();
+                        b_num_shots.removeAllItems();
+                        int shotsPerTon = m_vTypes.get(
+                                m_choice.getSelectedIndex()).getShots();
+                        for (int i = 0; i <= shotsPerTon; i++){
+                            b_num_shots.addItem(i);
+                        }
+                        if (currShots <= shotsPerTon){
+                            b_num_shots.setSelectedItem(currShots);
+                        } else {
+                            b_num_shots.setSelectedItem(shotsPerTon);
+                        }
+
+                    }}); */
+
+
+                int loc;
+                if (m.getLocation() == Entity.LOC_NONE) {
+                    // oneshot weapons don't have a location of their own
+                    Mounted linkedBy = m.getLinkedBy();
+                    loc = linkedBy.getLocation();
+                } else {
+                    loc = m.getLocation();
+                }
+                
+                String sDesc = '(' + entity.getLocationAbbr(loc) + ')';
+                JLabel lLoc = new JLabel(sDesc);
+                GridBagLayout g = new GridBagLayout();
+                setLayout(g);
+                add(lLoc, GBC.std());
+                add(b_num_shots, GBC.eol());
+                //add(w_num_shots, GBC.eol());
+                //add(k_num_shots, GBC.eol());
+                //add(s_num_shots, GBC.eol());
+                //add(p_num_shots, GBC.eol());
+                if (clientgui.getClient().getGame().getOptions().booleanOption(
+                        OptionsConstants.BASE_LOBBY_AMMO_DUMP)) { //$NON-NLS-1$
+                    add(labDump, GBC.std());
+                    add(chDump, GBC.eol());
+                } 
+            }
+
+            public void applyChoice() {
+                int n = 0;
+                // If there's no selection, there's nothing we can do
+                if (n == -1) {
+                    return;
+                }
+                AmmoType at = m_vTypes.get(n);
+                m_mounted.changeAmmoType(at);
+                m_mounted.setShotsLeft((Integer)b_num_shots.getSelectedItem());
+                if (chDump.isSelected()) {
+                    m_mounted.setShotsLeft(0);
+                }
+            }
+
+            @Override
+            public void setEnabled(boolean enabled) {
+                b_num_shots.setEnabled(enabled);
+            }
+
+            /**
+             * Get the number of shots in the mount.
+             *
+             * @return the <code>int</code> number of shots in the mount.
+             */
+            int getShotsLeft() {
+                return m_mounted.getBaseShotsLeft();
+            }
+
+            /**
+             * Set the number of shots in the mount.
+             *
+             * @param shots
+             *            the <code>int</code> number of shots for the mount.
+             */
+            void setShotsLeft(int shots) {
+                m_mounted.setShotsLeft(shots);
+            }
+        } 
 
         // a choice panel for determining number of santa anna warheads
         class SantaAnnaChoicePanel extends JPanel {

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1042,10 +1042,16 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 }
                 m_num_shots = new JComboBox<String>();
                 int shotsPerTon = 0;
+                int magazineSize = 0;
+                int magazineLoadout = 0;
                 if (entity.usesWeaponBays()) {
                     shotsPerTon = m.getBaseShotsLeft();
                 } else {
                     shotsPerTon = curType.getShots();
+                }
+                if (curType.getAmmoType() == AmmoType.T_AR10) {
+                    magazineSize = (int) curType.getTonnage() * m.getOriginalShots();
+                    magazineLoadout = (int) curType.getTonnage() * m.getBaseShotsLeft();
                 }
                 JLabel labAeroMunitionType = new JLabel(curType.getName() + " : "); //$NON-NLS-1$
                 // BattleArmor always have a certain number of shots per slot
@@ -1067,21 +1073,37 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                     @Override
                     public void itemStateChanged(ItemEvent evt) {
                         int currShots = (Integer)m_num_shots.getSelectedItem();
+                        int magazineSize = (int) curType.getTonnage() * m.getOriginalShots();
+                        int shots = 0;
                         m_num_shots.removeAllItems();
+                        if (curType.getAmmoType() == AmmoType.T_AR10) {
+                            shots = magazineSize / (int) m_vTypes.get(
+                                m_choice.getSelectedIndex()).getTonnage();
+                        }
                         int shotsPerTon = m_vTypes.get(
                                 m_choice.getSelectedIndex()).getShots();
+                        
                         // BA always have a certain number of shots per slot
                         if (entity instanceof BattleArmor){
                             shotsPerTon = TestBattleArmor.NUM_SHOTS_PER_CRIT;
                         }
-                        for (int i = 0; i <= shotsPerTon; i++){
-                            m_num_shots.addItem(i);
-                        }
-                        if (currShots <= shotsPerTon){
-                            m_num_shots.setSelectedItem(currShots);
+                        if (curType.getAmmoType() == AmmoType.T_AR10) {
+                            for (int i = 0; i <= shots; i++){
+                                m_num_shots.addItem(i);                                
+                            }
+                            m_num_shots.setSelectedItem(shots);
                         } else {
-                            m_num_shots.setSelectedItem(shotsPerTon);
+                            for (int i = 0; i <= shotsPerTon; i++){
+                                m_num_shots.addItem(i);
+                            }
+                            if (currShots <= shotsPerTon){
+                                m_num_shots.setSelectedItem(currShots);
+                            } else {
+                                m_num_shots.setSelectedItem(shotsPerTon);
+                            }
                         }
+                        
+                            
 
                     }});
 
@@ -1103,9 +1125,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 setLayout(g);
                 add(lLoc, GBC.std());
                 if (curType.getAmmoType() == AmmoType.T_AR10) {    
-                    double magazineSize = curType.getTonnage() * m.getBaseShotsLeft();
-                    double magazineUse = curType.getTonnage() * m.getCurrentShots();
-                    String Desc = " " + magazineUse + " / " + magazineSize + "tons left ";
+                    String Desc =  (magazineSize - magazineLoadout) + " " + " / " + magazineSize + " tons left ";
                     JLabel lMag = new JLabel(Desc);
                     add (lMag, GBC.std());
                 }

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -708,7 +708,13 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                             .booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_HOTLOAD)) { //$NON-NLS-1$
                 continue;
             }
-            if (at.hasFlag(AmmoType.F_CAP_MISSILE)) {
+            if (at.hasFlag(AmmoType.F_CAP_MISSILE)
+                    && !((at.getAmmoType() == AmmoType.T_KRAKEN_T)
+                            || (at.getAmmoType() == AmmoType.T_KRAKENM)
+                            || (at.getAmmoType() == AmmoType.T_PIRANHA)
+                            || (at.getAmmoType() == AmmoType.T_STINGRAY) 
+                            || (at.getAmmoType() == AmmoType.T_SWORDFISH) 
+                            || (at.getAmmoType() == AmmoType.T_MANTA_RAY))) {
                 CapMissileChoicePanel cmcp;
                 cmcp = new CapMissileChoicePanel(m);
                 panCapMissile.add(cmcp, GBC.eol());
@@ -1265,16 +1271,12 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 //k_num_shots = new JComboBox<String>();
                 //s_num_shots = new JComboBox<String>();
                 //p_num_shots = new JComboBox<String>();
-                int shotsPerTon = 0;
-                if (entity.usesWeaponBays()) {
-                    shotsPerTon = m.getBaseShotsLeft();
-                } else {
-                    shotsPerTon = curType.getShots();
-                }
-                JLabel labAeroMunitionType = new JLabel(curType.getName() + " : "); //$NON-NLS-1$
+
+                int shots = m.getBaseShotsLeft();
+                int magazineSize = (int) (curType.getTonnage() * shots);
                 int stepSize = 1;
                 
-                for (int i = 0; i <= shotsPerTon; i += stepSize){
+                for (int i = 0; i <= shots; i += stepSize){
                     b_num_shots.addItem(i);
                 }
                 b_num_shots.setSelectedItem(m_mounted.getBaseShotsLeft());
@@ -1284,7 +1286,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 public void itemStateChanged(ItemEvent evt) {
                         int currShots = (Integer)b_num_shots.getSelectedItem();
                         b_num_shots.removeAllItems();
-                        int shotsPerTon = m_vTypes.get(
+                        int shots = m_vTypes.get(
                                 m_choice.getSelectedIndex()).getShots();
                         for (int i = 0; i <= shotsPerTon; i++){
                             b_num_shots.addItem(i);
@@ -1292,7 +1294,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                         if (currShots <= shotsPerTon){
                             b_num_shots.setSelectedItem(currShots);
                         } else {
-                            b_num_shots.setSelectedItem(shotsPerTon);
+                            b_num_shots.setSelectedItem(shots);
                         }
 
                     }}); */

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -373,7 +373,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
             ((MineChoicePanel) newVar).applyChoice();
         }
         // update Capital Missile setting
-        for (final Object newVar : m_vSantaAnna) {
+        for (final Object newVar : m_vCapMissile) {
             ((CapMissileChoicePanel) newVar).applyChoice();
         }
         // update Santa Anna setting
@@ -635,10 +635,14 @@ public class EquipChoicePanel extends JPanel implements Serializable {
 
             // don't allow ammo switching of most things for Aeros
             // allow only MML, ATM, NARC
+            aeroShotsOnly = false;
             if ((entity instanceof Aero)
                     && !((at.getAmmoType() == AmmoType.T_MML)
                             || (at.getAmmoType() == AmmoType.T_ATM)
-                            || (at.getAmmoType() == AmmoType.T_NARC))) {
+                            || (at.getAmmoType() == AmmoType.T_NARC)
+                            || (at.getAmmoType() == AmmoType.T_AR10)
+                            || (at.getAmmoType() == AmmoType.T_WHITE_SHARK)
+                            || (at.getAmmoType() == AmmoType.T_KILLER_WHALE))) {
                 aeroShotsOnly = true;
             }
 
@@ -707,24 +711,12 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                     && !client.getGame().getOptions()
                             .booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_HOTLOAD)) { //$NON-NLS-1$
                 continue;
-            }
-            if (at.hasFlag(AmmoType.F_CAP_MISSILE)
-                    && !((at.getAmmoType() == AmmoType.T_KRAKEN_T)
-                            || (at.getAmmoType() == AmmoType.T_KRAKENM)
-                            || (at.getAmmoType() == AmmoType.T_PIRANHA)
-                            || (at.getAmmoType() == AmmoType.T_STINGRAY) 
-                            || (at.getAmmoType() == AmmoType.T_SWORDFISH) 
-                            || (at.getAmmoType() == AmmoType.T_MANTA_RAY))) {
-                CapMissileChoicePanel cmcp;
-                cmcp = new CapMissileChoicePanel(m);
-                panCapMissile.add(cmcp, GBC.eol());
-                m_vCapMissile.add(cmcp);
-            } else {
+            }           
                 MunitionChoicePanel mcp;
                 mcp = new MunitionChoicePanel(m, vTypes);
                 panMunitions.add(mcp, GBC.eol());
                 m_vMunitions.add(mcp);
-            }
+            // }
         }
         }
 
@@ -1221,56 +1213,58 @@ public class EquipChoicePanel extends JPanel implements Serializable {
             CapMissileChoicePanel(Mounted m) {
                 m_mounted = m;
                 AmmoType curType = (AmmoType) m.getType();
+                b_num_shots = new JComboBox<String>();
+                w_num_shots = new JComboBox<String>();
+                k_num_shots = new JComboBox<String>();
+                s_num_shots = new JComboBox<String>();
+                p_num_shots = new JComboBox<String>();
                 if (m.getType().getName() == "Barracuda Ammo") {
                     barracuda.setVisible(true);
                     whiteshark.setVisible(false);
                     killerwhale.setVisible(false);
                     santaanna.setVisible(false);
                     peacemaker.setVisible(false);
-                    //b_num_shots.setVisible(true);
-                    //w_num_shots.setVisible(false);
-                    //k_num_shots.setVisible(false);
-                    //s_num_shots.setVisible(false);
-                    //p_num_shots.setVisible(false);
+                    b_num_shots.setVisible(true);
+                    w_num_shots.setVisible(false);
+                    k_num_shots.setVisible(false);
+                    s_num_shots.setVisible(false);
+                    p_num_shots.setVisible(false);
                 } else if (m.getType().getName() == "White Shark Ammo") {                    
                     whiteshark.setVisible(true);
                     santaanna.setVisible(true);
                     barracuda.setVisible(false);
                     killerwhale.setVisible(false);                   
                     peacemaker.setVisible(false);
-                    //w_num_shots.setVisible(true);
-                    //s_num_shots.setVisible(true);
-                    //b_num_shots.setVisible(false);
-                    //k_num_shots.setVisible(false);
-                    //p_num_shots.setVisible(false);
+                    w_num_shots.setVisible(true);
+                    s_num_shots.setVisible(true);
+                    b_num_shots.setVisible(false);
+                    k_num_shots.setVisible(false);
+                    p_num_shots.setVisible(false);
                 } else if (m.getType().getName() == "Killer Whale Ammo") {                    
                     killerwhale.setVisible(true);                   
                     peacemaker.setVisible(true);
                     whiteshark.setVisible(false);
                     santaanna.setVisible(false);
                     barracuda.setVisible(false);
-                    //k_num_shots.setVisible(true);
-                    //p_num_shots.setVisible(true);
-                    //b_num_shots.setVisible(false);
-                    //w_num_shots.setVisible(false);
-                    //s_num_shots.setVisible(false);
-                } else if (m.getType().getName() == "Capital Missile Launcher (AR10 Launcher)") {                    
+                    k_num_shots.setVisible(true);
+                    p_num_shots.setVisible(true);
+                    b_num_shots.setVisible(false);
+                    w_num_shots.setVisible(false);
+                    s_num_shots.setVisible(false);
+                } else if ((m.getType().getName() == "AR10 Barracuda Ammo")
+                        || (m.getType().getName() == "AR10 White Shark Ammo")
+                        || (m.getType().getName() == "AR10 Killer Whale Ammo")) {                    
                     killerwhale.setVisible(true);                   
                     peacemaker.setVisible(true);
                     whiteshark.setVisible(true);
                     santaanna.setVisible(true);
                     barracuda.setVisible(true);
-                    //k_num_shots.setVisible(true);
-                    //p_num_shots.setVisible(true);
-                    //b_num_shots.setVisible(true);
-                    //w_num_shots.setVisible(true);
-                    //s_num_shots.setVisible(true);
+                    k_num_shots.setVisible(true);
+                    p_num_shots.setVisible(true);
+                    b_num_shots.setVisible(true);
+                    w_num_shots.setVisible(true);
+                    s_num_shots.setVisible(true);
                 }
-                b_num_shots = new JComboBox<String>();
-                //w_num_shots = new JComboBox<String>();
-                //k_num_shots = new JComboBox<String>();
-                //s_num_shots = new JComboBox<String>();
-                //p_num_shots = new JComboBox<String>();
 
                 int shots = m.getBaseShotsLeft();
                 int magazineSize = (int) (curType.getTonnage() * shots);
@@ -1281,23 +1275,23 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 }
                 b_num_shots.setSelectedItem(m_mounted.getBaseShotsLeft());
 
-               /* m_choice.addItemListener(new ItemListener(){
+                b_num_shots.addItemListener(new ItemListener(){
                 @Override
                 public void itemStateChanged(ItemEvent evt) {
                         int currShots = (Integer)b_num_shots.getSelectedItem();
                         b_num_shots.removeAllItems();
                         int shots = m_vTypes.get(
-                                m_choice.getSelectedIndex()).getShots();
-                        for (int i = 0; i <= shotsPerTon; i++){
+                                b_num_shots.getSelectedIndex()).getShots();
+                        for (int i = 0; i <= shots; i++){
                             b_num_shots.addItem(i);
                         }
-                        if (currShots <= shotsPerTon){
+                        if (currShots <= shots){
                             b_num_shots.setSelectedItem(currShots);
                         } else {
                             b_num_shots.setSelectedItem(shots);
                         }
 
-                    }}); */
+                    }}); 
 
 
                 int loc;

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1035,7 +1035,12 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                     }
                 }
                 m_num_shots = new JComboBox<String>();
-                int shotsPerTon = curType.getShots();
+                int shotsPerTon = 0;
+                if (entity.usesWeaponBays()) {
+                    shotsPerTon = m.getBaseShotsLeft();
+                } else {
+                    shotsPerTon = curType.getShots();
+                }
                 JLabel labAeroMunitionType = new JLabel(curType.getName() + " : "); //$NON-NLS-1$
                 // BattleArmor always have a certain number of shots per slot
                 int stepSize = 1;
@@ -1117,9 +1122,14 @@ public class EquipChoicePanel extends JPanel implements Serializable {
             }
 
             public void applyChoice() {
-                int n = m_choice.getSelectedIndex();
+                int n;
+                if (aeroShotsOnly) {
+                    n = 0;
+                } else {
+                    n = m_choice.getSelectedIndex();
+                }
                 // If there's no selection, there's nothing we can do
-                if (n == -1){
+                if (n == -1) {
                     return;
                 }
                 AmmoType at = m_vTypes.get(n);

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -995,20 +995,20 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 Iterator<AmmoType> e = m_vTypes.iterator();
                 if (aeroShotsOnly) {
                     m_choice.setVisible(false);
-                } else {
-                    for (int x = 0; e.hasNext(); x++) {
+                }
+                for (int x = 0; e.hasNext(); x++) {
                     AmmoType at = e.next();
                     m_choice.addItem(at.getName());
-                        if (at.getInternalName() == curType.getInternalName()) {
+                    if (at.getInternalName() == curType.getInternalName()) {
                         m_choice.setSelectedIndex(x);
-                        }
                     }
                 }
+                
                 m_num_shots = new JComboBox<String>();
                 int shotsPerTon = 0;
                 int magazineSize = 0;
                 int magazineLoadout = 0;
-                if (entity.usesWeaponBays()) {
+                if (m.byShot()) {
                     shotsPerTon = m.getOriginalShots();                
                 } else {
                     shotsPerTon = curType.getShots();
@@ -1132,9 +1132,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
 
             public void applyChoice() {
                 int n = m_choice.getSelectedIndex();
-                if (m_choice.isVisible() == false) {
-                    n = 0;
-                } 
+
                 // If there's no selection, there's nothing we can do
                 if (n == -1) {
                     return;

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1045,13 +1045,15 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 int magazineSize = 0;
                 int magazineLoadout = 0;
                 if (entity.usesWeaponBays()) {
-                    shotsPerTon = m.getOriginalShots();
+                    shotsPerTon = m.getOriginalShots();                
                 } else {
                     shotsPerTon = curType.getShots();
                 }
                 if (curType.getAmmoType() == AmmoType.T_AR10) {
-                    magazineSize = (int) curType.getTonnage() * m.getOriginalShots();
+                    magazineSize = (int) m.getOriginalAmmoTons() * m.getOriginalShots();
                     magazineLoadout = (int) curType.getTonnage() * m.getBaseShotsLeft();
+                    shotsPerTon = magazineSize / (int) m_vTypes.get(
+                            m_choice.getSelectedIndex()).getTonnage();
                 }
                 JLabel labAeroMunitionType = new JLabel(curType.getName() + " : "); //$NON-NLS-1$
                 // BattleArmor always have a certain number of shots per slot
@@ -1073,21 +1075,27 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                     @Override
                     public void itemStateChanged(ItemEvent evt) {
                         int currShots = (Integer)m_num_shots.getSelectedItem();
-                        int magazineSize = (int) curType.getTonnage() * m.getOriginalShots();
+                        int magazineSize = (int) m.getOriginalAmmoTons() * m.getOriginalShots();
                         int shots = 0;
+                        int shotsPerTon = 0;
                         m_num_shots.removeAllItems();
                         if (curType.getAmmoType() == AmmoType.T_AR10) {
                             shots = magazineSize / (int) m_vTypes.get(
                                 m_choice.getSelectedIndex()).getTonnage();
-                        }
-                        int shotsPerTon = m_vTypes.get(
+                        } else if ((curType.getAmmoType() == AmmoType.T_KILLER_WHALE)
+                                    || (curType.getAmmoType() == AmmoType.T_WHITE_SHARK)) {
+                            shots = m.getOriginalShots();
+                        } else {
+                            shotsPerTon = m_vTypes.get(
                                 m_choice.getSelectedIndex()).getShots();
-                        
+                        }
                         // BA always have a certain number of shots per slot
                         if (entity instanceof BattleArmor){
                             shotsPerTon = TestBattleArmor.NUM_SHOTS_PER_CRIT;
                         }
-                        if (curType.getAmmoType() == AmmoType.T_AR10) {
+                        if ((curType.getAmmoType() == AmmoType.T_AR10)
+                                || (curType.getAmmoType() == AmmoType.T_KILLER_WHALE)
+                                || (curType.getAmmoType() == AmmoType.T_WHITE_SHARK)){    
                             for (int i = 0; i <= shots; i++){
                                 m_num_shots.addItem(i);                                
                             }

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -120,9 +120,6 @@ public class EquipChoicePanel extends JPanel implements Serializable {
     private ArrayList<MineChoicePanel> m_vMines = new ArrayList<MineChoicePanel>();
     private JPanel panMines = new JPanel();
     
-    private ArrayList<CapMissileChoicePanel> m_vCapMissile = new ArrayList<CapMissileChoicePanel>();
-    private JPanel panCapMissile = new JPanel();
-
     private ArrayList<SantaAnnaChoicePanel> m_vSantaAnna = new ArrayList<SantaAnnaChoicePanel>();
     private JPanel panSantaAnna = new JPanel();
 
@@ -371,10 +368,6 @@ public class EquipChoicePanel extends JPanel implements Serializable {
         // update mines setting
         for (final Object newVar : m_vMines) {
             ((MineChoicePanel) newVar).applyChoice();
-        }
-        // update Capital Missile setting
-        for (final Object newVar : m_vCapMissile) {
-            ((CapMissileChoicePanel) newVar).applyChoice();
         }
         // update Santa Anna setting
         for (final Object newVar : m_vSantaAnna) {
@@ -684,6 +677,12 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                         && !(entity instanceof Protomech)) {
                     continue;
                 }
+                
+                // Can't use Nuclear munitions unless the option is on
+                if (atCheck.hasFlag(AmmoType.F_NUCLEAR) &&
+                        !(gameOpts.booleanOption(OptionsConstants.ADVAERORULES_AT2_NUKES))) {
+                    continue;
+                }
 
                 // When dealing with machine guns, Protos can only
                 // use proto-specific machine gun ammo
@@ -695,13 +694,16 @@ public class EquipChoicePanel extends JPanel implements Serializable {
 
                 // Battle Armor ammo can't be selected at all.
                 // All other ammo types need to match on rack size and tech.
-                if (bTechMatch
+                // AR10 ammo is a little different as the missiles have different weights.
+                if ((bTechMatch
                         && (atCheck.getRackSize() == at.getRackSize())
                         && (atCheck.hasFlag(AmmoType.F_BATTLEARMOR) == at
                                 .hasFlag(AmmoType.F_BATTLEARMOR))
                         && (atCheck.hasFlag(AmmoType.F_ENCUMBERING) == at
                                 .hasFlag(AmmoType.F_ENCUMBERING))
-                        && (atCheck.getTonnage(entity) == at.getTonnage(entity))) {
+                        && (atCheck.getTonnage(entity) == at.getTonnage(entity)))
+                    || (bTechMatch 
+                        && ((atCheck.getAmmoType() == AmmoType.T_AR10) == (at.getAmmoType() == AmmoType.T_AR10)))) {
                     vTypes.add(atCheck);
                 }
             }
@@ -1100,6 +1102,13 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 GridBagLayout g = new GridBagLayout();
                 setLayout(g);
                 add(lLoc, GBC.std());
+                if (curType.getAmmoType() == AmmoType.T_AR10) {    
+                    double magazineSize = curType.getTonnage() * m.getBaseShotsLeft();
+                    double magazineUse = curType.getTonnage() * m.getCurrentShots();
+                    String Desc = " " + magazineUse + " / " + magazineSize + "tons left ";
+                    JLabel lMag = new JLabel(Desc);
+                    add (lMag, GBC.std());
+                }
                 if (aeroShotsOnly) {
                 add(labAeroMunitionType, GBC.std());
                 } else {
@@ -1183,182 +1192,6 @@ public class EquipChoicePanel extends JPanel implements Serializable {
             }
         }
         
-        class CapMissileChoicePanel extends JPanel {
-
-            private static final long serialVersionUID = 3401126035583995327L;
-
-            private ArrayList<AmmoType> m_vTypes;
-
-            private JLabel barracuda = new JLabel ("Barracuda Missiles: ");
-            private JLabel whiteshark = new JLabel ("White Shark Missiles: ");
-            private JLabel killerwhale = new JLabel ("Killer Whale Missiles: ");
-            private JLabel santaanna = new JLabel ("Santa Anna Missiles: ");
-            private JLabel peacemaker = new JLabel ("Peacemaker Missiles: ");
-
-            @SuppressWarnings("rawtypes")
-            private JComboBox b_num_shots;
-            private JComboBox w_num_shots;
-            private JComboBox k_num_shots;
-            private JComboBox s_num_shots;
-            private JComboBox p_num_shots;
-
-            private Mounted m_mounted;
-
-            JLabel labDump = new JLabel(
-                    Messages.getString("CustomMechDialog.labDump")); //$NON-NLS-1$
-
-            JCheckBox chDump = new JCheckBox();
-                       
-            @SuppressWarnings("unchecked")
-            CapMissileChoicePanel(Mounted m) {
-                m_mounted = m;
-                AmmoType curType = (AmmoType) m.getType();
-                b_num_shots = new JComboBox<String>();
-                w_num_shots = new JComboBox<String>();
-                k_num_shots = new JComboBox<String>();
-                s_num_shots = new JComboBox<String>();
-                p_num_shots = new JComboBox<String>();
-                if (m.getType().getName() == "Barracuda Ammo") {
-                    barracuda.setVisible(true);
-                    whiteshark.setVisible(false);
-                    killerwhale.setVisible(false);
-                    santaanna.setVisible(false);
-                    peacemaker.setVisible(false);
-                    b_num_shots.setVisible(true);
-                    w_num_shots.setVisible(false);
-                    k_num_shots.setVisible(false);
-                    s_num_shots.setVisible(false);
-                    p_num_shots.setVisible(false);
-                } else if (m.getType().getName() == "White Shark Ammo") {                    
-                    whiteshark.setVisible(true);
-                    santaanna.setVisible(true);
-                    barracuda.setVisible(false);
-                    killerwhale.setVisible(false);                   
-                    peacemaker.setVisible(false);
-                    w_num_shots.setVisible(true);
-                    s_num_shots.setVisible(true);
-                    b_num_shots.setVisible(false);
-                    k_num_shots.setVisible(false);
-                    p_num_shots.setVisible(false);
-                } else if (m.getType().getName() == "Killer Whale Ammo") {                    
-                    killerwhale.setVisible(true);                   
-                    peacemaker.setVisible(true);
-                    whiteshark.setVisible(false);
-                    santaanna.setVisible(false);
-                    barracuda.setVisible(false);
-                    k_num_shots.setVisible(true);
-                    p_num_shots.setVisible(true);
-                    b_num_shots.setVisible(false);
-                    w_num_shots.setVisible(false);
-                    s_num_shots.setVisible(false);
-                } else if ((m.getType().getName() == "AR10 Barracuda Ammo")
-                        || (m.getType().getName() == "AR10 White Shark Ammo")
-                        || (m.getType().getName() == "AR10 Killer Whale Ammo")) {                    
-                    killerwhale.setVisible(true);                   
-                    peacemaker.setVisible(true);
-                    whiteshark.setVisible(true);
-                    santaanna.setVisible(true);
-                    barracuda.setVisible(true);
-                    k_num_shots.setVisible(true);
-                    p_num_shots.setVisible(true);
-                    b_num_shots.setVisible(true);
-                    w_num_shots.setVisible(true);
-                    s_num_shots.setVisible(true);
-                }
-
-                int shots = m.getBaseShotsLeft();
-                int magazineSize = (int) (curType.getTonnage() * shots);
-                int stepSize = 1;
-                
-                for (int i = 0; i <= shots; i += stepSize){
-                    b_num_shots.addItem(i);
-                }
-                b_num_shots.setSelectedItem(m_mounted.getBaseShotsLeft());
-
-                b_num_shots.addItemListener(new ItemListener(){
-                @Override
-                public void itemStateChanged(ItemEvent evt) {
-                        int currShots = (Integer)b_num_shots.getSelectedItem();
-                        b_num_shots.removeAllItems();
-                        int shots = m_vTypes.get(
-                                b_num_shots.getSelectedIndex()).getShots();
-                        for (int i = 0; i <= shots; i++){
-                            b_num_shots.addItem(i);
-                        }
-                        if (currShots <= shots){
-                            b_num_shots.setSelectedItem(currShots);
-                        } else {
-                            b_num_shots.setSelectedItem(shots);
-                        }
-
-                    }}); 
-
-
-                int loc;
-                if (m.getLocation() == Entity.LOC_NONE) {
-                    // oneshot weapons don't have a location of their own
-                    Mounted linkedBy = m.getLinkedBy();
-                    loc = linkedBy.getLocation();
-                } else {
-                    loc = m.getLocation();
-                }
-                
-                String sDesc = '(' + entity.getLocationAbbr(loc) + ')';
-                JLabel lLoc = new JLabel(sDesc);
-                GridBagLayout g = new GridBagLayout();
-                setLayout(g);
-                add(lLoc, GBC.std());
-                add(b_num_shots, GBC.eol());
-                //add(w_num_shots, GBC.eol());
-                //add(k_num_shots, GBC.eol());
-                //add(s_num_shots, GBC.eol());
-                //add(p_num_shots, GBC.eol());
-                if (clientgui.getClient().getGame().getOptions().booleanOption(
-                        OptionsConstants.BASE_LOBBY_AMMO_DUMP)) { //$NON-NLS-1$
-                    add(labDump, GBC.std());
-                    add(chDump, GBC.eol());
-                } 
-            }
-
-            public void applyChoice() {
-                int n = 0;
-                // If there's no selection, there's nothing we can do
-                if (n == -1) {
-                    return;
-                }
-                AmmoType at = m_vTypes.get(n);
-                m_mounted.changeAmmoType(at);
-                m_mounted.setShotsLeft((Integer)b_num_shots.getSelectedItem());
-                if (chDump.isSelected()) {
-                    m_mounted.setShotsLeft(0);
-                }
-            }
-
-            @Override
-            public void setEnabled(boolean enabled) {
-                b_num_shots.setEnabled(enabled);
-            }
-
-            /**
-             * Get the number of shots in the mount.
-             *
-             * @return the <code>int</code> number of shots in the mount.
-             */
-            int getShotsLeft() {
-                return m_mounted.getBaseShotsLeft();
-            }
-
-            /**
-             * Set the number of shots in the mount.
-             *
-             * @param shots
-             *            the <code>int</code> number of shots for the mount.
-             */
-            void setShotsLeft(int shots) {
-                m_mounted.setShotsLeft(shots);
-            }
-        } 
-
         // a choice panel for determining number of santa anna warheads
         class SantaAnnaChoicePanel extends JPanel {
             /**

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1045,7 +1045,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 int magazineSize = 0;
                 int magazineLoadout = 0;
                 if (entity.usesWeaponBays()) {
-                    shotsPerTon = m.getBaseShotsLeft();
+                    shotsPerTon = m.getOriginalShots();
                 } else {
                     shotsPerTon = curType.getShots();
                 }
@@ -1091,7 +1091,11 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                             for (int i = 0; i <= shots; i++){
                                 m_num_shots.addItem(i);                                
                             }
-                            m_num_shots.setSelectedItem(shots);
+                            if (currShots <= shots){
+                                m_num_shots.setSelectedItem(currShots);
+                            } else {
+                                m_num_shots.setSelectedItem(shots);
+                            }
                         } else {
                             for (int i = 0; i <= shotsPerTon; i++){
                                 m_num_shots.addItem(i);
@@ -1130,9 +1134,9 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                     add (lMag, GBC.std());
                 }
                 if (aeroShotsOnly) {
-                add(labAeroMunitionType, GBC.std());
+                    add(labAeroMunitionType, GBC.std());
                 } else {
-                add(m_choice, GBC.std());
+                    add(m_choice, GBC.std());
                 }
                 add(m_num_shots, GBC.eol());
                 chHotLoad.setSelected(m_mounted.isHotLoaded());
@@ -1155,12 +1159,10 @@ public class EquipChoicePanel extends JPanel implements Serializable {
             }
 
             public void applyChoice() {
-                int n;
-                if (aeroShotsOnly) {
+                int n = m_choice.getSelectedIndex();
+                if (m_choice.isVisible() == false) {
                     n = 0;
-                } else {
-                    n = m_choice.getSelectedIndex();
-                }
+                } 
                 // If there's no selection, there's nothing we can do
                 if (n == -1) {
                     return;

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -45,13 +45,11 @@ import megamek.common.AmmoType;
 import megamek.common.BattleArmor;
 import megamek.common.Configuration;
 import megamek.common.CriticalSlot;
-import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.IBomber;
 import megamek.common.IGame;
 import megamek.common.Infantry;
-import megamek.common.Jumpship;
 import megamek.common.LocationFullException;
 import megamek.common.Mech;
 import megamek.common.MiscType;
@@ -119,9 +117,6 @@ public class EquipChoicePanel extends JPanel implements Serializable {
 
     private ArrayList<MineChoicePanel> m_vMines = new ArrayList<MineChoicePanel>();
     private JPanel panMines = new JPanel();
-    
-    private ArrayList<SantaAnnaChoicePanel> m_vSantaAnna = new ArrayList<SantaAnnaChoicePanel>();
-    private JPanel panSantaAnna = new JPanel();
 
     private BombChoicePanel m_bombs;
     private JPanel panBombs = new JPanel();
@@ -272,15 +267,6 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                     GBC.eop().anchor(GridBagConstraints.CENTER));
         }
 
-        // set up Santa Annas if using nukes
-        if (((entity instanceof Dropship) || (entity instanceof Jumpship))
-                && clientgui.getClient().getGame().getOptions().booleanOption(
-                        OptionsConstants.ADVAERORULES_AT2_NUKES)) { //$NON-NLS-1$
-            setupSantaAnna();
-            add(panSantaAnna,
-                    GBC.eop().anchor(GridBagConstraints.CENTER));
-        }
-
         if (entity.isBomber()) {
             setupBombs();
             add(panBombs, GBC.eop().anchor(GridBagConstraints.CENTER));
@@ -368,10 +354,6 @@ public class EquipChoicePanel extends JPanel implements Serializable {
         // update mines setting
         for (final Object newVar : m_vMines) {
             ((MineChoicePanel) newVar).applyChoice();
-        }
-        // update Santa Anna setting
-        for (final Object newVar : m_vSantaAnna) {
-            ((SantaAnnaChoicePanel) newVar).applyChoice();
         }
         // update bomb setting
         if (null != m_bombs) {
@@ -462,24 +444,6 @@ public class EquipChoicePanel extends JPanel implements Serializable {
             gbl.setConstraints(mcp, gbc);
             panMines.add(mcp);
             m_vMines.add(mcp);
-        }
-    }
-
-    private void setupSantaAnna() {
-        GridBagLayout gbl = new GridBagLayout();
-        panSantaAnna.setLayout(gbl);
-        for (Mounted m : entity.getAmmo()) {
-            AmmoType at = (AmmoType) m.getType();
-            // Santa Annas?
-            if (clientgui.getClient().getGame().getOptions().booleanOption(
-                    OptionsConstants.ADVAERORULES_AT2_NUKES)
-                    && ((at.getAmmoType() == AmmoType.T_KILLER_WHALE) || ((at
-                            .getAmmoType() == AmmoType.T_AR10) && at
-                            .hasFlag(AmmoType.F_AR10_KILLER_WHALE)))) {
-                SantaAnnaChoicePanel sacp = new SantaAnnaChoicePanel(m);
-                panSantaAnna.add(sacp, GBC.eol());
-                m_vSantaAnna.add(sacp);
-            }
         }
     }
     

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2346,16 +2346,26 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                 }
             }
         } else if (atype.getAmmoType() == AmmoType.T_AR10) {
-            if (atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)) {
+            if (atype.getMunitionType() == AmmoType.M_KILLER_WHALE) {
                 avShort = 4;
                 avMed = 4;
                 avLong = 4;
                 avExt = 4;
-            } else if (atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)) {
+            } else if (atype.getMunitionType() == AmmoType.M_WHITE_SHARK) {
                 avShort = 3;
                 avMed = 3;
                 avLong = 3;
                 avExt = 3;
+            } else if (atype.getMunitionType() == AmmoType.M_SANTA_ANNA){
+                avShort = 100;
+                avMed = 100;
+                avLong = 100;
+                avExt = 100;
+            } else if (atype.getMunitionType() == AmmoType.M_PEACEMAKER){
+                avShort = 1000;
+                avMed = 1000;
+                avLong = 1000;
+                avExt = 1000;
             } else {
                 avShort = 2;
                 avMed = 2;

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2346,12 +2346,12 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                 }
             }
         } else if (atype.getAmmoType() == AmmoType.T_AR10) {
-            if (atype.getMunitionType() == AmmoType.M_KILLER_WHALE) {
+            if (atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)) {
                 avShort = 4;
                 avMed = 4;
                 avLong = 4;
                 avExt = 4;
-            } else if (atype.getMunitionType() == AmmoType.M_WHITE_SHARK) {
+            } else if (atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)) {
                 avShort = 3;
                 avMed = 3;
                 avLong = 3;

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -205,6 +205,9 @@ public class Aero extends Entity implements IAero, IBomber {
     private int whoFirst = 0;
 
     private int eccmRoll = 0;
+    
+    //ASEW Missile Effects, per firing arc
+    protected int asewAffectedTurns[] = {0, 0};
 
     public Aero() {
         super();
@@ -421,6 +424,16 @@ public class Aero extends Entity implements IAero, IBomber {
     @Override
     public void setRandomMove(boolean randmove) {
         randomMove = randmove;
+    }
+    
+    @Override
+    public void setASEWAffected(int arc, int turns) {
+        asewAffectedTurns[arc] = turns;
+    }
+    
+    @Override
+    public int getASEWAffected(int arc) {
+        return asewAffectedTurns[arc];
     }
 
     @Override

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -207,7 +207,7 @@ public class Aero extends Entity implements IAero, IBomber {
     private int eccmRoll = 0;
     
     //ASEW Missile Effects, per firing arc
-    protected int asewAffectedTurns[] = {0, 0};
+    protected int asewAffectedTurns[] = {0,0,0,0};
 
     public Aero() {
         super();

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -206,9 +206,6 @@ public class Aero extends Entity implements IAero, IBomber {
 
     private int eccmRoll = 0;
     
-    //ASEW Missile Effects, per firing arc
-    protected int asewAffectedTurns[] = {0,0,0,0};
-
     public Aero() {
         super();
         // need to set altitude to something different than entity
@@ -426,16 +423,6 @@ public class Aero extends Entity implements IAero, IBomber {
         randomMove = randmove;
     }
     
-    @Override
-    public void setASEWAffected(int arc, int turns) {
-        asewAffectedTurns[arc] = turns;
-    }
-    
-    @Override
-    public int getASEWAffected(int arc) {
-        return asewAffectedTurns[arc];
-    }
-
     @Override
     public void setRolled(boolean roll) {
         rolled = roll;

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -328,6 +328,11 @@ public class AmmoType extends EquipmentType {
     public static final long M_MINE_CLEARANCE = 1l << 61;
     
     // Numbers 62-63 are used for Nuclear munitions, above 
+    
+    // AR10 Munitions
+    public static final long M_BARRACUDA = 1l << 64;
+    public static final long M_WHITE_SHARK = 1l << 65;
+    public static final long M_KILLER_WHALE = 1l << 66;
       
     /*
      * public static final String[] MUNITION_NAMES = { "Standard", "Cluster",
@@ -395,7 +400,7 @@ public class AmmoType extends EquipmentType {
                 return false;
             }
         }
-        if (getAmmoType() == T_AR10) {
+        /* if (getAmmoType() == T_AR10) {
             if (hasFlag(F_AR10_BARRACUDA) != ((AmmoType) other)
                     .hasFlag(F_AR10_BARRACUDA)) {
                 return false;
@@ -408,7 +413,7 @@ public class AmmoType extends EquipmentType {
                     .hasFlag(F_AR10_KILLER_WHALE)) {
                 return false;
             }
-        }
+        } */
         return ((getAmmoType() == ((AmmoType) other).getAmmoType()) && (getRackSize() == ((AmmoType) other)
                 .getRackSize()));
     }
@@ -1220,10 +1225,8 @@ public class AmmoType extends EquipmentType {
         EquipmentType.addType(AmmoType.createKrakenAmmo());
         EquipmentType.addType(AmmoType.createKillerWhaleAmmo());
         EquipmentType.addType(AmmoType.createPeacemakerAmmo());
-        EquipmentType.addType(AmmoType.createCLPeacemakerAmmo());
         EquipmentType.addType(AmmoType.createWhiteSharkAmmo());
         EquipmentType.addType(AmmoType.createSantaAnnaAmmo());
-        EquipmentType.addType(AmmoType.createCLSantaAnnaAmmo());
         EquipmentType.addType(AmmoType.createBarracudaAmmo());        
         EquipmentType.addType(AmmoType.createKillerWhaleTAmmo());
         EquipmentType.addType(AmmoType.createWhiteSharkTAmmo());
@@ -11554,11 +11557,12 @@ public class AmmoType extends EquipmentType {
                 ammo.addLookupName("AR10 Barracuda Ammo");
                 ammo.damagePerShot = 2;
                 ammo.ammoType = AmmoType.T_AR10;
+                ammo.munitionType = AmmoType.M_BARRACUDA;
                 ammo.shots = 1;
                 ammo.tonnage = 30;
                 ammo.bv = 65;
                 ammo.cost = 8000;
-                ammo.flags = ammo.flags.or(F_AR10_BARRACUDA).or(F_CAP_MISSILE);
+                ammo.flags = ammo.flags.or(F_CAP_MISSILE);
                 ammo.toHitModifier = -2;
                 ammo.capital = true;
                 //Set the date TP of these weapons to match the AR10 and the ratings to match the missiles
@@ -11586,11 +11590,12 @@ public class AmmoType extends EquipmentType {
                 ammo.addLookupName("AR10 KillerWhale Ammo");
                 ammo.damagePerShot = 4;
                 ammo.ammoType = AmmoType.T_AR10;
+                ammo.munitionType = AmmoType.M_KILLER_WHALE;
                 ammo.shots = 1;
                 ammo.tonnage = 50;
                 ammo.bv = 96;
                 ammo.cost = 20000;
-                ammo.flags = ammo.flags.or(F_AR10_KILLER_WHALE).or(F_CAP_MISSILE);
+                ammo.flags = ammo.flags.or(F_CAP_MISSILE);
                 ammo.capital = true;
                 //Set the date TP of these weapons to match the AR10 and the ratings to match the missiles
                 ammo.rulesRefs = "210,TM";
@@ -11618,11 +11623,12 @@ public class AmmoType extends EquipmentType {
                 ammo.addLookupName("AR10 WhiteShark Ammo");
                 ammo.damagePerShot = 3;
                 ammo.ammoType = AmmoType.T_AR10;
+                ammo.munitionType = AmmoType.M_WHITE_SHARK;
                 ammo.shots = 1;
                 ammo.tonnage = 40;
                 ammo.bv = 72;
                 ammo.cost = 14000;
-                ammo.flags = ammo.flags.or(F_AR10_WHITE_SHARK).or(F_CAP_MISSILE);
+                ammo.flags = ammo.flags.or(F_CAP_MISSILE);
                 ammo.capital = true;
                 //Set the date TP of these weapons to match the AR10 and the ratings to match the missiles
                 ammo.rulesRefs = "210,TM";
@@ -14775,14 +14781,20 @@ public class AmmoType extends EquipmentType {
         ammo.tonnage = 50;
         ammo.bv = 10000;
         ammo.cost = 40000000;
-        ammo.flags = ammo.flags.or(F_AR10_KILLER_WHALE).or(F_NUCLEAR)
+        ammo.flags = ammo.flags.or(F_NUCLEAR)
                 .or(F_CAP_MISSILE).or(F_PEACEMAKER);
         ammo.capital = true;
-
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_C)
-            .setISAdvancement(DATE_NONE, DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
-            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+        ammo.techAdvancement.setTechBase(TECH_BASE_IS)
+        .setIntroLevel(false)
+        .setUnofficial(false)
+        .setTechRating(RATING_E)
+        .setAvailability(RATING_F, RATING_F, RATING_F, RATING_F)
+        .setISAdvancement(2540, DATE_NONE, DATE_NONE, 2950, 3051)
+        .setISApproximate(true, false, false, true, true)
+        .setClanAdvancement(DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+        .setClanApproximate(false, false, false, false, false)
+        .setPrototypeFactions(F_TH)
+        .setReintroductionFactions(F_FS,F_LC);
         return ammo;
     } 
 
@@ -14804,40 +14816,19 @@ public class AmmoType extends EquipmentType {
         ammo.cost = 40000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_PEACEMAKER);
         ammo.capital = true;
-
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_C)
-            .setISAdvancement(DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
-            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+        ammo.techAdvancement.setTechBase(TECH_BASE_IS)
+        .setIntroLevel(false)
+        .setUnofficial(false)
+        .setTechRating(RATING_E)
+        .setAvailability(RATING_F, RATING_F, RATING_F, RATING_F)
+        .setISAdvancement(2220, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+        .setISApproximate(true, false, false, false, false)
+        .setClanAdvancement(DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+        .setClanApproximate(false, false, false, false, false)
+        .setPrototypeFactions(F_TH)
+        .setReintroductionFactions(F_FS,F_LC);
         return ammo;
-    }
-    
-    private static AmmoType createCLPeacemakerAmmo() {
-        AmmoType ammo = new AmmoType();
-
-        ammo.name = "Clan Peacemaker Ammo";
-        ammo.setInternalName("Ammo Clan Peacemaker");
-        ammo.addLookupName("CLPeacemaker Ammo");
-        ammo.shortName = "Peacemaker";
-        ammo.subMunitionBegin = 0;
-        ammo.subMunitionLength = ammo.shortName.length();
-        ammo.damagePerShot = 1000;
-        ammo.ammoType = AmmoType.T_KILLER_WHALE;
-        ammo.munitionType = AmmoType.M_PEACEMAKER;
-        ammo.shots = 1;
-        ammo.tonnage = 50;
-        ammo.bv = 10000;
-        ammo.cost = 40000000;
-        ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_PEACEMAKER);
-        ammo.capital = true;
-
-        ammo.techAdvancement.setTechBase(TECH_BASE_CLAN).setTechRating(RATING_C)
-            .setClanAdvancement(DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
-            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
-
-        return ammo;
-    }   
+    } 
 
     private static AmmoType createAR10SantaAnnaAmmo() {
         AmmoType ammo = new AmmoType();
@@ -14855,14 +14846,20 @@ public class AmmoType extends EquipmentType {
         ammo.tonnage = 40;
         ammo.bv = 1000;
         ammo.cost = 15000000;
-        ammo.flags = ammo.flags.or(F_AR10_WHITE_SHARK).or(F_NUCLEAR)
+        ammo.flags = ammo.flags.or(F_NUCLEAR)
                 .or(F_CAP_MISSILE).or(F_SANTA_ANNA);
         ammo.capital = true;
-
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_C)
-            .setISAdvancement(DATE_NONE, DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
-            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+        ammo.techAdvancement.setTechBase(TECH_BASE_IS)
+        .setIntroLevel(false)
+        .setUnofficial(false)
+        .setTechRating(RATING_E)
+        .setAvailability(RATING_F, RATING_F, RATING_F, RATING_F)
+        .setISAdvancement(2540, DATE_NONE, DATE_NONE, 2950, 3051)
+        .setISApproximate(true, false, false, true, true)
+        .setClanAdvancement(DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+        .setClanApproximate(false, false, false, false, false)
+        .setPrototypeFactions(F_TH)
+        .setReintroductionFactions(F_FS,F_LC);
         return ammo;
     } 
 
@@ -14884,41 +14881,18 @@ public class AmmoType extends EquipmentType {
         ammo.cost = 15000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_SANTA_ANNA);
         ammo.capital = true;
-
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_C)
-            .setISAdvancement(DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
-            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+        ammo.techAdvancement.setTechBase(TECH_BASE_IS)
+        .setIntroLevel(false)
+        .setUnofficial(false)
+        .setTechRating(RATING_E)
+        .setAvailability(RATING_F, RATING_F, RATING_F, RATING_F)
+        .setISAdvancement(2300, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+        .setISApproximate(true, false, false, false, false)
+        .setClanAdvancement(DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+        .setClanApproximate(false, false, false, false, false)
+        .setPrototypeFactions(F_TH);
         return ammo;
     }
-    
-    private static AmmoType createCLSantaAnnaAmmo() {
-        AmmoType ammo = new AmmoType();
-
-        ammo.name = "Clan Santa Anna Ammo";
-        ammo.setInternalName("Ammo Clan Santa Anna");
-        ammo.addLookupName("CLSantaAnna Ammo");
-        ammo.shortName = "Santa Anna";
-        ammo.subMunitionBegin = 0;
-        ammo.subMunitionLength = ammo.shortName.length();
-        ammo.damagePerShot = 100;
-        ammo.ammoType = AmmoType.T_WHITE_SHARK;
-        ammo.munitionType = AmmoType.M_SANTA_ANNA;
-        ammo.shots = 1;
-        ammo.tonnage = 40;
-        ammo.bv = 1000;
-        ammo.cost = 15000000;
-        ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_SANTA_ANNA);
-        ammo.capital = true;
-
-        ammo.techAdvancement.setTechBase(TECH_BASE_CLAN).setTechRating(RATING_C)
-            .setClanAdvancement(DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
-            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
-
-        return ammo;
-    }
-
 
     private static AmmoType createAlamoAmmo() {
         AmmoType ammo = new AmmoType();
@@ -14934,10 +14908,16 @@ public class AmmoType extends EquipmentType {
         ammo.cost = 1000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR);
         ammo.capital = true;
-
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setISAdvancement(DATE_NONE, DATE_NONE, 3067)
-            .setTechRating(RATING_C).setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
-            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+        ammo.techAdvancement.setTechBase(TECH_BASE_IS)
+        .setIntroLevel(false)
+        .setUnofficial(false)
+        .setTechRating(RATING_E)
+        .setAvailability(RATING_F, RATING_F, RATING_F, RATING_F)
+        .setISAdvancement(2200, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+        .setISApproximate(true, false, false, false, false)
+        .setClanAdvancement(DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+        .setClanApproximate(false, false, false, false, false)
+        .setPrototypeFactions(F_TH);
         return ammo;
     }
 

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -135,7 +135,10 @@ public class AmmoType extends EquipmentType {
 	public static final int T_LRM_IMP = 107;
 	public static final int T_LONG_TOM_PRIM = 108;
 	public static final int T_ARROWIV_PROTO = 109;
-    public static final int NUM_TYPES = 110;  //Should always be at the end with the highest number
+    public static final int T_KILLER_WHALE_T = 110;
+    public static final int T_WHITE_SHARK_T = 111;
+    public static final int T_BARRACUDA_T = 112;
+    public static final int NUM_TYPES = 113;  //Should always be at the end with the highest number
 
     // ammo flags
     public static final BigInteger F_MG = BigInteger.valueOf(1).shiftLeft(0);
@@ -400,20 +403,7 @@ public class AmmoType extends EquipmentType {
                 return false;
             }
         }
-        /* if (getAmmoType() == T_AR10) {
-            if (hasFlag(F_AR10_BARRACUDA) != ((AmmoType) other)
-                    .hasFlag(F_AR10_BARRACUDA)) {
-                return false;
-            }
-            if (hasFlag(F_AR10_WHITE_SHARK) != ((AmmoType) other)
-                    .hasFlag(F_AR10_WHITE_SHARK)) {
-                return false;
-            }
-            if (hasFlag(F_AR10_KILLER_WHALE) != ((AmmoType) other)
-                    .hasFlag(F_AR10_KILLER_WHALE)) {
-                return false;
-            }
-        } */
+
         return ((getAmmoType() == ((AmmoType) other).getAmmoType()) && (getRackSize() == ((AmmoType) other)
                 .getRackSize()));
     }
@@ -11171,7 +11161,7 @@ public class AmmoType extends EquipmentType {
 	            ammo.setInternalName("Ammo Barracuda-T");
 	            ammo.addLookupName("BarracudaT Ammo");
 	            ammo.damagePerShot = 2;
-	            ammo.ammoType = AmmoType.T_BARRACUDA;
+	            ammo.ammoType = AmmoType.T_BARRACUDA_T;
 	            ammo.shots = 1;
 	            ammo.tonnage = 30;
 	            ammo.bv = 65;
@@ -11201,7 +11191,7 @@ public class AmmoType extends EquipmentType {
                 ammo.setInternalName("Ammo White Shark-T");
                 ammo.addLookupName("WhiteSharkT Ammo");
                 ammo.damagePerShot = 3;
-                ammo.ammoType = AmmoType.T_WHITE_SHARK;
+                ammo.ammoType = AmmoType.T_WHITE_SHARK_T;
                 ammo.shots = 1;
                 ammo.tonnage = 40;
                 ammo.bv = 72;
@@ -11230,7 +11220,7 @@ public class AmmoType extends EquipmentType {
                 ammo.setInternalName("Ammo Killer Whale-T");
                 ammo.addLookupName("KillerWhaleT Ammo");
                 ammo.damagePerShot = 4;
-                ammo.ammoType = AmmoType.T_KILLER_WHALE;
+                ammo.ammoType = AmmoType.T_KILLER_WHALE_T;
                 ammo.shots = 1;
                 ammo.tonnage = 50;
                 ammo.bv = 96;

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -473,7 +473,7 @@ public class AmmoType extends EquipmentType {
         case T_ATM:
             return (munitionType == M_STANDARD)
                     || (munitionType == M_HIGH_EXPLOSIVE)
-                    || (munitionType == M_EXTENDED_RANGE);
+                    || (munitionType == M_EXTENDED_RANGE);        
         case T_AR10:
             return true;
         default:
@@ -1228,9 +1228,6 @@ public class AmmoType extends EquipmentType {
         EquipmentType.addType(AmmoType.createAR10WhiteSharkAmmo());
         EquipmentType.addType(AmmoType.createAR10SantaAnnaAmmo());
         EquipmentType.addType(AmmoType.createAR10BarracudaAmmo());
-        EquipmentType.addType(AmmoType.createAR10KillerWhaleTAmmo());
-        EquipmentType.addType(AmmoType.createAR10WhiteSharkTAmmo());
-        EquipmentType.addType(AmmoType.createAR10BarracudaTAmmo());
         EquipmentType.addType(AmmoType.createScreenLauncherAmmo());
         EquipmentType.addType(AmmoType.createAlamoAmmo());
         EquipmentType.addType(AmmoType.createLightSCCAmmo());
@@ -11074,6 +11071,7 @@ public class AmmoType extends EquipmentType {
 	            ammo.damagePerShot = 2;
 	            ammo.ammoType = AmmoType.T_BARRACUDA;
 	            ammo.shots = 1;
+	            ammo.tonnage = 30;
 	            ammo.bv = 65;
 	            ammo.cost = 8000;
 	            ammo.toHitModifier = -2;
@@ -11105,10 +11103,10 @@ public class AmmoType extends EquipmentType {
 	            ammo.damagePerShot = 3;
 	            ammo.ammoType = AmmoType.T_WHITE_SHARK;
 	            ammo.shots = 1;
+	            ammo.tonnage = 40;
 	            ammo.bv = 72;
 	            ammo.cost = 14000;
 	            ammo.capital = true;
-	            ammo.ammoRatio = 40;
 	            ammo.flags = ammo.flags.or(F_CAP_MISSILE);
 	            ammo.rulesRefs = "210,TM";
 	            ammo.techAdvancement.setTechBase(TECH_BASE_ALL)
@@ -11135,6 +11133,7 @@ public class AmmoType extends EquipmentType {
 	            ammo.damagePerShot = 4;
 	            ammo.ammoType = AmmoType.T_KILLER_WHALE;
 	            ammo.shots = 1;
+	            ammo.tonnage = 50;
 	            ammo.bv = 96;
 	            ammo.cost = 20000;
 	            ammo.capital = true;
@@ -11166,6 +11165,7 @@ public class AmmoType extends EquipmentType {
 	            ammo.damagePerShot = 2;
 	            ammo.ammoType = AmmoType.T_BARRACUDA;
 	            ammo.shots = 1;
+	            ammo.tonnage = 30;
 	            ammo.bv = 65;
 	            ammo.cost = 8000;
 	            ammo.toHitModifier = -2;
@@ -11195,6 +11195,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 3;
                 ammo.ammoType = AmmoType.T_WHITE_SHARK;
                 ammo.shots = 1;
+                ammo.tonnage = 40;
                 ammo.bv = 72;
                 ammo.cost = 14000;
                 ammo.capital = true;
@@ -11223,6 +11224,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 4;
                 ammo.ammoType = AmmoType.T_KILLER_WHALE;
                 ammo.shots = 1;
+                ammo.tonnage = 50;
                 ammo.bv = 96;
                 ammo.cost = 20000;
                 ammo.capital = true;
@@ -11250,6 +11252,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 10;
                 ammo.ammoType = AmmoType.T_KRAKEN_T;
                 ammo.shots = 1;
+                ammo.tonnage = 100;
                 ammo.bv = 288;
                 ammo.cost = 55000;
                 ammo.capital = true;
@@ -11276,6 +11279,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 10;
                 ammo.ammoType = AmmoType.T_KRAKENM;
                 ammo.shots = 1;
+                ammo.tonnage = 100;
                 ammo.bv = 288;
                 ammo.cost = 55000;
                 ammo.capital = true;
@@ -11303,6 +11307,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 0;
                 ammo.ammoType = AmmoType.T_SCREEN_LAUNCHER;
                 ammo.shots = 1;
+                ammo.tonnage = 10;
                 ammo.bv = 20;
                 ammo.cost = 10000;
                 ammo.rulesRefs = "237,TM";
@@ -11421,6 +11426,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 5;
                 ammo.ammoType = AmmoType.T_MANTA_RAY;
                 ammo.shots = 1;
+                ammo.tonnage = 18;
                 ammo.bv = 50;
                 ammo.cost = 30000;
                 ammo.ammoRatio = 18;
@@ -11450,6 +11456,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 4;
                 ammo.ammoType = AmmoType.T_SWORDFISH;
                 ammo.shots = 1;
+                ammo.tonnage = 15;
                 ammo.bv = 40;
                 ammo.cost = 25000;
                 ammo.capital = true;
@@ -11480,6 +11487,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 3;
                 ammo.ammoType = AmmoType.T_STINGRAY;
                 ammo.shots = 1;
+                ammo.tonnage = 12;
                 ammo.bv = 62;
                 ammo.cost = 19000;
                 ammo.ammoRatio = 12;
@@ -11510,6 +11518,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 3;
                 ammo.ammoType = AmmoType.T_PIRANHA;
                 ammo.shots = 1;
+                ammo.tonnage = 10;
                 ammo.bv = 84;
                 ammo.cost = 15000;
                 ammo.ammoRatio = 10;
@@ -11541,6 +11550,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 2;
                 ammo.ammoType = AmmoType.T_AR10;
                 ammo.shots = 1;
+                ammo.tonnage = 30;
                 ammo.bv = 65;
                 ammo.cost = 8000;
                 ammo.flags = ammo.flags.or(F_AR10_BARRACUDA).or(F_CAP_MISSILE);
@@ -11572,6 +11582,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 4;
                 ammo.ammoType = AmmoType.T_AR10;
                 ammo.shots = 1;
+                ammo.tonnage = 50;
                 ammo.bv = 96;
                 ammo.cost = 20000;
                 ammo.flags = ammo.flags.or(F_AR10_KILLER_WHALE).or(F_CAP_MISSILE);
@@ -11603,6 +11614,7 @@ public class AmmoType extends EquipmentType {
                 ammo.damagePerShot = 3;
                 ammo.ammoType = AmmoType.T_AR10;
                 ammo.shots = 1;
+                ammo.tonnage = 40;
                 ammo.bv = 72;
                 ammo.cost = 14000;
                 ammo.flags = ammo.flags.or(F_AR10_WHITE_SHARK).or(F_CAP_MISSILE);
@@ -11620,97 +11632,6 @@ public class AmmoType extends EquipmentType {
                     .setClanApproximate(true, false, false,false, false)
                     .setPrototypeFactions(F_TH)
                     .setProductionFactions(F_TH)
-                    .setReintroductionFactions(F_FS,F_LC);
-                return ammo;
-            }
-
-            private static AmmoType createAR10BarracudaTAmmo() {
-                AmmoType ammo = new AmmoType();
-
-                ammo.name = "AR10 Barracuda (Tele-Operated) Ammo";
-                ammo.setInternalName("Ammo AR10 Barracuda-T");
-                ammo.addLookupName("AR10 BarracudaT Ammo");
-                ammo.damagePerShot = 2;
-                ammo.ammoType = AmmoType.T_AR10;
-                ammo.shots = 1;
-                ammo.bv = 65;
-                ammo.cost = 8000;
-                ammo.flags = ammo.flags.or(F_AR10_BARRACUDA).or(F_TELE_MISSILE)
-                        .or(F_CAP_MISSILE);
-                ammo.toHitModifier = -2;
-                ammo.capital = true;
-                ammo.munitionType = AmmoType.M_TELE;
-                //Set the date of these weapons to match the Tele Missile itself
-                ammo.rulesRefs = "251,TW";
-                ammo.techAdvancement.setTechBase(TECH_BASE_IS)
-                    .setIntroLevel(false)
-                    .setUnofficial(false)
-                    .setTechRating(RATING_F)
-                    .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
-                    .setISAdvancement(3053, 3056, 3060, DATE_NONE, DATE_NONE)
-                    .setISApproximate(true, false, false, true, false)
-                    .setPrototypeFactions(F_CS,F_DC)
-                    .setProductionFactions(F_DC)
-                    .setReintroductionFactions(F_FS,F_LC);
-                return ammo;
-            }
-
-            private static AmmoType createAR10KillerWhaleTAmmo() {
-                AmmoType ammo = new AmmoType();
-
-                ammo.name = "AR10 Killer Whale (Tele-Operated) Ammo";
-                ammo.setInternalName("Ammo AR10 Killer Whale-T");
-                ammo.addLookupName("AR10 KillerWhaleT Ammo");
-                ammo.damagePerShot = 4;
-                ammo.ammoType = AmmoType.T_AR10;
-                ammo.shots = 1;
-                ammo.bv = 96;
-                ammo.cost = 20000;
-                ammo.flags = ammo.flags.or(F_AR10_KILLER_WHALE).or(F_TELE_MISSILE)
-                        .or(F_CAP_MISSILE);
-                ammo.capital = true;
-                ammo.munitionType = AmmoType.M_TELE;
-                //Set the date of these weapons to match the Tele Missile itself
-                ammo.rulesRefs = "251,TW";
-                ammo.techAdvancement.setTechBase(TECH_BASE_IS)
-                    .setIntroLevel(false)
-                    .setUnofficial(false)
-                    .setTechRating(RATING_F)
-                    .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
-                    .setISAdvancement(3053, 3056, 3060, DATE_NONE, DATE_NONE)
-                    .setISApproximate(true, false, false, true, false)
-                    .setPrototypeFactions(F_CS,F_DC)
-                    .setProductionFactions(F_DC)
-                    .setReintroductionFactions(F_FS,F_LC);
-                return ammo;
-            }
-
-            private static AmmoType createAR10WhiteSharkTAmmo() {
-                AmmoType ammo = new AmmoType();
-
-                ammo.name = "AR10 White Shark (Tele-Operated) Ammo";
-                ammo.setInternalName("Ammo AR10 White Shark-T");
-                ammo.addLookupName("AR10 WhiteSharkT Ammo");
-                ammo.damagePerShot = 3;
-                ammo.ammoType = AmmoType.T_AR10;
-                ammo.shots = 1;
-                ammo.bv = 72;
-                ammo.cost = 14000;
-                ammo.flags = ammo.flags.or(F_AR10_WHITE_SHARK).or(F_TELE_MISSILE)
-                        .or(F_CAP_MISSILE);
-                ammo.capital = true;
-                ammo.munitionType = AmmoType.M_TELE;
-                //Set the date of these weapons to match the Tele Missile itself
-                ammo.rulesRefs = "251,TW";
-                ammo.techAdvancement.setTechBase(TECH_BASE_IS)
-                    .setIntroLevel(false)
-                    .setUnofficial(false)
-                    .setTechRating(RATING_F)
-                    .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
-                    .setISAdvancement(3053, 3056, 3060, DATE_NONE, DATE_NONE)
-                    .setISApproximate(true, false, false, true, false)
-                    .setPrototypeFactions(F_CS,F_DC)
-                    .setProductionFactions(F_DC)
                     .setReintroductionFactions(F_FS,F_LC);
                 return ammo;
             }
@@ -14846,8 +14767,9 @@ public class AmmoType extends EquipmentType {
         ammo.ammoType = AmmoType.T_AR10;
         ammo.munitionType = AmmoType.M_PEACEMAKER;
         ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
+        ammo.tonnage = 50;
+        ammo.bv = 10000;
+        ammo.cost = 40000000;
         ammo.flags = ammo.flags.or(F_AR10_KILLER_WHALE).or(F_NUCLEAR)
                 .or(F_CAP_MISSILE).or(F_PEACEMAKER);
         ammo.capital = true;
@@ -14872,8 +14794,9 @@ public class AmmoType extends EquipmentType {
         ammo.ammoType = AmmoType.T_KILLER_WHALE;
         ammo.munitionType = AmmoType.M_PEACEMAKER;
         ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
+        ammo.tonnage = 50;
+        ammo.bv = 10000;
+        ammo.cost = 40000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_PEACEMAKER);
         ammo.capital = true;
 
@@ -14897,8 +14820,9 @@ public class AmmoType extends EquipmentType {
         ammo.ammoType = AmmoType.T_KILLER_WHALE;
         ammo.munitionType = AmmoType.M_PEACEMAKER;
         ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
+        ammo.tonnage = 50;
+        ammo.bv = 10000;
+        ammo.cost = 40000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_PEACEMAKER);
         ammo.capital = true;
 
@@ -14923,8 +14847,9 @@ public class AmmoType extends EquipmentType {
         ammo.ammoType = AmmoType.T_AR10;
         ammo.munitionType = AmmoType.M_SANTA_ANNA;
         ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
+        ammo.tonnage = 40;
+        ammo.bv = 1000;
+        ammo.cost = 15000000;
         ammo.flags = ammo.flags.or(F_AR10_KILLER_WHALE).or(F_NUCLEAR)
                 .or(F_CAP_MISSILE).or(F_SANTA_ANNA);
         ammo.capital = true;
@@ -14949,8 +14874,9 @@ public class AmmoType extends EquipmentType {
         ammo.ammoType = AmmoType.T_KILLER_WHALE;
         ammo.munitionType = AmmoType.M_SANTA_ANNA;
         ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
+        ammo.tonnage = 40;
+        ammo.bv = 1000;
+        ammo.cost = 15000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_SANTA_ANNA);
         ammo.capital = true;
 
@@ -14974,8 +14900,9 @@ public class AmmoType extends EquipmentType {
         ammo.ammoType = AmmoType.T_KILLER_WHALE;
         ammo.munitionType = AmmoType.M_SANTA_ANNA;
         ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
+        ammo.tonnage = 40;
+        ammo.bv = 1000;
+        ammo.cost = 15000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_SANTA_ANNA);
         ammo.capital = true;
 
@@ -14998,8 +14925,8 @@ public class AmmoType extends EquipmentType {
         ammo.rackSize = 1;
         ammo.ammoType = AmmoType.T_ALAMO;
         ammo.shots = 1;
-        ammo.bv = 0;
-        ammo.cost = 0;
+        ammo.bv = 100;
+        ammo.cost = 1000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR);
         ammo.capital = true;
 

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -331,12 +331,7 @@ public class AmmoType extends EquipmentType {
     public static final long M_MINE_CLEARANCE = 1l << 61;
     
     // Numbers 62-63 are used for Nuclear munitions, above 
-    
-    // AR10 Munitions
-    public static final long M_BARRACUDA = 1l << 64;
-    public static final long M_WHITE_SHARK = 1l << 65;
-    public static final long M_KILLER_WHALE = 1l << 66;
-      
+          
     /*
      * public static final String[] MUNITION_NAMES = { "Standard", "Cluster",
      * "Armor Piercing", "Flechette", "Incendiary", "Incendiary", "Precision",
@@ -11547,12 +11542,11 @@ public class AmmoType extends EquipmentType {
                 ammo.addLookupName("AR10 Barracuda Ammo");
                 ammo.damagePerShot = 2;
                 ammo.ammoType = AmmoType.T_AR10;
-                ammo.munitionType = AmmoType.M_BARRACUDA;
                 ammo.shots = 1;
                 ammo.tonnage = 30;
                 ammo.bv = 65;
                 ammo.cost = 8000;
-                ammo.flags = ammo.flags.or(F_CAP_MISSILE);
+                ammo.flags = ammo.flags.or(F_CAP_MISSILE).or(F_AR10_BARRACUDA);
                 ammo.toHitModifier = -2;
                 ammo.capital = true;
                 //Set the date TP of these weapons to match the AR10 and the ratings to match the missiles
@@ -11580,12 +11574,11 @@ public class AmmoType extends EquipmentType {
                 ammo.addLookupName("AR10 KillerWhale Ammo");
                 ammo.damagePerShot = 4;
                 ammo.ammoType = AmmoType.T_AR10;
-                ammo.munitionType = AmmoType.M_KILLER_WHALE;
                 ammo.shots = 1;
                 ammo.tonnage = 50;
                 ammo.bv = 96;
                 ammo.cost = 20000;
-                ammo.flags = ammo.flags.or(F_CAP_MISSILE);
+                ammo.flags = ammo.flags.or(F_CAP_MISSILE).or(F_AR10_KILLER_WHALE);
                 ammo.capital = true;
                 //Set the date TP of these weapons to match the AR10 and the ratings to match the missiles
                 ammo.rulesRefs = "210,TM";
@@ -11613,12 +11606,11 @@ public class AmmoType extends EquipmentType {
                 ammo.addLookupName("AR10 WhiteShark Ammo");
                 ammo.damagePerShot = 3;
                 ammo.ammoType = AmmoType.T_AR10;
-                ammo.munitionType = AmmoType.M_WHITE_SHARK;
                 ammo.shots = 1;
                 ammo.tonnage = 40;
                 ammo.bv = 72;
                 ammo.cost = 14000;
-                ammo.flags = ammo.flags.or(F_CAP_MISSILE);
+                ammo.flags = ammo.flags.or(F_CAP_MISSILE).or(F_AR10_WHITE_SHARK);
                 ammo.capital = true;
                 //Set the date TP of these weapons to match the AR10 and the ratings to match the missiles
                 ammo.rulesRefs = "210,TM";

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -354,6 +354,7 @@ public class AmmoType extends EquipmentType {
 
     // ratio for capital ammo
     private double ammoRatio;
+
     /**
      * Used for returning the submunition name for a submunition, such as
      * precision AC-10. The submunition name is pre-pended onto the
@@ -445,6 +446,10 @@ public class AmmoType extends EquipmentType {
 
     public int getShots() {
         return shots;
+    }
+    
+    public double getTonnage() {
+        return tonnage;
     }
     
     public double getAmmoRatio() {

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -14855,7 +14855,7 @@ public class AmmoType extends EquipmentType {
         ammo.tonnage = 40;
         ammo.bv = 1000;
         ammo.cost = 15000000;
-        ammo.flags = ammo.flags.or(F_AR10_KILLER_WHALE).or(F_NUCLEAR)
+        ammo.flags = ammo.flags.or(F_AR10_WHITE_SHARK).or(F_NUCLEAR)
                 .or(F_CAP_MISSILE).or(F_SANTA_ANNA);
         ammo.capital = true;
 
@@ -14876,7 +14876,7 @@ public class AmmoType extends EquipmentType {
         ammo.subMunitionBegin = 0;
         ammo.subMunitionLength = ammo.shortName.length();
         ammo.damagePerShot = 100;
-        ammo.ammoType = AmmoType.T_KILLER_WHALE;
+        ammo.ammoType = AmmoType.T_WHITE_SHARK;
         ammo.munitionType = AmmoType.M_SANTA_ANNA;
         ammo.shots = 1;
         ammo.tonnage = 40;
@@ -14902,7 +14902,7 @@ public class AmmoType extends EquipmentType {
         ammo.subMunitionBegin = 0;
         ammo.subMunitionLength = ammo.shortName.length();
         ammo.damagePerShot = 100;
-        ammo.ammoType = AmmoType.T_KILLER_WHALE;
+        ammo.ammoType = AmmoType.T_WHITE_SHARK;
         ammo.munitionType = AmmoType.M_SANTA_ANNA;
         ammo.shots = 1;
         ammo.tonnage = 40;

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -446,7 +446,7 @@ public class AmmoType extends EquipmentType {
     public int getShots() {
         return shots;
     }
-
+    
     public double getAmmoRatio() {
         return ammoRatio;
     }

--- a/megamek/src/megamek/common/BombType.java
+++ b/megamek/src/megamek/common/BombType.java
@@ -278,7 +278,7 @@ public class BombType extends AmmoType {
 		bomb.bombType = BombType.B_AS;
 		bomb.shots = 1;
 		bomb.bv = 114;
-		bomb.cost = 0;
+		bomb.cost = 15000;
 		bomb.rulesRefs = "358,TO";
 		bomb.techAdvancement.setTechBase(TECH_BASE_ALL)
 		.setIntroLevel(false)
@@ -330,7 +330,7 @@ public class BombType extends AmmoType {
 		bomb.bombType = BombType.B_ASEW;
 		bomb.shots = 1;
 		bomb.bv = 75;
-		bomb.cost = 0;
+		bomb.cost = 20000;
 		bomb.rulesRefs = "358,TO";
 		bomb.techAdvancement.setTechBase(TECH_BASE_IS).setIntroLevel(false).setUnofficial(false).setTechRating(RATING_E)
 		        .setAvailability(RATING_X, RATING_X, RATING_E, RATING_E)
@@ -382,7 +382,7 @@ public class BombType extends AmmoType {
 		bomb.flags = bomb.flags.or(AmmoType.F_SPACE_BOMB);
 		bomb.shots = 1;
 		bomb.bv = 0;
-		bomb.cost = 0;
+		bomb.cost = 3000;
 		bomb.rulesRefs = "358,TO";
 		bomb.techAdvancement.setTechBase(TECH_BASE_ALL)
 		.setIntroLevel(false)
@@ -443,7 +443,7 @@ public class BombType extends AmmoType {
 		bomb.flags = bomb.flags.or(AmmoType.F_SPACE_BOMB);
 		bomb.shots = 1;
 		bomb.bv = 34;
-		bomb.cost = 0;
+		bomb.cost = 2000;
 		bomb.rulesRefs = "359,TO";
 		bomb.techAdvancement.setTechBase(TECH_BASE_ALL)
 		.setIntroLevel(false)
@@ -549,7 +549,7 @@ public class BombType extends AmmoType {
 		bomb.flags = bomb.flags.or(AmmoType.F_GROUND_BOMB);
 		bomb.shots = 1;
 		bomb.bv = 16;
-		bomb.cost = 0;
+		bomb.cost = 6000;
 		bomb.rulesRefs = "359,TO";
 		bomb.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
 		        .setTechRating(RATING_C).setAvailability(RATING_D, RATING_D, RATING_D, RATING_C)
@@ -629,7 +629,7 @@ public class BombType extends AmmoType {
 		bomb.bombType = BombType.B_LAA;
 		bomb.shots = 1;
 		bomb.bv = 17;
-		bomb.cost = 0;
+		bomb.cost = 6000;
 		bomb.rulesRefs = "359,TO";
 		bomb.techAdvancement.setTechBase(TECH_BASE_IS).setIntroLevel(false).setUnofficial(false).setTechRating(RATING_E)
 		        .setAvailability(RATING_X, RATING_X, RATING_F, RATING_D)
@@ -759,7 +759,7 @@ public class BombType extends AmmoType {
 		bomb.flags = bomb.flags.or(AmmoType.F_GROUND_BOMB);
 		bomb.shots = 1;
 		bomb.bv = 0;
-		bomb.cost = 0;
+		bomb.cost = 12000;
 		bomb.rulesRefs = "360,TO";
 		bomb.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
 		        .setTechRating(RATING_C).setAvailability(RATING_E, RATING_E, RATING_D, RATING_D)
@@ -786,7 +786,7 @@ public class BombType extends AmmoType {
 		bomb.bombType = BombType.B_TORPEDO;
 		bomb.shots = 1;
 		bomb.bv = 10;
-		bomb.cost = 0;
+		bomb.cost = 7000;
 		bomb.rulesRefs = "360,TO";
 		bomb.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
 		        .setTechRating(RATING_B).setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)

--- a/megamek/src/megamek/common/BombType.java
+++ b/megamek/src/megamek/common/BombType.java
@@ -808,8 +808,8 @@ public class BombType extends AmmoType {
 		bomb.ammoType = AmmoType.T_ALAMO;
 		bomb.bombType = BombType.B_ALAMO;
 		bomb.shots = 1;
-		bomb.bv = 0;
-		bomb.cost = 0;
+		bomb.bv = 100;
+		bomb.cost = 1000000;
 		bomb.flags = bomb.flags.or(F_NUCLEAR).or(AmmoType.F_OTHER_BOMB);
 		bomb.capital = true;
 		bomb.techAdvancement.setTechBase(TechAdvancement.TECH_BASE_IS).setTechRating(RATING_E)

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -34,6 +34,18 @@ public class Dropship extends SmallCraft {
      *
      */
     private static final long serialVersionUID = 1528728632696989565L;
+    
+    //ASEW Missile Effects, per location
+    private int asewAffectedTurns[] = {0,0,0,0};
+    
+    public void setASEWAffected(int arc, int turns) {
+        asewAffectedTurns[arc] = turns;
+    }
+    
+    public int getASEWAffected(int arc) {
+        return asewAffectedTurns[arc];
+    }
+    
     // escape pods and lifeboats
     int escapePods = 0;
     int lifeBoats = 0;

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -399,6 +399,11 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * Keeps track of the current TSEMP effect on this entity
      */
     private int tsempEffect = TSEMPWeapon.TSEMP_EFFECT_NONE;
+    
+    /**
+     * Keeps track of the current ASEW effect on this entity
+     */
+    protected int asewAffectedTurns = 0;
 
     /**
      * Keeps track of whether this Entity fired a TSEMP this turn
@@ -14606,6 +14611,14 @@ public abstract class Entity extends TurnOrdered implements Transporter,
 
     public void setHasFiredTsemp(boolean hasFiredTSEMP) {
         hasFiredTsemp = hasFiredTSEMP;
+    }
+    
+    public void setASEWAffected(int turns) {
+        asewAffectedTurns = turns;
+    }
+    
+    public int getASEWAffected() {
+        return asewAffectedTurns;
     }
 
     public boolean hasActivatedRadicalHS() {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3389,6 +3389,10 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             mounted.setByShot(true);
             mounted.setShotsLeft(nAmmo);
             mounted.setOriginalShots(nAmmo);
+            AmmoType atype = (AmmoType) mounted.getType();
+            if (atype.getAmmoType() == AmmoType.T_AR10) {
+                mounted.setOriginalAmmoTons(atype.getTonnage());
+            } 
         }
 
         addEquipment(mounted, loc, rearMounted);

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -68,6 +68,10 @@ public interface IAero {
     boolean isRandomMove();
 
     void setRandomMove(boolean randmove);
+    
+    void setASEWAffected(int arc, int turns);
+    
+    public int getASEWAffected(int arc);
 
     boolean didAccLast();
 

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -69,10 +69,6 @@ public interface IAero {
 
     void setRandomMove(boolean randmove);
     
-    void setASEWAffected(int arc, int turns);
-    
-    public int getASEWAffected(int arc);
-
     boolean didAccLast();
 
     void setAccLast(boolean b);

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -86,6 +86,17 @@ public class Jumpship extends Aero {
         super();
         damThresh = new int[] { 0, 0, 0, 0, 0, 0 };
     }
+    
+    //ASEW Missile Effects, per location
+    private int asewAffectedTurns[] = { 0, 0, 0, 0, 0, 0};
+    
+    public void setASEWAffected(int arc, int turns) {
+        asewAffectedTurns[arc] = turns;
+    }
+    
+    public int getASEWAffected(int arc) {
+        return asewAffectedTurns[arc];
+    }
 
     protected static final TechAdvancement TA_JUMPSHIP = new TechAdvancement(TECH_BASE_ALL)
             .setAdvancement(DATE_NONE, 2300).setISApproximate(false, true)

--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -142,6 +142,9 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
     private int fatalThresh = 0;
     private int currentDamage = 0;
     private Map<String, Integer> weaponGroups = new HashMap<String, Integer>();
+    
+    //ASEW Missile Effects
+    protected int asewAffectedTurns = 0;
 
     public LandAirMech(int inGyroType, int inCockpitType, int inLAMType) {
         super(inGyroType, inCockpitType);
@@ -1205,6 +1208,16 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
     @Override
     public void setRandomMove(boolean randmove) {
         randomMove = randmove;
+    }
+    
+    @Override
+    public void setASEWAffected(int arc, int turns) {
+        asewAffectedTurns = turns;
+    }
+    
+    @Override
+    public int getASEWAffected(int arc) {
+        return asewAffectedTurns;
     }
 
     @Override

--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -143,9 +143,6 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
     private int currentDamage = 0;
     private Map<String, Integer> weaponGroups = new HashMap<String, Integer>();
     
-    //ASEW Missile Effects
-    protected int asewAffectedTurns = 0;
-
     public LandAirMech(int inGyroType, int inCockpitType, int inLAMType) {
         super(inGyroType, inCockpitType);
         lamType = inLAMType;
@@ -1210,16 +1207,6 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
         randomMove = randmove;
     }
     
-    @Override
-    public void setASEWAffected(int arc, int turns) {
-        asewAffectedTurns = turns;
-    }
-    
-    @Override
-    public int getASEWAffected(int arc) {
-        return asewAffectedTurns;
-    }
-
     @Override
     public void setRolled(boolean roll) {
         rolled = roll;

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1440,9 +1440,10 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
             // AR10's have heat based upon the loaded missile
             if (wtype.getName().equals("AR10")){
                 AmmoType ammoType = (AmmoType)getLinked().getType();
-                if (ammoType.getMunitionType() == AmmoType.M_BARRACUDA){
+                if (ammoType.hasFlag(AmmoType.F_AR10_BARRACUDA)){
                     return 10;
-                }else if (ammoType.getMunitionType() ==AmmoType.M_WHITE_SHARK){
+                }else if ((ammoType.hasFlag(AmmoType.F_AR10_WHITE_SHARK))
+                            || (ammoType.hasFlag(AmmoType.F_SANTA_ANNA))){
                     return 15;
                 } else { // AmmoType.getMunitionType() == AmmoType.M_KILLER_WHALE
                     return 20;

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -196,11 +196,7 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         this.type = type;
         typeName = type.getInternalName();
 
-        if ((type instanceof AmmoType)
-                && (type.hasFlag(AmmoType.F_SANTA_ANNA)
-                        || (type.hasFlag(AmmoType.F_PEACEMAKER)))) {
-            shotsLeft = 0;
-        } else if (type instanceof AmmoType) {
+        if (type instanceof AmmoType) {
             shotsLeft = ((AmmoType) type).getShots();
         }
         if ((type instanceof MiscType) && type.hasFlag(MiscType.F_MINE)) {
@@ -1441,11 +1437,11 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
             // AR10's have heat based upon the loaded missile
             if (wtype.getName().equals("AR10")){
                 AmmoType ammoType = (AmmoType)getLinked().getType();
-                if (ammoType.hasFlag(AmmoType.F_AR10_BARRACUDA)){
+                if (ammoType.getMunitionType() == AmmoType.M_BARRACUDA){
                     return 10;
-                }else if (ammoType.hasFlag(AmmoType.F_AR10_WHITE_SHARK)){
+                }else if (ammoType.getMunitionType() ==AmmoType.M_WHITE_SHARK){
                     return 15;
-                } else { // AmmoType.F_AR10_KILLER_WHALTE
+                } else { // AmmoType.getMunitionType() == AmmoType.M_KILLER_WHALE
                     return 20;
                 }
             }

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -96,6 +96,9 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
     private int originalShots;
     private boolean m_bPendingDump;
     private boolean m_bDumping;
+    
+    //For AR10 magazines, we need to store the original ammo tonnage
+    private double originalAmmoTons;
 
     // A list of ids (equipment numbers) for the weapons and ammo linked to
     // this bay (if the mounted is of the BayWeapon type)
@@ -1720,6 +1723,14 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
 
     public void setOriginalShots(int shots) {
         originalShots = shots;
+    }
+    
+    public double getOriginalAmmoTons() {
+        return originalAmmoTons;
+    }
+    
+    public void setOriginalAmmoTons(double atons) {
+        originalAmmoTons = atons;
     }
 
     public boolean isModeSwitchable() {

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -196,7 +196,11 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         this.type = type;
         typeName = type.getInternalName();
 
-        if (type instanceof AmmoType) {
+        if ((type instanceof AmmoType)
+                && (type.hasFlag(AmmoType.F_SANTA_ANNA)
+                        || (type.hasFlag(AmmoType.F_PEACEMAKER)))) {
+            shotsLeft = 0;
+        } else if (type instanceof AmmoType) {
             shotsLeft = ((AmmoType) type).getShots();
         }
         if ((type instanceof MiscType) && type.hasFlag(MiscType.F_MINE)) {

--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -27,6 +27,17 @@ public class SpaceStation extends Jumpship {
      *
      */
     private static final long serialVersionUID = -3160156173650960985L;
+    
+    //ASEW Missile Effects, per location
+    private int asewAffectedTurns[] = { 0, 0, 0, 0, 0, 0};
+    
+    public void setASEWAffected(int arc, int turns) {
+        asewAffectedTurns[arc] = turns;
+    }
+    
+    public int getASEWAffected(int arc) {
+        return asewAffectedTurns[arc];
+    }
 
     private static final TechAdvancement TA_SPACE_STATION = new TechAdvancement(TECH_BASE_ALL)
             .setAdvancement(DATE_ES, DATE_ES)

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -46,6 +46,19 @@ public class Warship extends Jumpship {
         damThresh = new int[] { 0, 0, 0, 0, 0, 0, 0, 0 };
     }
     
+    //ASEW Missile Effects, per location
+    private int asewAffectedTurns[] = { 0, 0, 0, 0, 0, 0, 0, 0};
+    
+    @Override
+    public void setASEWAffected(int arc, int turns) {
+        asewAffectedTurns[arc] = turns;
+    }
+    
+    @Override
+    public int getASEWAffected(int arc) {
+        return asewAffectedTurns[arc];
+    }
+    
     @Override
     public double getStrategicFuelUse() {
     	double tonsperday = 0;

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -311,6 +311,14 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             return (new ToHitData(TargetRoll.AUTOMATIC_FAIL, "Cannot launch bomb in mech mode."));
         }
         
+        // ASEW Missiles cannot be launched in an atmosphere
+        if ((wtype.getAmmoType() == BombType.B_ASEW)
+                && !game.getBoard().inSpace()) {
+            return (new ToHitData(TargetRoll.AUTOMATIC_FAIL, "Cannot launch ASEW missile in an atmosphere."));
+        }
+        
+        
+        
         Targetable swarmSecondaryTarget = target;
         Targetable swarmPrimaryTarget = oldTarget;
         if (exchangeSwarmTarget) {
@@ -733,7 +741,21 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         if (ae.isSufferingEMI()) {
             toHit.addModifier(+2, "electromagnetic interference");
         }
-
+        
+        //ASEW Missiles
+        // +4 for trying to fire one at a target of < 500 tons
+        if (wtype.getAmmoType() == BombType.B_ASEW && te.getWeight() < 500.0) {
+            toHit.addModifier(4, "target is less than 500 tons");
+        }
+        // +4 attack penalty for ASEW affected locations
+        if (ae instanceof Aero) {
+            Aero a = (Aero) ae;
+            for (int loc = 0; loc <= ae.locations(); loc++) {
+                if (weapon.getFacing() == loc && a.getASEWAffected(loc) > 0) {
+                    toHit.addModifier(4, "location affected by ASEW missile");
+                }
+            }
+        }
         // evading bonuses (
         if ((te != null) && te.isEvading()) {
             toHit.addModifier(te.getEvasionBonus(), "target is evading");

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -932,7 +932,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                         Mounted bammo = bweap.getLinked();
                         if (bammo != null) {
                             AmmoType batype = (AmmoType) bammo.getType();
-                            if (!batype.hasFlag(AmmoType.F_AR10_BARRACUDA)) {
+                            if (!(batype.getMunitionType() == AmmoType.M_BARRACUDA)) {
                                 onlyBarracuda = false;
                             }
                         }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -964,7 +964,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                         Mounted bammo = bweap.getLinked();
                         if (bammo != null) {
                             AmmoType batype = (AmmoType) bammo.getType();
-                            if (!(batype.getMunitionType() == AmmoType.M_BARRACUDA)) {
+                            if (!(batype.hasFlag(AmmoType.F_AR10_BARRACUDA))) {
                                 onlyBarracuda = false;
                             }
                         }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -312,7 +312,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
         
         // ASEW Missiles cannot be launched in an atmosphere
-        if ((wtype.getAmmoType() == BombType.B_ASEW)
+        if ((wtype.getAmmoType() == AmmoType.T_ASEW_MISSILE)
                 && !game.getBoard().inSpace()) {
             return (new ToHitData(TargetRoll.AUTOMATIC_FAIL, "Cannot launch ASEW missile in an atmosphere."));
         }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -744,18 +744,28 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         
         //ASEW Missiles
         // +4 for trying to fire one at a target of < 500 tons
-        if (wtype.getAmmoType() == BombType.B_ASEW && te.getWeight() < 500.0) {
+        if (wtype.getAmmoType() == AmmoType.T_ASEW_MISSILE && te.getWeight() < 500.0) {
             toHit.addModifier(4, "target is less than 500 tons");
         }
         // +4 attack penalty for ASEW affected locations
-        if (ae instanceof Aero) {
-            Aero a = (Aero) ae;
-            for (int loc = 0; loc <= ae.locations(); loc++) {
-                if (weapon.getFacing() == loc && a.getASEWAffected(loc) > 0) {
-                    toHit.addModifier(4, "location affected by ASEW missile");
-                }
+        if (ae instanceof Dropship) {
+            Dropship d = (Dropship) ae;
+            int loc = weapon.getLocation();
+            if (d.getASEWAffected(loc) > 0) {
+                toHit.addModifier(4, "weapon arc affected by ASEW missile");
+            }            
+        } else if (ae instanceof Jumpship) {
+            Jumpship j = (Jumpship) ae;
+            int loc = weapon.getLocation();
+            if (j.getASEWAffected(loc) > 0) {
+                toHit.addModifier(4, "weapon arc affected by ASEW missile");
+            } 
+        } else {
+            if (ae.getASEWAffected() > 0) {
+                toHit.addModifier(4, "attacker affected by ASEW missile");
             }
         }
+        
         // evading bonuses (
         if ((te != null) && te.isEvading()) {
             toHit.addModifier(te.getEvasionBonus(), "target is evading");

--- a/megamek/src/megamek/common/loaders/BLKDropshipFile.java
+++ b/megamek/src/megamek/common/loaders/BLKDropshipFile.java
@@ -246,7 +246,7 @@ public class BLKDropshipFile extends BLKFile implements IMechLoader {
         }
 
         boolean rearMount = false;
-        int nAmmo = 1;
+        int nAmmo = 0;
         // set up a new weapons bay mount
         Mounted bayMount = null;
         // set up a new bay type
@@ -255,7 +255,7 @@ public class BLKDropshipFile extends BLKFile implements IMechLoader {
         if (saEquip[0] != null) {
             for (String element : saEquip) {
                 rearMount = false;
-                nAmmo = 1;
+                nAmmo = 0;
                 newBay = false;
                 String equipName = element.trim();
 

--- a/megamek/src/megamek/common/weapons/ASEWMissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ASEWMissileWeaponHandler.java
@@ -1,0 +1,206 @@
+/**
+ * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ *  for more details.
+ */
+package megamek.common.weapons;
+
+import java.util.Vector;
+
+import megamek.common.Aero;
+import megamek.common.BattleArmor;
+import megamek.common.Building;
+import megamek.common.Entity;
+import megamek.common.IGame;
+import megamek.common.Infantry;
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.server.Server;
+import megamek.server.Server.DamageType;
+
+/**
+ * @author MKerensky
+ */
+public class ASEWMissileWeaponHandler extends ThunderBoltWeaponHandler {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 6359291710822171023L;
+
+    /**
+     * @param t
+     * @param w
+     * @param g
+     * @param s
+     */
+    public ASEWMissileWeaponHandler(ToHitData t, WeaponAttackAction w, IGame g,
+            Server s) {
+        super(t, w, g, s);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * megamek.common.weapons.WeaponHandler#handleEntityDamage(megamek.common
+     * .Entity, java.util.Vector, megamek.common.Building, int, int, int, int)
+     */
+    @Override
+    protected void handleEntityDamage(Entity entityTarget,
+            Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
+            int bldgAbsorbs) {
+        int nDamage;
+        missed = false;
+
+        hit = entityTarget.rollHitLocation(toHit.getHitTable(),
+                toHit.getSideTable(), waa.getAimedLocation(),
+                waa.getAimingMode(), toHit.getCover());
+        hit.setGeneralDamageType(generalDamageType);
+        hit.setCapital(wtype.isCapital());
+        hit.setBoxCars(roll == 12);
+        hit.setCapMisCritMod(getCapMisMod());
+        hit.setFirstHit(firstHit);
+        hit.setAttackerId(getAttackerId());
+        if (weapon.isWeaponGroup()) {
+            hit.setSingleAV(attackValue);
+        }
+        if (entityTarget instanceof Aero) {
+            Aero a = (Aero) entityTarget;
+                a.setASEWAffected(hit.getLocation(), 2);
+        }
+        
+        if (!bSalvo) {
+            // Each hit in the salvo get's its own hit location.
+            Report r = new Report(3405);
+            r.subject = subjectId;
+            r.add(toHit.getTableDesc());
+            r.add(entityTarget.getLocationAbbr(hit));
+            vPhaseReport.addElement(r);
+            if (weapon.isRapidfire()) {
+                r.newlines = 0;
+                r = new Report(3225);
+                r.subject = subjectId;
+                r.add(numRapidFireHits * 3);
+                vPhaseReport.add(r);
+            }
+        } else {
+            Report.addNewline(vPhaseReport);
+        }
+
+        // for non-salvo shots, report that the aimed shot was successfull
+        // before applying damage
+        if (hit.hitAimedLocation() && !bSalvo) {
+            Report r = new Report(3410);
+            r.subject = subjectId;
+            vPhaseReport.lastElement().newlines = 0;
+            vPhaseReport.addElement(r);
+        }
+        // Resolve damage normally.
+        nDamage = nDamPerHit * Math.min(nCluster, hits);
+
+        if (bDirect) {
+            hit.makeDirectBlow(toHit.getMoS() / 3);
+        }
+        
+        // Report calcDmgPerHitReports here
+        if (calcDmgPerHitReport.size() > 0) {
+            vPhaseReport.addAll(calcDmgPerHitReport);
+        }
+    
+        // A building may be damaged, even if the squad is not.
+        if (bldgAbsorbs > 0) {
+            int toBldg = Math.min(bldgAbsorbs, nDamage);
+            nDamage -= toBldg;
+            Report.addNewline(vPhaseReport);
+            Vector<Report> buildingReport = server.damageBuilding(bldg, toBldg,
+                    entityTarget.getPosition());
+            for (Report report : buildingReport) {
+                report.subject = subjectId;
+            }
+            vPhaseReport.addAll(buildingReport);
+        // Units on same level, report building absorbs no damage
+        } else if (bldgAbsorbs == Integer.MIN_VALUE) {
+            Report.addNewline(vPhaseReport);
+            Report r = new Report(9976);
+            r.subject = ae.getId();
+            r.indent(2);
+            vPhaseReport.add(r);
+        // Cases where absorbed damage doesn't reduce incoming damage
+        } else if (bldgAbsorbs < 0) {
+            int toBldg = -bldgAbsorbs;
+            Report.addNewline(vPhaseReport);
+            Vector<Report> buildingReport = server.damageBuilding(bldg, toBldg,
+                    entityTarget.getPosition());
+            for (Report report : buildingReport) {
+                report.subject = subjectId;
+            }
+            vPhaseReport.addAll(buildingReport);
+        }
+
+        nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);
+        nDamage = checkLI(nDamage, entityTarget, vPhaseReport);
+
+        // some buildings scale remaining damage that is not absorbed
+        // TODO: this isn't quite right for castles brian
+        if (null != bldg) {
+            nDamage = (int) Math.floor(bldg.getDamageToScale() * nDamage);
+        }
+
+        // A building may absorb the entire shot.
+        if (nDamage == 0) {
+            Report r = new Report(3415);
+            r.subject = subjectId;
+            r.indent(2);
+            r.addDesc(entityTarget);
+            vPhaseReport.addElement(r);
+            missed = true;
+        } else {
+            if (bGlancing) {
+                hit.makeGlancingBlow();
+            }
+            vPhaseReport
+                    .addAll(server.damageEntity(entityTarget, hit, nDamage,
+                            false, ae.getSwarmTargetId() == entityTarget
+                                    .getId() ? DamageType.IGNORE_PASSENGER
+                                    : damageType, false, false, throughFront,
+                            underWater, nukeS2S));
+            // for salvo shots, report that the aimed location was hit after
+            // applying damage, because the location is first reported when
+            // dealing the damage
+            if (hit.hitAimedLocation() && bSalvo) {
+                Report r = new Report(3410);
+                r.subject = subjectId;
+                vPhaseReport.lastElement().newlines = 0;
+                vPhaseReport.addElement(r);
+            }
+        }
+        // If a BA squad is shooting at infantry, damage may be random and need
+        // to be rerolled for the next hit (if any) from the same attack.
+        if ((ae instanceof BattleArmor) && (target instanceof Infantry)) {
+            nDamPerHit = calcDamagePerHit();
+        }
+    }
+    
+    /**
+     * Calculate the attack value based on range
+     *
+     * @return an <code>int</code> representing the attack value at that range.
+     */
+    @Override
+    protected int calcAttackValue() {
+        calcCounterAV();
+        int av = 0;
+        return av;
+    }
+
+}

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -83,13 +83,13 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
 
                 AmmoType atype = (AmmoType) bayWAmmo.getType();
                 if (bayWType.getAtClass() == (20)
-                		&& atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)) {
+                		&& atype.getMunitionType() == AmmoType.M_KILLER_WHALE) {
                 	weaponarmor = 40;
                 } else if (bayWType.getAtClass() == (20)
-                		&& atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)) {
+                		&& atype.getMunitionType() == AmmoType.M_WHITE_SHARK) {
                 	weaponarmor = 30;
                 } else if (bayWType.getAtClass() == (20)
-                		&& atype.hasFlag(AmmoType.F_AR10_BARRACUDA)) {
+                		&& atype.getMunitionType() == AmmoType.M_BARRACUDA) {
                 	weaponarmor = 20;
                 } else {
                 weaponarmor = bayWType.getMissileArmor();
@@ -190,12 +190,12 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
             return 0;
         }
         if (atype.getAmmoType() == AmmoType.T_WHITE_SHARK
-                || atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)
+                || atype.getMunitionType() == AmmoType.M_WHITE_SHARK
                 // Santa Anna, per IO rules
                 || atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
             return 9;
         } else if (atype.getAmmoType() == AmmoType.T_KILLER_WHALE
-                || atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)
+                || atype.getMunitionType() == AmmoType.M_KILLER_WHALE
                 || atype.getAmmoType() == AmmoType.T_MANTA_RAY
                 || atype.getAmmoType() == AmmoType.T_ALAMO) {
             return 10;
@@ -216,11 +216,15 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
             WeaponType bayWType, int range, int wId) {
         //AR10 munitions
     	if (atype.getAmmoType() == AmmoType.T_AR10) {
-            if (atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)) {
+            if (atype.getMunitionType() == AmmoType.M_KILLER_WHALE) {
                 current_av = 4;
-            } else if (atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)) {
+            } else if (atype.getMunitionType() == AmmoType.M_WHITE_SHARK) {
                 current_av = 3;
-            } else {
+            } else if (atype.getMunitionType() == AmmoType.M_PEACEMAKER) {
+                current_av = 1000;
+            }else if (atype.getMunitionType() == AmmoType.M_SANTA_ANNA) {
+                current_av = 100;
+            }else {
                 current_av = 2;
             }
         }

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -82,14 +82,16 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
                 double current_av = 0;
 
                 AmmoType atype = (AmmoType) bayWAmmo.getType();
-                if (bayWType.getAtClass() == (20)
-                		&& atype.getMunitionType() == AmmoType.M_KILLER_WHALE) {
+                if (bayWType.getAtClass() == (WeaponType.CLASS_AR10)
+                		&& (atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)
+                		        || atype.hasFlag(AmmoType.F_PEACEMAKER))) {
                 	weaponarmor = 40;
-                } else if (bayWType.getAtClass() == (20)
-                		&& atype.getMunitionType() == AmmoType.M_WHITE_SHARK) {
+                } else if (bayWType.getAtClass() == (WeaponType.CLASS_AR10)
+                		&& (atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)
+                                || atype.hasFlag(AmmoType.F_SANTA_ANNA))) {
                 	weaponarmor = 30;
-                } else if (bayWType.getAtClass() == (20)
-                		&& atype.getMunitionType() == AmmoType.M_BARRACUDA) {
+                } else if (bayWType.getAtClass() == (WeaponType.CLASS_AR10)
+                		&& atype.hasFlag(AmmoType.F_AR10_BARRACUDA)) {
                 	weaponarmor = 20;
                 } else {
                 weaponarmor = bayWType.getMissileArmor();
@@ -190,12 +192,12 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
             return 0;
         }
         if (atype.getAmmoType() == AmmoType.T_WHITE_SHARK
-                || atype.getMunitionType() == AmmoType.M_WHITE_SHARK
+                || atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)
                 // Santa Anna, per IO rules
                 || atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
             return 9;
         } else if (atype.getAmmoType() == AmmoType.T_KILLER_WHALE
-                || atype.getMunitionType() == AmmoType.M_KILLER_WHALE
+                || atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)
                 || atype.getAmmoType() == AmmoType.T_MANTA_RAY
                 || atype.getAmmoType() == AmmoType.T_ALAMO) {
             return 10;
@@ -216,9 +218,9 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
             WeaponType bayWType, int range, int wId) {
         //AR10 munitions
     	if (atype.getAmmoType() == AmmoType.T_AR10) {
-            if (atype.getMunitionType() == AmmoType.M_KILLER_WHALE) {
+            if (atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)) {
                 current_av = 4;
-            } else if (atype.getMunitionType() == AmmoType.M_WHITE_SHARK) {
+            } else if (atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)) {
                 current_av = 3;
             } else if (atype.getMunitionType() == AmmoType.M_PEACEMAKER) {
                 current_av = 1000;

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -255,7 +255,7 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
     
     @Override
     protected int calcCapMissileAMSMod() {
-        CapMissileAMSMod = (int) Math.ceil(CounterAV / 10.0);
+        CapMissileAMSMod = (int) Math.floor(CounterAV / 10.0);
         return CapMissileAMSMod;
     }
     

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -282,12 +282,12 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
             return 0;
         }
         if (atype.getAmmoType() == AmmoType.T_WHITE_SHARK
-                || atype.getMunitionType() == AmmoType.M_WHITE_SHARK
+                || atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)
                 // Santa Anna, per IO rules
                 || atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
             return 9;
         } else if (atype.getAmmoType() == AmmoType.T_KILLER_WHALE
-                || atype.getMunitionType() == AmmoType.M_KILLER_WHALE
+                || atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)
                 || atype.getAmmoType() == AmmoType.T_MANTA_RAY
                 || atype.getAmmoType() == AmmoType.T_ALAMO) {
             return 10;

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -215,12 +215,12 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
             return 0;
         }
         if (atype.getAmmoType() == AmmoType.T_WHITE_SHARK
-                || atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)
+                || atype.getMunitionType() == AmmoType.M_WHITE_SHARK
                 // Santa Anna, per IO rules
                 || atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
             return 9;
         } else if (atype.getAmmoType() == AmmoType.T_KILLER_WHALE
-                || atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)
+                || atype.getMunitionType() == AmmoType.M_KILLER_WHALE
                 || atype.getAmmoType() == AmmoType.T_MANTA_RAY
                 || atype.getAmmoType() == AmmoType.T_ALAMO) {
             return 10;

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -20,6 +20,7 @@ import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.IGame;
 import megamek.common.Mounted;
+import megamek.common.RangeType;
 import megamek.common.Targetable;
 import megamek.common.ToHitData;
 import megamek.common.WeaponType;
@@ -49,6 +50,61 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
             Server s) {
         super(t, w, g, s);
         advancedPD = g.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADV_POINTDEF);
+    }
+    
+    /**
+     * Calculate the attack value based on range
+     *
+     * @return an <code>int</code> representing the attack value at that range.
+     */
+    @Override
+    protected int calcAttackValue() {
+        int av = 0;
+        double counterAV = calcCounterAV();
+        int armor = wtype.getMissileArmor();
+        // if we have a ground firing unit, then AV should not be determined by
+        // aero range brackets
+        if (!ae.isAirborne() || game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_UAC_TWOROLLS)) {
+            if (usesClusterTable()) {
+                // for cluster weapons just use the short range AV
+                av = wtype.getRoundShortAV();
+            } else {
+                // otherwise just use the full weapon damage by range
+                av = wtype.getDamage(nRange);
+            }
+        } else {
+            // we have an airborne attacker, so we need to use aero range
+            // brackets
+            int range = RangeType.rangeBracket(nRange, wtype.getATRanges(),
+                    true, false);
+            if (range == WeaponType.RANGE_SHORT) {
+                av = wtype.getRoundShortAV();
+            } else if (range == WeaponType.RANGE_MED) {
+                av = wtype.getRoundMedAV();
+            } else if (range == WeaponType.RANGE_LONG) {
+                av = wtype.getRoundLongAV();
+            } else if (range == WeaponType.RANGE_EXT) {
+                av = wtype.getRoundExtAV();
+            }
+        }
+        
+        if (ammo.getType().hasFlag(AmmoType.F_NUCLEAR)) {
+            nukeS2S = true;
+        }
+        
+        CapMissileArmor = armor - (int) counterAV;
+        CapMissileAMSMod = calcCapMissileAMSMod();
+        
+        if (bDirect) {
+            av = Math.min(av + (toHit.getMoS() / 3), av * 2);
+        }
+        if (bGlancing) {
+            av = (int) Math.floor(av / 2.0);
+
+        }
+        av = (int) Math.floor(getBracketingMultiplier() * av);
+        
+        return av;
     }
     
     // check for AMS and Point Defense Bay fire
@@ -181,13 +237,13 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
                 
                 // set the pdbay as having fired, if it did
                 if (pdAV > 0) {
-                    pdBayEngagedMissile = true;
+                    pdBayEngagedCap = true;
                 }
                 counterAV += (int) Math.ceil(pdAV / 2.0);
                 
                 // set the ams as having fired, if it did
                 if (amsAV > 0) {
-                    amsBayEngagedMissile = true;
+                    amsBayEngagedCap = true;
                 }
                 // AMS add their full damage
                 counterAV += amsAV;
@@ -196,6 +252,17 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
         CounterAV = (int) counterAV;
         return counterAV;
     } // end getAMSAV
+    
+    @Override
+    protected int calcCapMissileAMSMod() {
+        CapMissileAMSMod = (int) Math.ceil(CounterAV / 10.0);
+        return CapMissileAMSMod;
+    }
+    
+    @Override
+    protected int getCapMissileAMSMod() {
+        return CapMissileAMSMod;
+    }
     
     @Override
     protected int getCapMisMod() {

--- a/megamek/src/megamek/common/weapons/bombs/CLASEWMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/bombs/CLASEWMissileWeapon.java
@@ -15,7 +15,14 @@ package megamek.common.weapons.bombs;
 
 import megamek.common.AmmoType;
 import megamek.common.BombType;
+import megamek.common.IGame;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.weapons.ASEWMissileWeaponHandler;
+import megamek.common.weapons.AttackHandler;
+import megamek.common.weapons.MissileBayWeaponHandler;
 import megamek.common.weapons.missiles.ThunderBoltWeapon;
+import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -60,5 +67,11 @@ public class CLASEWMissileWeapon extends ThunderBoltWeapon {
         .setAvailability(RATING_X, RATING_X, RATING_E, RATING_E)
         .setISAdvancement(3067, 3073, DATE_NONE, DATE_NONE, DATE_NONE)
         .setISApproximate(false, false, false, false, false);
+    }
+    
+    @Override
+    protected AttackHandler getCorrectHandler(ToHitData toHit,
+            WeaponAttackAction waa, IGame game, Server server) {
+        return new ASEWMissileWeaponHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/bombs/ISASEWMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/bombs/ISASEWMissileWeapon.java
@@ -15,7 +15,13 @@ package megamek.common.weapons.bombs;
 
 import megamek.common.AmmoType;
 import megamek.common.BombType;
+import megamek.common.IGame;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.weapons.ASEWMissileWeaponHandler;
+import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.missiles.ThunderBoltWeapon;
+import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -62,5 +68,11 @@ public class ISASEWMissileWeapon extends ThunderBoltWeapon {
         .setISApproximate(false, false, false, false, false)
         .setPrototypeFactions(F_LC)
         .setProductionFactions(F_LC);
+    }
+    
+    @Override
+    protected AttackHandler getCorrectHandler(ToHitData toHit,
+            WeaponAttackAction waa, IGame game, Server server) {
+        return new ASEWMissileWeaponHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissKillerWhaleWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissKillerWhaleWeapon.java
@@ -86,10 +86,7 @@ public class CapMissKillerWhaleWeapon extends CapitalMissileWeapon {
             WeaponAttackAction waa, IGame game, Server server) {
         AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
                 .getEquipment(waa.getWeaponId()).getLinked().getType();
-        // Let's try not doing this. We should be able to deal with nuclear ammo from the cap missile handler.
-       /* if (atype.hasFlag(AmmoType.F_NUCLEAR)) {
-            return new SantaAnnaHandler(toHit, waa, game, server);
-        } */
+
         if (atype.hasFlag(AmmoType.F_TELE_MISSILE)) {
             return new TeleMissileHandler(toHit, waa, game, server);
         }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1868,7 +1868,7 @@ public class Server implements Runnable {
             } else {
                 entity.setDone(false);
             }
-
+            
             // reset spotlights
             entity.setIlluminated(false);
             entity.setUsedSearchlight(false);
@@ -1880,6 +1880,37 @@ public class Server implements Runnable {
         }
         game.clearIlluminatedPositions();
         send(new Packet(Packet.COMMAND_CLEAR_ILLUM_HEXES));
+    }
+    
+    /*
+     *  Called during the end phase. Checks each entity for ASEW effects counters and decrements them by 1 if > 0
+     */
+    
+    public void decrementASEWTurns() {
+        for (Iterator<Entity> e = game.getEntities(); e.hasNext(); ) {
+            final Entity entity = e.next();
+            // Decrement ASEW effects
+            if (entity instanceof Dropship) {
+                Dropship d = (Dropship) entity;
+                for (int loc = 0; loc < d.locations(); loc++) {
+                    if (d.getASEWAffected(loc) > 0) {
+                        d.setASEWAffected(loc, d.getASEWAffected(loc) - 1);
+                    } 
+                }
+            } else if (entity instanceof Jumpship) {
+                Jumpship j = (Jumpship) entity;
+                for (int loc = 0; loc < j.locations(); loc++) {
+                    if (j.getASEWAffected(loc) > 0) {
+                        j.setASEWAffected(loc, j.getASEWAffected(loc) - 1);
+                    } 
+                }
+            } else {
+                if (entity.getASEWAffected() > 0) {
+                    entity.setASEWAffected(entity.getASEWAffected() - 1);
+                }
+            }
+        }
+        
     }
 
     /**
@@ -3213,7 +3244,7 @@ public class Server implements Runnable {
                     }
                 }
                 // Decrement the ASEWAffected counter
-                
+                decrementASEWTurns();
                 break;
             case PHASE_END_REPORT:
                 if (changePlayersTeam) {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -3212,6 +3212,8 @@ public class Server implements Runnable {
                         changePhase(IGame.Phase.PHASE_INITIATIVE);
                     }
                 }
+                // Decrement the ASEWAffected counter
+                
                 break;
             case PHASE_END_REPORT:
                 if (changePlayersTeam) {
@@ -22714,7 +22716,7 @@ public class Server implements Runnable {
                 vDesc.addElement(r);
             }
         }
-
+        
         // infantry armor can reduce damage
         if (isPlatoon && (((Infantry) te).getDamageDivisor() != 1.0)) {
             r = new Report(6074);


### PR DESCRIPTION
+Enhancement: AR10 magazines have a base tonnage from the BLK file and can be loaded with alternate missile types in the lobby accordingly
+Enhancement: Added Peacemaker and Santa Anna nuclear munitions (S2S only) per IO rules. Can be loaded into appropriate capital missile launchers just like other alternate muntions, instead of the 'replace x killer whale warheads with nukes' option. 
+Enhancement: Ability to set number of shots in each aero ammo bin, even if you can't change the munition
+Enhancement: added functionality for Alamo (S2S) and ASEW bombs