### PR TITLE
Optional Cargo/Transport Bay Damage on Cargo Critical Hit for Large Craft

### DIFF
--- a/megamek/i18n/megamek/common/options/messages.properties
+++ b/megamek/i18n/megamek/common/options/messages.properties
@@ -444,6 +444,8 @@ GameOptionsInfo.option.allow_large_squadrons.displayableName=(Unofficial) Allow 
 GameOptionsInfo.option.allow_large_squadrons.description=Allow up to 10 fighters in a squadron instead of the arbitrary 6 of the official record sheets.
 GameOptionsInfo.option.aero_sanity.displayableName=(Unofficial) Aero sanity mod for damage
 GameOptionsInfo.option.aero_sanity.description= A modification of aero damage rules to make damage consistent across different unit types.\nSee document in the docs folder for details.
+GameOptionsInfo.option.cargo_bay_damage.displayableName=(Unofficial) Damage Cargo/Transport Bays on Cargo Critical Hit
+GameOptionsInfo.option.cargo_bay_damage.description= If a Cargo critical hit is taken, the cargo/transport bay itself suffers damage in addition to the cargo/units inside.
 
 
 GameOptionsInfo.group.initiative.displayableName=Initiative Rules

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -992,6 +992,7 @@
 9160=\ <font color='C00000'>Thrusters hit!</font>
 9165=\ <font color='C00000'>Cargo hit! <data>% of cargo is lost.</font>
 9166=\ <font color='C00000'>Transport bays hit! <data> units destroyed.</font>
+9167=\ <font color='C00000'><data> Bay #<data> damaged!</font>
 9170=\ <font color='C00000'>An <data> bay door is destroyed!</font>
 9171=\ There are no functioning bay doors on this vessel.
 9175=\ <font color='C00000'>Docking Collar hit. Dropship will be unable to dock.</font>

--- a/megamek/src/megamek/common/options/GameOptions.java
+++ b/megamek/src/megamek/common/options/GameOptions.java
@@ -270,6 +270,7 @@ public class GameOptions extends AbstractOptions {
         addOption(advAeroRules, OptionsConstants.ADVAERORULES_AA_MOVE_MOD, false); //$NON-NLS-1$
         addOption(advAeroRules, OptionsConstants.ADVAERORULES_ALLOW_LARGE_SQUADRONS, false); //$NON-NLS-1$
         addOption(advAeroRules, OptionsConstants.ADVAERORULES_SINGLE_NO_CAP, false); //$NON-NLS-1$
+        addOption(advAeroRules, OptionsConstants.ADVAERORULES_CARGO_BAY_DAMAGE, false); //$NON-NLS-1$
 
         IBasicOptionGroup initiative = addGroup("initiative"); //$NON-NLS-1$
         addOption(initiative, OptionsConstants.INIT_INF_MOVE_EVEN, false); //$NON-NLS-1$

--- a/megamek/src/megamek/common/options/OptionsConstants.java
+++ b/megamek/src/megamek/common/options/OptionsConstants.java
@@ -483,6 +483,7 @@ public class OptionsConstants {
     public static final String ADVAERORULES_AA_MOVE_MOD= "aa_move_mod";  //$NON-NLS$
     public static final String ADVAERORULES_ALLOW_LARGE_SQUADRONS= "allow_large_squadrons";  //$NON-NLS$
     public static final String ADVAERORULES_SINGLE_NO_CAP= "single_no_cap";  //$NON-NLS$
+    public static final String ADVAERORULES_CARGO_BAY_DAMAGE= "cargo_bay_damage";  //$NON-NLS$
 
     public static final String INIT_INF_MOVE_EVEN= "inf_move_even";  //$NON-NLS$
     public static final String INIT_INF_DEPLOY_EVEN= "inf_deploy_even";  //$NON-NLS$

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -72,108 +72,11 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 
 import megamek.MegaMek;
 import megamek.client.ui.swing.util.PlayerColors;
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.Bay;
-import megamek.common.BipedMech;
-import megamek.common.Board;
-import megamek.common.BoardDimensions;
-import megamek.common.BombType;
-import megamek.common.Building;
+import megamek.common.*;
 import megamek.common.Building.BasementType;
 import megamek.common.Building.DemolitionCharge;
-import megamek.common.BuildingTarget;
-import megamek.common.CalledShot;
-import megamek.common.CommonConstants;
-import megamek.common.Compute;
-import megamek.common.ComputeECM;
-import megamek.common.Configuration;
-import megamek.common.ConvFighter;
-import megamek.common.Coords;
-import megamek.common.Crew;
-import megamek.common.CriticalSlot;
-import megamek.common.Dropship;
-import megamek.common.ECMInfo;
-import megamek.common.EjectedCrew;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EntityMovementType;
-import megamek.common.EntitySelector;
-import megamek.common.EntityWeightClass;
-import megamek.common.EquipmentMode;
-import megamek.common.EquipmentType;
-import megamek.common.FighterSquadron;
-import megamek.common.Flare;
-import megamek.common.FuelTank;
-import megamek.common.Game;
-import megamek.common.GameTurn;
-import megamek.common.GunEmplacement;
-import megamek.common.HexTarget;
-import megamek.common.HitData;
-import megamek.common.IAero;
-import megamek.common.IArmorState;
-import megamek.common.IBoard;
-import megamek.common.IBomber;
-import megamek.common.IEntityRemovalConditions;
-import megamek.common.IGame;
 import megamek.common.IGame.Phase;
-import megamek.common.IHex;
-import megamek.common.ILocationExposureStatus;
-import megamek.common.INarcPod;
-import megamek.common.IPlayer;
-import megamek.common.ITerrain;
-import megamek.common.Infantry;
-import megamek.common.InfernoTracker;
-import megamek.common.Jumpship;
-import megamek.common.LandAirMech;
-import megamek.common.LargeSupportTank;
-import megamek.common.LocationFullException;
-import megamek.common.LosEffects;
-import megamek.common.MapSettings;
-import megamek.common.Mech;
-import megamek.common.MechWarrior;
-import megamek.common.Minefield;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.MovePath;
 import megamek.common.MovePath.MoveStepType;
-import megamek.common.MoveStep;
-import megamek.common.OffBoardDirection;
-import megamek.common.PhysicalResult;
-import megamek.common.PilotingRollData;
-import megamek.common.PlanetaryConditions;
-import megamek.common.Player;
-import megamek.common.Protomech;
-import megamek.common.QuadMech;
-import megamek.common.QuadVee;
-import megamek.common.Report;
-import megamek.common.Roll;
-import megamek.common.SmallCraft;
-import megamek.common.SpaceStation;
-import megamek.common.SpecialHexDisplay;
-import megamek.common.SuperHeavyTank;
-import megamek.common.SupportTank;
-import megamek.common.SupportVTOL;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
-import megamek.common.TargetRollModifier;
-import megamek.common.Targetable;
-import megamek.common.Team;
-import megamek.common.TechConstants;
-import megamek.common.TeleMissile;
-import megamek.common.Terrain;
-import megamek.common.Terrains;
-import megamek.common.ToHitData;
-import megamek.common.TripodMech;
-import megamek.common.TurnOrdered;
-import megamek.common.TurnVectors;
-import megamek.common.UnitLocation;
-import megamek.common.VTOL;
-import megamek.common.Warship;
-import megamek.common.WeaponComparatorBV;
-import megamek.common.WeaponType;
 import megamek.common.actions.AbstractAttackAction;
 import megamek.common.actions.AirmechRamAttackAction;
 import megamek.common.actions.ArtilleryAttackAction;
@@ -26141,6 +26044,19 @@ public class Server implements Runnable {
                     r.subject = aero.getId();
                     r.add((int) (percentDestroyed * 100));
                     reports.add(r);
+                    Vector<Bay> cargoBays = new Vector<Bay>();
+                    for (Bay next : aero.getTransportBays()) {
+                        if ((next instanceof CargoBay)
+                                || (next instanceof InsulatedCargoBay)
+                                || (next instanceof LiquidCargoBay)
+                                || (next instanceof LivestockCargoBay)
+                                || (next instanceof RefrigeratedCargoBay)) {
+                            cargoBays.add(next);
+                        }
+                        
+                    }
+                    Bay targetBay = cargoBays.get(Compute.randomInt(cargoBays.size()));
+                    targetBay.setBayDamaged();
                 } else {
                     // units were hit
                     // get a list of units

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -26044,19 +26044,27 @@ public class Server implements Runnable {
                     r.subject = aero.getId();
                     r.add((int) (percentDestroyed * 100));
                     reports.add(r);
-                    Vector<Bay> cargoBays = new Vector<Bay>();
-                    for (Bay next : aero.getTransportBays()) {
-                        if ((next instanceof CargoBay)
-                                || (next instanceof InsulatedCargoBay)
-                                || (next instanceof LiquidCargoBay)
-                                || (next instanceof LivestockCargoBay)
-                                || (next instanceof RefrigeratedCargoBay)) {
-                            cargoBays.add(next);
-                        }
+                    if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_CARGO_BAY_DAMAGE)) {
+                        Vector<Bay> cargoBays = new Vector<Bay>();
+                        for (Bay next : aero.getTransportBays()) {
+                            if ((next instanceof CargoBay)
+                                    || (next instanceof InsulatedCargoBay)
+                                    || (next instanceof LiquidCargoBay)
+                                    || (next instanceof LivestockCargoBay)
+                                    || (next instanceof RefrigeratedCargoBay)) {
+                                cargoBays.add(next);
+                            }
                         
+                        }
+                        Bay targetBay = cargoBays.get(Compute.randomInt(cargoBays.size()));
+                        targetBay.setBayDamaged();
+                        //report the damage
+                        r = new Report(9167);
+                        r.subject = aero.getId();
+                        r.add(targetBay.getType());
+                        r.add(targetBay.getBayNumber());
+                        reports.add(r);
                     }
-                    Bay targetBay = cargoBays.get(Compute.randomInt(cargoBays.size()));
-                    targetBay.setBayDamaged();
                 } else {
                     // units were hit
                     // get a list of units
@@ -26074,10 +26082,17 @@ public class Server implements Runnable {
                         if (units.size() > 0) {
                             Entity target = units.get(Compute.randomInt(units
                                                                                 .size()));
-                            // damage the cargo bay itself
-                            Bay targetBay = aero.getBay(target);
-                            targetBay.setBayDamaged();
-                            
+                            if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_CARGO_BAY_DAMAGE)) {
+                                // damage the cargo bay itself
+                                Bay targetBay = aero.getBay(target);
+                                targetBay.setBayDamaged();
+                                //report the damage
+                                r = new Report(9167);
+                                r.subject = aero.getId();
+                                r.add(targetBay.getType());
+                                r.add(targetBay.getBayNumber());
+                                reports.add(r);
+                            }
                             //This dooms the selected transported unit
                             reports.addAll(destroyEntity(target, "cargo damage",
                                                        false, false));
@@ -26105,13 +26120,14 @@ public class Server implements Runnable {
                 // docking collar hit
                 // different effect for dropships and jumpships
                 if (aero instanceof Dropship) {
+                    //damage the docking collar. There isn't but one...
                     ((Dropship)aero).setDamageDockCollar(true);
                     r = new Report(9175);
                     r.subject = aero.getId();
                     reports.add(r);
                 }
                 if (aero instanceof Jumpship) {
-                    // damage the docking collar
+                    // damage a random docking collar
                     if (aero.damageDockCollar()) {
                         r = new Report(9176);
                         r.subject = aero.getId();

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -26158,6 +26158,11 @@ public class Server implements Runnable {
                         if (units.size() > 0) {
                             Entity target = units.get(Compute.randomInt(units
                                                                                 .size()));
+                            // damage the cargo bay itself
+                            Bay targetBay = aero.getBay(target);
+                            targetBay.setBayDamaged();
+                            
+                            //This dooms the selected transported unit
                             reports.addAll(destroyEntity(target, "cargo damage",
                                                        false, false));
                         }


### PR DESCRIPTION
The SO master repair tables have values listed for repairing a transport or cargo bay, but the combat rules have no means of damaging one. I previously added the ability to damage the bay in the lobby. This adds an option that damages the appropriate bay when a Cargo critical hit is taken. 