### PR TITLE
Aero Sensor Suites and Visibility in Atmosphere/Low Vis Conditions

### DIFF
--- a/megamek/i18n/megamek/common/messages.properties
+++ b/megamek/i18n/megamek/common/messages.properties
@@ -18,6 +18,7 @@ Engine.None=\ None
 Engine.Steam=\ Steam
 Engine.Battery=\ Battery
 Engine.Solar=\ Solar
+Entity.sensor_range_vs_ground_target=Air to Ground Range
 EntityWeightClass.0=Ultra Light/PA(L)/Exoskeleton
 EntityWeightClass.1=Light
 EntityWeightClass.2=Medium

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -97,9 +97,6 @@ public class Compute {
     public static final int ARC_HEXSIDE_3 = 35;
     public static final int ARC_HEXSIDE_4 = 36;
     public static final int ARC_HEXSIDE_5 = 37;
-    
-    //Needed to make sure fighters can display to players that they have two active sensor ranges
-    private static int atgSensorRange = 0;
 
     private static MMRandom random = MMRandom.generate(MMRandom.R_DEFAULT);
 
@@ -226,13 +223,6 @@ public class Compute {
                                    58.3, 41.6, 27.7, 16.6, 8.3, 2.78, 0};
             return odds[n];
         }
-    }
-    
-    /**
-     * Returns the range of an aero's sensors against ground targets
-     */
-    public static int getAtgSensorRange() {
-        return atgSensorRange;
     }
     
     /**
@@ -4218,7 +4208,6 @@ public class Compute {
             //Basic sensor range listed in errata
                 range = 1;
             }
-            atgSensorRange = range;
             return range;
         }
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4018,10 +4018,15 @@ public class Compute {
         
         //Aeros have to check visibility to ground targets for the closest point of approach along their flight path
         //Because the rules state "within X hexes of the flight path" we're using ground distance so altitude doesn't screw us up
-        if (ae.isAirborne() && !target.isAirborne()) {
-            distance = Compute.effectiveDistance(game, ae, target, true);
+        if (ae.isAirborne() && !target.isAirborne() && (target instanceof Entity)) {
+            Entity te = (Entity) target;
+            distance = te.getPosition().distance(
+                    getClosestFlightPath(te.getId(),
+                            te.getPosition(), (Entity) ae));
+            return (distance > minSensorRange) && (distance <= maxSensorRange);
         }
-        distance += 2 * target.getAltitude();
+        //This didn't work right for Aeros. Should account for the difference in altitude, not just add the target's altitude to distance
+        distance += Math.abs(2 * target.getAltitude() - 2 * ae.getAltitude());
         return (distance > minSensorRange) && (distance <= maxSensorRange);
     }
 
@@ -4171,7 +4176,7 @@ public class Compute {
         
         //If we're an airborne aero, sensor range is limited to within a few hexes of the flightline against ground targets
         //TO Dec 2017 Errata p17
-        if (ae.isAirborne() && !te.isAirborne()) {
+        if (te != null && ae.isAirborne() && !te.isAirborne()) {
             //Can't see anything if above Alt 8.
             if (ae.getAltitude() > 8) {
                 return 0;

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -3958,13 +3958,25 @@ public class Compute {
                 targetPos = Compute.getClosestFlightPath(ae.getId(),
                         ae.getPosition(), te);
             }
+            //Airborne aeros can only see ground targets they overfly, and only at Alt <=8
+            if (isAirToGround(ae, target)) {
+                if (ae.getAltitude() > 8) {
+                    return false;
+                }
+                if (ae.passedOver(target)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
         }
 
         visualRange = Math.max(visualRange, 1);
         int distance;
         // Ground distance
         distance = ae.getPosition().distance(targetPos);
-        distance += 2 * target.getAltitude();
+        //Need to track difference in altitude, not just add altitude to the range
+        distance += Math.abs(2 * target.getAltitude() - 2 * ae.getAltitude());
         return distance <= visualRange;
 
     }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4013,14 +4013,14 @@ public class Compute {
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_INCLUSIVE_SENSOR_RANGE)) {
             minSensorRange = 0;
         }
+                
+        int distance = ae.getPosition().distance(target.getPosition());
         
-        Coords aePos = ae.getPosition();
         //Aeros have to check visibility to ground targets for the closest point of approach along their flight path
+        //Because the rules state "within X hexes of the flight path" we're using ground distance so altitude doesn't screw us up
         if (ae.isAirborne() && !target.isAirborne()) {
-            aePos = Compute.getClosestFlightPath(attackerId, aPos, te)
+            distance = Compute.effectiveDistance(game, ae, target, true);
         }
-        
-        int distance = aePos.distance(target.getPosition());
         distance += 2 * target.getAltitude();
         return (distance > minSensorRange) && (distance <= maxSensorRange);
     }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -12700,12 +12700,19 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         }
         int bracket = Compute.getSensorBracket(getSensorCheck());
         int range = getActiveSensor().getRangeByBracket();
+        int groundRange = 0;
+        if (getActiveSensor().isBAP()) {
+            groundRange = 2;
+        } else {
+            groundRange = 1;
+        }
         int maxSensorRange = bracket * range;
         int minSensorRange = Math.max((bracket - 1) * range, 0);
-        int maxGroundSensorRange = bracket * Compute.getAtgSensorRange();
-        int minGroundSensorRange = Math.max((bracket - 1) * Compute.getAtgSensorRange(), 0);
+        int maxGroundSensorRange = bracket * groundRange;
+        int minGroundSensorRange = Math.max((maxGroundSensorRange - 1), 0);
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_INCLUSIVE_SENSOR_RANGE)) {
             minSensorRange = 0;
+            minGroundSensorRange = 0;
         }
         if (isAirborne() && game.getBoard().onGround()) {
             return getActiveSensor().getDisplayName() + " (" + minSensorRange + "-"

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -12702,8 +12702,15 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         int range = getActiveSensor().getRangeByBracket();
         int maxSensorRange = bracket * range;
         int minSensorRange = Math.max((bracket - 1) * range, 0);
+        int maxGroundSensorRange = bracket * Compute.getAtgSensorRange();
+        int minGroundSensorRange = Math.max((bracket - 1) * Compute.getAtgSensorRange(), 0);
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_INCLUSIVE_SENSOR_RANGE)) {
             minSensorRange = 0;
+        }
+        if (isAirborne() && game.getBoard().onGround()) {
+            return getActiveSensor().getDisplayName() + " (" + minSensorRange + "-"
+                    + maxSensorRange + ")" + " {Ground Range" + " (" + minGroundSensorRange + "-"
+                    + maxGroundSensorRange + ")}";
         }
         return getActiveSensor().getDisplayName() + " (" + minSensorRange + "-"
                + maxSensorRange + ")";

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -189,6 +189,8 @@ public abstract class Entity extends TurnOrdered implements Transporter,
 
     protected String camoCategory = IPlayer.NO_CAMO;
     protected String camoFileName = null;
+    
+    protected String aeroGroundSensorText = "Ground Range";
 
     /**
      * ID settable by external sources (such as mm.net)
@@ -12716,7 +12718,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         }
         if (isAirborne() && game.getBoard().onGround()) {
             return getActiveSensor().getDisplayName() + " (" + minSensorRange + "-"
-                    + maxSensorRange + ")" + " {Ground Range" + " (" + minGroundSensorRange + "-"
+                    + maxSensorRange + ")" + " {" + aeroGroundSensorText + " (" + minGroundSensorRange + "-"
                     + maxGroundSensorRange + ")}";
         }
         return getActiveSensor().getDisplayName() + " (" + minSensorRange + "-"

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -165,6 +165,8 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     public static final int DMG_CRIPPLED = 4;
     
     public static final int USE_STRUCTURAL_RATING = -1;
+    
+    public static final String ENTITY_AIR_TO_GROUND_SENSOR_RANGE= Messages.getString("Entity.sensor_range_vs_ground_target");
 
     // Weapon sort order defines
     public static enum WeaponSortOrder {
@@ -190,8 +192,6 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     protected String camoCategory = IPlayer.NO_CAMO;
     protected String camoFileName = null;
     
-    protected String aeroGroundSensorText = "Ground Range";
-
     /**
      * ID settable by external sources (such as mm.net)
      */
@@ -12718,7 +12718,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         }
         if (isAirborne() && game.getBoard().onGround()) {
             return getActiveSensor().getDisplayName() + " (" + minSensorRange + "-"
-                    + maxSensorRange + ")" + " {" + aeroGroundSensorText + " (" + minGroundSensorRange + "-"
+                    + maxSensorRange + ")" + " {" + ENTITY_AIR_TO_GROUND_SENSOR_RANGE + " (" + minGroundSensorRange + "-"
                     + maxGroundSensorRange + ")}";
         }
         return getActiveSensor().getDisplayName() + " (" + minSensorRange + "-"

--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -241,6 +241,10 @@ public class MechFileParser {
             ent.getSensors().add(new Sensor(Sensor.TYPE_VEE_MAGSCAN));
             ent.getSensors().add(new Sensor(Sensor.TYPE_VEE_SEISMIC));
             ent.setNextSensor(ent.getSensors().firstElement());
+        } else if (ent.hasETypeFlag(Entity.ETYPE_AERO) || ent.hasETypeFlag(Entity.ETYPE_CONV_FIGHTER)) {
+            //ASFs and Conventional Fighters get a combined sensor suite
+            ent.getSensors().add(new Sensor(Sensor.TYPE_AERO_SENSOR));
+            ent.setNextSensor(ent.getSensors().firstElement());
         } else if (ent instanceof BattleArmor) {
             if (ent.hasWorkingMisc(MiscType.F_HEAT_SENSOR)) {
                 ent.getSensors().add(new Sensor(Sensor.TYPE_BA_HEAT));

--- a/megamek/src/megamek/common/Sensor.java
+++ b/megamek/src/megamek/common/Sensor.java
@@ -47,6 +47,10 @@ public class Sensor implements Serializable {
     public static final int TYPE_EW_EQUIPMENT = 15;
     public static final int TYPE_NOVA = 16;
     public static final int TYPE_BAPP = 17;
+    public static final int TYPE_AERO_SENSOR = 18;
+    //TODO: These are placeholders and will be implemented in a later PR
+    public static final int TYPE_SPACECRAFT_ACTIVE = 19;
+    public static final int TYPE_SPACECRAFT_PASSIVE = 20;
 
     public static final String WATCHDOG = "WatchdogECMSuite";
     public static final String NOVA = "NovaCEWS";
@@ -65,7 +69,8 @@ public class Sensor implements Serializable {
             "Beagle Active Probe", "Clan BAP", "Bloodhound AP", "Watchdog",
             "Light AP", "Mech IR", "Vehicle IR", "Mech Magscan",
             "Vehicle Magscan", "Heat Sensors", "Improved Sensors",
-            "Mech Seismic", "Vehicle Seismic", "EW Equipment", "Nova CEWS", "Beagle Active Probe Prototype"};
+            "Mech Seismic", "Vehicle Seismic", "EW Equipment", "Nova CEWS", "Beagle Active Probe Prototype", 
+            "Aero Sensor Suite", "Spacecraft Active Sensor Suite", "Spacecraft Passive Sensor Suite"};
     public static final int SIZE = sensorNames.length;
 
     /**
@@ -116,6 +121,9 @@ public class Sensor implements Serializable {
                 return 9;
             case TYPE_MEK_MAGSCAN:
             case TYPE_MEK_IR:
+                //Under the current errata (3.0,Dec 2017), the rules only give aero sensor ranges against overflown ground units
+                //No differences in range are mentioned for any sensor but active probe, so I'm assuming magscan range for standard sensors
+            case TYPE_AERO_SENSOR:
                 return 10;
             case TYPE_MEK_RADAR:
                 return 8;
@@ -140,7 +148,7 @@ public class Sensor implements Serializable {
                 && ((los.getHardBuildings() + los.getSoftBuildings()) > 0)) {
             return 0;
         }
-
+        
         if (los.isBlockedByHill()
                 && (type != TYPE_MEK_SEISMIC)
                 && (type != TYPE_VEE_SEISMIC)


### PR DESCRIPTION
This fix addresses bug #387 

It accounts for the December 2017 errata surrounding aero spotting and sensors, and adds a basic sensor package to all ASFs and CFs.

I still have a bit more testing to do around range reporting vs actual effect, but I wanted to go ahead and put it out here for review in case there's anything major I need to change and retest. 

This testing was completed and it seems to work.  I will admit that I didn't think about the low atmosphere map when writing this, just space and ground (mostly ground).  We found major issues with low atmo during testing last night anyway, so once that's fixed I'll make another PR to integrate this with it. 