### PR TITLE
Weapons bay ammo display/MUL loading fix

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BayMunitionsChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BayMunitionsChoicePanel.java
@@ -42,6 +42,7 @@ import megamek.common.SimpleTechLevel;
 import megamek.common.WeaponType;
 import megamek.common.logging.DefaultMmLogger;
 import megamek.common.options.OptionsConstants;
+import megamek.common.ITechnology;
 
 /**
  * @author Neoancient
@@ -76,13 +77,12 @@ public class BayMunitionsChoicePanel extends JPanel {
                     List<Integer> key = new ArrayList<>(2);
                     key.add(atype.getAmmoType());
                     key.add(atype.getRackSize());
-                    key.add(atype.getTechBase());
                     ammoByType.putIfAbsent(key, new ArrayList<>());
                     ammoByType.get(key).add(ammo);
                 }
             }
             for (List<Integer> key : ammoByType.keySet()) {
-                AmmoRowPanel row = new AmmoRowPanel(bay, key.get(0), key.get(1), key.get(2), ammoByType.get(key));
+                AmmoRowPanel row = new AmmoRowPanel(bay, key.get(0), key.get(1), ammoByType.get(key));
                 gbc.gridy++;
                 add(row, gbc);
                 rows.add(row);
@@ -163,14 +163,21 @@ public class BayMunitionsChoicePanel extends JPanel {
         
         private double tonnage = 0;
         
-        AmmoRowPanel(Mounted bay, int at, int rackSize, int techBase, List<Mounted> ammoMounts) {
+        AmmoRowPanel(Mounted bay, int at, int rackSize, List<Mounted> ammoMounts) {
             this.bay = bay;
             this.at = at;
             this.rackSize = rackSize;
-            this.techBase = techBase;
             this.ammoMounts = new ArrayList<>(ammoMounts);
             this.spinners = new ArrayList<>();
             Dimension spinnerSize =new Dimension(55, 25);
+            
+            final Optional<WeaponType> wtype = bay.getBayWeapons().stream()
+                    .map(wNum -> entity.getEquipment(wNum))
+                    .map(m -> (WeaponType) m.getType()).findAny();
+            
+            // set the bay's tech base to that of any weapon in the bay
+            // an assumption is made here that bays don't mix clan-only and IS-only tech base
+            this.techBase = wtype.isPresent() ? wtype.get().getTechBase() : WeaponType.TECH_BASE_ALL;
             
             munitions = AmmoType.getMunitionsFor(at).stream()
                     .filter(this::includeMunition).collect(Collectors.toList());
@@ -200,9 +207,6 @@ public class BayMunitionsChoicePanel extends JPanel {
             gbc.anchor = GridBagConstraints.WEST;
             gbc.insets = new Insets(0, 5, 0, 5);
             gbc.gridwidth = 5;
-            final Optional<WeaponType> wtype = bay.getBayWeapons().stream()
-                    .map(wNum -> entity.getEquipment(wNum))
-                    .map(m -> (WeaponType) m.getType()).findAny();
             add(new JLabel("(" + entity.getLocationAbbr(bay.getLocation()) + ") "
                     + (wtype.isPresent()? wtype.get().getName() : "?")), gbc);
             gbc.gridx = 5;

--- a/megamek/src/megamek/client/ui/swing/BayMunitionsChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BayMunitionsChoicePanel.java
@@ -42,7 +42,6 @@ import megamek.common.SimpleTechLevel;
 import megamek.common.WeaponType;
 import megamek.common.logging.DefaultMmLogger;
 import megamek.common.options.OptionsConstants;
-import megamek.common.ITechnology;
 
 /**
  * @author Neoancient

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -312,13 +312,10 @@ public class EntityListFile {
                         haveSlot = true;
                     }
 
-                    
                     // Record ammunition slots in undestroyed locations.
                     // N.B. the slot CAN\"T be damaged at this point.
-                    // If the ammo is mounted in a bay, it will be handled differently
                     else if (!isDestroyed && (mount != null)
-                            && (mount.getType() instanceof AmmoType) 
-                            && (mount.getEntity().getBayByAmmo(mount) == null)) {
+                            && (mount.getType() instanceof AmmoType)) {
                         thisLoc.append(indentStr(indentLvl+1) + "<slot index=\"");
                         thisLoc.append(String.valueOf(loop + 1));
                         thisLoc.append("\" type=\"");
@@ -329,36 +326,7 @@ public class EntityListFile {
                         thisLoc.append(CommonConstants.NL);
                         haveSlot = true;
                     }
-                    
-                    // If the piece of equipment is a bay that contains ammo
-                    // Record the ammo
-                    else if(!isDestroyed && (mount != null)
-                            && mount.getBayAmmo().size() > 0) {
-                        
-                        thisLoc.append(indentStr(indentLvl+1) + "<weaponsBay index=\"");
-                        thisLoc.append(String.valueOf(loop + 1));
-                        thisLoc.append("\" type=\"");
-                        thisLoc.append(mount.getType().getInternalName());
-                        thisLoc.append("\">");
-                        thisLoc.append(CommonConstants.NL);
-                        
-                        for(int ammoSlotID : mount.getBayAmmo()) {
-                            Mounted bayAmmo = entity.getEquipment(ammoSlotID);
-                            
-                            thisLoc.append(indentStr(indentLvl+2) + "<weaponsBayAmmo index=\"");
-                            thisLoc.append(String.valueOf(ammoSlotID));
-                            thisLoc.append("\" type=\"");
-                            thisLoc.append(bayAmmo.getType().getInternalName());
-                            thisLoc.append("\" shots=\"");
-                            thisLoc.append(String.valueOf(bayAmmo.getBaseShotsLeft()));
-                            thisLoc.append("\"/>");
-                            thisLoc.append(CommonConstants.NL);
-                        }
-                        
-                        thisLoc.append(indentStr(indentLvl+1) + "</weaponsBay>");
-                        thisLoc.append(CommonConstants.NL);
-                    }
-                        
+
                     // Record the munition type of oneshot launchers
                     else if (!isDestroyed && (mount != null)
                             && (mount.getType() instanceof WeaponType)

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -312,10 +312,13 @@ public class EntityListFile {
                         haveSlot = true;
                     }
 
+                    
                     // Record ammunition slots in undestroyed locations.
                     // N.B. the slot CAN\"T be damaged at this point.
+                    // If the ammo is mounted in a bay, it will be handled differently
                     else if (!isDestroyed && (mount != null)
-                            && (mount.getType() instanceof AmmoType)) {
+                            && (mount.getType() instanceof AmmoType) 
+                            && (mount.getEntity().getBayByAmmo(mount) == null)) {
                         thisLoc.append(indentStr(indentLvl+1) + "<slot index=\"");
                         thisLoc.append(String.valueOf(loop + 1));
                         thisLoc.append("\" type=\"");
@@ -326,7 +329,36 @@ public class EntityListFile {
                         thisLoc.append(CommonConstants.NL);
                         haveSlot = true;
                     }
-
+                    
+                    // If the piece of equipment is a bay that contains ammo
+                    // Record the ammo
+                    else if(!isDestroyed && (mount != null)
+                            && mount.getBayAmmo().size() > 0) {
+                        
+                        thisLoc.append(indentStr(indentLvl+1) + "<weaponsBay index=\"");
+                        thisLoc.append(String.valueOf(loop + 1));
+                        thisLoc.append("\" type=\"");
+                        thisLoc.append(mount.getType().getInternalName());
+                        thisLoc.append("\">");
+                        thisLoc.append(CommonConstants.NL);
+                        
+                        for(int ammoSlotID : mount.getBayAmmo()) {
+                            Mounted bayAmmo = entity.getEquipment(ammoSlotID);
+                            
+                            thisLoc.append(indentStr(indentLvl+2) + "<weaponsBayAmmo index=\"");
+                            thisLoc.append(String.valueOf(ammoSlotID));
+                            thisLoc.append("\" type=\"");
+                            thisLoc.append(bayAmmo.getType().getInternalName());
+                            thisLoc.append("\" shots=\"");
+                            thisLoc.append(String.valueOf(bayAmmo.getBaseShotsLeft()));
+                            thisLoc.append("\"/>");
+                            thisLoc.append(CommonConstants.NL);
+                        }
+                        
+                        thisLoc.append(indentStr(indentLvl+1) + "</weaponsBay>");
+                        thisLoc.append(CommonConstants.NL);
+                    }
+                        
                     // Record the munition type of oneshot launchers
                     else if (!isDestroyed && (mount != null)
                             && (mount.getType() instanceof WeaponType)

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -27,7 +27,6 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
@@ -278,7 +277,7 @@ public class EntityListFile {
                     // if the "equipment" is a weapons bay, 
                     // then let's make a note of it
                     if(entity.usesWeaponBays() && 
-                            slot.getMount().getBayAmmo() != null) {
+                            slot.getMount().getBayAmmo().size() > 0) {
                         baySlotMap.put(slot.getMount(), loop + 1);
                     }
 

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -24,8 +24,11 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import megamek.MegaMek;
@@ -240,6 +243,9 @@ public class EntityListFile {
                 }
             }
 
+            // 
+            Map<Mounted, Integer> baySlotMap = new HashMap<>();
+            
             // Walk through the slots in this location.
             for (int loop = 0; loop < entity.getNumberOfCriticals(loc); loop++) {
 
@@ -267,6 +273,13 @@ public class EntityListFile {
                     Mounted mount = null;
                     if (CriticalSlot.TYPE_EQUIPMENT == slot.getType()) {
                         mount = slot.getMount();
+                    }
+                    
+                    // if the "equipment" is a weapons bay, 
+                    // then let's make a note of it
+                    if(entity.usesWeaponBays() && 
+                            slot.getMount().getBayAmmo() != null) {
+                        baySlotMap.put(slot.getMount(), loop + 1);
                     }
 
                     if (mount != null && mount.getType() instanceof BombType) {
@@ -316,12 +329,27 @@ public class EntityListFile {
                     // N.B. the slot CAN\"T be damaged at this point.
                     else if (!isDestroyed && (mount != null)
                             && (mount.getType() instanceof AmmoType)) {
+                        
+                        String bayIndex = "";
+                        
+                        for(Mounted bay : baySlotMap.keySet()) {
+                            if(bay.ammoInBay(entity.getEquipmentNum(mount))) {
+                                bayIndex = String.valueOf(baySlotMap.get(bay));
+                            }
+                        }
+                        
                         thisLoc.append(indentStr(indentLvl+1) + "<slot index=\"");
                         thisLoc.append(String.valueOf(loop + 1));
                         thisLoc.append("\" type=\"");
                         thisLoc.append(mount.getType().getInternalName());
                         thisLoc.append("\" shots=\"");
                         thisLoc.append(String.valueOf(mount.getBaseShotsLeft()));
+                        
+                        if(!bayIndex.isEmpty()) {
+                            thisLoc.append("\" weaponsBayIndex=\"");
+                            thisLoc.append(bayIndex);
+                        }
+                        
                         thisLoc.append("\"/>");
                         thisLoc.append(CommonConstants.NL);
                         haveSlot = true;

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -149,8 +149,6 @@ public class MULParser {
     private static final String BAYDOORS = "doors";
     private static final String BAY = "transportBay";
     private static final String BAYDAMAGE = "damage";
-    private static final String WEAPONSBAY = "weaponsBay";
-    private static final String WEAPONSBAYAMMO = "weaponsBayAmmo";
     private static final String MDAMAGE = "damage";
     private static final String MPENALTY = "penalty";
     private static final String C3MASTERIS = "c3MasterIs";
@@ -1232,8 +1230,6 @@ public class MULParser {
                     blowOffLocation(entity, loc);
                 } else if (nodeName.equalsIgnoreCase(SLOT)){
                     locAmmoCount = parseSlot(currEle, entity, loc, locAmmoCount);
-                } else if (nodeName.equalsIgnoreCase(WEAPONSBAY)) {
-                    parseWeaponsBay(currEle, entity, loc);
                 } else if (nodeName.equalsIgnoreCase(STABILIZER)){
                     String hit = currEle.getAttribute(IS_HIT);
                     if (!hit.equals("")) {
@@ -1555,8 +1551,72 @@ public class MULParser {
 
                 // Is the mounted a type of ammo?
                 if (mounted.getType() instanceof AmmoType) {
-                    parseAmmo(shots, type, capacity, mounted, entity, indexVal, locAmmoCount);
-                } 
+
+                    // Get the saved ammo load.
+                    EquipmentType newLoad = EquipmentType.get(type);
+                    if (newLoad instanceof AmmoType) {
+
+                        // Try to get a good shots value.
+                        int shotsVal = -1;
+                        try {
+                            shotsVal = Integer.parseInt(shots);
+                        } catch (NumberFormatException excep) {
+                            // Handled by the next if test.
+                        }
+                        if (shots.equals(NA)) {
+                            shotsVal = IArmorState.ARMOR_NA;
+                            warning.append(
+                                    "Expected to find number of shots for ")
+                                    .append(type)
+                                    .append(", but found ")
+                                    .append(shots)
+                                    .append(" instead.\n");
+                        } else if ((shotsVal < 0) || (shotsVal > 200)) {
+                            warning.append(
+                                    "Found invalid shots value for slot: ")
+                                    .append(shots).append(".\n");
+                        } else {
+
+                            // Change to the saved ammo type and shots.
+                            mounted.changeAmmoType((AmmoType) newLoad);
+                            mounted.setShotsLeft(shotsVal);
+
+                        } // End have-good-shots-value
+                        try {
+                            double capVal = Double.parseDouble(capacity);
+                            mounted.setAmmoCapacity(capVal);
+                        } catch (NumberFormatException excep) {
+                            // Handled by the next if test.
+                        }
+                        if (capacity.equals(NA)) {
+                            if (entity.hasETypeFlag(Entity.ETYPE_BATTLEARMOR)
+                                    || entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
+                                mounted.setAmmoCapacity(mounted.getOriginalShots()
+                                         * ((AmmoType) mounted.getType()).getKgPerShot() * 1000);
+                            } else {
+                                mounted.setAmmoCapacity(mounted.getOriginalShots()
+                                        * mounted.getType().getTonnage(entity)
+                                        / ((AmmoType) mounted.getType()).getShots());
+                            }
+                        }
+                        
+
+                    } else {
+                        // Bad XML equipment.
+                        warning.append("XML file expects ")
+                                .append(type)
+                                .append(" equipment at index ")
+                                .append(indexVal)
+                                .append(" of location ")
+                                .append(loc)
+                                .append(", but Entity has ")
+                                .append(mounted.getType()
+                                        .getInternalName())
+                                .append("there .\n");
+                    }
+
+                } // End slot-for-ammo
+
                 // Not an ammo slot... does file agree with template?
                 else if (!mounted.getType().getInternalName()
                         .equals(type)) {
@@ -1599,82 +1659,6 @@ public class MULParser {
 
         } // End have-required-fields
         return locAmmoCount;
-    }
-    
-    /**
-     * Helper function that parses the passed-in strings containing ammo-related information and contains
-     * logic to add the parsed results to the given entity.
-     * @param shots Number of shots, drawn from XML
-     * @param type Type of ammo, drawn from XML
-     * @param capacity Capacity, drawn from XML
-     * @param mounted The mounted equipment object
-     * @param entity The entity on which to mount the equipment
-     * @param indexVal The index at which we expected to mount the equipment 
-     * @param loc The location in which we expected to mount the equipment
-     */
-    private void parseAmmo(String shots, String type, String capacity, Mounted mounted, Entity entity, int indexVal, int loc) {
-     // Get the saved ammo load.
-        EquipmentType newLoad = EquipmentType.get(type);
-        if (newLoad instanceof AmmoType) {
-
-            // Try to get a good shots value.
-            int shotsVal = -1;
-            try {
-                shotsVal = Integer.parseInt(shots);
-            } catch (NumberFormatException excep) {
-                // Handled by the next if test.
-            }
-            if (shots.equals(NA)) {
-                shotsVal = IArmorState.ARMOR_NA; // this indicates "no ammo", apparently 
-                warning.append(
-                        "Expected to find number of shots for ")
-                        .append(type)
-                        .append(", but found ")
-                        .append(shots)
-                        .append(" instead.\n");
-            } else if ((shotsVal < 0) || (shotsVal > 200)) {
-                warning.append(
-                        "Found invalid shots value for slot: ")
-                        .append(shots).append(".\n");
-            } else {
-
-                // Change to the saved ammo type and shots.
-                mounted.changeAmmoType((AmmoType) newLoad);
-                mounted.setShotsLeft(shotsVal);
-
-            } // End have-good-shots-value
-            try {
-                double capVal = Double.parseDouble(capacity);
-                mounted.setAmmoCapacity(capVal);
-            } catch (NumberFormatException excep) {
-                // Handled by the next if test.
-            }
-            if (capacity.equals(NA)) {
-                if (entity.hasETypeFlag(Entity.ETYPE_BATTLEARMOR)
-                        || entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
-                    mounted.setAmmoCapacity(mounted.getOriginalShots()
-                             * ((AmmoType) mounted.getType()).getKgPerShot() * 1000);
-                } else {
-                    mounted.setAmmoCapacity(mounted.getOriginalShots()
-                            * mounted.getType().getTonnage(entity)
-                            / ((AmmoType) mounted.getType()).getShots());
-                }
-            }
-            
-
-        } else {
-            // Bad XML equipment.
-            warning.append("XML file expects ")
-                    .append(type)
-                    .append(" equipment at index ")
-                    .append(indexVal)
-                    .append(" of location ")
-                    .append(loc)
-                    .append(", but Entity has ")
-                    .append(mounted.getType()
-                            .getInternalName())
-                    .append("there .\n");
-        }
     }
     
     /**
@@ -2249,60 +2233,6 @@ public class MULParser {
             ex.printStackTrace();
         }
         
-    }
-    
-    private void parseWeaponsBay(Element weaponBayTag, Entity entity, int loc) {
-        if(!entity.usesWeaponBays()) {
-            warning.append("Found a weapons bay record, but entity doesn't use weapon bays.");
-            return;
-        }
-        
-        int bayIndex = Integer.parseInt(weaponBayTag.getAttribute(INDEX));
-        Mounted bayMount = entity.getEquipment(bayIndex);
-        if(bayMount == null) {
-            warning.append(String.format("Invalid bay index %d", bayIndex));
-            return;
-        }
-        
-        // Handle children
-        NodeList nl = weaponBayTag.getChildNodes();
-        for (int i = 0; i < nl.getLength(); i++) {
-            Node currNode = nl.item(i);
-
-            if (currNode.getParentNode() != weaponBayTag) {
-                continue;
-            }
-            int nodeType = currNode.getNodeType();
-            if ((nodeType == Node.ELEMENT_NODE) &&
-                    (currNode.getNodeName().equalsIgnoreCase(WEAPONSBAYAMMO))) {
-                Element currEle = (Element)currNode;
-                
-                int ammoIndex = Integer.parseInt(currEle.getAttribute(INDEX));
-                String ammoType = currEle.getAttribute(TYPE);
-                String shotsLeft = currEle.getAttribute(SHOTS);
-                
-                Mounted ammoMount = entity.getEquipment(ammoIndex);
-                
-                if(ammoMount == null) {
-                    ammoMount = new Mounted(entity, EquipmentType.get(ammoType));
-                    try {
-                        entity.addEquipment(ammoMount, loc, bayMount.isRearMounted(), 1);
-                    } catch(Exception e) {
-                        warning.append(String.format("Error adding ammo at index %d: %s", ammoIndex, e));
-                    }
-                    
-                    bayMount.addAmmoToBay(entity.getEquipmentNum(ammoMount));
-                } else {
-                    // "restore transient state". Not sure what it means, but it's called when parsing regular ammo bins.
-                    ammoMount.restore();
-                }
-                
-                parseAmmo(shotsLeft, ammoType, "", ammoMount, entity, ammoIndex, loc);
-                
-            } else {
-                continue;
-            }
-        }
     }
     
     /**

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -149,6 +149,7 @@ public class MULParser {
     private static final String BAYDOORS = "doors";
     private static final String BAY = "transportBay";
     private static final String BAYDAMAGE = "damage";
+    private static final String WEAPONS_BAY_INDEX = "weaponsBayIndex";
     private static final String MDAMAGE = "damage";
     private static final String MPENALTY = "penalty";
     private static final String C3MASTERIS = "c3MasterIs";
@@ -1343,6 +1344,7 @@ public class MULParser {
         String quirks = slotTag.getAttribute(QUIRKS);
         String trooperMiss = slotTag.getAttribute(TROOPER_MISS);
         String rfmg = slotTag.getAttribute(RFMG);
+        String bayIndex = slotTag.getAttribute(WEAPONS_BAY_INDEX);
 
         // Did we find required attributes?
         if ((index == null) || (index.length() == 0)) {
@@ -1477,7 +1479,17 @@ public class MULParser {
             // Try to get the critical slot.
             CriticalSlot slot = entity.getCritical(loc, indexVal);
 
-            // Did we get it?
+            // If we couldn't find a critical slot, 
+            // it's possible that this is "extra" ammo in a weapons bay, so we may attempt
+            // to shove it in there
+            if (slot == null) {
+                if(entity.usesWeaponBays() &&
+                        !bayIndex.isEmpty()) {
+                    addExtraAmmoToBay(entity, loc, type, bayIndex);
+                    slot = entity.getCritical(loc, indexVal);
+                }
+            }
+            
             if (slot == null) {
                 if (!type.equals(EMPTY)) {
                     warning.append("Could not find the ")
@@ -2233,6 +2245,35 @@ public class MULParser {
             ex.printStackTrace();
         }
         
+    }
+    
+    /**
+     * Worker function that takes an entity, a location, an ammo type string and the critical index
+     * of a weapons bay in the given location and attempts to add the ammo type there.
+     * @param entity The entity we're working on loading
+     * @param loc The location index on the entity
+     * @param type The ammo type string
+     * @param bayIndex The crit index of the bay where we want to load the ammo on the location where the bay is
+     * @return A generated critical slot entry
+     */
+    private void addExtraAmmoToBay(Entity entity, int loc, String type, String bayIndex) {
+        // here, we need to do the following:
+        // 1: get the bay to which this ammo belongs, and add it to said bay
+        // 2: add the ammo to the entity as a "new" piece of equipment
+        // 3: add the ammo to a crit slot on the bay's location
+        
+        int bayCritIndex = Integer.parseInt(bayIndex);
+        Mounted bay = entity.getCritical(loc, bayCritIndex - 1).getMount();
+        
+        Mounted ammo = new Mounted(entity, AmmoType.get(type));
+
+        try {
+            entity.addEquipment(ammo, loc, bay.isRearMounted());
+        } catch(LocationFullException lfe) {
+            // silently swallow it, since dropship locations have about a hundred crit slots
+        }
+        
+        bay.addAmmoToBay(entity.getEquipmentNum(ammo));
     }
     
     /**


### PR DESCRIPTION
This is a change that prevents the following behavior:

- Experimental tech level and year 3150
- User adds an Overlord A3 dropship
- User goes to configure -> equipment, looks at an AR-10 launcher, drops the two default warheads lower and adds some tele-operated ones in addition to the regular ones. clicks ok
- User goes back to configure -> equipment, now there are two ammo rows for the AR-10 launcher, one with just the regular warheads, one with the tele-operated ones.

This still preserves the behavior where clan weapons can't select IS ammo by setting the row's "tech base" to that of the weapon being displayed.

The changes to MULParser and EntityFileList prevent the following behavior:

- Unit adds Overlord A3
- User configures equipment, changes AR-10 launcher to have non-default ammo load out with at least three ammo types
- Save unit list to MUL file
- Load unit list from MUL file, the AR-10 launcher only has the first two ammo types loaded.