### PR TITLE
Fix the image cache

### DIFF
--- a/megamek/src/megamek/client/ui/swing/TilesetManager.java
+++ b/megamek/src/megamek/client/ui/swing/TilesetManager.java
@@ -381,11 +381,17 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
         int width = board.getWidth();
         int height = board.getHeight();
         // We want to cache as many of the images as we can, but if we have
-        //  more images than cache size, lets not waste time
+        // more images than cache size, lets not waste time
         if ((width*height) > ImageCache.MAX_SIZE){
             // Find the largest size by size square we can fit in the cache
             int max_dim = (int)Math.sqrt(ImageCache.MAX_SIZE);
-            width = height = max_dim;
+            if (width < max_dim) {
+        	        height = (int)(ImageCache.MAX_SIZE / width);
+            } else if (height < max_dim) {
+        	        width = (int)(ImageCache.MAX_SIZE / height);
+            } else {
+                width = height = max_dim;
+            }
         }
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {

--- a/megamek/src/megamek/client/ui/swing/util/ImageCache.java
+++ b/megamek/src/megamek/client/ui/swing/util/ImageCache.java
@@ -27,7 +27,7 @@ public class ImageCache<K, V> {
     /**
      * Default maximum size
      */
-    public static int MAX_SIZE = 20000;
+    public static int MAX_SIZE = 30000;
     
 
     /**


### PR DESCRIPTION
Fix the image cache causing null hexes, and make the cache size larger to accommodate the most commonly played large board sizes