### PR TITLE
XCT infantry

### DIFF
--- a/megamek/i18n/megamek/common/messages.properties
+++ b/megamek/i18n/megamek/common/messages.properties
@@ -196,6 +196,7 @@ Infantry.specialization8=Paramedics
 Infantry.specialization9=Paratroops
 Infantry.specialization10=TAG Troops
 Infantry.specialization11=SCUBA
+Infantry.specialization12=Xenoplanetary Condition-Trained Troops
 
 Infantry.specializationTip0=Bridge-building Engineers (Unimplemented)
 Infantry.specializationTip1=Demolition Engineers are able to place charges in buildings during the physical phase, if the building is targeted for an attack.
@@ -209,6 +210,7 @@ Infantry.specializationTip8=Paramedics (Unimplemented)
 Infantry.specializationTip9=Paratroops (Unimplemented)
 Infantry.specializationTip10=TAG Troops
 Infantry.specializationTip11=SCUBA
+Infantry.specializationTip12=Xenoplanetary Condition-Trained Troops ignore certain planetary conditions modifiers.
 
 WeaponType.DirectFire=Direct fire
 WeaponType.BallisticCluster=Ballistic Cluster

--- a/megamek/i18n/megamek/common/messages.properties
+++ b/megamek/i18n/megamek/common/messages.properties
@@ -195,8 +195,8 @@ Infantry.specialization7=Mountain Troops
 Infantry.specialization8=Paramedics
 Infantry.specialization9=Paratroops
 Infantry.specialization10=TAG Troops
-Infantry.specialization11=SCUBA
-Infantry.specialization12=Xenoplanetary Condition-Trained Troops
+Infantry.specialization11=Xenoplanetary Condition-Trained Troops
+Infantry.specialization12=SCUBA
 
 Infantry.specializationTip0=Bridge-building Engineers (Unimplemented)
 Infantry.specializationTip1=Demolition Engineers are able to place charges in buildings during the physical phase, if the building is targeted for an attack.
@@ -209,8 +209,8 @@ Infantry.specializationTip7=Mountain Troops are able to make larger elevation ch
 Infantry.specializationTip8=Paramedics (Unimplemented)
 Infantry.specializationTip9=Paratroops (Unimplemented)
 Infantry.specializationTip10=TAG Troops
-Infantry.specializationTip11=SCUBA
-Infantry.specializationTip12=Xenoplanetary Condition-Trained Troops ignore certain planetary conditions modifiers.
+Infantry.specializationTip11=Xenoplanetary Condition-Trained Troops ignore certain planetary conditions modifiers.
+Infantry.specializationTip12=SCUBA
 
 WeaponType.DirectFire=Direct fire
 WeaponType.BallisticCluster=Ballistic Cluster

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -65,8 +65,8 @@ public class Infantry extends Entity {
     public static int PARAMEDICS        = 1 << 8;
     public static int PARATROOPS        = 1 << 9;
     public static int TAG_TROOPS        = 1 << 10;
-    public static int SCUBA             = 1 << 11;
-    public static int XCT               = 1 << 12;
+    public static int XCT               = 1 << 11;
+    public static int SCUBA             = 1 << 12;
     public static int NUM_SPECIALIZATIONS = 13;
     public static int COMBAT_ENGINEERS = BRIDGE_ENGINEERS | DEMO_ENGINEERS
             | FIRE_ENGINEERS | MINE_ENGINEERS | SENSOR_ENGINEERS

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1620,7 +1620,7 @@ public class Infantry extends Entity {
         }
 
         if (hasSpecialization(XCT)) {
-            multiplier *= 1.5;
+            multiplier *= 5;
         }
 
         /* TODO: paramedics cost an addition x0.375 per paramedic */

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -66,7 +66,8 @@ public class Infantry extends Entity {
     public static int PARATROOPS        = 1 << 9;
     public static int TAG_TROOPS        = 1 << 10;
     public static int SCUBA             = 1 << 11;
-    public static int NUM_SPECIALIZATIONS = 12;
+    public static int XCT               = 1 << 12;
+    public static int NUM_SPECIALIZATIONS = 13;
     public static int COMBAT_ENGINEERS = BRIDGE_ENGINEERS | DEMO_ENGINEERS
             | FIRE_ENGINEERS | MINE_ENGINEERS | SENSOR_ENGINEERS
             | TRENCH_ENGINEERS;
@@ -1850,6 +1851,10 @@ public class Infantry extends Entity {
                 (getMovementMode() == EntityMovementMode.TRACKED) ||
                 (getMovementMode() == EntityMovementMode.SUBMARINE) ||
                 (getMovementMode() == EntityMovementMode.VTOL);
+    }
+
+    public boolean isXCT() {
+        return hasSpecialization(XCT);
     }
 
     /*

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1697,6 +1697,17 @@ public class Infantry extends Entity {
 
     @Override
     public boolean doomedInExtremeTemp() {
+        if (getArmorKit() != null) {
+            if (getArmorKit().hasSubType(MiscType.S_XCT_VACUUM)) {
+                return false;
+            } else if (getArmorKit().hasSubType(MiscType.S_COLD_WEATHER) && (game.getPlanetaryConditions().getTemperature() < -30)) {
+                return false;
+            } else if (getArmorKit().hasSubType(MiscType.S_HOT_WEATHER) && (game.getPlanetaryConditions().getTemperature() > 50)) {
+                return false;
+            } else {
+                return true;
+            }
+        }
         if (hasSpaceSuit() || isMechanized()) {
             return false;
         }
@@ -1705,7 +1716,11 @@ public class Infantry extends Entity {
 
     @Override
     public boolean doomedInVacuum() {
-        return !hasSpaceSuit();
+        if (getMovementMode() == EntityMovementMode.VTOL) {
+            return true;
+        } else {
+            return !hasSpaceSuit();
+        }
     }
 
     @Override

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1306,8 +1306,20 @@ public class Infantry extends Entity {
             bvText.append(endColumn);
             bvText.append(endRow);
         }
-        
-        //TODO: add + 0.1 for XCT
+
+        if (hasSpecialization(XCT)) {
+            utm += 0.1;
+            bvText.append(startRow);
+            bvText.append(startColumn);
+            bvText.append("XCT:");
+            bvText.append(endColumn);
+            bvText.append(startColumn);
+            bvText.append(endColumn);
+            bvText.append(startColumn);
+            bvText.append("0.1");
+            bvText.append(endColumn);
+            bvText.append(endRow);
+        }
         
         bvText.append(startRow);
         bvText.append(startColumn);
@@ -1606,6 +1618,11 @@ public class Infantry extends Entity {
         if (hasSpecialization(PARATROOPS)) {
         	multiplier *= 3;
         }
+
+        if (hasSpecialization(XCT)) {
+            multiplier *= 1.5;
+        }
+
         /* TODO: paramedics cost an addition x0.375 per paramedic */
 
         cost = cost * multiplier;

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -3653,7 +3653,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(misc.name);
         misc.addLookupName("SpacesuitCombat");
         misc.damageDivisor = 1.0;
-        misc.subType = S_ENCUMBERING | S_SPACE_SUIT | S_XCT_VACUUM |S_COLD_WEATHER;
+        misc.subType = S_ENCUMBERING | S_SPACE_SUIT | S_XCT_VACUUM | S_COLD_WEATHER;
         misc.cost = 7000;
         misc.flags = misc.flags.or(F_INF_EQUIPMENT).or(F_ARMOR_KIT);
         misc.rulesRefs = "318,TO";

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -339,6 +339,13 @@ public class MiscType extends EquipmentType {
     public static final long S_SNEAK_ECM = 1L << 3;
     public static final long S_ENCUMBERING = 1L << 4;
     public static final long S_SPACE_SUIT = 1L << 5;
+    public static final long S_XCT_VACUUM   = 1L << 6;
+    public static final long S_COLD_WEATHER = 1L << 7;
+    public static final long S_HOT_WEATHER  = 1L << 8;
+    // Unimplemented atmospheric conditions
+    public static final long S_HAZARDOUS_LIQ = 1L << 9;
+    public static final long S_TAINTED_ATMO = 1L << 10;
+    public static final long S_TOXIC_ATMO   = 1L << 11;
 
     // Secondary flag for tracks
     public static final long S_QUADVEE_WHEELS = 1L;
@@ -3372,7 +3379,7 @@ public class MiscType extends EquipmentType {
         misc.addLookupName("ISEnvironmentSuitHostile");
         misc.addLookupName("CLEnvironmentSuitHostile");
         misc.damageDivisor = 2.0;
-        misc.subType = S_ENCUMBERING | S_SPACE_SUIT;
+        misc.subType = S_ENCUMBERING | S_SPACE_SUIT | S_XCT_VACUUM | S_COLD_WEATHER | S_HOT_WEATHER;
         misc.cost = 10000;
         misc.flags = misc.flags.or(F_INF_EQUIPMENT).or(F_ARMOR_KIT);
         misc.rulesRefs = "317,TO";
@@ -3394,7 +3401,7 @@ public class MiscType extends EquipmentType {
         misc.addLookupName("ISEnvironmentSuitMarine");
         misc.addLookupName("CLEnvironmentSuitMarine");
         misc.damageDivisor = 2.0;
-        misc.subType = S_SPACE_SUIT;
+        misc.subType = S_SPACE_SUIT | S_XCT_VACUUM | S_COLD_WEATHER | S_HOT_WEATHER;
         misc.cost = 15000;
         misc.flags = misc.flags.or(F_INF_EQUIPMENT).or(F_ARMOR_KIT);
         misc.rulesRefs = "317,TO";
@@ -3453,6 +3460,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(misc.name);
         misc.addLookupName("HeatSuit");
         misc.damageDivisor = 1.0;
+        misc.subType = S_COLD_WEATHER;
         misc.cost = 100;
         misc.flags = misc.flags.or(F_INF_EQUIPMENT).or(F_ARMOR_KIT);
         misc.rulesRefs = "317,TO";
@@ -3494,6 +3502,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(misc.name);
         misc.addLookupName("ISMechWarriorCoolingSuit");
         misc.damageDivisor = 1.0;
+        misc.subType = S_HOT_WEATHER;
         misc.cost = 500;
         misc.flags = misc.flags.or(F_INF_EQUIPMENT).or(F_ARMOR_KIT);
         misc.rulesRefs = "317,TO";
@@ -3605,7 +3614,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(misc.name);
         misc.addLookupName("SnowSuit");
         misc.damageDivisor = 1.0;
-        misc.subType = S_ENCUMBERING;
+        misc.subType = S_ENCUMBERING | S_COLD_WEATHER;
         misc.cost = 70;
         misc.flags = misc.flags.or(F_INF_EQUIPMENT).or(F_ARMOR_KIT);
         misc.rulesRefs = "318,TO";
@@ -3624,7 +3633,7 @@ public class MiscType extends EquipmentType {
         misc.name = "Spacesuit";
         misc.setInternalName(misc.name);
         misc.damageDivisor = 1.0;
-        misc.subType = S_ENCUMBERING | S_SPACE_SUIT;
+        misc.subType = S_ENCUMBERING | S_SPACE_SUIT | S_XCT_VACUUM | S_COLD_WEATHER;
         misc.cost = 5000;
         misc.flags = misc.flags.or(F_INF_EQUIPMENT).or(F_ARMOR_KIT);
         misc.rulesRefs = "318,TO";
@@ -3644,7 +3653,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(misc.name);
         misc.addLookupName("SpacesuitCombat");
         misc.damageDivisor = 1.0;
-        misc.subType = S_ENCUMBERING | S_SPACE_SUIT;
+        misc.subType = S_ENCUMBERING | S_SPACE_SUIT | S_XCT_VACUUM |S_COLD_WEATHER;
         misc.cost = 7000;
         misc.flags = misc.flags.or(F_INF_EQUIPMENT).or(F_ARMOR_KIT);
         misc.rulesRefs = "318,TO";

--- a/megamek/src/megamek/common/PlanetaryConditions.java
+++ b/megamek/src/megamek/common/PlanetaryConditions.java
@@ -585,7 +585,7 @@ public class PlanetaryConditions implements Serializable {
         }
 
         // temperature difference
-        if((en instanceof Tank) || (en instanceof Infantry) || (en instanceof Protomech)) {
+        if((en instanceof Tank) || ((en instanceof Infantry) && !((Infantry)en).isXCT()) || (en instanceof Protomech)) {
             mod -= Math.abs(getTemperatureDifference(50,-30));
         }
 


### PR DESCRIPTION
XCT Infantry are trained to fight in hostile environments. As such they do not have the same penalties normal infantry with the same equipment would.

In MM terms that means no movement penalty in extreme weather. The other environments that would have a significant benefit are Tainted/Toxic Atmosphere as well as Hazardous Liquid Pools. None of these are currently coded in MM

For XCT troops to be effective you will need to make sure they have the proper armor kits. These are detailed on p350 of TacOps.