### PR TITLE
Take intro date into account when calculating era availability.

### DIFF
--- a/megamek/src/megamek/common/CompositeTechLevel.java
+++ b/megamek/src/megamek/common/CompositeTechLevel.java
@@ -426,7 +426,8 @@ public class CompositeTechLevel implements ITechnology, Serializable {
 
     @Override
     public int getBaseAvailability(int era) {
-        if (era < 0 || era > availability.length) {
+        if ((era < 0) || (era > availability.length)
+                || (ITechnology.getTechEra(introYear) > era)) {
             return RATING_X;
         }
         return availability[era];


### PR DESCRIPTION
Previously calculated era availability codes for units using only
components.

I'm not sure this has a practical effect anywhere, but when the era availability for a unit is shown in the summary it can show it as available before the intro date.

![image](https://user-images.githubusercontent.com/16927464/41205370-9f1636e2-6cb7-11e8-8139-78621a624796.png)
