### PR TITLE
Clan AMSBay Verifier Fix for Laser AMS requiring Ammo

### DIFF
--- a/megamek/src/megamek/common/weapons/other/CLLaserAMS.java
+++ b/megamek/src/megamek/common/weapons/other/CLLaserAMS.java
@@ -42,7 +42,7 @@ public class CLLaserAMS extends LaserWeapon {
         rackSize = 2;
         damage = 2; // # of d6 of missiles affected
         shortAV = 3;
-        ammoType = AmmoType.T_AMS;
+        ammoType = AmmoType.T_NA;
         tonnage = 1f;
         criticals = 1;
         bv = 45;


### PR DESCRIPTION
This should fix the issue I reported where bays containing only Clan Laser AMS are failing verification due to lack of 10 shots or more ammo. The Clan LAMS still had an ammotype set for AMS ammo, when it should have been T_NA.