### PR TITLE
Implementation of weapon-ammo selector in lobby, and caseless ammo swap restriction in-game

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -889,6 +889,7 @@ CustomMechDialog.tooltipBackupGunner=The crew member that will take over if the 
 CustomMechDialog.tooltipBackupPilot=The crew member that will take over if the pilot is incapacitated 
 CustomMechDialog.MEAPanelTitle=Modular Equipment Adaptors
 CustomMechDialog.MunitionsPanelTitle=Select Munitions
+CustomMechDialog.WeaponSelectionTitle=Select Ammunition for Weapons
 CustomMechDialog.None=None
 CustomMechDialog.North=North
 CustomMechDialog.NetworkTooBig.title=C3 Network Too Big

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -720,6 +720,10 @@ public class EquipChoicePanel extends JPanel implements Serializable {
         }
     }
 
+    /**
+     * Worker function that creates a series of weapon ammo choice panels that allow the user to pick a particular ammo bin for an 
+     * ammo-using weapon with matching ammo.
+     */
     private void setupWeaponAmmoChoice() {
         GridBagLayout gbl = new GridBagLayout();
         panWeaponAmmoSelector.setLayout(gbl);
@@ -1296,7 +1300,16 @@ public class EquipChoicePanel extends JPanel implements Serializable {
             }
         }
         
-        class WeaponAmmoChoicePanel extends JPanel implements ItemListener {
+        /**
+         * A panel representing the option to choose a particular ammo bin for an individual weapon.
+         * @author NickAragua
+         *
+         */
+        class WeaponAmmoChoicePanel extends JPanel {
+            /**
+             * 
+             */
+            private static final long serialVersionUID = 604670659251519188L;
             // the weapon being displayed in this row
             private Mounted m_mounted;
             private ArrayList<Mounted> matchingAmmoBins;
@@ -1321,7 +1334,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 weaponName.setText("(" + weapon.getEntity().getLocationAbbr(weapon.getLocation()) + ") " + weapon.getName());
                 add(weaponName, GBC.std());
                 
-                ammoBins = new JComboBox();
+                ammoBins = new JComboBox<>();
                 matchingAmmoBins = new ArrayList<>();
                 
                 for(Mounted ammoBin : weapon.getEntity().getAmmo()) {
@@ -1358,6 +1371,12 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 validate();
             }
             
+            /**
+             * Refreshes a single item in the ammo type combo box to display the correct ammo type name.
+             * Because the underlying ammo bin hasn't been updated yet, we carry out the name swap "in-place".
+             * @param ammoBin The ammo bin whose ammo type has probably changed.
+             * @param selectedAmmoType The new ammo type.
+             */
             public void refreshAmmoBinName(Mounted ammoBin, AmmoType selectedAmmoType) {
                 int index = 0;
                 boolean matchFound = false;
@@ -1388,11 +1407,6 @@ public class EquipChoicePanel extends JPanel implements Serializable {
              */
             public void applyChoice() {
                 m_mounted.setLinked(matchingAmmoBins.get(ammoBins.getSelectedIndex()));
-            }
-            
-            @Override
-            public void itemStateChanged(ItemEvent e) {
-                refreshAmmoBinNames();
             }
         }
 

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1136,7 +1136,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 add(lLoc, GBC.std());
                 add(m_choice, GBC.std());
                 add(m_num_shots, GBC.eol());
-                //add(m_weapon_choice, GBC.eol());
+
                 chHotLoad.setSelected(m_mounted.isHotLoaded());
                 if (clientgui.getClient().getGame().getOptions().booleanOption(
                         OptionsConstants.BASE_LOBBY_AMMO_DUMP)) { //$NON-NLS-1$

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1857,8 +1857,11 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                                                  .elementAt(n));
             wtype = (WeaponType) mounted.getType();
         }
+        
         if (wtype.getAmmoType() == AmmoType.T_NA) {
             m_chAmmo.setEnabled(false);
+        
+        // this is the situation where there's some kind of ammo but it's not changeable
         } else if (wtype.hasFlag(WeaponType.F_ONESHOT)) {
             m_chAmmo.setEnabled(false);
             Mounted mountedAmmo = mounted.getLinked();
@@ -1887,8 +1890,14 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                     rightBay = oldmount.ammoInBay(entity
                                                           .getEquipmentNum(mountedAmmo));
                 }
+                
+                // covers the situation where a weapon using non-caseless ammo should 
+                // not be able to switch to caseless on the fly and vice versa
+                boolean amCaseless = ((AmmoType) mounted.getLinked().getType()).getMunitionType() == AmmoType.M_CASELESS;
+                boolean etCaseless = ((AmmoType) atype).getMunitionType() == AmmoType.M_CASELESS;
+                boolean caselessMismatch = amCaseless != etCaseless;                
 
-                if (mountedAmmo.isAmmoUsable() && same && rightBay
+                if (mountedAmmo.isAmmoUsable() && same && rightBay && !caselessMismatch
                     && (atype.getAmmoType() == wtype.getAmmoType())
                     && (atype.getRackSize() == wtype.getRackSize())) {
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3524,14 +3524,13 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     public int getTotalMunitionsOfType(EquipmentType et) {
         int totalShotsLeft = 0;
         
-        // specifically don't count caseless munitions as being of the same type
+        // specifically don't count caseless munitions as being of the same type as non-caseless
         for (Mounted amounted : getAmmo()) {
             boolean amCaseless = ((AmmoType) amounted.getType()).getMunitionType() == AmmoType.M_CASELESS;
             boolean etCaseless = ((AmmoType) et).getMunitionType() == AmmoType.M_CASELESS;
             boolean caselessMismatch = amCaseless != etCaseless;
             
-            if (amounted.getType().equals(et) && !caselessMismatch &&
-                    !amounted.isDumping()) {                
+            if (amounted.getType().equals(et) && !caselessMismatch && !amounted.isDumping()) {                
                 totalShotsLeft += amounted.getUsableShotsLeft();
             }
         }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3514,7 +3514,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
 
     /**
      * Determine how much ammunition (of all munition types) remains which is
-     * compatable with the given ammo.
+     * compatible with the given ammo.
      *
      * @param et - the <code>EquipmentType</code> of the ammo to be found. This
      *           value may be <code>null</code>.
@@ -3523,8 +3523,15 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      */
     public int getTotalMunitionsOfType(EquipmentType et) {
         int totalShotsLeft = 0;
+        
+        // specifically don't count caseless munitions as being of the same type
         for (Mounted amounted : getAmmo()) {
-            if (amounted.getType().equals(et) && !amounted.isDumping()) {
+            boolean amCaseless = ((AmmoType) amounted.getType()).getMunitionType() == AmmoType.M_CASELESS;
+            boolean etCaseless = ((AmmoType) et).getMunitionType() == AmmoType.M_CASELESS;
+            boolean caselessMismatch = amCaseless != etCaseless;
+            
+            if (amounted.getType().equals(et) && !caselessMismatch &&
+                    !amounted.isDumping()) {                
                 totalShotsLeft += amounted.getUsableShotsLeft();
             }
         }


### PR DESCRIPTION
Implements:
- The ability, under the "equipment" tab in lobby unit configuration to pick ammo for weapons out of all available matching ammo bins.
- Adjustment to ammo-counting, so that weapons using caseless ammo don't count non-caseless ammo as part of the "total ammo", and vice versa
- Preventing the user from switching between caseless and non-caseless ammo in-game.