### PR TITLE
Change guessed firing plan sorting algorithm

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -51,8 +51,6 @@ import megamek.common.TargetRoll;
 import megamek.common.Targetable;
 import megamek.common.Terrains;
 import megamek.common.TripodMech;
-import megamek.common.UnitType;
-import megamek.common.VTOL;
 import megamek.common.logging.LogLevel;
 import megamek.common.options.OptionsConstants;
 
@@ -227,34 +225,6 @@ public class BasicPathRanker extends PathRanker {
         }
     }
 
-    /**
-     * Performs some evaluation of the path specific to aerotech units
-     * @param movePath the path to check
-     * @return A 'RankedPath' object with a certain evaluation
-     */
-    RankedPath doAeroSpecificRanking(MovePath movePath) {
-        // stalling is awful
-    	if(AeroPathUtil.willStall(movePath)) {
-            return new RankedPath(-1000d, movePath, "stall");
-        }
-
-        // crashing is even worse
-        if (AeroPathUtil.willCrash(movePath)) {
-            return new RankedPath(-10000d, movePath, "crash");
-        }
-
-        // Flying off board should only be done if necessary, but is better than taking a lot of damage.
-        // VTOLs really should not be flying off board as they can just stop moving instead
-        if (movePath.fliesOffBoard()) {
-            if (UnitType.isVTOL(movePath.getEntity())) {
-                return new RankedPath(-5000d, movePath, "off-board");
-            }
-            return new RankedPath(-5d, movePath, "off-board");
-        }
-
-        return null;
-    }
-
     @Override
     protected List<TargetRoll> getPSRList(MovePath path) {
         return super.getPSRList(path);
@@ -378,7 +348,7 @@ public class BasicPathRanker extends PathRanker {
                                         FireControl.DOES_NOT_TRACK_HEAT,
                                         null);
             myFiringPlan = getFireControl().determineBestFiringPlan(guess);
-        }
+        }//
         return myFiringPlan.getUtility();
     }
 

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -348,7 +348,7 @@ public class BasicPathRanker extends PathRanker {
                                         FireControl.DOES_NOT_TRACK_HEAT,
                                         null);
             myFiringPlan = getFireControl().determineBestFiringPlan(guess);
-        }//
+        }
         return myFiringPlan.getUtility();
     }
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2085,6 +2085,7 @@ public class FireControl {
         }
 
         // Get the best firing plan that falls under our heat limit.
+        // Now emulates the logic from getBestFiringPlanUnderHeat, rather than sorting the firing plans low to high then picking the lowest one
         final FiringPlan[] heatPlans = calcFiringPlansUnderHeat(shooter, alphaStrike);
         FiringPlan bestPlan = new FiringPlan(target);
         

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2086,13 +2086,14 @@ public class FireControl {
 
         // Get the best firing plan that falls under our heat limit.
         final FiringPlan[] heatPlans = calcFiringPlansUnderHeat(shooter, alphaStrike);
-        Arrays.sort(heatPlans);
-        if (0 < heatPlans.length) {
-            return heatPlans[0];
-        } else {
-            // Return a do nothing plan
-            return new FiringPlan(target);
+        FiringPlan bestPlan = new FiringPlan(target);
+        
+        for (final FiringPlan firingPlan : heatPlans) {
+            if ((bestPlan.getUtility() < firingPlan.getUtility())) {
+                bestPlan = firingPlan;
+            }
         }
+        return bestPlan;
     }
 
     private FiringPlan getBestFiringPlanUnderHeat(final Targetable target,

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -137,7 +137,7 @@ public abstract class PathRanker {
         HomeEdge homeEdge = getOwner().getHomeEdge();
         boolean fleeing = getOwner().isFallingBack(mover);
         //Infantry with zero move or with field guns cannot move and shoot, so we want to take that into account for path ranking.
-        boolean isZeroMoveInfantry = mover instanceof Infantry && (mover.getWalkMP() == 0 || ((Infantry)mover).hasFieldGun());
+        boolean isZeroMoveInfantry = mover.hasETypeFlag(Entity.ETYPE_INFANTRY) && (mover.getWalkMP() == 0 || ((Infantry)mover).hasFieldGun());
         if (isZeroMoveInfantry) {
             startingPathList.add(new MovePath(game, mover)); //If we can't move and still fire, we want to consider not moving.
         }


### PR DESCRIPTION
Previously, for whatever reason, the "guess firing plan" method (called when evaluating the utility of a particular move path) was sorting a path's potential firing plans from lowest to highest then *returning the lowest utility firing plan*. 

So, for example, a unit of field gunners would consider not moving, but since some of those firing plans had utility 0, considered the "firing utility" of the zero-move move path to be 0 and opt to move instead, even though they could stand still and fire the field guns.