### PR TITLE
Fix for phantom mechwarrior crash

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -28249,6 +28249,15 @@ public class Server implements Runnable {
             while (iter.hasMoreElements()) {
                 int mechWarriorId = iter.nextElement();
                 Entity mw = game.getEntity(mechWarriorId);
+                
+                // in some situations, a "picked up" mechwarrior won't actually exist
+                // probably this is brought about by picking up a mechwarrior in a previous MekHQ scenario
+                // then having the same unit get blown up in a subsequent scenario 
+                // in that case, we simply move on
+                if(mw == null) {
+                    continue;
+                }
+                
                 mw.setDestroyed(true);
                 // We can safely remove these, as they can't be targeted
                 game.removeEntity(mw.getId(), condition);


### PR DESCRIPTION
I encountered a random-seeming crash bug where getting a particular unit of mine blown up would freeze the server. Turns out, the same unit had picked up a mechwarrior in a previous MekHQ scenario and MekHQ never quite released it.

Here, we introduce a simple null check to make sure we're not trying to eliminate non-existent mechwarriors.