### PR TITLE
Updates the symlink in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-megamek/docs/readme.txt
+megamek/docs/1-Readme/readme.txt


### PR DESCRIPTION
The symlink for `README.md` was broken when the `docs/` folder was reorganized.  This fixes the symlink.