### PR TITLE
Fix for #936 - check if an entity has been moved before trying to move it

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -712,6 +712,12 @@ public class Princess extends BotClient {
         final StringBuilder msg = new StringBuilder("Deciding who to move next.");
         for (final Entity entity : myEntities) {
             msg.append("\n\tUnit ").append(entity.getDisplayName());
+            
+            if(entity.isDone()) {
+                msg.append("has already moved this phase");
+                continue;
+            }
+            
             if ((entity.isOffBoard() 
                 || (null == entity.getPosition())
                 || !getGame().getTurn().isValidEntity(entity, getGame()))


### PR DESCRIPTION
Just what the title says.