### PR TITLE
Airborne Aero Artillery Fire (Bug #205)

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -5845,12 +5845,18 @@ public class Compute {
         if ((attacker == null) || (target == null)) {
             return false;
         }
+        
+        //Artillery attacks need to return differently, since none of the usual air to ground modifiers apply to them
+        if (target.getTargetType() == Targetable.TYPE_HEX_ARTILLERY) {
+            return false;
+        }
 
         if (attacker.game.getBoard().inSpace()) {
             return false;
         }
         // According to errata, VTOL and WiGes are considered ground targets
         return attacker.isAirborne() && !target.isAirborne();
+        
     }
 
     public static boolean isAirToAir(Entity attacker, Targetable target) {

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3013,8 +3013,27 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             if (ae.isAirborne()) {
                 if (isArtilleryDirect) {
                     return "Airborne aerospace units can't make direct-fire artillery attacks";
-                } else if (isArtilleryIndirect && (wtype.getAmmoType() != AmmoType.T_ARROW_IV)) {
-                    return "Airborne aerospace units can't fire non-Arrow-IV artillery.";
+                } else if (isArtilleryIndirect) {
+                    if (ae.getAltitude() > 9) {
+                        return "Airborne aerospace units can't make artillery attacks from above Altitude 9.";
+                    }
+                    if (ae.usesWeaponBays()) {
+                        //For Dropships
+                        for (int wId : weapon.getBayWeapons()) {
+                            Mounted bayW = ae.getEquipment(wId);
+                            // check the loaded ammo for the Arrow IV flag
+                            Mounted bayWAmmo = bayW.getLinked();
+                            AmmoType bAType = (AmmoType) bayWAmmo.getType();
+                            if (bAType.getAmmoType() != AmmoType.T_ARROW_IV) {
+                                return "Airborne aerospace units can't fire non-Arrow-IV artillery.";
+                            }
+                        }
+                    } else if ((wtype.getAmmoType() != BombType.B_ARROW)
+                            || (wtype.getAmmoType() != BombType.B_HOMING)
+                            || (wtype.getAmmoType() != AmmoType.T_ARROW_IV)) {
+                        //For Fighters, LAMs, Small Craft and VTOLs
+                        return "Airborne aerospace units can't make non-Arrow-IV artillery/bomb attacks.";
+                    }
                 }
             }
         } else {

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3982,7 +3982,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     && !((wtype instanceof ArtilleryWeapon) || wtype.hasFlag(WeaponType.F_ARTILLERY))) {
                 return "Target is too low for nose weapons";
             }
-            if ((!weapon.isRearMounted() && (weapon.getLocation() != Aero.LOC_AFT)) && (altDif < 0)) {
+            if ((!weapon.isRearMounted() && (weapon.getLocation() != Aero.LOC_AFT)) && (altDif < 0)
+                    && !((wtype instanceof ArtilleryWeapon) || wtype.hasFlag(WeaponType.F_ARTILLERY))) {
                 return "Target is too low for front-side weapons";
             }
             if ((weapon.getLocation() == Aero.LOC_AFT)) {

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3028,11 +3028,9 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                                 return "Airborne aerospace units can't fire non-Arrow-IV artillery.";
                             }
                         }
-                    } else if ((wtype.getAmmoType() != BombType.B_ARROW)
-                            || (wtype.getAmmoType() != BombType.B_HOMING)
-                            || (wtype.getAmmoType() != AmmoType.T_ARROW_IV)) {
+                    } else if (wtype.getAmmoType() != AmmoType.T_ARROW_IV) {
                         //For Fighters, LAMs, Small Craft and VTOLs
-                        return "Airborne aerospace units can't make non-Arrow-IV artillery/bomb attacks.";
+                        return "Airborne aerospace units can't make non-Arrow-IV artillery attacks.";
                     }
                 }
             }

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -149,10 +149,6 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
             return true;
         }
         Mounted ammoUsed = ae.getEquipment(aaa.getAmmoId());
-        //TODO: Not sure why atype is defined the way it is here. 
-        //I'm removing most of the references to it in order to handle bay ammo.
-        final AmmoType atype = ammoUsed == null ? null : (AmmoType) ammoUsed
-                .getType();
         // Are there any valid spotters?
         if ((null != spottersBefore) && !isFlak) {
             // fetch possible spotters now

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -86,6 +86,33 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
         }
         return false;
     }
+        
+    @Override
+    protected void useAmmo() {
+        for (int wId : weapon.getBayWeapons()) {
+            Mounted bayW = ae.getEquipment(wId);
+            // check the currently loaded ammo
+            Mounted bayWAmmo = bayW.getLinked();
+
+            if (bayWAmmo == null) {// Can't happen. w/o legal ammo, the weapon
+                // *shouldn't* fire.
+                System.out.println("Handler can't find any ammo!  Oh no!");
+            }
+
+            int shots = bayW.getCurrentShots();
+            for (int i = 0; i < shots; i++) {
+                if (null == bayWAmmo
+                        || bayWAmmo.getUsableShotsLeft() < 1) {
+                    // try loading something else
+                    ae.loadWeaponWithSameAmmo(bayW);
+                    bayWAmmo = bayW.getLinked();
+                }
+                if (null != bayWAmmo) {
+                    bayWAmmo.setShotsLeft(bayWAmmo.getBaseShotsLeft() - 1);
+                }
+            }
+        }
+    }
 
     /*
      * (non-Javadoc)

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -149,6 +149,8 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
             return true;
         }
         Mounted ammoUsed = ae.getEquipment(aaa.getAmmoId());
+        //TODO: Not sure why atype is defined the way it is here. 
+        //I'm removing most of the references to it in order to handle bay ammo.
         final AmmoType atype = ammoUsed == null ? null : (AmmoType) ammoUsed
                 .getType();
         // Are there any valid spotters?
@@ -373,49 +375,53 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                 return !bMissed;
             }
         }
-
-        if (atype.getMunitionType() == AmmoType.M_FLARE) {
-            int radius;
-            if (atype.getAmmoType() == AmmoType.T_ARROW_IV) {
-                radius = 4;
-            } else if (atype.getAmmoType() == AmmoType.T_LONG_TOM) {
-                radius = 3;
-            } else if (atype.getAmmoType() == AmmoType.T_SNIPER) {
-                radius = 2;
-            } else {
-                radius = 1;
+        for (int wId : weapon.getBayWeapons()) {
+            Mounted bayW = ae.getEquipment(wId);
+            Mounted bayWAmmo = bayW.getLinked();
+            AmmoType bayAmmoType = (AmmoType) bayWAmmo.getType();
+            if (bayAmmoType.getMunitionType() == AmmoType.M_FLARE) {
+                int radius;
+                if (bayAmmoType.getAmmoType() == AmmoType.T_ARROW_IV) {
+                    radius = 4;
+                } else if (bayAmmoType.getAmmoType() == AmmoType.T_LONG_TOM) {
+                    radius = 3;
+                } else if (bayAmmoType.getAmmoType() == AmmoType.T_SNIPER) {
+                    radius = 2;
+                } else {
+                    radius = 1;
+                }
+                server.deliverArtilleryFlare(targetPos, radius);
+                return false;
             }
-            server.deliverArtilleryFlare(targetPos, radius);
-            return false;
-        }
-        if (atype.getMunitionType() == AmmoType.M_DAVY_CROCKETT_M) {
-            // The appropriate term here is "Bwahahahahaha..."
-            server.doNuclearExplosion(targetPos, 1, vPhaseReport);
-            return false;
-        }
-        if (atype.getMunitionType() == AmmoType.M_FASCAM) {
-            server.deliverFASCAMMinefield(targetPos, ae.getOwner().getId(),
-                    atype.getRackSize(), ae.getId());
-            return false;
-        }
-        if (atype.getMunitionType() == AmmoType.M_INFERNO_IV) {
-            server.deliverArtilleryInferno(targetPos, ae, subjectId,
-                    vPhaseReport);
-            return false;
-        }
-        if (atype.getMunitionType() == AmmoType.M_VIBRABOMB_IV) {
-            server.deliverThunderVibraMinefield(targetPos, ae.getOwner()
-                    .getId(), atype.getRackSize(), waa.getOtherAttackInfo(), ae
-                    .getId());
-            return false;
-        }
-        if (atype.getMunitionType() == AmmoType.M_SMOKE) {
-            server.deliverArtillerySmoke(targetPos, vPhaseReport);
-            return false;
-        }
-        if (atype.getMunitionType() == AmmoType.M_LASER_INHIB) {
-            server.deliverLIsmoke(targetPos, vPhaseReport);
-            return false;
+            if (bayAmmoType.getMunitionType() == AmmoType.M_DAVY_CROCKETT_M) {
+                // The appropriate term here is "Bwahahahahaha..."
+                server.doNuclearExplosion(targetPos, 1, vPhaseReport);
+                return false;
+            }
+            if (bayAmmoType.getMunitionType() == AmmoType.M_FASCAM) {
+                server.deliverFASCAMMinefield(targetPos, ae.getOwner().getId(),
+                        bayAmmoType.getRackSize(), ae.getId());
+                return false;
+            }
+            if (bayAmmoType.getMunitionType() == AmmoType.M_INFERNO_IV) {
+                server.deliverArtilleryInferno(targetPos, ae, subjectId,
+                        vPhaseReport);
+                return false;
+            }
+            if (bayAmmoType.getMunitionType() == AmmoType.M_VIBRABOMB_IV) {
+                server.deliverThunderVibraMinefield(targetPos, ae.getOwner()
+                        .getId(), bayAmmoType.getRackSize(), waa.getOtherAttackInfo(), ae
+                        .getId());
+                return false;
+            }
+            if (bayAmmoType.getMunitionType() == AmmoType.M_SMOKE) {
+                server.deliverArtillerySmoke(targetPos, vPhaseReport);
+                return false;
+            }
+            if (bayAmmoType.getMunitionType() == AmmoType.M_LASER_INHIB) {
+                server.deliverLIsmoke(targetPos, vPhaseReport);
+                return false;
+            }
         }
         int altitude = 0;
         if (isFlak) {
@@ -448,12 +454,16 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                 server.removeMinefield(mf);
             }
         }
-
-        server.artilleryDamageArea(targetPos, aaa.getCoords(), atype,
-                subjectId, ae, isFlak, altitude, mineClear, vPhaseReport,
-                asfFlak, -1);
-
-        // artillery may unintentially clear minefields, but only if it wasn't
+        for (int wId : weapon.getBayWeapons()) {
+            Mounted bayW = ae.getEquipment(wId);
+            Mounted bayWAmmo = bayW.getLinked();
+            AmmoType bayAmmoType = (AmmoType) bayWAmmo.getType();
+            
+            server.artilleryDamageArea(targetPos, aaa.getCoords(), bayAmmoType,
+                    subjectId, ae, isFlak, altitude, mineClear, vPhaseReport,
+                    asfFlak, -1);
+        }
+        // artillery may unintentionally clear minefields, but only if it wasn't
         // trying to
         if (!mineClear && game.containsMinefield(targetPos)) {
             Enumeration<Minefield> minefields = game.getMinefields(targetPos)

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -148,7 +148,6 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
             System.err.println("Artillery Entity is null!");
             return true;
         }
-        Mounted ammoUsed = ae.getEquipment(aaa.getAmmoId());
         // Are there any valid spotters?
         if ((null != spottersBefore) && !isFlak) {
             // fetch possible spotters now

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -42,6 +42,9 @@ import megamek.common.ToHitData;
 import megamek.common.VTOL;
 import megamek.common.actions.ArtilleryAttackAction;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.logging.LogLevel;
+import megamek.common.logging.DefaultMmLogger;
+import megamek.common.logging.MMLogger;
 import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 
@@ -55,12 +58,32 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
      */
     private static final long serialVersionUID = -1277649123562229298L;
     boolean handledAmmoAndReport = false;
+    private MMLogger logger = null;
 
     /**
      * This consructor may only be used for deserialization.
      */
     protected ArtilleryBayWeaponIndirectFireHandler() {
         super();
+    }
+    
+    /**
+     * Write debug information to the logs.
+     *
+     * @param methodName Name of the method logging is coming from
+     * @param message Message to log
+     */
+    @SuppressWarnings("unused")
+    private void logDebug(String methodName, String message) {
+        getLogger().log(getClass(), methodName, LogLevel.DEBUG, message);
+    }
+    
+    private MMLogger getLogger() {
+        if (null == logger) {
+            logger = DefaultMmLogger.getInstance();
+        }
+
+        return logger;
     }
 
     /**
@@ -89,6 +112,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
         
     @Override
     protected void useAmmo() {
+        final String METHOD_NAME = "useAmmo()";
         for (int wId : weapon.getBayWeapons()) {
             Mounted bayW = ae.getEquipment(wId);
             // check the currently loaded ammo
@@ -96,7 +120,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
 
             if (bayWAmmo == null) {// Can't happen. w/o legal ammo, the weapon
                 // *shouldn't* fire.
-                System.out.println("Handler can't find any ammo!  Oh no!");
+                logDebug(METHOD_NAME, "Handler can't find any ammo! Oh no!");
             }
 
             int shots = bayW.getCurrentShots();


### PR DESCRIPTION
This fixes bug #205 , correcting a number of issues within the Artillery Bay Indirect Handler that threw NPEs and some that prevented artillery weapons from being fired by airborne units.

Note that per errata, Artillery weapons should not be grouped in bays. This fix works properly when separate artillery bays are created for each artillery weapon and its ammunition. It will waste ammo and only resolve a single shot impact if used if used with a bay of multiple weapons. Pending work from Hammer and Neoancient will change the unit files to resolve this. 