### PR TITLE
Fix for Bug #864

### DIFF
--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -332,7 +332,10 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         int av = 0;
         int counterAV = 0;
         int range = RangeType.rangeBracket(nRange, wtype.getATRanges(), true, false);
-        if (range == WeaponType.RANGE_SHORT) {
+        // if we have a ground firing unit, then AV should not be determined by
+        // aero range brackets. This really is only an issue with IS SRMs
+        // I can't think of any missiles that don't have the same AV at all ranges, so the short AV should be fine.
+        if (!ae.isAirborne() || (range == WeaponType.RANGE_SHORT)) {
             av = wtype.getRoundShortAV();
         } else if (range == WeaponType.RANGE_MED) {
             av = wtype.getRoundMedAV();


### PR DESCRIPTION
CalcAttackValue in WeaponHandler returns the shortAV if the attacker is not airborne.  I had forgotten to include this in the CalcAttackValue override in MissileWeaponHandler.

There are many other overrides for other missile types, but they all have at least a mediumAV (range of 12) and don't have this problem when shot at strafing aeros.

This fix does not break AMS in anyway.