### PR TITLE
Rebuild of nuclear weapon overhaul

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2359,11 +2359,45 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                 avMed = 3;
                 avLong = 3;
                 avExt = 3;
+            } else if (atype.getMunitionType() == AmmoType.M_SANTA_ANNA) {
+                avShort = 100;
+                avMed = 100;
+                avLong = 100;
+                avExt = 100;
+            } else if (atype.getMunitionType() == AmmoType.M_PEACEMAKER) {
+                avShort = 1000;
+                avMed = 1000;
+                avLong = 1000;
+                avExt = 1000;
             } else {
                 avShort = 2;
                 avMed = 2;
                 avLong = 2;
                 avExt = 2;
+            }
+        } else if (atype.getAmmoType() == AmmoType.T_KILLER_WHALE) {
+            if (atype.getMunitionType() == AmmoType.M_PEACEMAKER) {
+                avShort = 1000;
+                avMed = 1000;
+                avLong = 1000;
+                avExt = 1000; 
+            } else {
+                avShort = 4;
+                avMed = 4;
+                avLong = 4;
+                avExt = 4;
+            }
+        } else if (atype.getAmmoType() == AmmoType.T_WHITE_SHARK) {
+            if (atype.getMunitionType() == AmmoType.M_SANTA_ANNA) {
+                avShort = 100;
+                avMed = 100;
+                avLong = 100;
+                avExt = 100; 
+            } else {
+                avShort = 3;
+                avMed = 3;
+                avLong = 3;
+                avExt = 3;
             }
         }
 

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -1199,10 +1199,8 @@ public class AmmoType extends EquipmentType {
         EquipmentType.addType(AmmoType.createKrakenAmmo());
         EquipmentType.addType(AmmoType.createKillerWhaleAmmo());
         EquipmentType.addType(AmmoType.createPeacemakerAmmo());
-        EquipmentType.addType(AmmoType.createCLPeacemakerAmmo());
         EquipmentType.addType(AmmoType.createWhiteSharkAmmo());
         EquipmentType.addType(AmmoType.createSantaAnnaAmmo());
-        EquipmentType.addType(AmmoType.createCLSantaAnnaAmmo());
         EquipmentType.addType(AmmoType.createBarracudaAmmo());        
         EquipmentType.addType(AmmoType.createKillerWhaleTAmmo());
         EquipmentType.addType(AmmoType.createWhiteSharkTAmmo());
@@ -1212,9 +1210,6 @@ public class AmmoType extends EquipmentType {
         EquipmentType.addType(AmmoType.createAR10WhiteSharkAmmo());
         EquipmentType.addType(AmmoType.createAR10SantaAnnaAmmo());
         EquipmentType.addType(AmmoType.createAR10BarracudaAmmo());
-        EquipmentType.addType(AmmoType.createAR10KillerWhaleTAmmo());
-        EquipmentType.addType(AmmoType.createAR10WhiteSharkTAmmo());
-        EquipmentType.addType(AmmoType.createAR10BarracudaTAmmo());
         EquipmentType.addType(AmmoType.createScreenLauncherAmmo());
         EquipmentType.addType(AmmoType.createAlamoAmmo());
         EquipmentType.addType(AmmoType.createLightSCCAmmo());
@@ -11609,97 +11604,6 @@ public class AmmoType extends EquipmentType {
                     .setReintroductionFactions(F_FS,F_LC);
                 return ammo;
             }
-
-            private static AmmoType createAR10BarracudaTAmmo() {
-                AmmoType ammo = new AmmoType();
-
-                ammo.name = "AR10 Barracuda (Tele-Operated) Ammo";
-                ammo.setInternalName("Ammo AR10 Barracuda-T");
-                ammo.addLookupName("AR10 BarracudaT Ammo");
-                ammo.damagePerShot = 2;
-                ammo.ammoType = AmmoType.T_AR10;
-                ammo.shots = 1;
-                ammo.bv = 65;
-                ammo.cost = 8000;
-                ammo.flags = ammo.flags.or(F_AR10_BARRACUDA).or(F_TELE_MISSILE)
-                        .or(F_CAP_MISSILE);
-                ammo.toHitModifier = -2;
-                ammo.capital = true;
-                ammo.munitionType = AmmoType.M_TELE;
-                //Set the date of these weapons to match the Tele Missile itself
-                ammo.rulesRefs = "251,TW";
-                ammo.techAdvancement.setTechBase(TECH_BASE_IS)
-                    .setIntroLevel(false)
-                    .setUnofficial(false)
-                    .setTechRating(RATING_F)
-                    .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
-                    .setISAdvancement(3053, 3056, 3060, DATE_NONE, DATE_NONE)
-                    .setISApproximate(true, false, false, true, false)
-                    .setPrototypeFactions(F_CS,F_DC)
-                    .setProductionFactions(F_DC)
-                    .setReintroductionFactions(F_FS,F_LC);
-                return ammo;
-            }
-
-            private static AmmoType createAR10KillerWhaleTAmmo() {
-                AmmoType ammo = new AmmoType();
-
-                ammo.name = "AR10 Killer Whale (Tele-Operated) Ammo";
-                ammo.setInternalName("Ammo AR10 Killer Whale-T");
-                ammo.addLookupName("AR10 KillerWhaleT Ammo");
-                ammo.damagePerShot = 4;
-                ammo.ammoType = AmmoType.T_AR10;
-                ammo.shots = 1;
-                ammo.bv = 96;
-                ammo.cost = 20000;
-                ammo.flags = ammo.flags.or(F_AR10_KILLER_WHALE).or(F_TELE_MISSILE)
-                        .or(F_CAP_MISSILE);
-                ammo.capital = true;
-                ammo.munitionType = AmmoType.M_TELE;
-                //Set the date of these weapons to match the Tele Missile itself
-                ammo.rulesRefs = "251,TW";
-                ammo.techAdvancement.setTechBase(TECH_BASE_IS)
-                    .setIntroLevel(false)
-                    .setUnofficial(false)
-                    .setTechRating(RATING_F)
-                    .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
-                    .setISAdvancement(3053, 3056, 3060, DATE_NONE, DATE_NONE)
-                    .setISApproximate(true, false, false, true, false)
-                    .setPrototypeFactions(F_CS,F_DC)
-                    .setProductionFactions(F_DC)
-                    .setReintroductionFactions(F_FS,F_LC);
-                return ammo;
-            }
-
-            private static AmmoType createAR10WhiteSharkTAmmo() {
-                AmmoType ammo = new AmmoType();
-
-                ammo.name = "AR10 White Shark (Tele-Operated) Ammo";
-                ammo.setInternalName("Ammo AR10 White Shark-T");
-                ammo.addLookupName("AR10 WhiteSharkT Ammo");
-                ammo.damagePerShot = 3;
-                ammo.ammoType = AmmoType.T_AR10;
-                ammo.shots = 1;
-                ammo.bv = 72;
-                ammo.cost = 14000;
-                ammo.flags = ammo.flags.or(F_AR10_WHITE_SHARK).or(F_TELE_MISSILE)
-                        .or(F_CAP_MISSILE);
-                ammo.capital = true;
-                ammo.munitionType = AmmoType.M_TELE;
-                //Set the date of these weapons to match the Tele Missile itself
-                ammo.rulesRefs = "251,TW";
-                ammo.techAdvancement.setTechBase(TECH_BASE_IS)
-                    .setIntroLevel(false)
-                    .setUnofficial(false)
-                    .setTechRating(RATING_F)
-                    .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
-                    .setISAdvancement(3053, 3056, 3060, DATE_NONE, DATE_NONE)
-                    .setISApproximate(true, false, false, true, false)
-                    .setPrototypeFactions(F_CS,F_DC)
-                    .setProductionFactions(F_DC)
-                    .setReintroductionFactions(F_FS,F_LC);
-                return ammo;
-            }
             
     //Industrial Muntions
             
@@ -14832,15 +14736,17 @@ public class AmmoType extends EquipmentType {
         ammo.ammoType = AmmoType.T_AR10;
         ammo.munitionType = AmmoType.M_PEACEMAKER;
         ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
-        ammo.flags = ammo.flags.or(F_AR10_KILLER_WHALE).or(F_NUCLEAR)
+        ammo.bv = 10000;
+        ammo.cost = 40000000;
+        ammo.flags = ammo.flags.or(F_NUCLEAR)
                 .or(F_CAP_MISSILE).or(F_PEACEMAKER);
         ammo.capital = true;
 
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_C)
-            .setISAdvancement(DATE_NONE, DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
+        ammo.techAdvancement.setTechBase(TECH_BASE_IS)
+            .setTechRating(RATING_E)
+            .setISAdvancement(2540, DATE_NONE, DATE_NONE, 2950, 3051)
+            .setISApproximate(true, false, false, true, true)
+            .setAvailability(RATING_F, RATING_F, RATING_F, RATING_F)
             .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
         return ammo;
     } 
@@ -14858,43 +14764,19 @@ public class AmmoType extends EquipmentType {
         ammo.ammoType = AmmoType.T_KILLER_WHALE;
         ammo.munitionType = AmmoType.M_PEACEMAKER;
         ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
+        ammo.bv = 10000;
+        ammo.cost = 40000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_PEACEMAKER);
         ammo.capital = true;
 
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_C)
-            .setISAdvancement(DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
+        ammo.techAdvancement.setTechBase(TECH_BASE_IS)
+            .setTechRating(RATING_E)
+            .setISAdvancement(2220, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+            .setISApproximate(true, false, false, false, false)
+            .setAvailability(RATING_F, RATING_F, RATING_F, RATING_F)            
             .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
         return ammo;
-    }
-    
-    private static AmmoType createCLPeacemakerAmmo() {
-        AmmoType ammo = new AmmoType();
-
-        ammo.name = "Clan Peacemaker Ammo";
-        ammo.setInternalName("Ammo Clan Peacemaker");
-        ammo.addLookupName("CLPeacemaker Ammo");
-        ammo.shortName = "Peacemaker";
-        ammo.subMunitionBegin = 0;
-        ammo.subMunitionLength = ammo.shortName.length();
-        ammo.damagePerShot = 1000;
-        ammo.ammoType = AmmoType.T_KILLER_WHALE;
-        ammo.munitionType = AmmoType.M_PEACEMAKER;
-        ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
-        ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_PEACEMAKER);
-        ammo.capital = true;
-
-        ammo.techAdvancement.setTechBase(TECH_BASE_CLAN).setTechRating(RATING_C)
-            .setClanAdvancement(DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
-            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
-
-        return ammo;
-    }   
+    } 
 
     private static AmmoType createAR10SantaAnnaAmmo() {
         AmmoType ammo = new AmmoType();
@@ -14909,15 +14791,17 @@ public class AmmoType extends EquipmentType {
         ammo.ammoType = AmmoType.T_AR10;
         ammo.munitionType = AmmoType.M_SANTA_ANNA;
         ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
-        ammo.flags = ammo.flags.or(F_AR10_KILLER_WHALE).or(F_NUCLEAR)
+        ammo.bv = 1000;
+        ammo.cost = 15000000;
+        ammo.flags = ammo.flags.or(F_NUCLEAR)
                 .or(F_CAP_MISSILE).or(F_SANTA_ANNA);
         ammo.capital = true;
 
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_C)
-            .setISAdvancement(DATE_NONE, DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
+        ammo.techAdvancement.setTechBase(TECH_BASE_IS)
+            .setTechRating(RATING_E)
+            .setISAdvancement(2540, DATE_NONE, DATE_NONE, 2950, 3051)
+            .setISApproximate(true, false, false, true, true)
+            .setAvailability(RATING_F, RATING_F, RATING_F, RATING_F)
             .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
         return ammo;
     } 
@@ -14932,48 +14816,23 @@ public class AmmoType extends EquipmentType {
         ammo.subMunitionBegin = 0;
         ammo.subMunitionLength = ammo.shortName.length();
         ammo.damagePerShot = 100;
-        ammo.ammoType = AmmoType.T_KILLER_WHALE;
+        ammo.ammoType = AmmoType.T_WHITE_SHARK;
         ammo.munitionType = AmmoType.M_SANTA_ANNA;
         ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
+        ammo.bv = 1000;
+        ammo.cost = 15000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_SANTA_ANNA);
         ammo.capital = true;
 
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_C)
-            .setISAdvancement(DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
+        ammo.techAdvancement.setTechBase(TECH_BASE_IS)
+            .setTechRating(RATING_E)
+            .setISAdvancement(2300, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+            .setISApproximate(true, false, false, false, false)
+            .setAvailability(RATING_F, RATING_F, RATING_F, RATING_F)
             .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
         return ammo;
     }
     
-    private static AmmoType createCLSantaAnnaAmmo() {
-        AmmoType ammo = new AmmoType();
-
-        ammo.name = "Clan Santa Anna Ammo";
-        ammo.setInternalName("Ammo Clan Santa Anna");
-        ammo.addLookupName("CLSantaAnna Ammo");
-        ammo.shortName = "Santa Anna";
-        ammo.subMunitionBegin = 0;
-        ammo.subMunitionLength = ammo.shortName.length();
-        ammo.damagePerShot = 100;
-        ammo.ammoType = AmmoType.T_KILLER_WHALE;
-        ammo.munitionType = AmmoType.M_SANTA_ANNA;
-        ammo.shots = 1;
-        ammo.bv = 96;
-        ammo.cost = 20000;
-        ammo.flags = ammo.flags.or(F_NUCLEAR).or(F_CAP_MISSILE).or(F_SANTA_ANNA);
-        ammo.capital = true;
-
-        ammo.techAdvancement.setTechBase(TECH_BASE_CLAN).setTechRating(RATING_C)
-            .setClanAdvancement(DATE_NONE, 3067)
-            .setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
-            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
-
-        return ammo;
-    }
-
-
     private static AmmoType createAlamoAmmo() {
         AmmoType ammo = new AmmoType();
 
@@ -14984,13 +14843,16 @@ public class AmmoType extends EquipmentType {
         ammo.rackSize = 1;
         ammo.ammoType = AmmoType.T_ALAMO;
         ammo.shots = 1;
-        ammo.bv = 0;
-        ammo.cost = 0;
+        ammo.bv = 100;
+        ammo.cost = 1000000;
         ammo.flags = ammo.flags.or(F_NUCLEAR);
         ammo.capital = true;
 
-        ammo.techAdvancement.setTechBase(TECH_BASE_IS).setISAdvancement(DATE_NONE, DATE_NONE, 3067)
-            .setTechRating(RATING_C).setAvailability(RATING_E, RATING_E, RATING_E, RATING_E)
+        ammo.techAdvancement.setTechBase(TECH_BASE_IS)
+            .setISAdvancement(2200, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+            .setISApproximate(true, false, false, false, false)
+            .setTechRating(RATING_E)
+            .setAvailability(RATING_F, RATING_F, RATING_F, RATING_F)
             .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
         return ammo;
     }

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -82,13 +82,15 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
                 double current_av = 0;
 
                 AmmoType atype = (AmmoType) bayWAmmo.getType();
-                if (bayWType.getAtClass() == (20)
-                		&& atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)) {
+                if (bayWType.getAtClass() == (WeaponType.CLASS_AR10)
+                		&& (atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)
+                		        || atype.hasFlag(AmmoType.F_PEACEMAKER))) {
                 	weaponarmor = 40;
-                } else if (bayWType.getAtClass() == (20)
-                		&& atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)) {
+                } else if (bayWType.getAtClass() == (WeaponType.CLASS_AR10)
+                		&& (atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)
+                                || atype.hasFlag(AmmoType.F_SANTA_ANNA))) {
                 	weaponarmor = 30;
-                } else if (bayWType.getAtClass() == (20)
+                } else if (bayWType.getAtClass() == (WeaponType.CLASS_AR10)
                 		&& atype.hasFlag(AmmoType.F_AR10_BARRACUDA)) {
                 	weaponarmor = 20;
                 } else {
@@ -220,11 +222,15 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
                 current_av = 4;
             } else if (atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)) {
                 current_av = 3;
+            } else if (atype.hasFlag(AmmoType.F_PEACEMAKER)) {
+                current_av = 1000;
+            } else if (atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
+                current_av = 100;
             } else {
                 current_av = 2;
             }
         }
-    	//Nuclear Warheads
+    	//Nuclear Warheads for non-AR10 missiles
     	if (atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
     	    current_av = 100;
     	} else if (atype.hasFlag(AmmoType.F_PEACEMAKER)) {

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -20,6 +20,7 @@ import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.IGame;
 import megamek.common.Mounted;
+import megamek.common.RangeType;
 import megamek.common.Targetable;
 import megamek.common.ToHitData;
 import megamek.common.WeaponType;
@@ -49,6 +50,72 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
             Server s) {
         super(t, w, g, s);
         advancedPD = g.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADV_POINTDEF);
+    }
+    
+    /**
+     * Calculate the attack value based on range
+     *
+     * @return an <code>int</code> representing the attack value at that range.
+     */
+    @Override
+    protected int calcAttackValue() {
+        int av = 0;
+        double counterAV = calcCounterAV();
+        int armor = wtype.getMissileArmor();
+        // if we have a ground firing unit, then AV should not be determined by
+        // aero range brackets
+        if (!ae.isAirborne() || game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_UAC_TWOROLLS)) {
+            if (usesClusterTable()) {
+                // for cluster weapons just use the short range AV
+                av = wtype.getRoundShortAV();
+            } else {
+                // otherwise just use the full weapon damage by range
+                av = wtype.getDamage(nRange);
+            }
+        } else {
+            // we have an airborne attacker, so we need to use aero range
+            // brackets
+            int range = RangeType.rangeBracket(nRange, wtype.getATRanges(),
+                    true, false);
+            if (range == WeaponType.RANGE_SHORT) {
+                av = wtype.getRoundShortAV();
+            } else if (range == WeaponType.RANGE_MED) {
+                av = wtype.getRoundMedAV();
+            } else if (range == WeaponType.RANGE_LONG) {
+                av = wtype.getRoundLongAV();
+            } else if (range == WeaponType.RANGE_EXT) {
+                av = wtype.getRoundExtAV();
+            }
+        }
+        
+        if (ammo.getType().hasFlag(AmmoType.F_NUCLEAR)) {
+            nukeS2S = true;
+        }
+        
+        CapMissileArmor = armor - (int) counterAV;
+        CapMissileAMSMod = calcCapMissileAMSMod();
+        
+        if (bDirect) {
+            av = Math.min(av + (toHit.getMoS() / 3), av * 2);
+        }
+        if (bGlancing) {
+            av = (int) Math.floor(av / 2.0);
+
+        }
+        av = (int) Math.floor(getBracketingMultiplier() * av);
+        
+        return av;
+    }
+  
+    @Override
+    protected int calcCapMissileAMSMod() {
+        CapMissileAMSMod = (int) Math.ceil(CounterAV / 10.0);
+        return CapMissileAMSMod;
+    }
+    
+    @Override
+    protected int getCapMissileAMSMod() {
+        return CapMissileAMSMod;
     }
     
     // check for AMS and Point Defense Bay fire
@@ -181,13 +248,13 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
                 
                 // set the pdbay as having fired, if it did
                 if (pdAV > 0) {
-                    pdBayEngagedMissile = true;
+                    pdBayEngagedCap = true;
                 }
                 counterAV += (int) Math.ceil(pdAV / 2.0);
                 
                 // set the ams as having fired, if it did
                 if (amsAV > 0) {
-                    amsBayEngagedMissile = true;
+                    amsBayEngagedCap = true;
                 }
                 // AMS add their full damage
                 counterAV += amsAV;
@@ -234,5 +301,10 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
         } else {
             return 11;
         }
+    }
+    
+    @Override
+    protected int getCounterAV() {
+        return CounterAV;
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissKillerWhaleWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissKillerWhaleWeapon.java
@@ -86,10 +86,6 @@ public class CapMissKillerWhaleWeapon extends CapitalMissileWeapon {
             WeaponAttackAction waa, IGame game, Server server) {
         AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
                 .getEquipment(waa.getWeaponId()).getLinked().getType();
-        // Let's try not doing this. We should be able to deal with nuclear ammo from the cap missile handler.
-       /* if (atype.hasFlag(AmmoType.F_NUCLEAR)) {
-            return new SantaAnnaHandler(toHit, waa, game, server);
-        } */
         if (atype.hasFlag(AmmoType.F_TELE_MISSILE)) {
             return new TeleMissileHandler(toHit, waa, game, server);
         }


### PR DESCRIPTION
Rebuild of PR714. This contains only Alamo/santa anna/peacemaker code - prices, damage values, ammotypes (per IO rules) and capitalmissilehandler code for Alamos.
You still can't load or fire any of these without additional work.