### PR TITLE
Fix for #704 Allow bots to unload stranded infantry from disabled transports

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -18,6 +18,7 @@ v0.43.5-git
 + PR #701: Space stations now require 2 pilots, which fixes issues in MHQ
 + Issue #680: Updated startup.sh to handle Java 9
 + PR #706: Fixed several quirk-related NPEs. Implemented display of partial repairs on unit info card.
++ Issue #704, #299: Bot units will now scamper out of disabled transports.
 
 v0.43.4 (2017-10-01 11:00 UTC)
 + Issue #573: Jumping through buildings.

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -123,6 +123,11 @@ public abstract class BotClient extends Client {
                     );
                     worker.start();
                 }
+                
+                // unloading "stranded" units happens as part of a game turn change, so that's where we do it.
+                if(canUnloadStranded()) {
+                    sendUnloadStranded(getStrandedEntities());
+                }
             }
 
             @Override
@@ -213,6 +218,32 @@ public abstract class BotClient extends Client {
 
     protected abstract void checkMoral();
 
+    /**
+     * Helper function that determines which of this bot's entities are stranded inside immobilized transports. 
+     * @return Array of entity IDs.
+     */
+    public int[] getStrandedEntities() {
+        List<Integer> entitiesToUnload = new ArrayList<>();
+        
+        // Basically, we loop through all entities owned by the current player
+        // And if the entity happens to be in a disabled transport, then we unload it
+        // For future development, consider not unloading a particular entity if doing so would kill it.
+        for(Entity currentEntity : getGame().getPlayerEntities(getLocalPlayer(), true)) {
+            Entity transport = currentEntity.getTransportId() != Entity.NONE ? game.getEntity(currentEntity.getTransportId()) : null;
+            
+            if(transport != null && transport.isPermanentlyImmobilized(true)) {
+                entitiesToUnload.add(currentEntity.getId());
+            }
+        }
+        
+        int[] entityIDs = new int[entitiesToUnload.size()];
+        for(int x = 0; x < entitiesToUnload.size(); x++) {
+            entityIDs[x] = entitiesToUnload.get(x);
+        }
+        
+        return entityIDs;
+    }
+    
     public List<Entity> getEntitiesOwned() {
         ArrayList<Entity> result = new ArrayList<>();
         for (Entity entity : game.getEntitiesVector()) {


### PR DESCRIPTION
Fixes issue #704. Bot-owned units stranded inside a disabled transport will now scamper out without stopping the game.