### PR TITLE
Observer Initiative & TacGen ICB Reset

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -2,21 +2,6 @@ VERSION HISTORY:
 ----------------
 v0.43.9-git
 + Issue #902: Fixed multiple issues relating to configuring ammo in weapon bays
-+ PR #916: Make MUL files work for tracking ammo on GunEmplacements
-+ PR #928: Corrections to scenarios, new keyword for handling random maps
-	Fixes Issue #927: Scenario random maps don't work with the new board directory structure
-+ PR #924: Fix for #215: Entity Sprites displacement in Deployment
-	Fixes Issue #215: Entity Sprites displacement in Deployment
-+ PR #921: Fixes boardview tooltip NPEs
-+ PR #919: Pavement hexes not turned to mud in rainy conditions
-	Fixes Issue #546: Can get bogged down on pavement
-+ PR #915: Board Background / BoardEditor fixes
-+ PR #839: Add check to ignore SI damage for squadron status display
-+ PR #917: Implemented break in PD heat checks instead of continue
-+ PR #909: Add MiscType entry for Clan Endo-Composite structure
-	Fixes Issue MegaMek/megameklab#143: Endo-Composite not showing up as an option
-+ PR #923: Bogdown after DFA
-	Fixes Issue #420: Jumping Mech is Not Bogged Down in Swamp Automatically After Sucessful DFA
 
 v0.43.8-RC2 (2018-02-11 22:40 UTC)
 + PR#877: Add the missing new skin files.

--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -2,6 +2,21 @@ VERSION HISTORY:
 ----------------
 v0.43.9-git
 + Issue #902: Fixed multiple issues relating to configuring ammo in weapon bays
++ PR #916: Make MUL files work for tracking ammo on GunEmplacements
++ PR #928: Corrections to scenarios, new keyword for handling random maps
+	Fixes Issue #927: Scenario random maps don't work with the new board directory structure
++ PR #924: Fix for #215: Entity Sprites displacement in Deployment
+	Fixes Issue #215: Entity Sprites displacement in Deployment
++ PR #921: Fixes boardview tooltip NPEs
++ PR #919: Pavement hexes not turned to mud in rainy conditions
+	Fixes Issue #546: Can get bogged down on pavement
++ PR #915: Board Background / BoardEditor fixes
++ PR #839: Add check to ignore SI damage for squadron status display
++ PR #917: Implemented break in PD heat checks instead of continue
++ PR #909: Add MiscType entry for Clan Endo-Composite structure
+	Fixes Issue MegaMek/megameklab#143: Endo-Composite not showing up as an option
++ PR #923: Bogdown after DFA
+	Fixes Issue #420: Jumping Mech is Not Bogged Down in Swamp Automatically After Sucessful DFA
 
 v0.43.8-RC2 (2018-02-11 22:40 UTC)
 + PR#877: Add the missing new skin files.

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -2428,11 +2428,17 @@ public class Game implements Serializable, IGame {
             TurnOrdered.rollInitAndResolveTies(getEntitiesVector(), vRerolls, false);
         } else {
             TurnOrdered.rollInitAndResolveTies(teams, initiativeRerollRequests,
-                                               getOptions()
-                                                       .booleanOption(OptionsConstants.INIT_INITIATIVE_STREAK_COMPENSATION));
+                    getOptions().booleanOption(OptionsConstants.INIT_INITIATIVE_STREAK_COMPENSATION));
         }
         initiativeRerollRequests.removeAllElements();
 
+    }
+    
+    public void handleInitiativeCompensation() {
+        if (getOptions().booleanOption(OptionsConstants.INIT_INITIATIVE_STREAK_COMPENSATION)) {
+            TurnOrdered.resetInitiativeCompensation(teams, initiativeRerollRequests,
+                    getOptions().booleanOption(OptionsConstants.INIT_INITIATIVE_STREAK_COMPENSATION));
+        }
     }
 
     public int getNoOfInitiativeRerollRequests() {

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -2436,8 +2436,7 @@ public class Game implements Serializable, IGame {
     
     public void handleInitiativeCompensation() {
         if (getOptions().booleanOption(OptionsConstants.INIT_INITIATIVE_STREAK_COMPENSATION)) {
-            TurnOrdered.resetInitiativeCompensation(teams, initiativeRerollRequests,
-                    getOptions().booleanOption(OptionsConstants.INIT_INITIATIVE_STREAK_COMPENSATION));
+            TurnOrdered.resetInitiativeCompensation(teams, getOptions().booleanOption(OptionsConstants.INIT_INITIATIVE_STREAK_COMPENSATION));
         }
     }
 

--- a/megamek/src/megamek/common/IGame.java
+++ b/megamek/src/megamek/common/IGame.java
@@ -1084,6 +1084,8 @@ public interface IGame {
     abstract void addInitiativeRerollRequest(Team t);
 
     abstract void rollInitAndResolveTies();
+    
+    abstract void handleInitiativeCompensation();
 
     abstract int getNoOfInitiativeRerollRequests();
 

--- a/megamek/src/megamek/common/InitiativeRoll.java
+++ b/megamek/src/megamek/common/InitiativeRoll.java
@@ -58,13 +58,23 @@ public class InitiativeRoll implements Comparable<InitiativeRoll>, Serializable 
     }
 
     /**
+     * Set observers to -1, and don't ever let them be anything else!
+     */
+    public void observerRoll() {
+        rolls.addElement(-1);
+        originalRolls.addElement(-1);
+        bonuses.addElement(0);
+        wasRollReplaced.addElement(new Boolean(false));
+    }
+
+    /**
      * Replace the previous init roll with a new one, and make a note that it
      * was replaced. Used for Tactical Genius special pilot ability (lvl 3).
      */
     public void replaceRoll(int bonus) {
         Integer roll = new Integer(Compute.d6(2));
         rolls.setElementAt(roll, size() - 1);
-        bonuses.setElementAt(bonus, size()-1);
+        bonuses.setElementAt(bonus, size() - 1);
         wasRollReplaced.setElementAt(new Boolean(true), size() - 1);
     }
 

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -282,7 +282,9 @@ public final class Player extends TurnOrdered implements IPlayer {
         if (!observer) {
             setSeeAll(false);
         }
-        game.getTeamForPlayer(this).cacheObversverStatus();
+        if (game != null && game.getTeamForPlayer(this) != null) {
+            game.getTeamForPlayer(this).cacheObversverStatus();
+        }
     }
 
     @Override

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -282,6 +282,7 @@ public final class Player extends TurnOrdered implements IPlayer {
         if (!observer) {
             setSeeAll(false);
         }
+        game.getTeamForPlayer(this).cacheObversverStatus();
     }
 
     @Override

--- a/megamek/src/megamek/common/Team.java
+++ b/megamek/src/megamek/common/Team.java
@@ -30,6 +30,7 @@ public final class Team extends TurnOrdered {
     private static final long serialVersionUID = 2270215552964191597L;
     private Vector<IPlayer> players = new Vector<IPlayer>();
     private int id;
+    private Boolean ObserverTeam = null;
 
     public Team(int newID) {
         id = newID;
@@ -53,6 +54,22 @@ public final class Team extends TurnOrdered {
 
     public void addPlayer(IPlayer p) {
         players.addElement(p);
+    }
+    
+    public boolean isObserverTeam() {
+        if (ObserverTeam == null) {
+            cacheObversverStatus();
+        }
+        return ObserverTeam.booleanValue();
+    }
+    
+    public void cacheObversverStatus() {
+        ObserverTeam = new Boolean(true);
+        for (int i = 0; i < players.size(); i++) {
+            if (!players.get(i).isObserver()) {
+                ObserverTeam = false;
+            }
+        }
     }
 
     //get the next player on this team.

--- a/megamek/src/megamek/common/Team.java
+++ b/megamek/src/megamek/common/Team.java
@@ -40,8 +40,28 @@ public final class Team extends TurnOrdered {
         return players.size();
     }
 
+    public int getNonObserverSize() {
+        int nonObservers = 0;
+        for (int i = 0; i < players.size(); i++) {
+            if (!players.get(i).isObserver()) {
+                nonObservers++;
+            }
+        }
+        return nonObservers;
+    }
+
     public Enumeration<IPlayer> getPlayers() {
         return players.elements();
+    }
+
+    public Enumeration<IPlayer> getNonObserverPlayers() {
+        Vector<IPlayer> nonObservers = new Vector<IPlayer>();
+        for (int i = 0; i < players.size(); i++) {
+            if (!players.get(i).isObserver()) {
+                nonObservers.add(players.get(i));
+            }
+        }
+        return nonObservers.elements();
     }
     
     public Vector<IPlayer> getPlayersVector() {

--- a/megamek/src/megamek/common/TurnOrdered.java
+++ b/megamek/src/megamek/common/TurnOrdered.java
@@ -280,14 +280,13 @@ public abstract class TurnOrdered implements ITurnOrdered {
      * 
      * @param v
      *            A vector of items that need to have turns.
-     * @param rerollRequests
      * @param bInitCompBonus
      *            A flag that determines whether initiative compensation bonus
      *            should be used: used to prevent one side getting long init win
      *            streaks
      */
     public static void resetInitiativeCompensation(List<? extends ITurnOrdered> v,
-            List<? extends ITurnOrdered> rerollRequests, boolean bInitCompBonus) {
+            boolean bInitCompBonus) {
         // initiative compensation
         if (bInitCompBonus && (v.size() > 0) && (v.get(0) instanceof Team)) {
             final ITurnOrdered comparisonElement = v.get(0);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -2688,6 +2688,10 @@ public class Server implements Runnable {
                 Enumeration<IPlayer> players2 = game.getPlayers();
                 while (players2.hasMoreElements()) {
                     IPlayer player = players2.nextElement();
+                    // Players who started the game as observers get ignored
+                    if (player.getInitialBV() == 0) {
+                        continue;
+                    }
                     Report r = new Report();
                     r.type = Report.PUBLIC;
                     if (doBlind() && suppressBlindBV()) {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -4218,12 +4218,18 @@ public class Server implements Runnable {
                 // use the team iniative
                 if (team.getSize() == 1) {
                     final IPlayer player = team.getPlayers().nextElement();
+                    if (player.isObserver()) {
+                        continue;
+                    }
                     r = new Report(1015, Report.PUBLIC);
                     r.add(Server.getColorForPlayer(player));
                     r.add(team.getInitiative().toString());
                     addReport(r);
                 } else {
                     // Multiple players. List the team, then break it down.
+                    if (team.isObserverTeam()) {
+                        continue;
+                    }
                     r = new Report(1015, Report.PUBLIC);
                     r.add(IPlayer.teamNames[team.getId()]);
                     r.add(team.getInitiative().toString());
@@ -4231,6 +4237,9 @@ public class Server implements Runnable {
                     for (Enumeration<IPlayer> j = team.getPlayers(); j
                             .hasMoreElements(); ) {
                         final IPlayer player = j.nextElement();
+                        if (player.isObserver()) {
+                            continue;
+                        }
                         r = new Report(1015, Report.PUBLIC);
                         r.indent();
                         r.add(player.getName());

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -2250,8 +2250,9 @@ public class Server implements Runnable {
 
         // need at least one entity in the game for the lounge phase to end
         if (!game.phaseHasTurns(game.getPhase())
-            && ((game.getPhase() != IGame.Phase.PHASE_LOUNGE) || (game
-                                                                          .getNoOfEntities() > 0))) {
+            && ((game.getPhase() != IGame.Phase.PHASE_LOUNGE)
+                    || (game.getNoOfEntities() > 0))) {
+            game.handleInitiativeCompensation();
             endCurrentPhase();
         }
     }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -2008,6 +2008,10 @@ public class Server implements Runnable {
         Enumeration<IPlayer> players = game.getPlayers();
         while (players.hasMoreElements()) {
             IPlayer player = players.nextElement();
+            // Players who started the game as observers get ignored
+            if (player.getInitialBV() == 0) {
+                continue;
+            }
             r = new Report();
             r.type = Report.PUBLIC;
             r.messageId = 7016;
@@ -4213,33 +4217,29 @@ public class Server implements Runnable {
         } else {
             for (Enumeration<Team> i = game.getTeams(); i.hasMoreElements(); ) {
                 final Team team = i.nextElement();
+                
+                // Teams with no active players can be ignored
+                if (team.isObserverTeam()) {
+                    continue;
+                }
 
-                // If there is only one player, list them as the 'team', and
-                // use the team iniative
-                if (team.getSize() == 1) {
-                    final IPlayer player = team.getPlayers().nextElement();
-                    if (player.isObserver()) {
-                        continue;
-                    }
+                // If there is only one non-observer player, list
+                // them as the 'team', and use the team initiative
+                if (team.getNonObserverSize() == 1) {
+                    final IPlayer player = team.getNonObserverPlayers().nextElement();
                     r = new Report(1015, Report.PUBLIC);
                     r.add(Server.getColorForPlayer(player));
                     r.add(team.getInitiative().toString());
                     addReport(r);
                 } else {
                     // Multiple players. List the team, then break it down.
-                    if (team.isObserverTeam()) {
-                        continue;
-                    }
                     r = new Report(1015, Report.PUBLIC);
                     r.add(IPlayer.teamNames[team.getId()]);
                     r.add(team.getInitiative().toString());
                     addReport(r);
-                    for (Enumeration<IPlayer> j = team.getPlayers(); j
+                    for (Enumeration<IPlayer> j = team.getNonObserverPlayers(); j
                             .hasMoreElements(); ) {
                         final IPlayer player = j.nextElement();
-                        if (player.isObserver()) {
-                            continue;
-                        }
                         r = new Report(1015, Report.PUBLIC);
                         r.indent();
                         r.add(player.getName());


### PR DESCRIPTION
This PR addresses the following:
Fixes #339 
Fixes #345 
Fixes #804
Fixes round reports showing initiative for observers
Fixes round reports showing BV information for players who never had any (original observers)