### PR TITLE
Pavement hexes not turned to mud in rainy conditions

### DIFF
--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -1003,7 +1003,9 @@ public class BoardUtilities {
                     if(hex.containsTerrain(Terrains.WATER) && !hex.containsTerrain(Terrains.RAPIDS) && (hex.depth() > 0)) {
                         hex.addTerrain(tf.createTerrain(Terrains.RAPIDS, 1));
                     }
-                    else if(!hex.containsTerrain(Terrains.BUILDING) && !hex.containsTerrain(Terrains.ROAD)) {
+                    else if(!hex.containsTerrain(Terrains.BUILDING)
+                            && !hex.containsTerrain(Terrains.PAVEMENT)
+                            && !hex.containsTerrain(Terrains.ROAD)) {
                         hex.addTerrain(tf.createTerrain(Terrains.MUD, 1));
                         if(hex.containsTerrain(Terrains.WATER)) {
                             hex.removeTerrain(Terrains.WATER);
@@ -1021,7 +1023,9 @@ public class BoardUtilities {
                         hex.addTerrain(tf.createTerrain(Terrains.SWAMP, 1));
                         hex.removeTerrain(Terrains.WATER);
                     }
-                    else if(!hex.containsTerrain(Terrains.BUILDING) && !hex.containsTerrain(Terrains.ROAD)) {
+                    else if(!hex.containsTerrain(Terrains.BUILDING) 
+                            && !hex.containsTerrain(Terrains.PAVEMENT)
+                            && !hex.containsTerrain(Terrains.ROAD)) {
                         hex.addTerrain(tf.createTerrain(Terrains.MUD, 1));
                     }
                 }


### PR DESCRIPTION
This should fix bug #546 

Previously rainy conditions would turn pavement hexes into mud+pavement, allowing units to get stuck (not mechs tho as these have since become unstuckable by mud). Now, like road and building hexes, pavement does not get mud.

Note that pavement+mud as well as swamp+mud can still be created in the BoardEditor and will still trigger bogdown. To solve this we'd have to define rules for such hexes.