### PR TITLE
Ground to air fix (fix for #864)

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -1,6 +1,7 @@
 VERSION HISTORY:
 ----------------
 v0.43.9-git
++ Issue #902: Fixed multiple issues relating to configuring ammo in weapon bays
 
 v0.43.8-RC2 (2018-02-11 22:40 UTC)
 + PR#877: Add the missing new skin files.

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -476,7 +476,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
     protected int getAMSHitsMod(Vector<Report> vPhaseReport) {
         if ((target == null)
                 || (target.getTargetType() != Targetable.TYPE_ENTITY)
-                || (waa.isAirToAir(game) && CounterAV > 0)) {
+                || CounterAV > 0) {
             return 0;
         }
         int apdsMod = 0;

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -781,8 +781,8 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         attackValue = calcAttackValue();
         CounterAV = getCounterAV();
         
-        //This is for firing ATM/LRM/MML/MRM/SRMs at a dropship
-        if (entityTarget != null && entityTarget.usesWeaponBays()) {
+        //This is for firing ATM/LRM/MML/MRM/SRMs at a dropship, but is ignored for ground-to-air fire
+        if (entityTarget != null && entityTarget.usesWeaponBays() && !waa.isGroundToAir(game)) {
             nDamPerHit = attackValue;
         } else {
             //This is for all other targets in atmosphere
@@ -810,10 +810,8 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         int nCluster = calcnCluster();
         int id = vPhaseReport.size();
         int hits;
-        if (target.isAirborne() || 
-            game.getBoard().inSpace() || 
-            (entityTarget != null && entityTarget.usesWeaponBays() &&
-                    !game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_IND_WEAPONS_GROUNDED_DROPPER))) {
+        if (game.getBoard().inSpace() ||
+            (target.isAirborne() && !waa.isGroundToAir(game))) {
             // Ensures AMS state is properly updated
             getAMSHitsMod(new Vector<Report>());
             int[] aeroResults = calcAeroDamage(entityTarget, vPhaseReport);

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -807,7 +807,11 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         CounterAV = getCounterAV();
         
         //This is for firing ATM/LRM/MML/MRM/SRMs at a dropship, but is ignored for ground-to-air fire
-        if (entityTarget != null && entityTarget.usesWeaponBays() && !waa.isGroundToAir(game)) {
+        if (entityTarget != null 
+                && entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP) 
+                //Capital fighters and grounded dropships using weapons bays still use AV
+                && (ae.isCapitalFighter() || (ae.hasETypeFlag(Entity.ETYPE_DROPSHIP) && ae.usesWeaponBays()))
+                && !waa.isGroundToAir(game)) {
             nDamPerHit = attackValue;
         } else {
             //This is for all other targets in atmosphere

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -27,6 +27,7 @@ import megamek.common.BattleArmor;
 import megamek.common.Building;
 import megamek.common.Compute;
 import megamek.common.Coords;
+import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.EquipmentMode;
 import megamek.common.EquipmentType;
@@ -174,6 +175,14 @@ public class WeaponHandler implements AttackHandler, Serializable {
                 //Don't defend against ground fire with bay fire unless attacked by bay fire
                 //Prevents ammo and heat being used twice for dropships defending here and with getAMSHitsMod()
                 || (waa.isGroundToAir(game) && !ae.usesWeaponBays())) {
+            return false;
+        }
+        if (target instanceof Dropship 
+                && waa.isAirToGround(game)
+                && !ae.usesWeaponBays()
+                && game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_IND_WEAPONS_GROUNDED_DROPPER)) {
+            //Prevents a grounded dropship using individual weapons from engaging with AMSBays unless attacked by a dropship or capital fighter
+            //You can get some blank missile weapons fire reports due to the attackvalue / ndamageperhit conversion if this isn't done
             return false;
         }
         return true;

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -919,7 +919,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
             int nCluster = calcnCluster();
             int id = vPhaseReport.size();
             int hits = calcHits(vPhaseReport);
-            if (target.isAirborne() || game.getBoard().inSpace() || ae.usesWeaponBays()) {
+            if ((target.isAirborne() && !waa.isGroundToAir(game)) || game.getBoard().inSpace() || ae.usesWeaponBays()) {
                 // if we added a line to the phase report for calc hits, remove
                 // it now
                 while (vPhaseReport.size() > id) {

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -170,7 +170,10 @@ public class WeaponHandler implements AttackHandler, Serializable {
         advancedPD = game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADV_POINTDEF);
         if ((target == null)
                 || (target.getTargetType() != Targetable.TYPE_ENTITY)
-                || !advancedPD) {
+                || !advancedPD
+                //Don't defend against ground fire with bay fire unless attacked by bay fire
+                //Prevents ammo and heat being used twice for dropships defending here and with getAMSHitsMod()
+                || (waa.isGroundToAir(game) && !ae.usesWeaponBays())) {
             return false;
         }
         return true;

--- a/megamek/src/megamek/common/weapons/capitalweapons/AR10Weapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/AR10Weapon.java
@@ -89,11 +89,7 @@ public class AR10Weapon extends CapitalMissileWeapon {
             WeaponAttackAction waa, IGame game, Server server) {
         AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
                 .getEquipment(waa.getWeaponId()).getLinked().getType();
-        // Let's try not doing this. We should be able to deal with nuclear ammo from the cap missile handler.
-       /* if (atype.hasFlag(AmmoType.F_NUCLEAR)) {
-            return new SantaAnnaHandler(toHit, waa, game, server);
-        } */
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE)) {
+        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace()) {
             return new TeleMissileHandler(toHit, waa, game, server);
         }
         return new AR10Handler(toHit, waa, game, server);

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissKillerWhaleWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissKillerWhaleWeapon.java
@@ -86,7 +86,7 @@ public class CapMissKillerWhaleWeapon extends CapitalMissileWeapon {
             WeaponAttackAction waa, IGame game, Server server) {
         AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
                 .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE)) {
+        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace()) {
             return new TeleMissileHandler(toHit, waa, game, server);
         }
         return new KillerWhaleHandler(toHit, waa, game, server);

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissKrakenWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissKrakenWeapon.java
@@ -84,7 +84,7 @@ public class CapMissKrakenWeapon extends CapitalMissileWeapon {
             WeaponAttackAction waa, IGame game, Server server) {
         AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
                 .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE)) {
+        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace()) {
             return new TeleMissileHandler(toHit, waa, game, server);
         }
         return new CapitalMissileHandler (toHit, waa, game, server);

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleBarracudaWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleBarracudaWeapon.java
@@ -85,7 +85,7 @@ public class CapMissTeleBarracudaWeapon extends CapitalMissileWeapon {
             WeaponAttackAction waa, IGame game, Server server) {
         AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
                 .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE))
+        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace())
             return new BarracudaTHandler(toHit, waa, game, server);
         return new BarracudaHandler(toHit, waa, game, server);
     }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKillerWhaleWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKillerWhaleWeapon.java
@@ -84,7 +84,7 @@ public class CapMissTeleKillerWhaleWeapon extends CapitalMissileWeapon {
             WeaponAttackAction waa, IGame game, Server server) {
         AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
                 .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE))
+        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace())
             return new KillerWhaleTHandler(toHit, waa, game, server);
         return new KillerWhaleHandler(toHit, waa, game, server);
     }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKrakenWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKrakenWeapon.java
@@ -21,6 +21,7 @@ import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AttackHandler;
+import megamek.common.weapons.CapitalMissileHandler;
 import megamek.common.weapons.KrakenTHandler;
 import megamek.server.Server;
 
@@ -83,6 +84,9 @@ public class CapMissTeleKrakenWeapon extends CapitalMissileWeapon {
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, IGame game, Server server) {
-        return new KrakenTHandler(toHit, waa, game, server);
+        if (game.getBoard().inSpace()) {
+            return new KrakenTHandler(toHit, waa, game, server);
+        }
+        return new CapitalMissileHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleWhiteSharkWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleWhiteSharkWeapon.java
@@ -85,7 +85,7 @@ public class CapMissTeleWhiteSharkWeapon extends CapitalMissileWeapon {
             WeaponAttackAction waa, IGame game, Server server) {
         AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
                 .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE))
+        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace())
             return new WhiteSharkTHandler(toHit, waa, game, server);
         return new WhiteSharkHandler(toHit, waa, game, server);
     }


### PR DESCRIPTION
Changes behavior of ground-to-air fire so that attacks use the cluster hits table and ground ranges rather than converting to AV and inflicting 0 damage if range > short. 

Also allows aero AMS to engage these attacks and cleans up the getAMSHitsMod method to the same standards as CalcCounterAV. 

In further testing, I found and resolved a number of bugs affecting reporting/AMS/Damage resolution and its interaction with the optional rules "Grounded Dropships use individual weapons"  and "Single fighters not capital"  I have resolved these and I'm satisfied that this doesn't break any previously working functionality around aero combat in space/atmo. 

Probably needs a new review, though. 