### PR TITLE
fixed NPE when loading bays with invalid index

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8012,6 +8012,8 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     }
 
     public Bay getBayById(int bayNumber) {
+        //TODO: Change transports to a map or other indexed data structure to avoid
+        // linear-time algorithm.
         for (Transporter next : transports) {
             if (next instanceof Bay) {
                 if (((Bay) next).getBayNumber() == bayNumber) {

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -1910,7 +1910,7 @@ public class MULParser {
     		if (bay < 0) {
     			warning.append("Found invalid index value for bay: ").append(index).append(".\n");
     			return;
-    		} else if (bay > entity.getTransportBays().size()) {
+    		} else if (entity.getBayById(bay) == null) {
     			warning.append("The entity, ")
     			.append(entity.getShortName())
     			.append(" does not have a bay at index: ")


### PR DESCRIPTION
This is a fix for issue #903, which probably came about as a result of my recent changes to the BLK file parsing code (the implicit ordering of bays has changed). This may result in bay damage recorded in MUL files not being parsed properly when loading MULs from a previous version, most likely in the case where a bay didn't have an explicit number or had a bay number of 0.

Since we don't technically support loading Megamek games across versions, I consider it an acceptable side effect.

The comment is something I flagged for myself for a post-stable performance improvement.