### PR TITLE
Fix strategic fuel calc for warships

### DIFF
--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -223,6 +223,24 @@ public class Warship extends Jumpship {
         }
         return armWeight;
     }
+    
+    @Override
+    //Jumpships and Space Stations use 10% of the fuel Warships do...
+    public double getStrategicFuelUse() {
+        double fuelUse;
+        if (weight >= 200000) {
+            fuelUse = 39.52;
+        } else if (weight >= 100000) {
+            fuelUse = 19.75;
+        } else {
+            //Per Stratops, this is impossible for Warships, but Primitive Jumpships in IO can be this small
+            fuelUse = 9.77;
+        } 
+        if (isPrimitive()) {
+            return fuelUse * primitiveFuelFactor();
+        }
+        return fuelUse;
+    }
 
     @Override
     public double getCost(boolean ignoreAmmo) {


### PR DESCRIPTION
Warships use different tons/burn day than jumpships. 