### PR TITLE
Defer calculating initial BV when adding multiple entities to game.

### DIFF
--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -1257,6 +1257,9 @@ public class Game implements Serializable, IGame {
         for (int i = 0; i < entities.size(); i++) {
             addEntity(entities.get(i), false);
         }
+        // We need to delay calculating BV until all units have been added because
+        // C3 network connections will be cleared if the master is not in the game yet.
+        entities.forEach(e -> e.setInitialBV(e.calculateBattleValue(false, false)));
         processGameEvent(new GameEntityNewEvent(this, entities));
     }
 
@@ -1325,10 +1328,9 @@ public class Game implements Serializable, IGame {
             ((Mech) entity).setCondEjectHeadshot(true);
         }
 
-        entity.setInitialBV(entity.calculateBattleValue(false, false));
-
         assert (entities.size() == entityIds.size()) : "Add Entity failed";
         if (genEvent) {
+            entity.setInitialBV(entity.calculateBattleValue(false, false));
             processGameEvent(new GameEntityNewEvent(this, entity));
         }
     }


### PR DESCRIPTION
I noticed this while working on my force generation feature, but it also applies to units saved to a MUL file. If there is a configured C3 network, it only restores the network correctly if the unit with the C3 master is first. This is because the initial BV is calculated after every added Entity, and when checking for on a slaved unit it will clear the connection if the master is not in the game.

There was already a mechanism in place to delay sending dispatching an event when multiple Entities are added at once, so I used that to defer the initial BV calculations as well.