### PR TITLE
Fix for #949: Fixed cost for CASE

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10343,7 +10343,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         int count = implicitClanCASE();
         if (count > 0) {
             long itemCost = 50000;
-            cost += 50000 * itemCost;
+            cost += count * itemCost;
             if (null != bvText) {
                 for (int i = 0; i < count; i++) {
                     bvText.append(startColumn);


### PR DESCRIPTION
Instead of multiplying the cost of CASE by the number of locations, it
multiplies the C-bill cost by itself, with the result that CASE costs
5,000 ^ 2 C-bills.

Fixes #949: Kraken (Bane) 3 costs over 5 billion c-bills