### PR TITLE
Fix for tooltip NPEs, #936

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -4756,6 +4756,11 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     }
 
     public void mouseExited(MouseEvent me) {
+        // Reset the tooltip dismissal delay to the preference
+        // value so that elements outside the boardview can
+        // use tooltips
+        ToolTipManager.sharedInstance().setDismissDelay(
+                GUIPreferences.getInstance().getTooltipDismissDelay());
     }
 
     public void mouseClicked(MouseEvent me) {
@@ -5535,7 +5540,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
     public String getToolTipText(MouseEvent e) {
         // If new instance of mouse event, redraw obscured hexes and elevations.
         repaint();
-
+        
         StringBuffer txt = new StringBuffer();
         IHex mhex = null;
         final Point point = e.getPoint();
@@ -5545,9 +5550,11 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             double deltaMagnitude = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
             if (deltaMagnitude > GUIPreferences.getInstance().getTooltipDistSuppression()) {
                 prevTipX = -1; prevTipY = -1;
-                // This is used to fool the tooltip manager into resetting the tip
-                ToolTipManager.sharedInstance().mousePressed(null);
-                return new String("");
+                // Set the dismissal delay to 0 so that the tooltip 
+                // goes away and does not reappear until the mouse 
+                // has moved more than the suppression distance 
+                ToolTipManager.sharedInstance().setDismissDelay(0);
+                return new String(""); //$NON-NLS-1$
             }
         }
         prevTipX = point.x; prevTipY = point.y;
@@ -5921,13 +5928,18 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         }
 
         txt.append("</html>"); //$NON-NLS-1$
+
         // Check to see if the tool tip is completely empty
-        if (txt.toString().equals("<html></html>")) {
-            // Returning null prevents the tooltip from being displayed
-            // This prevents a small blue tooltip rectangle being drawn at the
-            // edge of the board
-            return null;
+        if (txt.toString().equals("<html></html>")) { //$NON-NLS-1$
+            return new String(""); //$NON-NLS-1$
         }
+        
+        // Now that a valid tooltip text seems to be present,
+        // (re)set the tooltip dismissal delay time to the preference 
+        // value so that the tooltip actually appears
+        ToolTipManager.sharedInstance().setDismissDelay(
+                GUIPreferences.getInstance().getTooltipDismissDelay());
+        
         return txt.toString();
     }
 


### PR DESCRIPTION
Suggestion for a fix for #936 (the tooltip NPEs part).

This uses the dismissal delay to get rid of the tooltip. The TT does not always vanish at once; when the mouse is moved really fast the tooltip stays visible for a few frames but it mostly works. No NPEs.

I tried the other few settings of the ToolTipManager but none of them seemed useful.

I also checked the suppression distances and it's really difficult to move the mouse without getting 1, 2, 4 as the first distances (in that order). Therefore I'd recommend less than 5 as the default suppression distance. For me 0 works best.
