### PR TITLE
Fix for #829: Weapon Mode button

### DIFF
--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -1676,8 +1676,7 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
         if (weaponId == -1) {
             setFireModeEnabled(false);
         } else {
-            Mounted m = ce().getEquipment(weaponId);
-            setFireModeEnabled(m.isModeSwitchable());
+            adaptFireModeEnabled(ce().getEquipment(weaponId));
         }
         updateTarget();
     }
@@ -1698,8 +1697,7 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
         if (weaponId == -1) {
             setFireModeEnabled(false);
         } else {
-            Mounted m = ce().getEquipment(weaponId);
-            setFireModeEnabled(m.isModeSwitchable());
+            adaptFireModeEnabled(ce().getEquipment(weaponId));
         }
         updateTarget();
     }
@@ -1984,8 +1982,7 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
         }
 
         if ((weaponId != -1) && (ce() != null) && !isStrafing) {
-            Mounted m = ce().getEquipment(weaponId);
-            setFireModeEnabled(m.isModeSwitchable());
+            adaptFireModeEnabled(ce().getEquipment(weaponId));
         }
 
         updateSearchlight();
@@ -2391,6 +2388,19 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
     protected void setFireModeEnabled(boolean enabled) {
         buttons.get(FiringCommand.FIRE_MODE).setEnabled(enabled);
         clientgui.getMenuBar().setFireModeEnabled(enabled);
+    }
+    
+    /**
+     * Enables the mode button when mode switching is allowed
+     * (always true except for LAMs with certain weapons) and
+     * the weapon has modes. Disables otherwise.
+     *  
+     * @param m The active weapon
+     */
+    protected void adaptFireModeEnabled(Mounted m) {
+        if (m.isModeSwitchable()) {
+            setFireModeEnabled(m.getType().hasModes());
+        } 
     }
 
     protected void setFireCalledEnabled(boolean enabled) {

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -1667,17 +1667,12 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
         if (ce() == null) {
             return;
         }
-        int weaponId = clientgui.mechD.wPan.selectNextWeapon();
+        clientgui.mechD.wPan.selectNextWeapon();
 
         if (ce().getId() != clientgui.mechD.wPan.getSelectedEntityId()) {
             clientgui.mechD.wPan.displayMech(ce());
         }
 
-        if (weaponId == -1) {
-            setFireModeEnabled(false);
-        } else {
-            adaptFireModeEnabled(ce().getEquipment(weaponId));
-        }
         updateTarget();
     }
 
@@ -1688,17 +1683,13 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
         if (ce() == null) {
             return;
         }
-        int weaponId = clientgui.mechD.wPan.selectPrevWeapon();
+
+        clientgui.mechD.wPan.selectPrevWeapon();
 
         if (ce().getId() != clientgui.mechD.wPan.getSelectedEntityId()) {
             clientgui.mechD.wPan.displayMech(ce());
         }
 
-        if (weaponId == -1) {
-            setFireModeEnabled(false);
-        } else {
-            adaptFireModeEnabled(ce().getEquipment(weaponId));
-        }
         updateTarget();
     }
 
@@ -1983,7 +1974,9 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
 
         if ((weaponId != -1) && (ce() != null) && !isStrafing) {
             adaptFireModeEnabled(ce().getEquipment(weaponId));
-        }
+        } else {
+            setFireModeEnabled(false);
+        } 
 
         updateSearchlight();
 
@@ -2398,9 +2391,7 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
      * @param m The active weapon
      */
     protected void adaptFireModeEnabled(Mounted m) {
-        if (m.isModeSwitchable()) {
-            setFireModeEnabled(m.getType().hasModes());
-        } 
+        setFireModeEnabled(m.isModeSwitchable() & m.getType().hasModes());
     }
 
     protected void setFireCalledEnabled(boolean enabled) {

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -28,7 +28,6 @@ import java.util.Vector;
 
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.bayweapons.BayWeapon;
-import megamek.common.weapons.lasers.EnergyWeapon;
 import megamek.common.weapons.ppc.PPCWeapon;
 
 /**
@@ -3328,36 +3327,6 @@ public class Aero extends Entity implements IAero, IBomber {
     @Override
     public boolean didAccDecNow() {
         return accDecNow;
-    }
-
-    @Override
-    public void setGameOptions() {
-        super.setGameOptions();
-
-        for (Mounted mounted : getWeaponList()) {
-            if ((mounted.getType() instanceof EnergyWeapon)
-                    && (((WeaponType) mounted.getType()).getAmmoType() == AmmoType.T_NA) && (game != null)
-                    && game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_ENERGY_WEAPONS)) {
-
-                ArrayList<String> modes = new ArrayList<String>();
-                String[] stringArray = {};
-                int damage = ((WeaponType) mounted.getType()).getDamage();
-
-                if (damage == WeaponType.DAMAGE_VARIABLE) {
-                    damage = ((WeaponType) mounted.getType()).damageShort;
-                }
-
-                for (; damage >= 0; damage--) {
-                    modes.add("Damage " + damage);
-                }
-                if (((WeaponType) mounted.getType()).hasFlag(WeaponType.F_FLAMER)) {
-                    modes.add("Heat");
-                }
-                ((WeaponType) mounted.getType()).setModes(modes.toArray(stringArray));
-            }
-
-        }
-
     }
 
     /*

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11634,10 +11634,8 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         }
 
         for (Mounted mounted : getWeaponList()) {
-
             if (mounted.getType() instanceof Weapon)
                 ((Weapon) mounted.getType()).adaptToGameOptions(game.getOptions());
-            // TODO: Gauss remove mode text when weapon stays unchanged
         }
 
         for (Mounted misc : getMisc()) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -62,6 +62,7 @@ import megamek.common.weapons.AltitudeBombAttack;
 import megamek.common.weapons.CapitalMissileBearingsOnlyHandler;
 import megamek.common.weapons.DiveBombAttack;
 import megamek.common.weapons.SpaceBombAttack;
+import megamek.common.weapons.Weapon;
 import megamek.common.weapons.WeaponHandler;
 import megamek.common.weapons.autocannons.ACWeapon;
 import megamek.common.weapons.battlearmor.ISBAPopUpMineLauncher;
@@ -11641,6 +11642,10 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         }
 
         for (Mounted mounted : getWeaponList()) {
+                  
+            if (mounted.getType() instanceof Weapon)
+                ((Weapon) mounted.getType()).adaptToGameOptions(game.getOptions());
+            
             if ((mounted.getType() instanceof GaussWeapon)
                 && gameOpts.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GAUSS_WEAPONS)) {
                 String[] modes = {"Powered Up", "Powered Down"};

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11634,19 +11634,10 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         }
 
         for (Mounted mounted : getWeaponList()) {
-                  
+
             if (mounted.getType() instanceof Weapon)
                 ((Weapon) mounted.getType()).adaptToGameOptions(game.getOptions());
-            
-            // TODO: Gauss behavior (Chat: "Switch to normal")
             // TODO: Gauss remove mode text when weapon stays unchanged
-            // Bombast Laser: OK
-            // Gauss: Semi-OK
-            // Energy Weapon: OK
-            // PPC Inhibitor: OK
-            // AC rapid fire & kind rapid fire: OK
-            
-
         }
 
         for (Mounted misc : getMisc()) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11646,29 +11646,27 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             if (mounted.getType() instanceof Weapon)
                 ((Weapon) mounted.getType()).adaptToGameOptions(game.getOptions());
             
-            if ((mounted.getType() instanceof GaussWeapon)
-                && gameOpts.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GAUSS_WEAPONS)) {
-                String[] modes = {"Powered Up", "Powered Down"};
-                ((WeaponType) mounted.getType()).setModes(modes);
-                ((WeaponType) mounted.getType()).setInstantModeSwitch(false);
-            } else if ((mounted.getType() instanceof ACWeapon)
+            if ((mounted.getType() instanceof ACWeapon)
                        && gameOpts.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RAPID_AC)) {
                 String[] modes = {"", "Rapid"};
                 ((WeaponType) mounted.getType()).setModes(modes);
+                // -----> is in mounted. should be in ACWeapon
                 if (gameOpts.booleanOption(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC)) {
                     mounted.setKindRapidFire(true);
                 }
-            } else if (mounted.getType() instanceof ISBombastLaser) {
-                int damage = 12;
-                ArrayList<String> modes = new ArrayList<String>();
-                String[] stringArray = {};
-
-                for (; damage >= 7; damage--) {
-                    modes.add("Damage " + damage);
-                }
-                ((WeaponType) mounted.getType()).setModes(modes
-                                                                  .toArray(stringArray));
-            } else if (((WeaponType) mounted.getType()).isCapital()
+            } else 
+//                if (mounted.getType() instanceof ISBombastLaser) {
+//                int damage = 12;
+//                ArrayList<String> modes = new ArrayList<String>();
+//                String[] stringArray = {};
+//
+//                for (; damage >= 7; damage--) {
+//                    modes.add("Damage " + damage);
+//                }
+//                ((WeaponType) mounted.getType()).setModes(modes
+//                                                                  .toArray(stringArray));
+//            } else 
+                if (((WeaponType) mounted.getType()).isCapital()
                        && (((WeaponType) mounted.getType()).getAtClass()
                            != WeaponType.CLASS_CAPITAL_MISSILE)
                        && (((WeaponType) mounted.getType()).getAtClass()

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -64,13 +64,10 @@ import megamek.common.weapons.DiveBombAttack;
 import megamek.common.weapons.SpaceBombAttack;
 import megamek.common.weapons.Weapon;
 import megamek.common.weapons.WeaponHandler;
-import megamek.common.weapons.autocannons.ACWeapon;
 import megamek.common.weapons.battlearmor.ISBAPopUpMineLauncher;
 import megamek.common.weapons.bayweapons.AR10BayWeapon;
 import megamek.common.weapons.bayweapons.BayWeapon;
-import megamek.common.weapons.bayweapons.CapitalLaserBayWeapon;
 import megamek.common.weapons.bayweapons.CapitalMissileBayWeapon;
-import megamek.common.weapons.bayweapons.SubCapLaserBayWeapon;
 import megamek.common.weapons.bayweapons.TeleOperatedMissileBayWeapon;
 import megamek.common.weapons.bombs.BombArrowIV;
 import megamek.common.weapons.bombs.BombISRL10;
@@ -84,8 +81,6 @@ import megamek.common.weapons.bombs.ISASEWMissileWeapon;
 import megamek.common.weapons.bombs.ISASMissileWeapon;
 import megamek.common.weapons.bombs.ISBombTAG;
 import megamek.common.weapons.bombs.ISLAAMissileWeapon;
-import megamek.common.weapons.gaussrifles.GaussWeapon;
-import megamek.common.weapons.lasers.ISBombastLaser;
 import megamek.common.weapons.other.TSEMPWeapon;
 
 /**
@@ -11629,10 +11624,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         if ((this instanceof SmallCraft) && !(this instanceof Dropship)
             && !hasActiveECM() && isMilitary()) {
             try {
-                String prefix = "IS";
-                if (isClan()) {
-                    prefix = "CL";
-                }
+                String prefix = isClan() ? "CL" : "IS";
                 this.addEquipment(
                         EquipmentType.get(prefix + BattleArmor.SINGLE_HEX_ECM),
                         Aero.LOC_NOSE, false);
@@ -11646,102 +11638,14 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             if (mounted.getType() instanceof Weapon)
                 ((Weapon) mounted.getType()).adaptToGameOptions(game.getOptions());
             
-            if ((mounted.getType() instanceof ACWeapon)
-                       && gameOpts.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RAPID_AC)) {
-                String[] modes = {"", "Rapid"};
-                ((WeaponType) mounted.getType()).setModes(modes);
-                // -----> is in mounted. should be in ACWeapon
-                if (gameOpts.booleanOption(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC)) {
-                    mounted.setKindRapidFire(true);
-                }
-            } else 
-//                if (mounted.getType() instanceof ISBombastLaser) {
-//                int damage = 12;
-//                ArrayList<String> modes = new ArrayList<String>();
-//                String[] stringArray = {};
-//
-//                for (; damage >= 7; damage--) {
-//                    modes.add("Damage " + damage);
-//                }
-//                ((WeaponType) mounted.getType()).setModes(modes
-//                                                                  .toArray(stringArray));
-//            } else 
-                if (((WeaponType) mounted.getType()).isCapital()
-                       && (((WeaponType) mounted.getType()).getAtClass()
-                           != WeaponType.CLASS_CAPITAL_MISSILE)
-                       && (((WeaponType) mounted.getType()).getAtClass()
-                               != WeaponType.CLASS_TELE_MISSILE)
-                       && (((WeaponType) mounted.getType()).getAtClass()
-                           != WeaponType.CLASS_AR10)) {
-                ArrayList<String> modes = new ArrayList<String>();
-                String[] stringArray = {};
-                modes.add("");
-                if (gameOpts.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BRACKET_FIRE)) {
-                    modes.add("Bracket 80%");
-                    modes.add("Bracket 60%");
-                    modes.add("Bracket 40%");
-                }
-                if (((mounted.getType() instanceof CapitalLaserBayWeapon)
-                     || (mounted.getType() instanceof SubCapLaserBayWeapon))
-                    && gameOpts.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_AAA_LASER)) {
-                    modes.add("AAA");
-                    ((WeaponType) mounted.getType()).addEndTurnMode("AAA");
-                }
-                if (modes.size() > 1) {
-                    ((WeaponType) mounted.getType()).setModes(modes
-                                                                      .toArray(stringArray));
-                }
-            } else if ((((WeaponType) mounted.getType()).getAtClass() == WeaponType.CLASS_CAPITAL_MISSILE)
-                        || (((WeaponType) mounted.getType()).getAtClass() == WeaponType.CLASS_AR10)) {
-                 ArrayList<String> modes = new ArrayList<String>();
-                 String[] stringArray = {};
-                 ((WeaponType) mounted.getType()).setInstantModeSwitch(false);
-                 modes.add("Normal");
-                 if (gameOpts.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BEARINGS_ONLY_LAUNCH)) {
-                     modes.add("Bearings-Only Extreme Detection Range");
-                     modes.add("Bearings-Only Long Detection Range");
-                     modes.add("Bearings-Only Medium Detection Range");
-                     modes.add("Bearings-Only Short Detection Range");
-                 }
-
-                 if (modes.size() > 1) {
-                     ((WeaponType) mounted.getType()).setModes(modes
-                                                                       .toArray(stringArray));
-                 }
-                 
-            } else if ((((WeaponType) mounted.getType()).getAtClass() == WeaponType.CLASS_TELE_MISSILE)) {
-                ArrayList<String> modes = new ArrayList<String>();
-                String[] stringArray = {};
-                ((WeaponType) mounted.getType()).setInstantModeSwitch(false);
-                modes.add("Normal");
-                modes.add("Tele-Operated");                
-                if (gameOpts.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BEARINGS_ONLY_LAUNCH)) {
-                    modes.add("Bearings-Only Extreme Detection Range");
-                    modes.add("Bearings-Only Long Detection Range");
-                    modes.add("Bearings-Only Medium Detection Range");
-                    modes.add("Bearings-Only Short Detection Range");
-                }
-
-                if (modes.size() > 1) {
-                    ((WeaponType) mounted.getType()).setModes(modes
-                                                                      .toArray(stringArray));
-                }
-                
-            } else if (mounted.getType().hasFlag(WeaponType.F_AMS)
-                       && !gameOpts.booleanOption(OptionsConstants.BASE_AUTO_AMS)) {
-                Enumeration<EquipmentMode> modeEnum = mounted.getType().getModes();
-                ArrayList<String> newModes = new ArrayList<>();
-                while (modeEnum.hasMoreElements()) {
-                    newModes.add(modeEnum.nextElement().getName());
-                }
-                if (!newModes.contains("Automatic")) {
-                    newModes.add("Automatic");
-                }
-                String modes[] = new String[newModes.size()];
-                newModes.toArray(modes);
-                ((WeaponType) mounted.getType()).setModes(modes);
-                ((WeaponType) mounted.getType()).setInstantModeSwitch(false);
-            }
+            // TODO: Gauss behavior (Chat: "Switch to normal")
+            // TODO: Gauss remove mode text when weapon stays unchanged
+            // Bombast Laser: OK
+            // Gauss: Semi-OK
+            // Energy Weapon: OK
+            // PPC Inhibitor: OK
+            // AC rapid fire & kind rapid fire: OK
+            
 
         }
 

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -468,7 +468,7 @@ public class EquipmentType implements ITechnology {
      *         it can be in.
      */
     public boolean hasModes() {
-        return modes != null;
+        return (modes != null) && (!modes.isEmpty());
     }
 
     /**
@@ -529,6 +529,24 @@ public class EquipmentType implements ITechnology {
     public boolean removeMode(String mode) {
         if (modes != null) {
             return modes.remove(EquipmentMode.getMode(mode));
+        } else {
+            return false;
+        }
+    }
+    
+    /**
+     * Add a mode to the Equipment
+     *
+     * @param mode The mode to be added
+     * @return true if the mode was added; false if modes was null or the mode was already present
+     * @author Simon (Juliez)
+     */
+    public boolean addMode(String mode) {
+        if (modes == null) {
+            modes = new Vector<EquipmentMode>();
+        }
+        if (!modes.contains(EquipmentMode.getMode(mode))) {
+            return modes.add(EquipmentMode.getMode(mode));
         } else {
             return false;
         }

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -7478,11 +7478,6 @@ public abstract class Mech extends Entity {
     }
 
     @Override
-    public void setGameOptions() {
-        super.setGameOptions();
-    }
-
-    @Override
     public void setGrappleSide(int side) {
         grappledSide = side;
     }

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -44,7 +44,6 @@ import megamek.common.weapons.gaussrifles.GaussWeapon;
 import megamek.common.weapons.lasers.CLImprovedHeavyLaserLarge;
 import megamek.common.weapons.lasers.CLImprovedHeavyLaserMedium;
 import megamek.common.weapons.lasers.CLImprovedHeavyLaserSmall;
-import megamek.common.weapons.lasers.EnergyWeapon;
 import megamek.common.weapons.lasers.ISRISCHyperLaser;
 import megamek.common.weapons.other.ISMekTaser;
 import megamek.common.weapons.other.TSEMPWeapon;
@@ -7481,40 +7480,6 @@ public abstract class Mech extends Entity {
     @Override
     public void setGameOptions() {
         super.setGameOptions();
-
-        for (Mounted mounted : getWeaponList()) {
-            if ((mounted.getType() instanceof EnergyWeapon)
-                    && (((WeaponType) mounted.getType()).getAmmoType() == AmmoType.T_NA)
-                    && (game != null)
-                    && game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_ENERGY_WEAPONS)) {
-
-                ArrayList<String> modes = new ArrayList<String>();
-                String[] stringArray = {};
-
-                if ((mounted.getType() instanceof PPCWeapon) && (((WeaponType) mounted.getType()).getMinimumRange() > 0)
-                        && game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_PPC_INHIBITORS)) {
-                    modes.add("Field Inhibitor ON");
-                    modes.add("Field Inhibitor OFF");
-                }
-                int damage = ((WeaponType) mounted.getType()).getDamage();
-
-                if (damage == WeaponType.DAMAGE_VARIABLE) {
-                    damage = ((WeaponType) mounted.getType()).damageShort;
-                }
-
-                for (; damage >= 0; damage--) {
-                    modes.add("Damage " + damage);
-                }
-                if (((WeaponType) mounted.getType())
-                        .hasFlag(WeaponType.F_FLAMER)) {
-                    modes.add("Heat");
-                }
-                ((WeaponType) mounted.getType()).setModes(modes
-                        .toArray(stringArray));
-            }
-
-        }
-
     }
 
     @Override

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -53,7 +53,7 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
     private boolean tsempDowntime = false; // Needed for "every other turn"
                                            // TSEMP.
     private boolean rapidfire = false; // MGs in rapid-fire mode
-    private boolean kindRapidFire = false; // Reduced jam chance for rapid fired
+//    private boolean kindRapidFire = false; // Reduced jam chance for rapid fired
                                            // ACs.
     private boolean hotloaded = false; // Hotloading for ammoType
     private boolean repairable = true; // can the equipment mounted here be
@@ -1674,13 +1674,13 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         return facing;
     }
 
-    public boolean isKindRapidFire() {
-        return kindRapidFire;
-    }
-
-    public void setKindRapidFire(boolean kindRapidFire) {
-        this.kindRapidFire = kindRapidFire;
-    }
+//    public boolean isKindRapidFire() {
+//        return kindRapidFire;
+//    }
+//
+//    public void setKindRapidFire(boolean kindRapidFire) {
+//        this.kindRapidFire = kindRapidFire;
+//    }
 
     public int getOriginalShots() {
         return originalShots;

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -363,7 +363,11 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
                 mode = newMode;
                 pendingMode = -1;
             } else if (pendingMode != newMode) {
-                pendingMode = newMode;
+                if (mode == newMode) {
+                    pendingMode = -1;
+                } else {
+                    pendingMode = newMode;
+                }
             }
         }
         // all communications equipment mounteds need to have the same mode at

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -53,8 +53,6 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
     private boolean tsempDowntime = false; // Needed for "every other turn"
                                            // TSEMP.
     private boolean rapidfire = false; // MGs in rapid-fire mode
-//    private boolean kindRapidFire = false; // Reduced jam chance for rapid fired
-                                           // ACs.
     private boolean hotloaded = false; // Hotloading for ammoType
     private boolean repairable = true; // can the equipment mounted here be
     // repaired
@@ -1677,14 +1675,6 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
     public int getFacing() {
         return facing;
     }
-
-//    public boolean isKindRapidFire() {
-//        return kindRapidFire;
-//    }
-//
-//    public void setKindRapidFire(boolean kindRapidFire) {
-//        this.kindRapidFire = kindRapidFire;
-//    }
 
     public int getOriginalShots() {
         return originalShots;

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1677,7 +1677,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                 }
             }
         }
-        if (weapon.isKindRapidFire() && weapon.curMode().equals("Rapid")) {
+        if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC) 
+                && weapon.curMode().equals("Rapid")) {
             toHit.addModifier(1, "AC rapid fire mode");
         }
 

--- a/megamek/src/megamek/common/weapons/CLIATMWeapon.java
+++ b/megamek/src/megamek/common/weapons/CLIATMWeapon.java
@@ -19,6 +19,8 @@ import megamek.common.IGame;
 import megamek.common.TechAdvancement;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.missiles.MissileWeapon;
 import megamek.server.Server;
 
@@ -41,7 +43,6 @@ public abstract class CLIATMWeapon extends MissileWeapon {
         techAdvancement.setTechRating(RATING_F);
         techAdvancement.setAvailability(new int[]{ RATING_X, RATING_X, RATING_F, RATING_E });
         
-        setModes(new String[] { "", "Indirect" }); // iATMS can IDF
     }
 
     /*
@@ -84,5 +85,19 @@ public abstract class CLIATMWeapon extends MissileWeapon {
     @Override
     public boolean hasIndirectFire() {
         return true;
+    }
+    
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Indirect Fire
+        if (gOp.booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
+            addMode("");
+            addMode("Indirect");
+        } else {
+            removeMode("");
+            removeMode("Indirect");
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/RapidfireACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/RapidfireACWeaponHandler.java
@@ -26,6 +26,7 @@ import megamek.common.Mounted;
 import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 
 /**
@@ -37,7 +38,7 @@ public class RapidfireACWeaponHandler extends UltraWeaponHandler {
      */
     private static final long serialVersionUID = -1770392652874842106L;
 
-    private boolean kindRapidFire = false;
+//    private boolean kindRapidFire = false;
 
     /**
      * @param t
@@ -49,13 +50,13 @@ public class RapidfireACWeaponHandler extends UltraWeaponHandler {
         super(t, w, g, s);
     }
 
-    public boolean getKindRapidFire() {
-        return kindRapidFire;
-    }
-
-    public void setKindRapidFire(boolean kindRapidFire) {
-        this.kindRapidFire = kindRapidFire;
-    }
+//    public boolean getKindRapidFire() {
+//        return kindRapidFire;
+//    }
+//
+//    public void setKindRapidFire(boolean kindRapidFire) {
+//        this.kindRapidFire = kindRapidFire;
+//    }
 
     /*
      * (non-Javadoc)
@@ -65,6 +66,8 @@ public class RapidfireACWeaponHandler extends UltraWeaponHandler {
     @Override
     protected boolean doChecks(Vector<Report> vPhaseReport) {
         int jamLevel = 4;
+        boolean kindRapidFire = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC);
+//        if (kindRapidFire) {
         if (kindRapidFire) {
             jamLevel = 2;
         }

--- a/megamek/src/megamek/common/weapons/RapidfireACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/RapidfireACWeaponHandler.java
@@ -38,8 +38,6 @@ public class RapidfireACWeaponHandler extends UltraWeaponHandler {
      */
     private static final long serialVersionUID = -1770392652874842106L;
 
-//    private boolean kindRapidFire = false;
-
     /**
      * @param t
      * @param w
@@ -50,14 +48,6 @@ public class RapidfireACWeaponHandler extends UltraWeaponHandler {
         super(t, w, g, s);
     }
 
-//    public boolean getKindRapidFire() {
-//        return kindRapidFire;
-//    }
-//
-//    public void setKindRapidFire(boolean kindRapidFire) {
-//        this.kindRapidFire = kindRapidFire;
-//    }
-
     /*
      * (non-Javadoc)
      * 
@@ -67,7 +57,6 @@ public class RapidfireACWeaponHandler extends UltraWeaponHandler {
     protected boolean doChecks(Vector<Report> vPhaseReport) {
         int jamLevel = 4;
         boolean kindRapidFire = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC);
-//        if (kindRapidFire) {
         if (kindRapidFire) {
             jamLevel = 2;
         }

--- a/megamek/src/megamek/common/weapons/Weapon.java
+++ b/megamek/src/megamek/common/weapons/Weapon.java
@@ -27,6 +27,8 @@ import megamek.common.WeaponType;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
+import megamek.common.weapons.bayweapons.CapitalLaserBayWeapon;
+import megamek.common.weapons.bayweapons.SubCapLaserBayWeapon;
 import megamek.server.Server;
 
 /**
@@ -63,26 +65,81 @@ public abstract class Weapon extends WeaponType implements Serializable {
     }
     
     /**
-     * Adapt the weapon to the Game Options such as
+     * Adapt the weapon type to the Game Options such as
      * PPC Field Inhbitiors or Dial Down Damage, usually
      * adding or removing modes. <B><I>When overriding this in a
-     * weapon subclass, call super() first!</I></B>
+     * weapon subclass, call super()!</I></B>
      * 
      * @param gOp The GameOptions (game.getOptions())
      * @author Simon (Juliez)
      */
     public void adaptToGameOptions(GameOptions gOp) {
-        // First remove all present modes;
-        // Modes have to be re-added here or by overriding this method
-        // in the different sub-classes. 
-        clearModes();
-
         // Flamers are spread out over all sorts of weapon types not limited to FlamerWeapon.
-        // Therefore modes are added here.
-        if (gOp.booleanOption(OptionsConstants.BASE_FLAMER_HEAT) 
-                && hasFlag(WeaponType.F_FLAMER)) {
-            addMode("Damage");
-            addMode("Heat");
+        // Therefore modes are handled here.
+        if (hasFlag(WeaponType.F_FLAMER)) {
+            if (gOp.booleanOption(OptionsConstants.BASE_FLAMER_HEAT)) {
+                addMode("Damage");
+                addMode("Heat");
+            } else {
+                removeMode("Damage");
+                removeMode("Heat");
+            }
+        }
+        
+        // Capital weapons are spread out over all sorts of weapons.
+        if (isCapital()) {
+            if ((getAtClass() != WeaponType.CLASS_CAPITAL_MISSILE)
+                    && (getAtClass() != WeaponType.CLASS_TELE_MISSILE)
+                    && (getAtClass() != WeaponType.CLASS_AR10)) {
+
+                if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BRACKET_FIRE)) {
+                    addMode("");
+                    addMode("Bracket 80%");
+                    addMode("Bracket 60%");
+                    addMode("Bracket 40%");
+                } else {
+                    removeMode("Bracket 80%");
+                    removeMode("Bracket 60%");
+                    removeMode("Bracket 40%");
+                }
+                if ((this instanceof CapitalLaserBayWeapon)
+                        || (this instanceof SubCapLaserBayWeapon)) {
+                    if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_AAA_LASER)) {
+                        addMode("");
+                        addMode("AAA");
+                        addEndTurnMode("AAA");
+                    } else {
+                        removeMode("AAA");
+                    }
+                }
+                // If only the standard mode "" is left, remove that as well
+                if (getModesCount() == 1) {
+                    clearModes();
+                }
+
+            } else {
+
+                if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BEARINGS_ONLY_LAUNCH)) {
+                    setInstantModeSwitch(false);
+                    addMode("Bearings-Only Extreme Detection Range");
+                    addMode("Bearings-Only Long Detection Range");
+                    addMode("Bearings-Only Medium Detection Range");
+                    addMode("Bearings-Only Short Detection Range");
+                } else {
+                    removeMode("Bearings-Only Extreme Detection Range");
+                    removeMode("Bearings-Only Long Detection Range");
+                    removeMode("Bearings-Only Medium Detection Range");
+                    removeMode("Bearings-Only Short Detection Range");
+                }
+            }
+        }
+
+        if (hasFlag(WeaponType.F_AMS)) {
+            if (gOp.booleanOption(OptionsConstants.BASE_AUTO_AMS)) {
+                removeMode("Automatic");
+            } else {
+                addMode("Automatic");
+            }
         }
     }
 }

--- a/megamek/src/megamek/common/weapons/Weapon.java
+++ b/megamek/src/megamek/common/weapons/Weapon.java
@@ -25,6 +25,8 @@ import megamek.common.TargetRoll;
 import megamek.common.ToHitData;
 import megamek.common.WeaponType;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 
 /**
@@ -58,5 +60,29 @@ public abstract class Weapon extends WeaponType implements Serializable {
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, IGame game, Server server) {
         return new WeaponHandler(toHit, waa, game, server);
+    }
+    
+    /**
+     * Adapt the weapon to the Game Options such as
+     * PPC Field Inhbitiors or Dial Down Damage, usually
+     * adding or removing modes. When overriding this in a
+     * weapon subclass, super() should be called.
+     * 
+     * @param gOp The GameOptions (game.getOptions())
+     * @author Simon (Juliez)
+     */
+    public void adaptToGameOptions(GameOptions gOp) {
+        // First remove all present modes;
+        // Modes have to be re-added here or by overriding this method
+        // in the different sub-classes. 
+        clearModes();
+
+        // Flamers are spread out over all sorts of weapon types not limited to FlamerWeapon
+        // Therefore modes are added here.
+        if (gOp.booleanOption(OptionsConstants.BASE_FLAMER_HEAT) 
+                && hasFlag(WeaponType.F_FLAMER)) {
+            addMode("Damage");
+            addMode("Heat");
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/Weapon.java
+++ b/megamek/src/megamek/common/weapons/Weapon.java
@@ -92,16 +92,6 @@ public abstract class Weapon extends WeaponType implements Serializable {
                     && (getAtClass() != WeaponType.CLASS_TELE_MISSILE)
                     && (getAtClass() != WeaponType.CLASS_AR10)) {
 
-                if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BRACKET_FIRE)) {
-                    addMode("");
-                    addMode("Bracket 80%");
-                    addMode("Bracket 60%");
-                    addMode("Bracket 40%");
-                } else {
-                    removeMode("Bracket 80%");
-                    removeMode("Bracket 60%");
-                    removeMode("Bracket 40%");
-                }
                 if ((this instanceof CapitalLaserBayWeapon)
                         || (this instanceof SubCapLaserBayWeapon)) {
                     if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_AAA_LASER)) {
@@ -111,6 +101,16 @@ public abstract class Weapon extends WeaponType implements Serializable {
                     } else {
                         removeMode("AAA");
                     }
+                }
+                if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BRACKET_FIRE)) {
+                    addMode("");
+                    addMode("Bracket 80%");
+                    addMode("Bracket 60%");
+                    addMode("Bracket 40%");
+                } else {
+                    removeMode("Bracket 80%");
+                    removeMode("Bracket 60%");
+                    removeMode("Bracket 40%");
                 }
                 // If only the standard mode "" is left, remove that as well
                 if (getModesCount() == 1) {

--- a/megamek/src/megamek/common/weapons/Weapon.java
+++ b/megamek/src/megamek/common/weapons/Weapon.java
@@ -65,8 +65,8 @@ public abstract class Weapon extends WeaponType implements Serializable {
     /**
      * Adapt the weapon to the Game Options such as
      * PPC Field Inhbitiors or Dial Down Damage, usually
-     * adding or removing modes. When overriding this in a
-     * weapon subclass, super() should be called.
+     * adding or removing modes. <B><I>When overriding this in a
+     * weapon subclass, call super() first!</I></B>
      * 
      * @param gOp The GameOptions (game.getOptions())
      * @author Simon (Juliez)
@@ -77,7 +77,7 @@ public abstract class Weapon extends WeaponType implements Serializable {
         // in the different sub-classes. 
         clearModes();
 
-        // Flamers are spread out over all sorts of weapon types not limited to FlamerWeapon
+        // Flamers are spread out over all sorts of weapon types not limited to FlamerWeapon.
         // Therefore modes are added here.
         if (gOp.booleanOption(OptionsConstants.BASE_FLAMER_HEAT) 
                 && hasFlag(WeaponType.F_FLAMER)) {

--- a/megamek/src/megamek/common/weapons/artillery/ArtilleryCannonWeapon.java
+++ b/megamek/src/megamek/common/weapons/artillery/ArtilleryCannonWeapon.java
@@ -20,6 +20,8 @@ package megamek.common.weapons.artillery;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.AmmoWeapon;
 import megamek.common.weapons.ArtilleryCannonWeaponHandler;
 import megamek.common.weapons.AttackHandler;
@@ -37,7 +39,6 @@ public abstract class ArtilleryCannonWeapon extends AmmoWeapon {
 
     public ArtilleryCannonWeapon() {
         super();
-        setModes(new String[] { "", "Indirect" });
         damage = DAMAGE_ARTILLERY;
         flags = flags.or(F_BALLISTIC).or(F_MECH_WEAPON).or(F_AERO_WEAPON)
                 .or(F_TANK_WEAPON);
@@ -58,5 +59,19 @@ public abstract class ArtilleryCannonWeapon extends AmmoWeapon {
         // AmmoType atype = (AmmoType)
         // game.getEntity(waa.getEntityId()).getEquipment(waa.getWeaponId()).getLinked().getType();
         return new ArtilleryCannonWeaponHandler(toHit, waa, game, server);
+    }
+    
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Indirect Fire
+        if (gOp.booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
+            addMode("");
+            addMode("Indirect");
+        } else {
+            removeMode("");
+            removeMode("Indirect");
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
@@ -78,11 +78,6 @@ public abstract class ACWeapon extends AmmoWeapon {
 
         if (weapon.curMode().equals("Rapid")) {
             RapidfireACWeaponHandler ah = new RapidfireACWeaponHandler(toHit, waa, game, server);
-//            if (weapon.isKindRapidFire()) {
-//                ah.setKindRapidFire(true);
-//            } else {
-//                ah.setKindRapidFire(false);
-//            }
             return ah;
         }
         if (atype.getMunitionType() == AmmoType.M_ARMOR_PIERCING) {

--- a/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
@@ -78,11 +78,11 @@ public abstract class ACWeapon extends AmmoWeapon {
 
         if (weapon.curMode().equals("Rapid")) {
             RapidfireACWeaponHandler ah = new RapidfireACWeaponHandler(toHit, waa, game, server);
-            if (weapon.isKindRapidFire()) {
-                ah.setKindRapidFire(true);
-            } else {
-                ah.setKindRapidFire(false);
-            }
+//            if (weapon.isKindRapidFire()) {
+//                ah.setKindRapidFire(true);
+//            } else {
+//                ah.setKindRapidFire(false);
+//            }
             return ah;
         }
         if (atype.getMunitionType() == AmmoType.M_ARMOR_PIERCING) {
@@ -149,13 +149,13 @@ public abstract class ACWeapon extends AmmoWeapon {
     public void adaptToGameOptions(GameOptions gOp) {
         super.adaptToGameOptions(gOp);
 
-        // Add modes for allowing standard and light AC rapid fire
+        // Modes for allowing standard and light AC rapid fire
         if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RAPID_AC)) {
             addMode("");
             addMode("Rapid");
-//            if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC)) {
-//                mounted.setKindRapidFire(true);
-//            }
+        } else {
+            removeMode("");
+            removeMode("Rapid");
         }
     }
     

--- a/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
@@ -144,4 +144,19 @@ public abstract class ACWeapon extends AmmoWeapon {
     public int getBattleForceClass() {
         return BFCLASS_AC;
     }
+    
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Add modes for allowing standard and light AC rapid fire
+        if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RAPID_AC)) {
+            addMode("");
+            addMode("Rapid");
+//            if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC)) {
+//                mounted.setKindRapidFire(true);
+//            }
+        }
+    }
+    
 }

--- a/megamek/src/megamek/common/weapons/battlearmor/BAFlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/BAFlamerWeapon.java
@@ -43,8 +43,8 @@ public abstract class BAFlamerWeapon extends Weapon {
         flags = flags.or(F_FLAMER).or(F_ENERGY).or(F_BA_WEAPON)
                 .or(F_BURST_FIRE).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
         ammoType = AmmoType.T_NA;
-        String[] modeStrings = { "Damage", "Heat" };
-        setModes(modeStrings);
+//        String[] modeStrings = { "Damage", "Heat" };
+//        setModes(modeStrings);
         atClass = CLASS_POINT_DEFENSE;
     }
 

--- a/megamek/src/megamek/common/weapons/battlearmor/BAFlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/BAFlamerWeapon.java
@@ -43,8 +43,6 @@ public abstract class BAFlamerWeapon extends Weapon {
         flags = flags.or(F_FLAMER).or(F_ENERGY).or(F_BA_WEAPON)
                 .or(F_BURST_FIRE).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
         ammoType = AmmoType.T_NA;
-//        String[] modeStrings = { "Damage", "Heat" };
-//        setModes(modeStrings);
         atClass = CLASS_POINT_DEFENSE;
     }
 

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASupportPPC.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASupportPPC.java
@@ -51,7 +51,6 @@ public class CLBASupportPPC extends PPCWeapon {
         tonnage = 0.240;
         criticals = 2;
         flags = flags.or(F_BA_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
-        setModes(new String[] { "Field Inhibitor ON", "Field Inhibitor OFF" });
         cost = 14000;
         rulesRefs = "267,TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN).setTechRating(RATING_D)

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASupportPPC.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASupportPPC.java
@@ -52,7 +52,6 @@ public class ISBASupportPPC extends PPCWeapon {
         criticals = 2;
         flags = flags.or(F_BA_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);;
         bv = 12;
-        setModes(new String[] { "Field Inhibitor ON", "Field Inhibitor OFF" });
         rulesRefs = "267,TM";
         techAdvancement.setTechBase(TechAdvancement.TECH_BASE_IS)
             .setISAdvancement(3046, 3053, 3056).setTechRating(RATING_D)

--- a/megamek/src/megamek/common/weapons/bayweapons/TeleOperatedMissileBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/TeleOperatedMissileBayWeapon.java
@@ -43,6 +43,9 @@ public class TeleOperatedMissileBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Tele-Operated Capital Missile Bay";
+        String[] modeStrings = { "Normal", "Tele-Operated" };
+        setModes(modeStrings);
+        setInstantModeSwitch(false);
         this.setInternalName(this.name);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleBarracudaWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleBarracudaWeapon.java
@@ -42,6 +42,9 @@ public class CapMissTeleBarracudaWeapon extends CapitalMissileWeapon {
         this.name = "Tele-operated Missile (Barracuda-T)";
         this.setInternalName(this.name);
         this.addLookupName("BarracudaT");
+        String[] modeStrings = { "Normal", "Tele-Operated" };
+        setModes(modeStrings);
+        setInstantModeSwitch(false);
         this.heat = 10;
         this.damage = 2;
         this.ammoType = AmmoType.T_BARRACUDA_T;

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKillerWhaleWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKillerWhaleWeapon.java
@@ -42,6 +42,9 @@ public class CapMissTeleKillerWhaleWeapon extends CapitalMissileWeapon {
         this.name = "Tele-operated Missile (Killer Whale-T)";
         this.setInternalName(this.name);
         this.addLookupName("KillerWhaleT");
+        String[] modeStrings = { "Normal", "Tele-Operated" };
+        setModes(modeStrings);
+        setInstantModeSwitch(false);
         this.heat = 20;
         this.damage = 4;
         this.ammoType = AmmoType.T_KILLER_WHALE_T;

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKrakenWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKrakenWeapon.java
@@ -42,6 +42,9 @@ public class CapMissTeleKrakenWeapon extends CapitalMissileWeapon {
         this.setInternalName(this.name);
         this.addLookupName("KrakenT");
         this.addLookupName("Kraken T");
+        String[] modeStrings = { "Normal", "Tele-Operated" };
+        setModes(modeStrings);
+        setInstantModeSwitch(false);
         this.heat = 50;
         this.damage = 10;
         this.ammoType = AmmoType.T_KRAKEN_T;

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleWhiteSharkWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleWhiteSharkWeapon.java
@@ -42,6 +42,9 @@ public class CapMissTeleWhiteSharkWeapon extends CapitalMissileWeapon {
         this.name = "Tele-operated Missile (White Shark-T)";
         this.setInternalName(this.name);
         this.addLookupName("WhiteSharkT");
+        String[] modeStrings = { "Normal", "Tele-Operated" };
+        setModes(modeStrings);
+        setInstantModeSwitch(false);
         this.heat = 15;
         this.damage = 3;
         this.ammoType = AmmoType.T_WHITE_SHARK_T;

--- a/megamek/src/megamek/common/weapons/flamers/FlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/flamers/FlamerWeapon.java
@@ -41,8 +41,6 @@ public abstract class FlamerWeapon extends EnergyWeapon {
         super();
         flags = flags.or(F_FLAMER).or(F_BURST_FIRE);
         ammoType = AmmoType.T_NA;
-//        String[] modeStrings = { "Damage", "Heat" };
-//        setModes(modeStrings);
         atClass = CLASS_POINT_DEFENSE;
     }
 

--- a/megamek/src/megamek/common/weapons/flamers/FlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/flamers/FlamerWeapon.java
@@ -41,8 +41,8 @@ public abstract class FlamerWeapon extends EnergyWeapon {
         super();
         flags = flags.or(F_FLAMER).or(F_BURST_FIRE);
         ammoType = AmmoType.T_NA;
-        String[] modeStrings = { "Damage", "Heat" };
-        setModes(modeStrings);
+//        String[] modeStrings = { "Damage", "Heat" };
+//        setModes(modeStrings);
         atClass = CLASS_POINT_DEFENSE;
     }
 

--- a/megamek/src/megamek/common/weapons/flamers/VehicleFlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/flamers/VehicleFlamerWeapon.java
@@ -45,8 +45,8 @@ public abstract class VehicleFlamerWeapon extends AmmoWeapon {
         flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON)
                 .or(F_FLAMER).or(F_ENERGY).or(F_BURST_FIRE);
         ammoType = AmmoType.T_VEHICLE_FLAMER;
-        String[] modeStrings = { "Damage", "Heat" };
-        setModes(modeStrings);
+//        String[] modeStrings = { "Damage", "Heat" };
+//        setModes(modeStrings);
         atClass = CLASS_POINT_DEFENSE;
     }
 

--- a/megamek/src/megamek/common/weapons/flamers/VehicleFlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/flamers/VehicleFlamerWeapon.java
@@ -45,8 +45,6 @@ public abstract class VehicleFlamerWeapon extends AmmoWeapon {
         flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON)
                 .or(F_FLAMER).or(F_ENERGY).or(F_BURST_FIRE);
         ammoType = AmmoType.T_VEHICLE_FLAMER;
-//        String[] modeStrings = { "Damage", "Heat" };
-//        setModes(modeStrings);
         atClass = CLASS_POINT_DEFENSE;
     }
 

--- a/megamek/src/megamek/common/weapons/gaussrifles/GaussWeapon.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/GaussWeapon.java
@@ -47,7 +47,10 @@ public abstract class GaussWeapon extends AmmoWeapon {
             addMode("Powered Up");
             addMode("Powered Down");
             setInstantModeSwitch(false);
-        } 
+        } else {
+            removeMode("Powered Up");
+            removeMode("Powered Down");
+        }
     }
 
 }

--- a/megamek/src/megamek/common/weapons/gaussrifles/GaussWeapon.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/GaussWeapon.java
@@ -17,6 +17,8 @@
  */
 package megamek.common.weapons.gaussrifles;
 
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.AmmoWeapon;
 
 /**
@@ -34,6 +36,18 @@ public abstract class GaussWeapon extends AmmoWeapon {
                 .or(F_BALLISTIC).or(F_DIRECT_FIRE).or(F_NO_FIRES);
         explosive = true;
         atClass = CLASS_AC;
+    }
+
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Add modes for powering down Gauss weapons PPC field inhibitors according to TacOps, p.102
+        if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GAUSS_WEAPONS)) {
+            addMode("Powered Up");
+            addMode("Powered Down");
+            setInstantModeSwitch(false);
+        } 
     }
 
 }

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportHeavyFlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportHeavyFlamerWeapon.java
@@ -37,8 +37,8 @@ public class InfantrySupportHeavyFlamerWeapon extends InfantryWeapon {
 		cost = 200;
 		bv = 0.72;
 		flags = flags.or(F_DIRECT_FIRE).or(F_FLAMER).or(F_ENERGY).or(F_INF_SUPPORT);
-		String[] modeStrings = { "Damage", "Heat" };
-		setModes(modeStrings);
+//		String[] modeStrings = { "Damage", "Heat" };
+//		setModes(modeStrings);
 		infantryDamage = 0.79;
 		infantryRange = 0;
 		crew = 2;

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportHeavyFlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportHeavyFlamerWeapon.java
@@ -37,8 +37,6 @@ public class InfantrySupportHeavyFlamerWeapon extends InfantryWeapon {
 		cost = 200;
 		bv = 0.72;
 		flags = flags.or(F_DIRECT_FIRE).or(F_FLAMER).or(F_ENERGY).or(F_INF_SUPPORT);
-//		String[] modeStrings = { "Damage", "Heat" };
-//		setModes(modeStrings);
 		infantryDamage = 0.79;
 		infantryRange = 0;
 		crew = 2;

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportLRMInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportLRMInfernoWeapon.java
@@ -18,6 +18,8 @@
 package megamek.common.weapons.infantry;
 
 import megamek.common.AmmoType;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 
 /**
  * @author Sebastian Brocks
@@ -42,7 +44,6 @@ public class InfantrySupportLRMInfernoWeapon extends InfantryWeapon {
 		bv = 1.36;
 		tonnage = .03;
 		flags = flags.or(F_INFERNO).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
-		setModes(new String[] { "", "Indirect" });
 		infantryDamage = 0.19;
 		infantryRange = 3;
 		rulesRefs = "273,TM";
@@ -53,4 +54,18 @@ public class InfantrySupportLRMInfernoWeapon extends InfantryWeapon {
 		        .setAvailability(RATING_X, RATING_X, RATING_D, RATING_D);
 
 	}
+	
+	@Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Indirect Fire
+        if (gOp.booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
+            addMode("");
+            addMode("Indirect");
+        } else {
+            removeMode("");
+            removeMode("Indirect");
+        }
+    }
 }

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportLRMInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportLRMInfernoWeapon.java
@@ -26,36 +26,36 @@ import megamek.common.options.OptionsConstants;
  */
 public class InfantrySupportLRMInfernoWeapon extends InfantryWeapon {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = -966926675003846938L;
+    /**
+     *
+     */
+    private static final long serialVersionUID = -966926675003846938L;
 
-	public InfantrySupportLRMInfernoWeapon() {
-		super();
+    public InfantrySupportLRMInfernoWeapon() {
+        super();
 
-		name = "LRM Launcher (Corean Farshot) w/Inferno";
-		setInternalName(name);
-		addLookupName("InfantryInfernoLRM");
-		addLookupName("LRM Inferno Launcher");
-		addLookupName("LRM Inferno Launcher (FarShot)");
-		ammoType = AmmoType.T_NA;
-		cost = 2000;
-		bv = 1.36;
-		tonnage = .03;
-		flags = flags.or(F_INFERNO).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
-		infantryDamage = 0.19;
-		infantryRange = 3;
-		rulesRefs = "273,TM";
-		techAdvancement.setTechBase(TECH_BASE_IS).setISAdvancement(3055, 3057, 3065, DATE_NONE, DATE_NONE)
-		        .setISApproximate(true, false, false, false, false)
-		        .setPrototypeFactions(F_FW, F_CC)
-		        .setProductionFactions(F_FW).setTechRating(RATING_D)
-		        .setAvailability(RATING_X, RATING_X, RATING_D, RATING_D);
+        name = "LRM Launcher (Corean Farshot) w/Inferno";
+        setInternalName(name);
+        addLookupName("InfantryInfernoLRM");
+        addLookupName("LRM Inferno Launcher");
+        addLookupName("LRM Inferno Launcher (FarShot)");
+        ammoType = AmmoType.T_NA;
+        cost = 2000;
+        bv = 1.36;
+        tonnage = .03;
+        flags = flags.or(F_INFERNO).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
+        infantryDamage = 0.19;
+        infantryRange = 3;
+        rulesRefs = "273,TM";
+        techAdvancement.setTechBase(TECH_BASE_IS).setISAdvancement(3055, 3057, 3065, DATE_NONE, DATE_NONE)
+                .setISApproximate(true, false, false, false, false)
+                .setPrototypeFactions(F_FW, F_CC)
+                .setProductionFactions(F_FW).setTechRating(RATING_D)
+                .setAvailability(RATING_X, RATING_X, RATING_D, RATING_D);
 
-	}
-	
-	@Override
+    }
+    
+    @Override
     public void adaptToGameOptions(GameOptions gOp) {
         super.adaptToGameOptions(gOp);
 

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportLRMWeapon.java
@@ -26,34 +26,34 @@ import megamek.common.options.OptionsConstants;
  */
 public class InfantrySupportLRMWeapon extends InfantryWeapon {
 
-	/**
-	 *
-	 */
-	private static final long serialVersionUID = -966926675003846938L;
+    /**
+     *
+     */
+    private static final long serialVersionUID = -966926675003846938L;
 
-	public InfantrySupportLRMWeapon() {
-		super();
+    public InfantrySupportLRMWeapon() {
+        super();
 
-		name = "LRM Launcher (Corean Farshot)";
-		setInternalName(name);
-		addLookupName("InfantryLRM");
-		addLookupName("LRM Launcher");
-		addLookupName("LRM Launcher (FarShot)");
-		ammoType = AmmoType.T_NA;
-		cost = 2000;
-		bv = 3.44;
-		tonnage = .03;
-		flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
-		infantryDamage = 0.48;
-		infantryRange = 3;
-		rulesRefs = "273,TM";
-		techAdvancement.setTechBase(TECH_BASE_IS).setISAdvancement(3055, 3057, 3065, DATE_NONE, DATE_NONE)
-		        .setISApproximate(true, false, false, false, false).setPrototypeFactions(F_FW, F_CC)
-		        .setProductionFactions(F_FW).setTechRating(RATING_D)
-		        .setAvailability(RATING_X, RATING_X, RATING_D, RATING_D);
-	}
-	
-	@Override
+        name = "LRM Launcher (Corean Farshot)";
+        setInternalName(name);
+        addLookupName("InfantryLRM");
+        addLookupName("LRM Launcher");
+        addLookupName("LRM Launcher (FarShot)");
+        ammoType = AmmoType.T_NA;
+        cost = 2000;
+        bv = 3.44;
+        tonnage = .03;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
+        infantryDamage = 0.48;
+        infantryRange = 3;
+        rulesRefs = "273,TM";
+        techAdvancement.setTechBase(TECH_BASE_IS).setISAdvancement(3055, 3057, 3065, DATE_NONE, DATE_NONE)
+                .setISApproximate(true, false, false, false, false).setPrototypeFactions(F_FW, F_CC)
+                .setProductionFactions(F_FW).setTechRating(RATING_D)
+                .setAvailability(RATING_X, RATING_X, RATING_D, RATING_D);
+    }
+    
+    @Override
     public void adaptToGameOptions(GameOptions gOp) {
         super.adaptToGameOptions(gOp);
 

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportLRMWeapon.java
@@ -18,6 +18,8 @@
 package megamek.common.weapons.infantry;
 
 import megamek.common.AmmoType;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 
 /**
  * @author Sebastian Brocks
@@ -42,7 +44,6 @@ public class InfantrySupportLRMWeapon extends InfantryWeapon {
 		bv = 3.44;
 		tonnage = .03;
 		flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
-		setModes(new String[] { "", "Indirect" });
 		infantryDamage = 0.48;
 		infantryRange = 3;
 		rulesRefs = "273,TM";
@@ -51,4 +52,18 @@ public class InfantrySupportLRMWeapon extends InfantryWeapon {
 		        .setProductionFactions(F_FW).setTechRating(RATING_D)
 		        .setAvailability(RATING_X, RATING_X, RATING_D, RATING_D);
 	}
+	
+	@Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Indirect Fire
+        if (gOp.booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
+            addMode("");
+            addMode("Indirect");
+        } else {
+            removeMode("");
+            removeMode("Indirect");
+        }
+    }
 }

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportPortableFlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportPortableFlamerWeapon.java
@@ -39,8 +39,8 @@ public class InfantrySupportPortableFlamerWeapon extends InfantryWeapon {
 		cost = 100;
 		bv = 0.50;
 		flags = flags.or(F_DIRECT_FIRE).or(F_FLAMER).or(F_ENERGY).or(F_INF_SUPPORT).or(F_INF_ENCUMBER);
-		String[] modeStrings = { "Damage", "Heat" };
-		setModes(modeStrings);
+//		String[] modeStrings = { "Damage", "Heat" };
+//		setModes(modeStrings);
 		infantryDamage = 0.55;
 		infantryRange = 0;
 		crew = 1;

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportPortableFlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportPortableFlamerWeapon.java
@@ -39,8 +39,6 @@ public class InfantrySupportPortableFlamerWeapon extends InfantryWeapon {
 		cost = 100;
 		bv = 0.50;
 		flags = flags.or(F_DIRECT_FIRE).or(F_FLAMER).or(F_ENERGY).or(F_INF_SUPPORT).or(F_INF_ENCUMBER);
-//		String[] modeStrings = { "Damage", "Heat" };
-//		setModes(modeStrings);
 		infantryDamage = 0.55;
 		infantryRange = 0;
 		crew = 1;

--- a/megamek/src/megamek/common/weapons/infantry/InfantryTWFlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryTWFlamerWeapon.java
@@ -38,8 +38,6 @@ public class InfantryTWFlamerWeapon extends InfantryWeapon {
 		cost = 100;
 		bv = 0.36;
 		flags = flags.or(F_DIRECT_FIRE).or(F_FLAMER).or(F_ENERGY).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
-//		String[] modeStrings = { "Damage", "Heat" };
-//		setModes(modeStrings);
 		infantryDamage = 0.35;
 		infantryRange = 1;
 		crew = 1;

--- a/megamek/src/megamek/common/weapons/infantry/InfantryTWFlamerWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryTWFlamerWeapon.java
@@ -38,8 +38,8 @@ public class InfantryTWFlamerWeapon extends InfantryWeapon {
 		cost = 100;
 		bv = 0.36;
 		flags = flags.or(F_DIRECT_FIRE).or(F_FLAMER).or(F_ENERGY).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
-		String[] modeStrings = { "Damage", "Heat" };
-		setModes(modeStrings);
+//		String[] modeStrings = { "Damage", "Heat" };
+//		setModes(modeStrings);
 		infantryDamage = 0.35;
 		infantryRange = 1;
 		crew = 1;

--- a/megamek/src/megamek/common/weapons/lasers/EnergyWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/EnergyWeapon.java
@@ -19,7 +19,10 @@ package megamek.common.weapons.lasers;
 
 import megamek.common.IGame;
 import megamek.common.ToHitData;
+import megamek.common.WeaponType;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.EnergyWeaponHandler;
 import megamek.common.weapons.Weapon;
@@ -53,5 +56,25 @@ public abstract class EnergyWeapon extends Weapon {
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, IGame game, Server server) {
         return new EnergyWeaponHandler(toHit, waa, game, server);
+    }
+    
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Add modes for dialed-down damage according to TacOps, p.102
+        // Adds a mode for each damage value down to zero; zero is included
+        // as it is specifically mentioned in TacOps.
+        if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_ENERGY_WEAPONS)) {
+            int damage = getDamage();
+
+            if (damage == WeaponType.DAMAGE_VARIABLE) {
+                damage = damageShort;
+            }
+
+            for (; damage >= 0; damage--) {
+                addMode("Damage " + damage);
+            }
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/lasers/EnergyWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/EnergyWeapon.java
@@ -65,16 +65,19 @@ public abstract class EnergyWeapon extends Weapon {
         // Add modes for dialed-down damage according to TacOps, p.102
         // Adds a mode for each damage value down to zero; zero is included
         // as it is specifically mentioned in TacOps.
-        if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_ENERGY_WEAPONS)
-                && !(this instanceof ISBombastLaser)) {
-            int damage = getDamage();
-
-            if (damage == WeaponType.DAMAGE_VARIABLE) {
-                damage = damageShort;
-            }
-
-            for (; damage >= 0; damage--) {
-                addMode("Damage " + damage);
+        // The bombast laser has its own rules with to-hit modifiers and does not
+        // get additional dial-down
+        if (!(this instanceof ISBombastLaser)) {
+            if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_ENERGY_WEAPONS)) {
+                int dmg = (damage == WeaponType.DAMAGE_VARIABLE) ? damageShort : damage;
+                for (; dmg >= 0; dmg--) {
+                    addMode("Damage " + dmg);
+                }
+            } else {
+                int dmg = (damage == WeaponType.DAMAGE_VARIABLE) ? damageShort : damage;
+                for (; dmg >= 0; dmg--) {
+                    removeMode("Damage " + dmg);
+                } 
             }
         }
     }

--- a/megamek/src/megamek/common/weapons/lasers/EnergyWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/EnergyWeapon.java
@@ -65,7 +65,8 @@ public abstract class EnergyWeapon extends Weapon {
         // Add modes for dialed-down damage according to TacOps, p.102
         // Adds a mode for each damage value down to zero; zero is included
         // as it is specifically mentioned in TacOps.
-        if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_ENERGY_WEAPONS)) {
+        if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_ENERGY_WEAPONS)
+                && !(this instanceof ISBombastLaser)) {
             int damage = getDamage();
 
             if (damage == WeaponType.DAMAGE_VARIABLE) {

--- a/megamek/src/megamek/common/weapons/lasers/ISBombastLaser.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISBombastLaser.java
@@ -21,7 +21,6 @@ import megamek.common.IGame;
 import megamek.common.SimpleTechLevel;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
-import megamek.common.options.GameOptions;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.BombastLaserWeaponHandler;
 import megamek.server.Server;
@@ -42,6 +41,9 @@ public class ISBombastLaser extends LaserWeapon {
         setInternalName(name);
         addLookupName("IS Bombast Laser");
         addLookupName("ISBombastLaser");
+        String[] modeStrings = { "Damage 12", "Damage 11", "Damage 10", 
+                "Damage 9", "Damage 8", "Damage 7" };
+        setModes(modeStrings);
         heat = 12;
         damage = 12;
         shortRange = 5;
@@ -79,16 +81,6 @@ public class ISBombastLaser extends LaserWeapon {
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, IGame game, Server server) {
         return new BombastLaserWeaponHandler(toHit, waa, game, server);
-    }
-    
-    @Override
-    public void adaptToGameOptions(GameOptions gOp) {
-        super.adaptToGameOptions(gOp);
-
-        // Modes for the damage values of the Bombast Laser
-        for (int damage = 12; damage >= 7; damage--) {
-            addMode("Damage " + damage);
-        }
     }
 
 }

--- a/megamek/src/megamek/common/weapons/lasers/ISBombastLaser.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISBombastLaser.java
@@ -21,6 +21,7 @@ import megamek.common.IGame;
 import megamek.common.SimpleTechLevel;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.BombastLaserWeaponHandler;
 import megamek.server.Server;
@@ -78,6 +79,16 @@ public class ISBombastLaser extends LaserWeapon {
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, IGame game, Server server) {
         return new BombastLaserWeaponHandler(toHit, waa, game, server);
+    }
+    
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Modes for the damage values of the Bombast Laser
+        for (int damage = 12; damage >= 7; damage--) {
+            addMode("Damage " + damage);
+        }
     }
 
 }

--- a/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
@@ -17,6 +17,8 @@ import megamek.common.AmmoType;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.LRMAntiTSMHandler;
 import megamek.common.weapons.LRMDeadFireHandler;
@@ -44,7 +46,6 @@ public abstract class LRMWeapon extends MissileWeapon {
     public LRMWeapon() {
         super();
         ammoType = AmmoType.T_LRM;
-        setModes(new String[] { "", "Indirect" });
         shortRange = 7;
         mediumRange = 14;
         longRange = 21;
@@ -107,5 +108,19 @@ public abstract class LRMWeapon extends MissileWeapon {
     @Override
     public boolean hasIndirectFire() {
         return true;
+    }
+    
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Indirect Fire
+        if (gOp.booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
+            addMode("");
+            addMode("Indirect");
+        } else {
+            removeMode("");
+            removeMode("Indirect");
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/LRTWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRTWeapon.java
@@ -17,6 +17,8 @@ import megamek.common.AmmoType;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.MissileWeaponHandler;
 import megamek.common.weapons.missiles.MissileWeapon;
@@ -35,7 +37,6 @@ public abstract class LRTWeapon extends MissileWeapon {
     public LRTWeapon() {
         super();
         ammoType = AmmoType.T_LRM_TORPEDO;
-        setModes(new String[] { "", "Indirect" });
         flags = flags.andNot(F_AERO_WEAPON);
     }
 
@@ -56,5 +57,19 @@ public abstract class LRTWeapon extends MissileWeapon {
     @Override
     public int getBattleForceClass() {
         return BFCLASS_TORP;
+    }
+    
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Indirect Fire
+        if (gOp.booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
+            addMode("");
+            addMode("Indirect");
+        } else {
+            removeMode("");
+            removeMode("Indirect");
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/missiles/MMLWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/MMLWeapon.java
@@ -21,6 +21,8 @@ import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.LRMAntiTSMHandler;
 import megamek.common.weapons.LRMDeadFireHandler;
@@ -54,7 +56,6 @@ public abstract class MMLWeapon extends MissileWeapon {
     public MMLWeapon() {
         super();
         this.ammoType = AmmoType.T_MML;
-        this.setModes(new String[] { "", "Indirect" });
         this.atClass = CLASS_MML;
     }
 
@@ -162,5 +163,19 @@ public abstract class MMLWeapon extends MissileWeapon {
     @Override
     public boolean hasIndirectFire() {
         return true;
+    }
+    
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Indirect Fire
+        if (gOp.booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
+            addMode("");
+            addMode("Indirect");
+        } else {
+            removeMode("");
+            removeMode("Indirect");
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/missiles/ThunderBoltWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/ThunderBoltWeapon.java
@@ -17,6 +17,8 @@ import megamek.common.BattleForceElement;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.ThunderBoltWeaponHandler;
 import megamek.server.Server;
@@ -36,7 +38,6 @@ public abstract class ThunderBoltWeapon extends MissileWeapon {
      */
     public ThunderBoltWeapon() {
         super();
-        this.setModes(new String[] { "", "Indirect" });
         this.rackSize = 1;
         atClass = CLASS_THUNDERBOLT;
     }
@@ -69,5 +70,19 @@ public abstract class ThunderBoltWeapon extends MissileWeapon {
     @Override
     public boolean hasIndirectFire() {
         return true;
+    }
+    
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Indirect Fire
+        if (gOp.booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
+            addMode("");
+            addMode("Indirect");
+        } else {
+            removeMode("");
+            removeMode("Indirect");
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/mortars/MekMortarWeapon.java
+++ b/megamek/src/megamek/common/weapons/mortars/MekMortarWeapon.java
@@ -19,6 +19,8 @@ import megamek.common.Compute;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.AmmoWeapon;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.MekMortarAirburstHandler;
@@ -42,7 +44,6 @@ public abstract class MekMortarWeapon extends AmmoWeapon {
         super();
         ammoType = AmmoType.T_MEK_MORTAR;
         damage = DAMAGE_BY_CLUSTERTABLE;
-        setModes(new String[] { "", "Indirect" });
         atClass = CLASS_NONE;
         flags = flags.or(F_MEK_MORTAR).or(F_MECH_WEAPON).or(F_MISSILE)
                 .or(F_TANK_WEAPON);
@@ -94,5 +95,19 @@ public abstract class MekMortarWeapon extends AmmoWeapon {
     @Override
     public boolean hasIndirectFire() {
         return true;
+    }
+    
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Indirect Fire
+        if (gOp.booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
+            addMode("");
+            addMode("Indirect");
+        } else {
+            removeMode("");
+            removeMode("Indirect");
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/ppc/CLEnhancedPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/CLEnhancedPPC.java
@@ -58,7 +58,6 @@ public class CLEnhancedPPC extends PPCWeapon {
         this.medAV = 12;
         this.longAV = 12;
         this.maxRange = RANGE_LONG;
-        setModes(new String[] { "Field Inhibitor ON", "Field Inhibitor OFF" });
         rulesRefs = "95,IO";
         techAdvancement.setTechBase(TECH_BASE_CLAN).setTechRating(RATING_F)
             .setAvailability(RATING_X, RATING_E, RATING_X, RATING_X)

--- a/megamek/src/megamek/common/weapons/ppc/CLImprovedPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/CLImprovedPPC.java
@@ -48,7 +48,6 @@ public class CLImprovedPPC extends PPCWeapon {
         waterMediumRange = 7;
         waterLongRange = 10;
         waterExtremeRange = 14;
-        setModes(new String[] { "Field Inhibitor ON", "Field Inhibitor OFF" });
         tonnage = 6.0f;
         criticals = 2;
         bv = 176;

--- a/megamek/src/megamek/common/weapons/ppc/ISHeavyPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISHeavyPPC.java
@@ -46,7 +46,6 @@ public class ISHeavyPPC extends PPCWeapon {
         waterMediumRange = 7;
         waterLongRange = 10;
         waterExtremeRange = 14;
-        setModes(new String[] { "Field Inhibitor ON", "Field Inhibitor OFF" });
         tonnage = 10.0f;
         criticals = 4;
         bv = 317;

--- a/megamek/src/megamek/common/weapons/ppc/ISLightPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISLightPPC.java
@@ -46,7 +46,6 @@ public class ISLightPPC extends PPCWeapon {
         waterMediumRange = 7;
         waterLongRange = 10;
         waterExtremeRange = 14;
-        setModes(new String[] { "Field Inhibitor ON", "Field Inhibitor OFF" });
         tonnage = 3.0f;
         criticals = 2;
         bv = 88;

--- a/megamek/src/megamek/common/weapons/ppc/ISPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISPPC.java
@@ -47,7 +47,6 @@ public class ISPPC extends PPCWeapon {
         waterMediumRange = 7;
         waterLongRange = 10;
         waterExtremeRange = 14;
-        setModes(new String[] { "Field Inhibitor ON", "Field Inhibitor OFF" });
         tonnage = 7.0f;
         criticals = 3;
         bv = 176;

--- a/megamek/src/megamek/common/weapons/ppc/PPCWeapon.java
+++ b/megamek/src/megamek/common/weapons/ppc/PPCWeapon.java
@@ -89,12 +89,16 @@ public abstract class PPCWeapon extends EnergyWeapon {
     public void adaptToGameOptions(GameOptions gOp) {
         super.adaptToGameOptions(gOp);
 
-        // Add modes for disengaging PPC field inhibitors according to TacOps, p.103
-        if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_PPC_INHIBITORS)) {
-            if (getMinimumRange() > 0) {
+        // Modes for disengaging PPC field inhibitors according to TacOps, p.103.
+        // The benefit is removing the minimum range, so only PPCs with a minimum range get the modes.
+        if (minimumRange > 0) {
+            if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_PPC_INHIBITORS)) { 
                 addMode("Field Inhibitor ON");
                 addMode("Field Inhibitor OFF");
+            } else {
+                removeMode("Field Inhibitor ON");
+                removeMode("Field Inhibitor OFF");
             }
-        } 
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/ppc/PPCWeapon.java
+++ b/megamek/src/megamek/common/weapons/ppc/PPCWeapon.java
@@ -23,6 +23,8 @@ import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.PPCHandler;
 import megamek.common.weapons.lasers.EnergyWeapon;
@@ -39,7 +41,6 @@ public abstract class PPCWeapon extends EnergyWeapon {
 
     public PPCWeapon() {
         super();
-        setModes(new String[] { "Field Inhibitor ON", "Field Inhibitor OFF" });
         flags = flags.or(F_DIRECT_FIRE).or(F_PPC);
         atClass = CLASS_PPC;
     }
@@ -82,5 +83,18 @@ public abstract class PPCWeapon extends EnergyWeapon {
             }
         }
         return damage / 10.0;        
+    }
+
+    @Override
+    public void adaptToGameOptions(GameOptions gOp) {
+        super.adaptToGameOptions(gOp);
+
+        // Add modes for disengaging PPC field inhibitors according to TacOps, p.103
+        if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_PPC_INHIBITORS)) {
+            if (getMinimumRange() > 0) {
+                addMode("Field Inhibitor ON");
+                addMode("Field Inhibitor OFF");
+            }
+        } 
     }
 }

--- a/megamek/src/megamek/common/weapons/primitive/ISPPCPrimitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISPPCPrimitive.java
@@ -44,7 +44,6 @@ public class ISPPCPrimitive extends PPCWeapon {
         waterMediumRange = 7;
         waterLongRange = 10;
         waterExtremeRange = 14;
-        setModes(new String[]{"Field Inhibitor ON", "Field Inhibitor OFF"});
         tonnage = 7.0f;
         criticals = 3;
         bv = 176;


### PR DESCRIPTION
As the title says, this should fix #829. The Mode button in the firing phase now respects if there are any modes and if a switch is allowed (LAM). This was the minor part.

The major part is that many modes were hard-coded into the weapon types or were set within **Mech** or **Aero** (but with effect for the weapon _type_, i.e. all units, not the unit or **Mounted** in question) with the strange result that in a game with only tanks, those would not be able to switch off PPC inhibitors while in a game with Mechs the tanks could.

This PR moves a method call for all game options adaptations to **Entity** and thus valid for all units. (Ideally this would be checked not for units but whenever a game is received or set up but I didnt want to add more chances for error now when there is no visible gain). The checks themselves are not in Entity, but instead placed in **Weapon** and subclasses, wherever applicable.

I would have wanted each weapon to know its own options but this would create a lot of repetitive code. Therefore I put some checks directly in Weapon.