### PR TITLE
Fix for bug # 716

### DIFF
--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -24,7 +24,6 @@ import megamek.common.Building;
 import megamek.common.Compute;
 import megamek.common.Coords;
 import megamek.common.Entity;
-import megamek.common.GunEmplacement;
 import megamek.common.HitData;
 import megamek.common.IGame;
 import megamek.common.Infantry;
@@ -470,24 +469,12 @@ public class ArtilleryWeaponIndirectHomingHandler extends
         
     protected int getAMSHitsMod(Vector<Report> vPhaseReport) {
         if ((target == null)
-                || !((target.getTargetType() == Targetable.TYPE_ENTITY)
-                || (target.getTargetType() == Targetable.TYPE_BLDG_TAG))) {
+                || (target.getTargetType() != Targetable.TYPE_ENTITY)) {
             return 0;
         }
         int apdsMod = 0;
         int amsMod = 0;
-        Entity entityTarget;
-        if (target.getTargetType() == Targetable.TYPE_BLDG_TAG) {
-            ArrayList<Entity> turrets = new ArrayList<Entity>();
-            for (Entity turret : game.getEntitiesVector(target.getPosition())) {
-                if (turret instanceof GunEmplacement) {
-                    turrets.add(turret); 
-                }
-            }
-        } else {
-            
-        }
-        entityTarget = (Entity) target;
+        Entity entityTarget = (Entity) target;
         // any AMS attacks by the target?
         ArrayList<Mounted> lCounters = waa.getCounterEquipment();
         if (null != lCounters) {

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -589,7 +589,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends
     //If you're firing missiles at a capital ship...
     @Override
     protected int calcCounterAV () {
-        if ((target == null) || !advancedPD) {
+        if (!(target instanceof Entity) || !advancedPD) {
             return 0;
         }
         int counterAV = 0;

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -24,6 +24,7 @@ import megamek.common.Building;
 import megamek.common.Compute;
 import megamek.common.Coords;
 import megamek.common.Entity;
+import megamek.common.GunEmplacement;
 import megamek.common.HitData;
 import megamek.common.IGame;
 import megamek.common.Infantry;
@@ -466,15 +467,27 @@ public class ArtilleryWeaponIndirectHomingHandler extends
             Vector<Report> vPhaseReport) {
         return true;
     }
-    
+        
     protected int getAMSHitsMod(Vector<Report> vPhaseReport) {
         if ((target == null)
-                || (target.getTargetType() != Targetable.TYPE_ENTITY)) {
+                || !((target.getTargetType() == Targetable.TYPE_ENTITY)
+                || (target.getTargetType() == Targetable.TYPE_BLDG_TAG))) {
             return 0;
         }
         int apdsMod = 0;
         int amsMod = 0;
-        Entity entityTarget = (Entity) target;
+        Entity entityTarget;
+        if (target.getTargetType() == Targetable.TYPE_BLDG_TAG) {
+            ArrayList<Entity> turrets = new ArrayList<Entity>();
+            for (Entity turret : game.getEntitiesVector(target.getPosition())) {
+                if (turret instanceof GunEmplacement) {
+                    turrets.add(turret); 
+                }
+            }
+        } else {
+            
+        }
+        entityTarget = (Entity) target;
         // any AMS attacks by the target?
         ArrayList<Mounted> lCounters = waa.getCounterEquipment();
         if (null != lCounters) {
@@ -509,10 +522,10 @@ public class ArtilleryWeaponIndirectHomingHandler extends
 
                     // build up some heat (assume target is ams owner)
                     if (counter.getType().hasFlag(WeaponType.F_HEATASDICE)) {
-                        entityTarget.heatBuildup += Compute.d6(counter
+                        apdsEnt.heatBuildup += Compute.d6(counter
                                 .getCurrentHeat());
                     } else {
-                        entityTarget.heatBuildup += counter.getCurrentHeat();
+                        apdsEnt.heatBuildup += counter.getCurrentHeat();
                     }
 
                     // decrement the ammo


### PR DESCRIPTION
Changes calcCounterAV() in homing missile handler to check for a non-entity target instead of a null target.