### PR TITLE
Fix for issue #878

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1456,7 +1456,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 if (null != cmd.getLastStep()) {
                     unusedVelocity = cmd.getLastStep().getVelocityLeft() > 0;
                 } else {
-                    unusedVelocity = ((IAero) ce()).getCurrentVelocity() > 0 &&
+                    unusedVelocity = (((IAero) ce()).getCurrentVelocity() > 0) &&
                             (ce().delta_distance == 0);
                 }
                 boolean flyoff = false;

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1456,7 +1456,8 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 if (null != cmd.getLastStep()) {
                     unusedVelocity = cmd.getLastStep().getVelocityLeft() > 0;
                 } else {
-                    unusedVelocity = ((IAero) ce()).getCurrentVelocity() > 0;
+                    unusedVelocity = ((IAero) ce()).getCurrentVelocity() > 0 &&
+                            (ce().delta_distance == 0);
                 }
                 boolean flyoff = false;
                 if ((null != cmd)

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -9219,9 +9219,9 @@ public class Server implements Runnable {
         entity.setAltitude(curAltitude);
         entity.setClimbMode(curClimbMode);
         
-        if(entity.isAirborne() && entity.isAero()) {
+        /*if(entity.isAirborne() && entity.isAero()) {
             ((IAero) entity).setCurrentVelocity(md.getFinalVelocityLeft());
-        }
+        }*/
 
         // add a list of places passed through
         entity.setPassedThrough(passedThrough);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -9218,10 +9218,6 @@ public class Server implements Runnable {
         }
         entity.setAltitude(curAltitude);
         entity.setClimbMode(curClimbMode);
-        
-        /*if(entity.isAirborne() && entity.isAero()) {
-            ((IAero) entity).setCurrentVelocity(md.getFinalVelocityLeft());
-        }*/
 
         // add a list of places passed through
         entity.setPassedThrough(passedThrough);


### PR DESCRIPTION
Undoes a previous attempt to address aero movement after revealing hidden units in Server.ProcessMovement that had side effects. Instead, the fix is implemented in MovementDisplay.java, in the code that nags the player about "not using all velocity".
