### PR TITLE
Board Background / BoardEditor fixes

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -692,6 +692,13 @@ public class BoardEditor extends JComponent implements ItemListener,
                 String title =  Messages.getString("BoardEditor.invalidBoard.title");
                 JOptionPane.showMessageDialog(this, msg, title, JOptionPane.ERROR_MESSAGE);
             }
+            // Board generation in a game always calls BoardUtilities.combine
+            // This serves no purpose here, but is necessary to create 
+            // flipBGVert/flipBGHoriz lists for the board, which is necessary 
+            // for the background image to work in the BoardEditor
+            board = BoardUtilities.combine(board.getWidth(), board.getHeight(), 1, 1, 
+                    new IBoard[]{board}, Arrays.asList(false), MapSettings.MEDIUM_GROUND);
+            game.setBoard(board);
             menuBar.setBoard(true);
         } catch (IOException ex) {
             System.err.println("error opening file to save!"); //$NON-NLS-1$

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -6580,9 +6580,10 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         int boardX = (int)((c.getX() + 0.0) / board.getSubBoardWidth());
         int boardY = (int)((c.getY() + 0.0) / board.getSubBoardHeight());
         int linIdx = boardY * board.getNumBoardsWidth() + boardX;
-        if (linIdx < 0 || linIdx > boardBackgrounds.size()) {
-            System.out.println("Error computing linear index "
-                    + "in BoardView1.getTransparentImage!");
+        if (linIdx < 0 || linIdx > boardBackgrounds.size() - 1) {
+            System.out.println("Error computing linear index or "
+                    + "missing background images "
+                    + "in BoardView1.getBoardBackgroundHexImage!");
             return null;
         }
         Image bgImg = getScaledImage(boardBackgrounds.get(linIdx), true);


### PR DESCRIPTION
Makes the BoardEditor able to load background images such as for the Carver Airstrip. Note: the BoardEditor won't save the BG image (-> further issue).