### PR TITLE
Implemented break in PD heat checks instead of continue

### DIFF
--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -266,11 +266,9 @@ public class WeaponHandler implements AttackHandler, Serializable {
                     
                     // build up some heat
                     //First Check to see if we have enough heat capacity to fire
-                    if (pdOverheated) {
-                        continue;
-                    } else if ((weaponHeat + bayW.getCurrentHeat()) > pdEnt.getHeatCapacity()) {
+                    if ((weaponHeat + bayW.getCurrentHeat()) > pdEnt.getHeatCapacity()) {
                         pdOverheated = true;
-                        continue;
+                        break;
                     }
                     if (counter.getType().hasFlag(WeaponType.F_HEATASDICE)) {
                         int heatDice = Compute.d6(bayW


### PR DESCRIPTION
Fixes bug preventing PD/AMS bays that will not cause the firing vessel to overheat from processing if they come after a bay that will cause the vessel to overheat. 