### PR TITLE
Add check to ignore SI damage for squadron status display

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -3893,10 +3893,6 @@ public class Aero extends Entity implements IAero, IBomber {
         double internalPercent = getInternalRemainingPercent();
         String msg = getDisplayName() + " CRIPPLED: ";
         if (internalPercent < 0.5) {
-            //Fighter squadrons can't take SI damage, so they always display as crippled without this check.
-            if (this.hasETypeFlag(ETYPE_FIGHTER_SQUADRON)) {
-                return false;
-            }
             System.out.println(msg + "only " + NumberFormat.getPercentInstance().format(internalPercent)
                     + " internals remaining.");
             return true;

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -3893,6 +3893,10 @@ public class Aero extends Entity implements IAero, IBomber {
         double internalPercent = getInternalRemainingPercent();
         String msg = getDisplayName() + " CRIPPLED: ";
         if (internalPercent < 0.5) {
+            //Fighter squadrons can't take SI damage, so they always display as crippled without this check.
+            if (this.hasETypeFlag(ETYPE_FIGHTER_SQUADRON)) {
+                return false;
+            }
             System.out.println(msg + "only " + NumberFormat.getPercentInstance().format(internalPercent)
                     + " internals remaining.");
             return true;
@@ -3942,6 +3946,10 @@ public class Aero extends Entity implements IAero, IBomber {
         }
 
         if (getInternalRemainingPercent() < 0.67) {
+            //Fighter squadrons can't take SI damage, so they always display as damaged without this check.
+            if (this.hasETypeFlag(ETYPE_FIGHTER_SQUADRON)) {
+                return false;
+            }
             return true;
         }
         if ((getCrew() != null) && (getCrew().getHits() == 3)) {
@@ -3971,6 +3979,10 @@ public class Aero extends Entity implements IAero, IBomber {
         }
 
         if (getInternalRemainingPercent() < 0.75) {
+            //Fighter squadrons can't take SI damage, so they always display as damaged without this check.
+            if (this.hasETypeFlag(ETYPE_FIGHTER_SQUADRON)) {
+                return false;
+            }
             return true;
         }
 
@@ -4000,6 +4012,10 @@ public class Aero extends Entity implements IAero, IBomber {
         }
 
         if (getInternalRemainingPercent() < 0.9) {
+            //Fighter squadrons can't take SI damage, so they always display as damaged without this check.
+            if (this.hasETypeFlag(ETYPE_FIGHTER_SQUADRON)) {
+                return false;
+            }
             return true;
         }
 

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -3942,10 +3942,6 @@ public class Aero extends Entity implements IAero, IBomber {
         }
 
         if (getInternalRemainingPercent() < 0.67) {
-            //Fighter squadrons can't take SI damage, so they always display as damaged without this check.
-            if (this.hasETypeFlag(ETYPE_FIGHTER_SQUADRON)) {
-                return false;
-            }
             return true;
         }
         if ((getCrew() != null) && (getCrew().getHits() == 3)) {
@@ -3975,10 +3971,6 @@ public class Aero extends Entity implements IAero, IBomber {
         }
 
         if (getInternalRemainingPercent() < 0.75) {
-            //Fighter squadrons can't take SI damage, so they always display as damaged without this check.
-            if (this.hasETypeFlag(ETYPE_FIGHTER_SQUADRON)) {
-                return false;
-            }
             return true;
         }
 
@@ -4008,10 +4000,6 @@ public class Aero extends Entity implements IAero, IBomber {
         }
 
         if (getInternalRemainingPercent() < 0.9) {
-            //Fighter squadrons can't take SI damage, so they always display as damaged without this check.
-            if (this.hasETypeFlag(ETYPE_FIGHTER_SQUADRON)) {
-                return false;
-            }
             return true;
         }
 

--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -155,12 +155,11 @@ public class FighterSquadron extends Aero {
     }
 
     /*
-     * base this on the max size of the fighter squadron, since the initial size
-     * can fluctuate due to joining and splitting
+     * Squadrons have an SI for PSR purposes, but don't take SI damage. This should return 100%.
      */
     @Override
     public double getInternalRemainingPercent() {
-        return (getActiveSubEntities().orElse(Collections.emptyList()).size() * 1.0 / getMaxSize());
+        return 1.0;
     }
 
     @Override

--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -111,6 +111,16 @@ public class FighterSquadron extends Aero {
                 .mapToInt(fid -> ((IAero) game.getEntity(fid)).getCap0Armor())
                 .sum();
     }
+    
+    /*
+     * Per SO, fighter squadrons can't actually be crippled
+     * Individual crippled fighters should be detached and sent home, but it isn't required by the rules
+     * @see megamek.common.Aero#isCrippled()
+     */
+    @Override
+    public boolean isCrippled() {
+        return false;
+    }
 
     /**
      * Returns the percent of the armor remaining


### PR DESCRIPTION
Fixes something that's been bugging me for a while - squadrons show as crippled/heavy damage/light damage, etc  based on how many fighters are in the squadron because the number of fighters is counting as the squadron's SI.

Squadrons now ignore the SI calculation for their damage status display, but damage to individual fighters is still tracked and applied properly on disband/unloading from the squadron. 