### PR TITLE
Artillery Class Cast Errors

### DIFF
--- a/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
@@ -727,6 +727,7 @@ public class PointblankShotDisplay extends FiringDisplay implements
                         clientgui.frame);
                 vsd.setVisible(true);
                 waa.setOtherAttackInfo(vsd.getSetting());
+                waa.setHomingShot(ammoType.getMunitionType() == AmmoType.M_HOMING && ammoMount.curMode().equals("Homing"));
             }
         }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -5853,12 +5853,12 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             }
             
             txt.append("<TABLE BORDER=0 BGCOLOR=#FFDDDD width=100%><TR><TD><FONT color=\"black\">");
-            if (aaa.turnsTilHit == 1)
+            if (aaa.getTurnsTilHit() == 1)
                 txt.append(Messages.getString("BoardView1.Tooltip.ArtilleryAttack1", 
                         new Object[] { wpName, ammoName }));
             else
                 txt.append(Messages.getString("BoardView1.Tooltip.ArtilleryAttackN", 
-                        new Object[] { wpName, ammoName, aaa.turnsTilHit }));
+                        new Object[] { wpName, ammoName, aaa.getTurnsTilHit() }));
             txt.append("</FONT></TD></TR></TABLE>");
         }
 

--- a/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
+++ b/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
@@ -34,7 +34,7 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements
      * 
      */
     private static final long serialVersionUID = -3893844894076028005L;
-    public int turnsTilHit;
+    private int turnsTilHit;
     private Vector<Integer> spotterIds; // IDs of possible spotters, won't know
                                         // until it lands.
     protected int playerId;
@@ -125,5 +125,21 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements
         // adjust distance for gravity
         distance = (int)Math.floor((double)distance/game.getPlanetaryConditions().getGravity());
         this.turnsTilHit = (int) (distance / launchVelocity); 
+    }
+    
+    public int getTurnsTilHit() {
+        return this.turnsTilHit;
+    }
+    
+    public void setTurnsTilHit(int turnsTilHit) {
+        this.turnsTilHit = turnsTilHit;
+    }
+    
+    public void decrementTurnsTilHit() {
+        decrementTurnsTilHit(1);
+    }
+    
+    public void decrementTurnsTilHit(int numTurns) {
+        this.turnsTilHit-=numTurns;
     }
 }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -157,6 +157,12 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
      * not be modified for terrain or movement. See TW pg 260
      */
     protected boolean isPointblankShot = false;
+    
+    /**
+     * Boolean flag that determines if this shot was fired using homing ammunition.
+     * Can be checked to allow casting of attack handlers to the proper homing handler.
+     */
+    protected boolean isHomingShot = false;
 
     // default to attacking an entity
     public WeaponAttackAction(int entityId, int targetId, int weaponId) {
@@ -4415,6 +4421,14 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
     public void setPointblankShot(boolean isPointblankShot) {
         this.isPointblankShot = isPointblankShot;
+    }
+
+    public boolean isHomingShot() {
+        return isHomingShot;
+    }
+
+    public void setHomingShot(boolean isHomingShot) {
+        this.isHomingShot = isHomingShot;
     }
     
     /*

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -158,33 +158,33 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                 r.newlines = 0;
                 r.subject = subjectId;
                 r.add(wtype.getName());
-                r.add(aaa.turnsTilHit);
+                r.add(aaa.getTurnsTilHit());
                 vPhaseReport.addElement(r);
                 Report.addNewline(vPhaseReport);
                 handledAmmoAndReport = true;
 
                 artyMsg = "Artillery bay fire Incoming, landing on round "
-                        + (game.getRoundCount() + aaa.turnsTilHit)
+                        + (game.getRoundCount() + aaa.getTurnsTilHit())
                         + ", fired by "
                         + game.getPlayer(aaa.getPlayerId()).getName();
                 game.getBoard().addSpecialHexDisplay(
                         aaa.getTarget(game).getPosition(),
                         new SpecialHexDisplay(
                                 SpecialHexDisplay.Type.ARTILLERY_INCOMING, game
-                                        .getRoundCount() + aaa.turnsTilHit,
+                                        .getRoundCount() + aaa.getTurnsTilHit(),
                                 game.getPlayer(aaa.getPlayerId()), artyMsg,
                                 SpecialHexDisplay.SHD_OBSCURED_TEAM));
             }
             // if this is the last targeting phase before we hit,
             // make it so the firing entity is announced in the
             // off-board attack phase that follows.
-            if (aaa.turnsTilHit == 0) {
+            if (aaa.getTurnsTilHit() == 0) {
                 setAnnouncedEntityFiring(false);
             }
             return true;
         }
-        if (aaa.turnsTilHit > 0) {
-            aaa.turnsTilHit--;
+        if (aaa.getTurnsTilHit() > 0) {
+            aaa.decrementTurnsTilHit();
             return true;
         }
         final Vector<Integer> spottersBefore = aaa.getSpotterIds();

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectHomingHandler.java
@@ -77,7 +77,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends
                 r.newlines = 0;
                 r.subject = subjectId;
                 r.add(wtype.getName());
-                r.add(aaa.turnsTilHit);
+                r.add(aaa.getTurnsTilHit());
                 vPhaseReport.addElement(r);
                 Report.addNewline(vPhaseReport);
                 handledAmmoAndReport = true;
@@ -85,13 +85,13 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends
             // if this is the last targeting phase before we hit,
             // make it so the firing entity is announced in the
             // off-board attack phase that follows.
-            if (aaa.turnsTilHit == 0) {
+            if (aaa.getTurnsTilHit() == 0) {
                 setAnnouncedEntityFiring(false);
             }
             return true;
         }
-        if (aaa.turnsTilHit > 0) {
-            aaa.turnsTilHit--;
+        if (aaa.getTurnsTilHit() > 0) {
+            aaa.decrementTurnsTilHit();
             return true;
         }
         Entity entityTarget;

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -112,33 +112,33 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                 r.newlines = 0;
                 r.subject = subjectId;
                 r.add(wtype.getName());
-                r.add(aaa.turnsTilHit);
+                r.add(aaa.getTurnsTilHit());
                 vPhaseReport.addElement(r);
                 Report.addNewline(vPhaseReport);
                 handledAmmoAndReport = true;
 
                 artyMsg = "Artillery fire Incoming, landing on round "
-                        + (game.getRoundCount() + aaa.turnsTilHit)
+                        + (game.getRoundCount() + aaa.getTurnsTilHit())
                         + ", fired by "
                         + game.getPlayer(aaa.getPlayerId()).getName();
                 game.getBoard().addSpecialHexDisplay(
                         aaa.getTarget(game).getPosition(),
                         new SpecialHexDisplay(
                                 SpecialHexDisplay.Type.ARTILLERY_INCOMING, game
-                                        .getRoundCount() + aaa.turnsTilHit,
+                                        .getRoundCount() + aaa.getTurnsTilHit(),
                                 game.getPlayer(aaa.getPlayerId()), artyMsg,
                                 SpecialHexDisplay.SHD_OBSCURED_TEAM));
             }
             // if this is the last targeting phase before we hit,
             // make it so the firing entity is announced in the
             // off-board attack phase that follows.
-            if (aaa.turnsTilHit == 0) {
+            if (aaa.getTurnsTilHit() == 0) {
                 setAnnouncedEntityFiring(false);
             }
             return true;
         }
-        if (aaa.turnsTilHit > 0) {
-            aaa.turnsTilHit--;
+        if (aaa.getTurnsTilHit() > 0) {
+            aaa.decrementTurnsTilHit();
             return true;
         }
         final Vector<Integer> spottersBefore = aaa.getSpotterIds();

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -84,7 +84,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends
                 r.newlines = 0;
                 r.subject = subjectId;
                 r.add(wtype.getName());
-                r.add(aaa.turnsTilHit);
+                r.add(aaa.getTurnsTilHit());
                 vPhaseReport.addElement(r);
                 Report.addNewline(vPhaseReport);
                 handledAmmoAndReport = true;
@@ -92,13 +92,13 @@ public class ArtilleryWeaponIndirectHomingHandler extends
             // if this is the last targeting phase before we hit,
             // make it so the firing entity is announced in the
             // off-board attack phase that follows.
-            if (aaa.turnsTilHit == 0) {
+            if (aaa.getTurnsTilHit() == 0) {
                 setAnnouncedEntityFiring(false);
             }
             return true;
         }
-        if (aaa.turnsTilHit > 0) {
-            aaa.turnsTilHit--;
+        if (aaa.getTurnsTilHit() > 0) {
+            aaa.decrementTurnsTilHit();
             return true;
         }
         Entity entityTarget;

--- a/megamek/src/megamek/common/weapons/CapitalMissileBearingsOnlyHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBearingsOnlyHandler.java
@@ -171,7 +171,7 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
                 r.newlines = 0;
                 r.subject = subjectId;
                 r.add(wtype.getName());
-                r.add(aaa.turnsTilHit);
+                r.add(aaa.getTurnsTilHit());
                 vPhaseReport.addElement(r);
                 Report.addNewline(vPhaseReport);
                 handledAmmoAndReport = true;
@@ -179,13 +179,13 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
             // if this is the last targeting phase before we hit,
             // make it so the firing entity is announced in the
             // off-board attack phase that follows.
-            if (aaa.turnsTilHit == 0) {
+            if (aaa.getTurnsTilHit() == 0) {
                 setAnnouncedEntityFiring(false);
             }
             return true;
         }
-        if (aaa.turnsTilHit > 0) {
-            aaa.turnsTilHit--;
+        if (aaa.getTurnsTilHit() > 0) {
+            aaa.decrementTurnsTilHit();
             return true;
         }
         Entity entityTarget = (aaa.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) aaa

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -13995,35 +13995,30 @@ public class Server implements Runnable {
                 continue;
             }
             
-            if (waa instanceof ArtilleryAttackAction) {
-                Entity target;
+            // For Bearings-only Capital Missiles
+            if (wh instanceof CapitalMissileBearingsOnlyHandler) {
                 ArtilleryAttackAction aaa = (ArtilleryAttackAction) waa;
-                if (wh instanceof CapitalMissileBearingsOnlyHandler) {
-                    if (aaa.turnsTilHit > 0 || game.getPhase() != IGame.Phase.PHASE_FIRING) {
-                        continue;
-                    }
-                    //For Bearings-only Capital Missiles
-                    target = (waa.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) waa
-                            .getTarget(game) : null;
-                    if (target == null) {
-                        continue;
-                    } 
-                } else {
-                    //For all other types of homing artillery
-                    target = (waa.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) waa
-                        .getTarget(game) : null;
-                    if (target == null) {
-                        //this will pick our TAG target back up and assign it to the waa                    
-                        ArtilleryWeaponIndirectHomingHandler hh = (ArtilleryWeaponIndirectHomingHandler) wh;
-                        hh.convertHomingShotToEntityTarget();
-                        target = (waa.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) waa
-                                .getTarget(game) : null;
-                        if (target == null) {
-                            //in case our target really is null. 
-                            continue;
-                        }
-                    }            
+                if (aaa.turnsTilHit > 0 || game.getPhase() != IGame.Phase.PHASE_FIRING) {
+                    continue;
                 }
+            }
+
+            // For all other types of homing artillery
+            if (waa instanceof ArtilleryAttackAction) {
+                // This will pick our TAG target back up and assign it to the waa
+                if (waa.isHomingShot() && wh instanceof ArtilleryWeaponIndirectHomingHandler) {
+                    ArtilleryWeaponIndirectHomingHandler hh = (ArtilleryWeaponIndirectHomingHandler) wh;
+                    hh.convertHomingShotToEntityTarget();
+                }
+
+                Entity target = (waa.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) waa
+                        .getTarget(game) : null;
+
+                // In case our target really is null.
+                if (target == null) {
+                    continue;
+                }
+
                 Vector<WeaponHandler> v = htAttacks.get(target);
                 if (v == null) {
                     v = new Vector<WeaponHandler>();

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -13998,7 +13998,7 @@ public class Server implements Runnable {
             // For Bearings-only Capital Missiles
             if (wh instanceof CapitalMissileBearingsOnlyHandler) {
                 ArtilleryAttackAction aaa = (ArtilleryAttackAction) waa;
-                if (aaa.turnsTilHit > 0 || game.getPhase() != IGame.Phase.PHASE_FIRING) {
+                if (aaa.getTurnsTilHit() > 0 || game.getPhase() != IGame.Phase.PHASE_FIRING) {
                     continue;
                 }
             }


### PR DESCRIPTION
Cleans up code in Server.assignAMS() related to an NPE that is caused by non-homing artillery rounds being casted to homing shots.
Partial fix for Issue #936: 0.43.9-RC3 Princess crashes
