### PR TITLE
Fix for #1000: Ignore AP-mounted weapons when calculating BA suit weight.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -1291,6 +1291,12 @@ public class TestBattleArmor extends TestEntity {
                     && (m.getBaMountLoc() == BattleArmor.MOUNT_LOC_NONE)) {
                 continue;
             }
+            
+            // The weight of an anti-personnel weapon in an AP mount or armored glove manipulator doesn't
+            // count toward suit weight limit.
+            if (m.isAPMMounted()) {
+                continue;
+            }
 
             WeaponType wt = (WeaponType) m.getType();
             if (m.isDWPMounted()) {


### PR DESCRIPTION
Per TM, p. 271, anti-personnel weapons in an AP mount or armored battle glove do not count toward the suit weight. The MM validator is counting them, causing some units to fail validation for being overweight when they shouldn't.