### PR TITLE
No modifier for bog-down check when infantry goes into mud

### DIFF
--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -546,6 +546,10 @@ public class Terrain implements ITerrain, Serializable {
         case (Terrains.MUD):
             if ((moveMode == EntityMovementMode.BIPED) || (moveMode == EntityMovementMode.QUAD)) {
                 return TargetRoll.AUTOMATIC_SUCCESS;
+                // any kind of infantry just gets a flat roll
+            } else if(moveMode == EntityMovementMode.INF_LEG || moveMode == EntityMovementMode.INF_MOTORIZED ||
+                    moveMode == EntityMovementMode.INF_JUMP || moveMode == EntityMovementMode.INF_UMU) {
+                return 0;
             }
             return -1;
         case (Terrains.TUNDRA):


### PR DESCRIPTION
Think I got it right. Addresses issue #856 