### PR TITLE
Board editor terrain list display name

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -43,8 +43,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
 
 import javax.imageio.ImageIO;
 import javax.swing.Box;
@@ -127,6 +125,7 @@ public class BoardEditor extends JComponent implements ItemListener,
 
         TerrainHelper[] terrains;
 
+        @SuppressWarnings("rawtypes")
         @Override
         public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected,
                 boolean cellHasFocus) {

--- a/megamek/src/megamek/common/Terrains.java
+++ b/megamek/src/megamek/common/Terrains.java
@@ -167,6 +167,22 @@ public class Terrains implements ITerrainFactory {
 
     public static String getDisplayName(int type, int level) {
         switch (type) {
+        case (BUILDING):
+            if (level == 1) {
+                return "Light building";
+            }
+            if (level == 2) {
+                return "Medium building";
+            }
+            if (level == 3) {
+                return "Heavy building";
+            }
+            if (level == 3) {
+                return "Hardened Building";
+            }
+            if (level == 5) {
+                return "Wall";
+            }
         case (WOODS):
             if (level == 1) {
                 return "Light woods";


### PR DESCRIPTION
This makes it so the terrain `JListBox` uses "displayable" names instead of the terrainType:lvl:exit format.  This makes things more human readable, but has the effect of hiding some of the gory details (although right now the old format is displayed as a tooltip).

I'm not yet convinced this is a good approach without further updates to the map editor.  It may hide information that's still kind of useful, even if it's a pain to have to understand the internal mechanisms.

It would be nice if the "level" text box could be changed to an editable combo-box, so things with actual levels like woods you could just select from the drop down but still edit it for things like building CF.  However, we don't have this information encoded yet to my knowledge.