### PR TITLE
Added client GUI option to display a mini armor status visual in the boardview mouse-over tooltip.

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -55,6 +55,17 @@ AdvancedOptions.ShowCoords.name=Show Hex Numbers
 AdvancedOptions.ShowCoords.tooltip=Configures whether hex numbers are printed in each hex or not.
 AdvancedOptions.ButtonsPerRow.name=Buttons Per Row
 AdvancedOptions.ButtonsPerRow.tooltip=Configures how many buttons are displayed per row for phase control panels.
+AdvancedOptions.ArmorMiniArmorChar.name=Armor character for tooltip
+AdvancedOptions.ArmorMiniArmorChar.description=The character representing blocks of armor when hovering the mouse over a unit.
+AdvancedOptions.ArmorMiniISChar.name=IS character for tooltip
+AdvancedOptions.ArmorMiniISChar.description=The character representing blocks of internal structure when hovering the mouse over a unit.
+AdvancedOptions.ArmorMiniDestroyedChar.name=Destroyed component character for tooltip
+AdvancedOptions.ArmorMiniDestroyedChar.description=The character representing a destroyed component when hovering the mouse over a unit.
+AdvancedOptions.ArmorMiniColorIntact.name=Armor Mini Visual - Intact Color
+AdvancedOptions.ArmorMiniColorPartialDmg.name=Armor Mini Visual - Partially Damaged Color
+AdvancedOptions.ArmorMiniColorDamaged.name=Armor Mini Visual - Damaged Color
+AdvancedOptions.AdvancedArmorMiniUnitsPerBlock.name=Armor Mini Visual - Points Per Char
+AdvancedOptions.AdvancedArmorMiniUnitsPerBlock.description=The number of armor or IS points represented by each character "block" in the tooltip.
 
 BoardEditor.BridgeBuildingElevError=Bridge/Building Elevation is an offset from the surface of a hex and hence must be a positive value!
 BoardEditor.butAddTerrain=Add/Set Terrain
@@ -259,6 +270,8 @@ BoardView1.Tooltip.Advs=<BR><FONT SIZE=-2 COLOR=#555555>&nbsp;&nbsp;{0} Advs.;</
 BoardView1.Tooltip.Adv1=<BR><FONT SIZE=-2 COLOR=#555555>&nbsp;&nbsp;1 Adv.;</FONT>
 BoardView1.Tooltip.ArmorInternals=Armor {0}; Internal {1}
 BoardView1.Tooltip.Armor=Armor: {0}
+BoardView1.Tooltip.ArmorMiniPanelPart={0}:&nbsp;&nbsp;
+BoardView1.Tooltip.BlockColored=<FONT COLOR=#{0}>{1}</FONT>
 BoardView1.Tooltip.Internals=Internal: {0}
 BoardView1.Tooltip.InfSpec=Specialization: {0}
 BoardView1.Tooltip.MD=<FONT SIZE=-2 COLOR=#555555>&nbsp;&nbsp;Manei Domini</FONT>
@@ -727,6 +740,7 @@ CommonSettingsDialog.tooltipDismissDelay=Tooltip dismiss delay:
 CommonSettingsDialog.tooltipDismissDelayTooltip:Sets the delay before a tooltip is dismised.  -1 uses the default for your look and feel.
 CommonSettingsDialog.Update=Update
 CommonSettingsDialog.showWpsinTT=Show unit weapons in the tooltip
+CommonSettingsDialog.showArmorMiniVisTT=Show mini armor visualization in the tooltip.
 CommonSettingsDialog.AOHexSHadows=Show ambient-occlusion-like hex shadows at the base of hills
 CommonSettingsDialog.useShadowMap=Show terrain and building shadows
 CommonSettingsDialog.levelHighlight=Level highlighting (thick borders at level changes)

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -55,17 +55,18 @@ AdvancedOptions.ShowCoords.name=Show Hex Numbers
 AdvancedOptions.ShowCoords.tooltip=Configures whether hex numbers are printed in each hex or not.
 AdvancedOptions.ButtonsPerRow.name=Buttons Per Row
 AdvancedOptions.ButtonsPerRow.tooltip=Configures how many buttons are displayed per row for phase control panels.
-AdvancedOptions.ArmorMiniArmorChar.name=Armor character for tooltip
+AdvancedOptions.ArmorMiniArmorChar.name=Armor Mini Visual - Armor character for tooltip
 AdvancedOptions.ArmorMiniArmorChar.description=The character representing blocks of armor when hovering the mouse over a unit.
-AdvancedOptions.ArmorMiniISChar.name=IS character for tooltip
+AdvancedOptions.ArmorMiniISChar.name=Armor Mini Visual - IS character for tooltip
 AdvancedOptions.ArmorMiniISChar.description=The character representing blocks of internal structure when hovering the mouse over a unit.
-AdvancedOptions.ArmorMiniDestroyedChar.name=Destroyed component character for tooltip
+AdvancedOptions.ArmorMiniDestroyedChar.name=Armor Mini Visual - Destroyed component character for tooltip
 AdvancedOptions.ArmorMiniDestroyedChar.description=The character representing a destroyed component when hovering the mouse over a unit.
 AdvancedOptions.ArmorMiniColorIntact.name=Armor Mini Visual - Intact Color
 AdvancedOptions.ArmorMiniColorPartialDmg.name=Armor Mini Visual - Partially Damaged Color
 AdvancedOptions.ArmorMiniColorDamaged.name=Armor Mini Visual - Damaged Color
-AdvancedOptions.AdvancedArmorMiniUnitsPerBlock.name=Armor Mini Visual - Points Per Char
-AdvancedOptions.AdvancedArmorMiniUnitsPerBlock.description=The number of armor or IS points represented by each character "block" in the tooltip.
+AdvancedOptions.ArmorMiniUnitsPerBlock.name=Armor Mini Visual - Points Per Char
+AdvancedOptions.ArmorMiniUnitsPerBlock.description=The number of armor or IS points represented by each character "block" in the tooltip.
+AdvancedOptions.ArmorMiniFrontSizeMod.name=Armor Mini Visual - Font Size Modifier
 
 BoardEditor.BridgeBuildingElevError=Bridge/Building Elevation is an offset from the surface of a hex and hence must be a positive value!
 BoardEditor.butAddTerrain=Add/Set Terrain
@@ -270,8 +271,12 @@ BoardView1.Tooltip.Advs=<BR><FONT SIZE=-2 COLOR=#555555>&nbsp;&nbsp;{0} Advs.;</
 BoardView1.Tooltip.Adv1=<BR><FONT SIZE=-2 COLOR=#555555>&nbsp;&nbsp;1 Adv.;</FONT>
 BoardView1.Tooltip.ArmorInternals=Armor {0}; Internal {1}
 BoardView1.Tooltip.Armor=Armor: {0}
-BoardView1.Tooltip.ArmorMiniPanelPart={0}:&nbsp;&nbsp;
-BoardView1.Tooltip.BlockColored=<FONT COLOR=#{0}>{1}</FONT>
+BoardView1.Tooltip.ArmorMiniPanelStart=<TABLE CELLSPACING=0 CELLPADDING=0><TBODY>
+BoardView1.Tooltip.ArmorMiniPanelPart=<TD><FONT SIZE={1}>{0}: </FONT><TD>
+BoardView1.Tooltip.ArmorMiniPanelPartRear=<TR><TD><FONT SIZE={1}>{0}R: </FONT><TD>
+BoardView1.Tooltip.ArmorMiniPanelPartNoRear=<TR><TD><TD><TD><FONT SIZE={1}>{0}: </FONT><TD>
+BoardView1.Tooltip.ArmorMiniPanelEnd=</TBODY></TABLE>
+BoardView1.Tooltip.BlockColored=<FONT COLOR=#{2} SIZE={1}>{0}</FONT>
 BoardView1.Tooltip.Internals=Internal: {0}
 BoardView1.Tooltip.InfSpec=Specialization: {0}
 BoardView1.Tooltip.MD=<FONT SIZE=-2 COLOR=#555555>&nbsp;&nbsp;Manei Domini</FONT>

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -195,6 +195,7 @@ public class CommonSettingsDialog extends ClientDialog implements
     private JCheckBox soundMute;
     private JCheckBox showMapHexPopup;
     private JCheckBox showWpsinTT;
+    private JCheckBox showArmorMiniVisTT;
     private JCheckBox chkAntiAliasing;
     private JComboBox<String> defaultWeaponSortOrder;
     private JTextField tooltipDelay;
@@ -479,6 +480,12 @@ public class CommonSettingsDialog extends ClientDialog implements
         row = new ArrayList<>();
         row.add(showWpsinTT);
         comps.add(row);
+
+        // copied from showWpsinTT, kept comment as it looks like a relevant compiler/editor flag?
+        showArmorMiniVisTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showArmorMiniVisTT")); //$NON-NLS-1$
+        row = new ArrayList<>();
+        row.add(showArmorMiniVisTT);
+        comps.add(row);
         
         // Horizontal Line and Spacer
         row = new ArrayList<>();
@@ -711,7 +718,8 @@ public class CommonSettingsDialog extends ClientDialog implements
         tooltipDelay.setText(Integer.toString(gs.getTooltipDelay()));
         tooltipDismissDelay.setText(Integer.toString(gs.getTooltipDismissDelay()));
         showWpsinTT.setSelected(gs.getShowWpsinTT());
-        
+        showArmorMiniVisTT.setSelected(gs.getshowArmorMiniVisTT());
+
         defaultWeaponSortOrder.setSelectedIndex(gs.getDefaultWeaponSortOrder());
 
         mouseWheelZoom.setSelected(gs.getMouseWheelZoom());
@@ -874,6 +882,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         gs.setSoundMute(soundMute.isSelected());
         gs.setShowMapHexPopup(showMapHexPopup.isSelected());
         gs.setShowWpsinTT(showWpsinTT.isSelected());
+        gs.setshowArmorMiniVisTT(showArmorMiniVisTT.isSelected());
         gs.setTooltipDelay(Integer.parseInt(tooltipDelay.getText()));
         gs.setTooltipDismissDelay(Integer.parseInt(tooltipDismissDelay.getText()));
         cs.setUnitStartChar(((String) unitStartChar.getSelectedItem())

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -84,6 +84,13 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ADVANCED_SHOW_FPS = "AdvancedShowFPS";
     public static final String ADVANCED_SHOW_COORDS = "AdvancedShowCoords";
     public static final String ADVANCED_BUTTONS_PER_ROW = "AdvancedButtonsPerRow";
+    public static final String ADVANCED_ARMORMINI_UNITS_PER_BLOCK = "AdvancedArmorMiniUnitsPerBlock";
+    public static final String ADVANCED_ARMORMINI_ARMOR_CHAR = "AdvancedArmorMiniArmorChar";
+    public static final String ADVANCED_ARMORMINI_IS_CHAR = "AdvancedArmorMiniISChar";
+    public static final String ADVANCED_ARMORMINI_DESTROYED_CHAR = "AdvancedArmorMiniDestroyedChar";
+    public static final String ADVANCED_ARMORMINI_COLOR_INTACT = "AdvancedArmorMiniColorIntact";
+    public static final String ADVANCED_ARMORMINI_COLOR_PARTIAL_DMG = "AdvancedArmorMiniColorPartialDmg";
+    public static final String ADVANCED_ARMORMINI_COLOR_DAMAGED = "AdvancedArmorMiniColorDamaged";
     /* --End advanced settings-- */
 
 
@@ -171,6 +178,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String SHOW_FIELD_OF_FIRE = "ShowFieldOfFire";
     public static final String SHOW_MAPHEX_POPUP = "ShowMapHexPopup";
     public static final String SHOW_WPS_IN_TT = "ShowWpsinTT";
+    public static final String SHOW_ARMOR_MINIVIS_TT = "showArmorMiniVisTT";
     public static final String SHOW_MOVE_STEP = "ShowMoveStep";
     public static final String SHOW_WRECKS = "ShowWrecks";
     public static final String SOUND_BING_FILENAME = "SoundBingFilename";
@@ -236,6 +244,13 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(ADVANCED_UNITOVERVIEW_VALID_COLOR, "cyan");
         setDefault(ADVANCED_FIRE_SOLN_CANSEE_COLOR, "cyan");
         setDefault(ADVANCED_FIRE_SOLN_NOSEE_COLOR, "red");
+        setDefault(ADVANCED_ARMORMINI_UNITS_PER_BLOCK, 10);
+        setDefault(ADVANCED_ARMORMINI_ARMOR_CHAR, "\u2588");
+        setDefault(ADVANCED_ARMORMINI_IS_CHAR, "\u2593");
+        setDefault(ADVANCED_ARMORMINI_DESTROYED_CHAR, "\u2327");
+        setDefault(ADVANCED_ARMORMINI_COLOR_INTACT, new Color(0, 0, 0)); // HTML hex #008000
+        setDefault(ADVANCED_ARMORMINI_COLOR_PARTIAL_DMG, new Color(221, 96, 0));  // HTML hex #DD6000
+        setDefault(ADVANCED_ARMORMINI_COLOR_DAMAGED, new Color(255, 204, 204));  // HTML hex #FFCCCC
 
 
         setDefault(ADVANCED_MOVE_FONT_TYPE,"SansSerif");
@@ -342,6 +357,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(WINDOW_SIZE_WIDTH, 800);
         store.setDefault(SHOW_MAPSHEETS, false);
         store.setDefault(SHOW_WPS_IN_TT, false);
+        store.setDefault(SHOW_ARMOR_MINIVIS_TT, false);
         store.setDefault(USE_ISOMETRIC, false);
         store.setDefault(SHOW_UNIT_OVERVIEW, true);
         store.setDefault(SHOW_DAMAGE_LEVEL, false);
@@ -697,6 +713,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
     
     public boolean getShowWpsinTT() {
         return store.getBoolean(SHOW_WPS_IN_TT);
+    }
+
+    public boolean getshowArmorMiniVisTT() {
+        return store.getBoolean(SHOW_ARMOR_MINIVIS_TT);
     }
 
     public boolean getShowMoveStep() {
@@ -1062,6 +1082,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
     
     public void setShowWpsinTT(boolean state) {
         store.setValue(SHOW_WPS_IN_TT, state);
+    }
+
+    public void setshowArmorMiniVisTT(boolean state) {
+        store.setValue(SHOW_ARMOR_MINIVIS_TT, state);
     }
 
     public void setShowMoveStep(boolean state) {

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -91,6 +91,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ADVANCED_ARMORMINI_COLOR_INTACT = "AdvancedArmorMiniColorIntact";
     public static final String ADVANCED_ARMORMINI_COLOR_PARTIAL_DMG = "AdvancedArmorMiniColorPartialDmg";
     public static final String ADVANCED_ARMORMINI_COLOR_DAMAGED = "AdvancedArmorMiniColorDamaged";
+    public static final String ADVANCED_ARMORMINI_FONT_SIZE_MOD = "AdvancedArmorMiniFrontSizeMod";
     /* --End advanced settings-- */
 
 
@@ -245,12 +246,13 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(ADVANCED_FIRE_SOLN_CANSEE_COLOR, "cyan");
         setDefault(ADVANCED_FIRE_SOLN_NOSEE_COLOR, "red");
         setDefault(ADVANCED_ARMORMINI_UNITS_PER_BLOCK, 10);
-        setDefault(ADVANCED_ARMORMINI_ARMOR_CHAR, "\u2588");
-        setDefault(ADVANCED_ARMORMINI_IS_CHAR, "\u2593");
+        setDefault(ADVANCED_ARMORMINI_ARMOR_CHAR, "\u2588");     // █
+        setDefault(ADVANCED_ARMORMINI_IS_CHAR, "\u2593");       //  ▓
         setDefault(ADVANCED_ARMORMINI_DESTROYED_CHAR, "\u2327");
         setDefault(ADVANCED_ARMORMINI_COLOR_INTACT, new Color(0, 0, 0)); // HTML hex #008000
         setDefault(ADVANCED_ARMORMINI_COLOR_PARTIAL_DMG, new Color(221, 96, 0));  // HTML hex #DD6000
         setDefault(ADVANCED_ARMORMINI_COLOR_DAMAGED, new Color(255, 204, 204));  // HTML hex #FFCCCC
+        setDefault(ADVANCED_ARMORMINI_FONT_SIZE_MOD, -2);
 
 
         setDefault(ADVANCED_MOVE_FONT_TYPE,"SansSerif");

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -663,7 +663,101 @@ class EntitySprite extends Sprite {
     private StringBuffer tooltipString;
     private final boolean BR = true;
     private final boolean NOBR = false;
-    
+
+    /**
+     * Builds a small table representing a unit's armor using visual block characters
+     * and adds it to the current tooltipString.
+     */
+    private void addArmorMiniVisToTT() {
+        String armorChar = GUIPreferences.getInstance().getString("AdvancedArmorMiniArmorChar");
+        String internalChar = GUIPreferences.getInstance().getString("AdvancedArmorMiniISChar");
+        String destroyedChar = GUIPreferences.getInstance().getString("AdvancedArmorMiniDestroyedChar");
+        String fontSize = Integer.toString(GUIPreferences.getInstance().getInt("AdvancedArmorMiniFrontSizeMod"));
+        // HTML color String from Preferences
+        String colorIntact = Integer
+                .toHexString(GUIPreferences.getInstance()
+                        .getColor("AdvancedArmorMiniColorIntact").getRGB() & 0xFFFFFF);
+        String colorPartialDmg = Integer
+                .toHexString(GUIPreferences.getInstance()
+                        .getColor("AdvancedArmorMiniColorPartialDmg").getRGB() & 0xFFFFFF);
+        String colorDamaged = Integer
+                .toHexString(GUIPreferences.getInstance()
+                        .getColor("AdvancedArmorMiniColorDamaged").getRGB() & 0xFFFFFF);
+        int visUnit = GUIPreferences.getInstance().getInt("AdvancedArmorMiniUnitsPerBlock");
+        addToTT("ArmorMiniPanelStart", BR);
+        for (int loc = 0 ; loc < entity.locations(); loc++) {
+            // addToTT("ArmorMiniPanelPart", BR, entity.getLocationAbbr(loc));
+            // If location is destroyed, mark it and move on
+            if (entity.getInternal(loc) == IArmorState.ARMOR_DOOMED ||
+                    entity.getInternal(loc) == IArmorState.ARMOR_DESTROYED) {
+                // This is a really awkward way of making sure
+                for (int a = 0; a <= Math.ceil(
+                        (entity.getTotalArmor() + entity.getTotalInternal())/(double) visUnit); a++) {
+                    addToTT("ArmorMiniPanelPartNoRear", BR, entity.getLocationAbbr(loc), fontSize);
+                    addToTT("BlockColored", NOBR, destroyedChar, fontSize, colorIntact);
+                }
+
+            } else {
+                // Put rear armor blocks first, with some spacing, if unit has any.
+                if (entity.hasRearArmor(loc)) {
+                    addToTT("ArmorMiniPanelPartRear", BR, entity.getLocationAbbr(loc), fontSize);
+                    for (int a = 0; a <= (entity.getOArmor(loc, true)/visUnit); a++) {
+                        if (a < (entity.getArmor(loc, true)/visUnit)) {
+                            addToTT("BlockColored", NOBR, armorChar, fontSize, colorIntact);
+                        } else if (a == (entity.getArmor(loc, true)/visUnit) &&
+                                (entity.getArmor(loc, true) % visUnit) > 0) {
+                            // Fraction of a visUnit left, but still display a "full" if at starting max armor
+                            if (entity.getArmor(loc, true) == entity.getOArmor(loc, true)) {
+                                addToTT("BlockColored", NOBR, armorChar, fontSize, colorIntact);
+                            } else {
+                                addToTT("BlockColored", NOBR, armorChar, fontSize, colorPartialDmg);;
+                            }
+                        } else if ((entity.getOArmor(loc, true) % visUnit) > 0) {
+                            addToTT("BlockColored", NOBR, armorChar, fontSize, colorDamaged);
+                        }
+                    }
+                    addToTT("ArmorMiniPanelPart", BR, entity.getLocationAbbr(loc), fontSize);
+                } else {
+                    addToTT("ArmorMiniPanelPartNoRear", BR, entity.getLocationAbbr(loc), fontSize);
+                }
+                // Add IS shade blocks.
+                for (int a = 0; a <= (entity.getOInternal(loc)/visUnit); a++) {
+                    if (a < (entity.getInternal(loc)/visUnit)) {
+                        addToTT("BlockColored", NOBR, internalChar, fontSize, colorIntact);
+                    } else if (a == (entity.getInternal(loc)/visUnit) &&
+                            (entity.getInternal(loc) % visUnit) > 0) {
+                        // Fraction of a visUnit left, but still display a "full" if at starting max armor
+                        if (entity.getInternal(loc) == entity.getOInternal(loc)) {
+                            addToTT("BlockColored", NOBR, internalChar, fontSize, colorIntact);
+                        } else {
+                            addToTT("BlockColored", NOBR, internalChar, fontSize, colorPartialDmg);
+                        }
+                    } else if ((entity.getOInternal(loc) % visUnit) > 0) {
+                        addToTT("BlockColored", NOBR, internalChar, fontSize, colorDamaged);
+                    }
+                }
+                // Add main armor blocks.
+                for (int a = 0; a <= (entity.getOArmor(loc)/visUnit); a++) {
+                    if (a < (entity.getArmor(loc)/visUnit)) {
+                        addToTT("BlockColored", NOBR, armorChar, fontSize, colorIntact);
+                    } else if (a == (entity.getArmor(loc)/visUnit) &&
+                            (entity.getArmor(loc) % visUnit) > 0) {
+                        // Fraction of a visUnit left, but still display a "full" if at starting max armor
+                        if (entity.getArmor(loc) == entity.getOArmor(loc)) {
+                            addToTT("BlockColored", NOBR, armorChar, fontSize, colorIntact);
+                        } else {
+                            addToTT("BlockColored", NOBR, armorChar, fontSize, colorPartialDmg);
+                        }
+                    } else if ((entity.getOArmor(loc) % visUnit) > 0){
+                        addToTT("BlockColored", NOBR, armorChar, fontSize, colorDamaged);
+                    }
+                }
+            }
+
+        }
+        addToTT("ArmorMiniPanelEnd", NOBR);
+    }
+
     /**
      * Adds a resource string to the entity tooltip
      * 
@@ -784,85 +878,7 @@ class EntitySprite extends Sprite {
         // Build a "status bar" visual representation of each
         // component of the unit using block element characters.
         if (GUIPreferences.getInstance().getBoolean(GUIPreferences.SHOW_ARMOR_MINIVIS_TT)) {
-            String armorChar = GUIPreferences.getInstance().getString("AdvancedArmorMiniArmorChar");
-            String internalChar = GUIPreferences.getInstance().getString("AdvancedArmorMiniISChar");
-            String destroyedChar = GUIPreferences.getInstance().getString("AdvancedArmorMiniDestroyedChar");
-            // HTML color String from Preferences
-            String colorIntact = Integer
-                    .toHexString(GUIPreferences.getInstance()
-                            .getColor("AdvancedArmorMiniColorIntact").getRGB() & 0xFFFFFF);
-            String colorPartialDmg = Integer
-                    .toHexString(GUIPreferences.getInstance()
-                            .getColor("AdvancedArmorMiniColorPartialDmg").getRGB() & 0xFFFFFF);
-            String colorDamaged = Integer
-                    .toHexString(GUIPreferences.getInstance()
-                            .getColor("AdvancedArmorMiniColorDamaged").getRGB() & 0xFFFFFF);
-            int visUnit = GUIPreferences.getInstance().getInt("AdvancedArmorMiniUnitsPerBlock");
-            for (int loc = 0 ; loc < entity.locations(); loc++) {
-                addToTT("ArmorMiniPanelPart", BR, entity.getLocationAbbr(loc));
-                // If location is destroyed, mark it and move on
-                if (entity.getInternal(loc) == IArmorState.ARMOR_DOOMED ||
-                        entity.getInternal(loc) == IArmorState.ARMOR_DESTROYED) {
-                    // This is a really awkward way of making sure
-                    for (int a = 0; a <= Math.ceil(
-                            (entity.getTotalArmor() + entity.getTotalInternal())/(double) visUnit); a++) {
-                        addToTT("BlockColored", NOBR, colorIntact, destroyedChar);
-                    }
-
-                } else {
-                    // Put rear armor blocks first, with some spacing, if unit has any.
-                    if (entity.hasRearArmor(loc)) {
-                        for (int a = 0; a <= (entity.getOArmor(loc, true)/visUnit); a++) {
-                            if (a < (entity.getArmor(loc, true)/visUnit)) {
-                                addToTT("BlockColored", NOBR, colorIntact, armorChar);
-                            } else if (a == (entity.getArmor(loc, true)/visUnit) &&
-                                    (entity.getArmor(loc, true) % visUnit) > 0) {
-                                // Fraction of a visUnit left, but still display a "full" if at starting max armor
-                                if (entity.getArmor(loc, true) == entity.getOArmor(loc, true)) {
-                                    addToTT("BlockColored", NOBR, colorIntact, armorChar);
-                                } else {
-                                    addToTT("BlockColored", NOBR, colorPartialDmg, armorChar);
-                                }
-                            } else if ((entity.getOArmor(loc, true) % visUnit) > 0) {
-                                addToTT("BlockColored", NOBR, colorDamaged, armorChar);
-                            }
-                        }
-                    }
-                    // Add IS shade blocks.
-                    for (int a = 0; a <= (entity.getOInternal(loc)/visUnit); a++) {
-                        if (a < (entity.getInternal(loc)/visUnit)) {
-                            addToTT("BlockColored", NOBR, colorIntact, internalChar);
-                        } else if (a == (entity.getInternal(loc)/visUnit) &&
-                                (entity.getInternal(loc) % visUnit) > 0) {
-                            // Fraction of a visUnit left, but still display a "full" if at starting max armor
-                            if (entity.getInternal(loc) == entity.getOInternal(loc)) {
-                                addToTT("BlockColored", NOBR, colorIntact, internalChar);
-                            } else {
-                                addToTT("BlockColored", NOBR, colorPartialDmg, internalChar);
-                            }
-                        } else if ((entity.getOInternal(loc) % visUnit) > 0) {
-                            addToTT("BlockColored", NOBR, colorDamaged, internalChar);
-                        }
-                    }
-                    // Add main armor blocks.
-                    for (int a = 0; a <= (entity.getOArmor(loc)/visUnit); a++) {
-                        if (a < (entity.getArmor(loc)/visUnit)) {
-                            addToTT("BlockColored", NOBR, colorIntact, armorChar);
-                        } else if (a == (entity.getArmor(loc)/visUnit) &&
-                                (entity.getArmor(loc) % visUnit) > 0) {
-                            // Fraction of a visUnit left, but still display a "full" if at starting max armor
-                            if (entity.getArmor(loc) == entity.getOArmor(loc)) {
-                                addToTT("BlockColored", NOBR, colorIntact, armorChar);
-                            } else {
-                                addToTT("BlockColored", NOBR, colorPartialDmg, armorChar);
-                            }
-                        } else if ((entity.getOArmor(loc) % visUnit) > 0){
-                            addToTT("BlockColored", NOBR, colorDamaged, armorChar);
-                        }
-                    }
-                }
-
-            }
+            addArmorMiniVisToTT();
         }
 
 

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -693,8 +693,7 @@ class EntitySprite extends Sprite {
                     entity.getInternal(loc) == IArmorState.ARMOR_DESTROYED) {
                 // This is a really awkward way of making sure
                 addToTT("ArmorMiniPanelPartNoRear", BR, entity.getLocationAbbr(loc), fontSize);
-                for (int a = 0; a <= Math.ceil(
-                        (entity.getTotalArmor() + entity.getTotalInternal())/(double) visUnit); a++) {
+                for (int a = 0; a <= entity.getOInternal(loc)/visUnit; a++) {
                     addToTT("BlockColored", NOBR, destroyedChar, fontSize, colorIntact);
                 }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -663,6 +663,7 @@ class EntitySprite extends Sprite {
     private StringBuffer tooltipString;
     private final boolean BR = true;
     private final boolean NOBR = false;
+    private boolean skipBRafterTable = false;
 
     /**
      * Builds a small table representing a unit's armor using visual block characters
@@ -691,9 +692,9 @@ class EntitySprite extends Sprite {
             if (entity.getInternal(loc) == IArmorState.ARMOR_DOOMED ||
                     entity.getInternal(loc) == IArmorState.ARMOR_DESTROYED) {
                 // This is a really awkward way of making sure
+                addToTT("ArmorMiniPanelPartNoRear", BR, entity.getLocationAbbr(loc), fontSize);
                 for (int a = 0; a <= Math.ceil(
                         (entity.getTotalArmor() + entity.getTotalInternal())/(double) visUnit); a++) {
-                    addToTT("ArmorMiniPanelPartNoRear", BR, entity.getLocationAbbr(loc), fontSize);
                     addToTT("BlockColored", NOBR, destroyedChar, fontSize, colorIntact);
                 }
 
@@ -767,8 +768,13 @@ class EntitySprite extends Sprite {
      * @param ttO a list of Objects to insert into the {x} places in the resource.
      */
     private void addToTT(String ttSName, boolean startBR, Object... ttO) {
-        if (startBR == BR)
-            tooltipString.append("<BR>");
+        if (startBR == BR){
+            if (skipBRafterTable) {
+                skipBRafterTable = false;
+            } else {
+                tooltipString.append("<BR>");
+            }
+        }
         if (ttO != null) {
             tooltipString.append(Messages.getString("BoardView1.Tooltip."
                     + ttSName, ttO));
@@ -879,6 +885,7 @@ class EntitySprite extends Sprite {
         // component of the unit using block element characters.
         if (GUIPreferences.getInstance().getBoolean(GUIPreferences.SHOW_ARMOR_MINIVIS_TT)) {
             addArmorMiniVisToTT();
+            skipBRafterTable = true;
         }
 
 


### PR DESCRIPTION
A small QoL hack that adds "gradient status bars", which I call here collectively the mini armor visualization, to the mouse-over tooltip on units in the board view. It is entirely optional and defaults to off (like weapons listing in tooltips) and the color and special characters used are configurable in the advanced client settings. 

Since I'm a beginner with Java, this is the best I could make in a reasonable amount of time that gives a quick glance at which units are damaged and how badly. 

![wip_at-a-glance_armor-tooltip](https://user-images.githubusercontent.com/360217/32710291-fe50c274-c804-11e7-903c-03ba6e3b1a6b.png)
![wip_at-a-glance_armor-tooltip_2](https://user-images.githubusercontent.com/360217/32710292-fe5d7bb8-c804-11e7-8eea-7d035b129eba.png)
![wip_at-a-glance_armor-tooltip_3](https://user-images.githubusercontent.com/360217/32710293-fe67b876-c804-11e7-976b-d83279e5f361.png)
