### PR TITLE
Fix for #948: armor for Clan industrial mechs

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -2335,6 +2335,7 @@ public class MiscType extends EquipmentType {
 
         misc.name = EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_COMMERCIAL);
         misc.setInternalName(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_COMMERCIAL, false));
+        misc.setInternalName(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_COMMERCIAL, true));
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 0;
         misc.hittable = false;
@@ -2404,6 +2405,7 @@ public class MiscType extends EquipmentType {
 
         misc.name = EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_INDUSTRIAL);
         misc.setInternalName(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_INDUSTRIAL, false));
+        misc.setInternalName(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_INDUSTRIAL, true));
         misc.addLookupName("Clan Industrial Armor");
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 0;
@@ -2456,6 +2458,7 @@ public class MiscType extends EquipmentType {
 
         misc.name = EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL);
         misc.setInternalName(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL, false));
+        misc.addLookupName(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL, true));
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 0;
         misc.hittable = false;

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -2344,10 +2344,10 @@ public class MiscType extends EquipmentType {
         misc.flags = misc.flags.or(F_COMMERCIAL_ARMOR).or(F_MECH_EQUIPMENT);
         misc.omniFixedOnly = true;
         misc.rulesRefs = "205,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_B)
+        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setTechRating(RATING_B)
                 .setAvailability(RATING_B, RATING_B, RATING_A, RATING_A)
-                .setISAdvancement(2290, 2300, 2310, DATE_NONE, DATE_NONE)
-                .setISApproximate(true, true, false, false, false).setPrototypeFactions(F_TA)
+                .setAdvancement(2290, 2300, 2310)
+                .setApproximate(true, true, false).setPrototypeFactions(F_TA)
                 .setProductionFactions(F_TA);
 
         return misc;
@@ -2415,10 +2415,10 @@ public class MiscType extends EquipmentType {
         misc.flags = misc.flags.or(F_INDUSTRIAL_ARMOR).or(F_MECH_EQUIPMENT);
         misc.omniFixedOnly = true;
         misc.rulesRefs = "205,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_C)
+        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setTechRating(RATING_C)
                 .setAvailability(RATING_B, RATING_C, RATING_B, RATING_B)
-                .setISAdvancement(2430, 2439, 2439, DATE_NONE, DATE_NONE)
-                .setISApproximate(true, true, true, false, false).setPrototypeFactions(F_TH)
+                .setAdvancement(2430, 2439, 2439)
+                .setApproximate(true, true, true).setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH);
         return misc;
     }
@@ -2467,12 +2467,10 @@ public class MiscType extends EquipmentType {
         misc.flags = misc.flags.or(F_HEAVY_INDUSTRIAL_ARMOR).or(F_MECH_EQUIPMENT);
         misc.omniFixedOnly = true;
         misc.rulesRefs = "205,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_D)
+        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setTechRating(RATING_D)
                 .setAvailability(RATING_C, RATING_C, RATING_C, RATING_B)
-                .setISAdvancement(2460, 2470, 2470, DATE_NONE, DATE_NONE)
-                .setISApproximate(false, true, false, false, false)
-                .setClanAdvancement(2460, 2470, 2470, DATE_NONE, DATE_NONE)
-                .setClanApproximate(false, true, false, false, false).setPrototypeFactions(F_TH)
+                .setAdvancement(2460, 2470, 2470)
+                .setApproximate(false, true, false).setPrototypeFactions(F_TH)
                 .setProductionFactions(F_TH);
         return misc;
     }

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -133,7 +133,7 @@ public class TestMech extends TestEntity {
                         && eq2.hasFlag(MiscType.F_MECH_EQUIPMENT)
                         && techManager.isLegal(eq2)
                         && (!isLam || (eq2.getCriticals(null) == 0))
-                        && (!industrialOnly || ((MiscType)eq).isIndustrial())) {
+                        && (!industrialOnly || ((null != eq) && ((MiscType)eq).isIndustrial()))) {
                     retVal.add(eq2);
                 }
             }


### PR DESCRIPTION
IO gives the tech base of industrial, heavy industrial, and commercial armor as IS, but this creates problems for Clan industrial mechs.

Added lookup names to  names for use with a Clan tech base and changed the tech base from IS to ALL.

Also found and fixed a possible NPE when dealing with armor for Clan industrial mechs.

Fixes #948.