### PR TITLE
Fixes boardview tooltip NPEs

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -5547,7 +5547,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 prevTipX = -1; prevTipY = -1;
                 // This is used to fool the tooltip manager into resetting the tip
                 ToolTipManager.sharedInstance().mousePressed(null);
-                return null;
+                return new String("");
             }
         }
         prevTipX = point.x; prevTipY = point.y;


### PR DESCRIPTION
`null` tooltips were generating NPEs.