### PR TITLE
Evasion fix capital missiles

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -974,7 +974,11 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             }
 
             // targeting mods for evasive action by large craft
-            if (aero.isEvading()) {
+            // Per TW, this does not apply when firing Capital Missiles
+            if (aero.isEvading() && 
+                    (!(wtype.getAtClass() == WeaponType.CLASS_CAPITAL_MISSILE 
+                            || wtype.getAtClass() == WeaponType.CLASS_AR10
+                            || wtype.getAtClass() == WeaponType.CLASS_TELE_MISSILE))) {
                 toHit.addModifier(+2, "attacker is evading");
             }
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -975,8 +975,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
             // targeting mods for evasive action by large craft
             // Per TW, this does not apply when firing Capital Missiles
-            if (aero.isEvading() && 
-                    (!(wtype.getAtClass() == WeaponType.CLASS_CAPITAL_MISSILE 
+            if (aero.isEvading() &&
+                    (!(wtype.getAtClass() == WeaponType.CLASS_CAPITAL_MISSILE
                             || wtype.getAtClass() == WeaponType.CLASS_AR10
                             || wtype.getAtClass() == WeaponType.CLASS_TELE_MISSILE))) {
                 toHit.addModifier(+2, "attacker is evading");


### PR DESCRIPTION
Per TW p77, the large craft "attacker is evading" penalty does not apply when firing capital missiles