### PR TITLE
Enable Princess to fly spacecraft using the "advanced" flight model

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -96,6 +96,10 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
     void setPathEnumerator(PathEnumerator pathEnumerator) {
         this.pathEnumerator = pathEnumerator;
     }
+    
+    PathEnumerator getPathEnumerator() {
+        return pathEnumerator;
+    }
 
     Map<Integer, Double> getBestDamageByEnemies() {
         return bestDamageByEnemies;
@@ -375,7 +379,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
 
         EntityEvaluationResponse returnResponse = new EntityEvaluationResponse();
 
-        int distance = calculateDistance(path, enemy.getPosition());                
+        int distance = enemy.getPosition().distance(path.getFinalCoords());                
         
         // How much damage can they do to me?
         double theirDamagePotential = calculateDamagePotential(enemy,
@@ -560,11 +564,8 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                 }
 
                 EntityEvaluationResponse eval;
-                // TODO: Always consider Aeros to have moved, as right now we
-                // don't try to predict their movement.
-                if ((!enemy.isSelectableThisTurn()) || enemy.isImmobile()
-                        || enemy.isAero()) { //For units that have already moved
-                    int alpha = 1;
+
+                if (evaluateAsMoved(enemy)) { //For units that have already moved
                     eval = evaluateMovedEnemy(enemy, pathCopy, game);
                 } else { //for units that have not moved this round
                     eval = evaluateUnmovedEnemy(enemy, path, extremeRange,
@@ -649,6 +650,15 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
 
     }
 
+    /**
+     * Worker function that determines if a given enemy entity should be evaluated as if it has moved.
+     */
+    protected boolean evaluateAsMoved(Entity enemy) {
+        // Aerospace units on ground maps can go pretty much anywhere they want, so it's
+        // somewhat pointless to try to predict their movement.
+        return !enemy.isSelectableThisTurn() || enemy.isImmobile() || enemy.isAero();
+    }
+    
     /**
      * Calculate who all other units would shoot at if I weren't around
      */
@@ -1233,16 +1243,6 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         hazardValue += dmg;
 
         return hazardValue;
-    }
-
-    /**
-     * Worker method for the distance calculation between a considered move path and a set of coordinates.
-     * @param path The move path being considered.
-     * @param coords The coordinates being considered.
-     * @return
-     */
-    protected int calculateDistance(MovePath path, Coords coords) {
-        return coords.distance(path.getFinalCoords());
     }
     
     /**

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -614,7 +614,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             utility += braveryMod;
 
             //noinspection StatementWithEmptyBody
-            if (path.getEntity().isAero()) {
+            if (path.getEntity().isAero() && !path.getEntity().isSpaceborne()) {
                 // No idea what original implementation was meant to be.
 
             } else {

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -52,6 +52,7 @@ import megamek.common.TargetRoll;
 import megamek.common.Targetable;
 import megamek.common.Terrains;
 import megamek.common.TripodMech;
+import megamek.common.MovePath.MoveStepType;
 import megamek.common.logging.LogLevel;
 import megamek.common.options.OptionsConstants;
 
@@ -374,7 +375,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
 
         EntityEvaluationResponse returnResponse = new EntityEvaluationResponse();
 
-        int distance = enemy.getPosition().distance(path.getFinalCoords());                
+        int distance = calculateDistance(path, enemy.getPosition());                
         
         // How much damage can they do to me?
         double theirDamagePotential = calculateDamagePotential(enemy,
@@ -563,6 +564,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                 // don't try to predict their movement.
                 if ((!enemy.isSelectableThisTurn()) || enemy.isImmobile()
                         || enemy.isAero()) { //For units that have already moved
+                    int alpha = 1;
                     eval = evaluateMovedEnemy(enemy, pathCopy, game);
                 } else { //for units that have not moved this round
                     eval = evaluateUnmovedEnemy(enemy, path, extremeRange,
@@ -1233,6 +1235,16 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         return hazardValue;
     }
 
+    /**
+     * Worker method for the distance calculation between a considered move path and a set of coordinates.
+     * @param path The move path being considered.
+     * @param coords The coordinates being considered.
+     * @return
+     */
+    protected int calculateDistance(MovePath path, Coords coords) {
+        return coords.distance(path.getFinalCoords());
+    }
+    
     /**
      * Simple data structure that holds a separate firing and physical damage number.
      *

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -165,10 +165,10 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             EntityEvaluationResponse returnResponse =
                     new EntityEvaluationResponse();
 
-            //Aeros always move after other units, and would require an 
+            //Airborne aeros always move after other units, and would require an 
             // entirely different evaluation
             //TODO (low priority) implement a way to see if I can dodge aero units
-            if (enemy.isAero()) {
+            if (enemy.isAirborne()) {
                 return returnResponse;
             }
             

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -52,7 +52,6 @@ import megamek.common.TargetRoll;
 import megamek.common.Targetable;
 import megamek.common.Terrains;
 import megamek.common.TripodMech;
-import megamek.common.MovePath.MoveStepType;
 import megamek.common.logging.LogLevel;
 import megamek.common.options.OptionsConstants;
 
@@ -168,7 +167,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             //Airborne aeros always move after other units, and would require an 
             // entirely different evaluation
             //TODO (low priority) implement a way to see if I can dodge aero units
-            if (enemy.isAirborne()) {
+            if (enemy.isAero() && enemy.isAirborne()) {
                 return returnResponse;
             }
             
@@ -656,7 +655,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
     protected boolean evaluateAsMoved(Entity enemy) {
         // Aerospace units on ground maps can go pretty much anywhere they want, so it's
         // somewhat pointless to try to predict their movement.
-        return !enemy.isSelectableThisTurn() || enemy.isImmobile() || enemy.isAero();
+        return !enemy.isSelectableThisTurn() || enemy.isImmobile() || (enemy.isAero() && enemy.isAirborne());
     }
     
     /**

--- a/megamek/src/megamek/client/bot/princess/BotGeometry.java
+++ b/megamek/src/megamek/client/bot/princess/BotGeometry.java
@@ -101,15 +101,15 @@ public class BotGeometry {
      * Coords stores x and y values. Since these are hexes, coordinates with odd x
      * values are a half-hex down. Directions work clockwise around the hex,
      * starting with zero at the top.
-     * -y
-     * 0
-     * _____
-     * 5 /     \ 1
+     *        -y
+     *        0
+     *      _____
+     *   5 /     \ 1
      * -x /       \ +x
-     * \       /
-     * 4 \_____/ 2
-     * 3
-     * +y
+     *    \       /
+     *   4 \_____/ 2
+     *        3
+     *        +y
      * ------------------------------
      * Direction is stored as above, but the meaning of 'intercept' depends
      * on the direction.  For directions 0,3, intercept means the y=0 intercept
@@ -239,7 +239,7 @@ public class BotGeometry {
                 if (getDirection() == 2) {
                     return h.getIntersection(this);
                 }
-                if (getDirection() == 0) {
+                if (getDirection() == 0 || getDirection() == 3) {
                     return new Coords(getIntercept(), h.getYfromX(getIntercept()));
                 }
                 //direction must be 1 here, and h.direction=2
@@ -392,7 +392,7 @@ public class BotGeometry {
             try {
                 while (cfit.hasNext()) {
                     CoordFacingCombo cf = cfit.next();
-                    if(cf != null) {
+                    if(cf != null && owner.getGame().getBoard().contains(cf.coords)) {
                         expandToInclude(cf.getCoords());
                     }
                 }
@@ -405,7 +405,7 @@ public class BotGeometry {
          * returns true if a point is inside the area
          * false if it is not
          */
-        boolean contains(Coords c) {
+        public boolean contains(Coords c) {
             final String METHOD_NAME = "contains(Coords)";
             owner.methodBegin(getClass(), METHOD_NAME);
 
@@ -448,7 +448,7 @@ public class BotGeometry {
         /**
          * Returns a vertex, with zero starting at the upper left of the hex
          */
-        Coords getVertexNum(int i) {
+        public Coords getVertexNum(int i) {
             final String METHOD_NAME = "getVertexNum(int)";
             owner.methodBegin(getClass(), METHOD_NAME);
 
@@ -505,7 +505,7 @@ public class BotGeometry {
             }
         }
 
-        HexLine[] getEdges() {
+        public HexLine[] getEdges() {
             EDGES_LOCK.readLock().lock();
             try {
                 return Arrays.copyOf(edges, edges.length);

--- a/megamek/src/megamek/client/bot/princess/EntityState.java
+++ b/megamek/src/megamek/client/bot/princess/EntityState.java
@@ -13,6 +13,7 @@
  */
 package megamek.client.bot.princess;
 
+import megamek.client.bot.princess.BotGeometry.CoordFacingCombo;
 import megamek.common.BuildingTarget;
 import megamek.common.Coords;
 import megamek.common.Entity;
@@ -111,6 +112,15 @@ public class EntityState {
         setSecondaryFacing(getFacing());
     }
 
+    /**
+     * Create an entity state from a Targetable, but pretend it's in a different hex facing in a different direction.
+     */
+    EntityState(Targetable target, CoordFacingCombo projectedTargetLocation) {
+        this(target);
+        position = projectedTargetLocation.getCoords();
+        facing = projectedTargetLocation.getFacing();
+    }
+    
     public Coords getPosition() {
         return position;
     }

--- a/megamek/src/megamek/client/bot/princess/InfantryPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryPathRanker.java
@@ -131,7 +131,7 @@ public class InfantryPathRanker extends BasicPathRanker implements IPathRanker {
             //Aeros always move after other units, and would require an 
             // entirely different evaluation
             //TODO (low priority) implement a way to see if I can dodge aero units
-            if (enemy.isAero()) {
+            if (enemy.isAirborne()) {
                 return returnResponse;
             }
             

--- a/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
@@ -1,11 +1,7 @@
 package megamek.client.bot.princess;
 
 import java.util.List;
-import java.util.Set;
-import java.util.TreeMap;
 
-import megamek.client.bot.princess.BotGeometry.CoordFacingCombo;
-import megamek.client.bot.princess.BotGeometry.HexLine;
 import megamek.common.Aero;
 import megamek.common.Compute;
 import megamek.common.Coords;
@@ -104,18 +100,6 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPa
         try {
             EntityEvaluationResponse returnResponse =
                     new EntityEvaluationResponse();
-            
-            // this path ends with a set of coordinates and a direction that I'm facing. 
-            // we examine the vertices of the area into which this enemy could potentially move, and make an 
-            // attempt to evaluate how much of that area is out of my main weapons arc
-            // a reasonable estimate is the percentage of vertices that are not in the main weapons arc
-            // that number will be the multiplier for the amount of damage *I* can do to the enemy.
-            // we will assume that the enemy will always move in such a way as to maximize their damage to me.
-            // due to characteristics of space combat (no minimum range) however, if their "optimal firing point"
-            // will result in me getting hit in a low-armor location, we apply a multiplier to the damage, 
-            // as it is really bad to get hit in an un-armored location
-            
-            // don't feel like doing this tonight, though, thanks wife.
             
             Coords finalCoords = path.getFinalCoords();
             Coords closest = getClosestCoordsTo(enemy.getId(), finalCoords);

--- a/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
@@ -1,0 +1,95 @@
+package megamek.client.bot.princess;
+
+import java.util.List;
+
+import megamek.common.Compute;
+import megamek.common.Coords;
+import megamek.common.Entity;
+import megamek.common.IGame;
+import megamek.common.Infantry;
+import megamek.common.LosEffects;
+import megamek.common.MovePath;
+
+public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPathRanker {
+
+    public NewtonianAerospacePathRanker(Princess owningPrincess) {
+        super(owningPrincess);
+    }
+    
+    /**
+     * Find the closest enemy to a unit with a path that ends at the given position.
+     */
+    public Entity findClosestEnemy(Entity me, Coords position, IGame game) {
+        final String METHOD_NAME = "findClosestEnemy(Entity, Coords, IGame)";
+        getOwner().methodBegin(PathRanker.class, METHOD_NAME);
+
+        try {
+            int range = 9999;
+            Entity closest = null;
+            List<Entity> enemies = getOwner().getEnemyEntities();
+            for (Entity e : enemies) {
+                // Also, skip withdrawing enemy bot units, to avoid humping disabled tanks and ejected mechwarriors
+                if (getOwner().getHonorUtil().isEnemyBroken(e.getTargetId(), e.getOwnerId(), getOwner().getForcedWithdrawal())) {
+                    continue;
+                }
+
+                // If a unit has not moved, assume it will move away from me.
+                int unmovedDistMod = 0;
+                if (e.isSelectableThisTurn() && !e.isImmobile()) {
+                    unmovedDistMod = e.getWalkMP(true, false, false);
+                }
+
+                if ((position.distance(e.getPosition()) + unmovedDistMod) < range) {
+                    range = position.distance(e.getPosition());
+                    closest = e;
+                }
+            }
+            return closest;
+        } finally {
+            getOwner().methodEnd(PathRanker.class, METHOD_NAME);
+        }
+    }
+    
+    double calculateMyDamagePotential(MovePath path, Entity enemy,
+            int distance, IGame game) {
+        Entity me = path.getEntity();
+        Coords pathFinalPosition = Compute.getFinalPosition(me.getPosition(), path.getFinalVectors());
+
+        int maxRange = me.getMaxWeaponRange();
+        if (distance > maxRange) {
+            return 0;
+        }
+
+        // If I don't have LoS, I can't do damage. We're on a space map so this probably is unnecessary.
+        LosEffects losEffects = 
+        LosEffects.calculateLos(game, me.getId(), enemy, pathFinalPosition, enemy.getPosition(), false);
+        if (!losEffects.canSee()) {
+            return 0;
+        }
+
+        FiringPlan myFiringPlan;
+        
+        FiringPlanCalculationParameters guess =
+        new FiringPlanCalculationParameters.Builder()
+          .buildGuess(path.getEntity(),
+                      new EntityState(path),
+                      enemy,
+                      null,
+                      FireControl.DOES_NOT_TRACK_HEAT,
+                      null);
+        myFiringPlan = getFireControl().determineBestFiringPlan(guess);
+        
+        return myFiringPlan.getUtility();
+    }
+    
+    /**
+     * Worker method for the distance calculation between a considered move path and a set of coordinates.
+     * @param path The move path being considered.
+     * @param coords The coordinates being considered.
+     * @return
+     */
+    @Override
+    protected int calculateDistance(MovePath path, Coords coords) {
+        return coords.distance(Compute.getFinalPosition(path.getEntity().getPosition(), path.getFinalVectors()));
+    }
+}

--- a/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
@@ -2,10 +2,11 @@ package megamek.client.bot.princess;
 
 import java.util.List;
 
-import megamek.common.Aero;
+import megamek.client.bot.princess.BotGeometry.ConvexBoardArea;
 import megamek.common.Compute;
 import megamek.common.Coords;
 import megamek.common.Entity;
+import megamek.common.IAero;
 import megamek.common.IGame;
 import megamek.common.LosEffects;
 import megamek.common.MovePath;
@@ -115,7 +116,7 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPa
             // placeholder logic:
             // if we are a spheroid, we can fire viably in any direction
             // if we are a fighter or aerodyne dropship, our most effective arc is forward
-            int arcToUse = ((Aero) path.getEntity()).isSpheroid() ? Compute.ARC_360 : Compute.ARC_NOSE;
+            int arcToUse = ((IAero) path.getEntity()).isSpheroid() ? Compute.ARC_360 : Compute.ARC_NOSE;
             double vertexCoverage = 1.0;
             
             // the idea here is that, if we have a limited firing arc, the target
@@ -124,11 +125,12 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPa
             // that are in our main firing arc, compared to the max (6).
             if(arcToUse != Compute.ARC_360) {
                 int inArcVertexCount = 0;
+                ConvexBoardArea movableArea = getPathEnumerator().getUnitMovableAreas().get(enemy.getId());
                 
-                for(int vertexNum = 0; vertexNum < 6; vertexNum++) {
-                    Coords vertex = getPathEnumerator().getUnitMovableAreas().get(enemy.getId()).getVertexNum(vertexNum);
+                for(int vertexNum = 0; vertexNum < 6; vertexNum++) {                    
+                    Coords vertex = movableArea.getVertexNum(vertexNum);
                     
-                    if(Compute.isInArc(finalCoords, path.getFinalFacing(), vertex, arcToUse)) {
+                    if(vertex != null && Compute.isInArc(finalCoords, path.getFinalFacing(), vertex, arcToUse)) {
                         inArcVertexCount++;
                     }
                 }

--- a/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
@@ -1,12 +1,13 @@
 package megamek.client.bot.princess;
 
 import java.util.List;
+import java.util.Set;
 
-import megamek.common.Compute;
+import megamek.client.bot.princess.BotGeometry.CoordFacingCombo;
+import megamek.client.bot.princess.BotGeometry.HexLine;
 import megamek.common.Coords;
 import megamek.common.Entity;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.LosEffects;
 import megamek.common.MovePath;
 
@@ -19,6 +20,7 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPa
     /**
      * Find the closest enemy to a unit with a path that ends at the given position.
      */
+    @Override
     public Entity findClosestEnemy(Entity me, Coords position, IGame game) {
         final String METHOD_NAME = "findClosestEnemy(Entity, Coords, IGame)";
         getOwner().methodBegin(PathRanker.class, METHOD_NAME);
@@ -50,10 +52,13 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPa
         }
     }
     
+    /**
+     * Calculate the damage potential 
+     */
+    @Override
     double calculateMyDamagePotential(MovePath path, Entity enemy,
             int distance, IGame game) {
         Entity me = path.getEntity();
-        Coords pathFinalPosition = Compute.getFinalPosition(me.getPosition(), path.getFinalVectors());
 
         int maxRange = me.getMaxWeaponRange();
         if (distance > maxRange) {
@@ -62,7 +67,7 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPa
 
         // If I don't have LoS, I can't do damage. We're on a space map so this probably is unnecessary.
         LosEffects losEffects = 
-        LosEffects.calculateLos(game, me.getId(), enemy, pathFinalPosition, enemy.getPosition(), false);
+        LosEffects.calculateLos(game, me.getId(), enemy, path.getFinalCoords(), enemy.getPosition(), false);
         if (!losEffects.canSee()) {
             return 0;
         }
@@ -81,15 +86,134 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPa
         
         return myFiringPlan.getUtility();
     }
+
+    /**
+     * Guesses a number of things about an enemy that has not yet moved
+     */
+    EntityEvaluationResponse evaluateUnmovedEnemy(Entity enemy, MovePath path,
+                                                  boolean useExtremeRange,
+                                                  boolean useLOSRange) {
+        final String METHOD_NAME =
+                "EntityEvaluationResponse evaluateUnmovedEnemy(Entity," +
+                "MovePath,IGame)";
+        getOwner().methodBegin(getClass(), METHOD_NAME);
+
+        try {
+            EntityEvaluationResponse returnResponse =
+                    new EntityEvaluationResponse();
+            
+            // this path ends with a set of coordinates and a direction that I'm facing. 
+            // we examine the vertices of the area into which this enemy could potentially move, and make an 
+            // attempt to evaluate how much of that area is out of my main weapons arc
+            // a reasonable estimate is the percentage of vertices that are not in the main weapons arc
+            // that number will be the multiplier for the amount of damage *I* can do to the enemy.
+            // we will assume that the enemy will always move in such a way as to maximize their damage to me.
+            // due to characteristics of space combat (no minimum range) however, if their "optimal firing point"
+            // will result in me getting hit in a low-armor location, we apply a multiplier to the damage, 
+            // as it is really bad to get hit in an un-armored location
+            
+            // don't feel like doing this tonight, though, thanks wife.
+            
+            Coords finalCoords = path.getFinalCoords();
+            Coords closest = getClosestCoordsTo(enemy.getId(), finalCoords);
+            if (closest == null) {
+                return returnResponse;
+            }
+            int range = closest.distance(finalCoords);
+            if(range == 0) {
+                range = 1;
+            }
+
+            returnResponse.addToMyEstimatedDamage(
+                        getMaxDamageAtRange(getFireControl(),
+                                            path.getEntity(),
+                                            range,
+                                            useExtremeRange,
+                                            useLOSRange));
+
+            //in general if an enemy can end its position in range, it can hit me
+            returnResponse.addToEstimatedEnemyDamage(
+                    getMaxDamageAtRange(getFireControl(),
+                                        enemy,
+                                        range,
+                                        useExtremeRange,
+                                        useLOSRange));
+
+
+            // check the potential places the other unit could get to.
+            // for each potential place, check the max damage I can do to the enemy, and the max damage he can do to me
+            // assume that the enemy will move in such a way as to do the most damage to me while taking the least damage
+            /*Set<CoordFacingCombo> potentialEnemyLocations = getPathEnumerator().getUnitPotentialLocations().get(enemy.getId());
+            getPathEnumerator().getUnitMovableAreas()
+            
+            EntityState myState = new EntityState(path);
+            double maxEnemyUtility = -9999;
+            
+            myState.getPosition().
+            
+            for(CoordFacingCombo potentialEnemyLocation: potentialEnemyLocations) {
+                EntityState enemyState = new EntityState(enemy, potentialEnemyLocation);
+                
+                // if the hex is entirely out of range, we may skip all the expensive calculations 
+                if(enemyState.getPosition().distance(myState.getPosition()) > enemy.getMaxWeaponRange()) {
+                    
+                    if(maxEnemyUtility < 0) {
+                        maxEnemyUtility = 0;
+                    }
+                    
+                    continue;
+                }
+                
+                // figure out the best shot the enemy an take from where they are
+                FiringPlanCalculationParameters enemyGuess =
+                        new FiringPlanCalculationParameters.Builder()
+                                .buildGuess(enemy,
+                                        enemyState,
+                                        path.getEntity(),
+                                        myState,
+                                        enemy.getHeatCapacity(),
+                                        null);
+                
+                FiringPlan projectedEnemyFiringPlan = getFireControl().determineBestFiringPlan(enemyGuess);
+
+                
+                // figure out the best shot I can take at the enemy from where I am
+                FiringPlanCalculationParameters myGuess =
+                        new FiringPlanCalculationParameters.Builder()
+                                .buildGuess(enemy,
+                                        enemyState,
+                                        path.getEntity(),
+                                        myState,
+                                        enemy.getHeatCapacity(),
+                                        null);
+                
+                FiringPlan projectedMyFiringPlan = getFireControl().determineBestFiringPlan(myGuess);
+                
+                if(projectedMyFiringPlan.getUtility() > 0) {
+                    int alpha = 1;
+                }
+                
+                // assume that, after I move, the enemy will move in such a way as to maximize their outgoing damage to me while
+                // minimizing the damage I do
+                double combinedUtilityToEnemy = projectedEnemyFiringPlan.getUtility() - projectedMyFiringPlan.getUtility();
+                if(combinedUtilityToEnemy > maxEnemyUtility) {
+                    maxEnemyUtility = combinedUtilityToEnemy;
+                    returnResponse.setEstimatedEnemyDamage(projectedEnemyFiringPlan.getUtility());
+                    returnResponse.setMyEstimatedDamage(projectedMyFiringPlan.getUtility());
+                }
+            }*/
+
+            return returnResponse;
+        } finally {
+            getOwner().methodEnd(getClass(), METHOD_NAME);
+        }
+    }
     
     /**
-     * Worker method for the distance calculation between a considered move path and a set of coordinates.
-     * @param path The move path being considered.
-     * @param coords The coordinates being considered.
-     * @return
+     * Worker function that determines if a given enemy entity should be evaluated as if it has moved.
      */
     @Override
-    protected int calculateDistance(MovePath path, Coords coords) {
-        return coords.distance(Compute.getFinalPosition(path.getEntity().getPosition(), path.getFinalVectors()));
+    protected boolean evaluateAsMoved(Entity enemy) {
+        return !enemy.isSelectableThisTurn() || enemy.isImmobile();
     }
 }

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -444,7 +444,7 @@ public class PathEnumerator {
         return unitPaths;
     }
 
-    protected Map<Integer, ConvexBoardArea> getUnitMovableAreas() {
+    public Map<Integer, ConvexBoardArea> getUnitMovableAreas() {
         return unitMovableAreas;
     }
 

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -42,6 +42,7 @@ import megamek.common.pathfinder.AeroGroundPathFinder.AeroGroundOffBoardFilter;
 import megamek.common.pathfinder.InfantryPathFinder;
 import megamek.common.pathfinder.LongestPathFinder;
 import megamek.common.pathfinder.MovePathFinder;
+import megamek.common.pathfinder.NewtonianAerospacePathFinder;
 import megamek.common.pathfinder.ShortestPathFinder;
 
 public class PathEnumerator {
@@ -240,6 +241,10 @@ public class PathEnumerator {
                 for(Integer length : pathLengths.keySet()) {
                     this.owner.log(this.getClass(), METHOD_NAME, LogLevel.DEBUG, "Paths of length " + length + ": " + pathLengths.get(length));
                 }
+            } else if(mover.isAero() && game.useVectorMove()) {
+                NewtonianAerospacePathFinder npf = NewtonianAerospacePathFinder.getInstance(getGame());
+                npf.run(new MovePath(game, mover));
+                paths.addAll(npf.getAllComputedPathsUncategorized());
             } else if (mover.isAero()) {
                 IAero aeroMover = (IAero)mover;
                 // Get the shortest paths possible.

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -50,7 +50,8 @@ public abstract class PathRanker implements IPathRanker {
      */
     public enum PathRankerType {
         Basic,
-        Infantry
+        Infantry,
+        NewtonianAerospace
     }
     
     private Princess owner;

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -174,7 +174,7 @@ public class Princess extends BotClient {
     IPathRanker getPathRanker(Entity entity) {
         if(entity.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
             return pathRankers.get(PathRankerType.Infantry);
-        } else if (entity.hasETypeFlag(Entity.ETYPE_AERO) && game.useVectorMove()) {
+        } else if (entity.isAero() && game.useVectorMove()) {
             return pathRankers.get(PathRankerType.NewtonianAerospace);
         }
         
@@ -345,6 +345,18 @@ public class Princess extends BotClient {
                 sendChat("deploying unit " + getEntity(entityNum).getChassis(), LogLevel.INFO);
             }
 
+            // if we are using forced withdrawal, and the entity being considered is crippled
+            // we will opt to not re-deploy the entity
+            if(getForcedWithdrawal() && getEntity(entityNum).isCrippled()) {
+                log(getClass(),
+                        METHOD_NAME,
+                        LogLevel.INFO,
+                        "Declining to deploy crippled unit: "
+                        + getEntity(entityNum).getChassis() + ". Removing unit.");
+                sendDeleteEntity(entityNum);
+                return;
+            }
+            
             // on the list to be deployed get a set of all the
             final List<Coords> startingCoords = getStartingCoordsArray(game.getEntity(entityNum));
             if (0 == startingCoords.size()) {
@@ -1749,7 +1761,7 @@ public class Princess extends BotClient {
         Entity pathEntity = path.getPath().getEntity();
         
         // we cannot evade if we are out of control
-        if(pathEntity.isAirborne() && ((Aero) pathEntity).isOutControlTotal()) {
+        if(pathEntity.isAero() && pathEntity.isAirborne() && ((IAero) pathEntity).isOutControlTotal()) {
             return;
         }
         

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -34,6 +34,7 @@ import megamek.client.bot.PhysicalOption;
 import megamek.client.bot.princess.FireControl.FireControlType;
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.client.ui.SharedUtility;
+import megamek.common.Aero;
 import megamek.common.AmmoType;
 import megamek.common.BattleArmor;
 import megamek.common.Building;
@@ -1745,11 +1746,18 @@ public class Princess extends BotClient {
      * @param path The path to process
      */
     private void evadeIfNotFiring(final RankedPath path) {
+        Entity pathEntity = path.getPath().getEntity();
+        
+        // we cannot evade if we are out of control
+        if(pathEntity.isAirborne() && ((Aero) pathEntity).isOutControlTotal()) {
+            return;
+        }
+        
         // if we're an airborne aircraft
         // and we're not going to do any damage anyway
         // and we can do so without causing a PSR
         // then evade
-        if(path.getPath().getEntity().isAirborne() &&
+        if(pathEntity.isAirborne() &&
            (0 >= path.getExpectedDamage()) &&
            (path.getPath().getMpUsed() <= AeroGroundPathFinder.calculateMaxSafeThrust((IAero) path.getPath()
                                                                                                   .getEntity()) - 2)) {

--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -853,7 +853,9 @@ public class SharedUtility {
                 // for purposes of bombing
                 en.addPassedThrough(right);
                 en.addPassedThrough(left);
-                client.sendUpdateEntity(en);
+                if(client !=  null) {
+                    client.sendUpdateEntity(en);
+                }
 
                 // if the left is preferred, increment i so next one is skipped
                 if ((leftTonnage < rightTonnage)

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -1399,6 +1399,11 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         //renderMovementBoundingBox((Graphics2D) g);
     }
     
+    /** 
+     * Debugging method that renders the bounding hex of a unit's movement envelope.
+     * Warning: very slow when rendering the bounding hex for really fast units.
+     * @param g Graphics object on which to draw.
+     */
     private void renderMovementBoundingBox(Graphics2D g) {
         if(selectedEntity != null) {
             Princess princess = new Princess("test", "localhost", 2020, LogLevel.DEBUG);
@@ -1420,10 +1425,11 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 }
             }
             
-            Coords d = cba.getEdges()[2].getIntersection(cba.getEdges()[3]);
-            
             for(Integer x = 0; x < 6; x++) {
                 Coords c = cba.getVertexNum(x);
+                if(c == null) {
+                    continue;
+                }
 
                 Point p = getCentreHexLocation(c.getX(), c.getY(), true);
                 p.translate(HEX_W / 2, HEX_H  / 2);

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -89,6 +89,9 @@ import javax.swing.plaf.metal.DefaultMetalTheme;
 import javax.swing.plaf.metal.MetalTheme;
 
 import megamek.client.TimerSingleton;
+import megamek.client.bot.princess.BotGeometry.ConvexBoardArea;
+import megamek.client.bot.princess.PathEnumerator;
+import megamek.client.bot.princess.Princess;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.event.BoardViewListener;
 import megamek.client.event.MechDisplayEvent;
@@ -168,6 +171,7 @@ import megamek.common.event.GameListener;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GameNewActionEvent;
 import megamek.common.event.GamePhaseChangeEvent;
+import megamek.common.logging.LogLevel;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.IClientPreferences;
@@ -1389,6 +1393,45 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
             g.setFont(fpsFont);
             g.setColor(Color.YELLOW);
             g.drawString(s, -getX() + 5, -getY() + 20);
+        }
+        
+        // debugging method that renders the bounding box of a unit's movement envelope.
+        //renderMovementBoundingBox((Graphics2D) g);
+    }
+    
+    private void renderMovementBoundingBox(Graphics2D g) {
+        if(selectedEntity != null) {
+            Princess princess = new Princess("test", "localhost", 2020, LogLevel.DEBUG);
+            princess.getGame().setBoard(this.game.getBoard());
+            PathEnumerator pathEnum = new PathEnumerator(princess, this.game);
+            pathEnum.recalculateMovesFor(this.selectedEntity);
+            
+            ConvexBoardArea cba = pathEnum.getUnitMovableAreas().get(this.selectedEntity.getId());
+            for(int x = 0; x < game.getBoard().getWidth(); x++) {
+                for(int y = 0; y < game.getBoard().getHeight(); y++) {
+                    Point p = getCentreHexLocation(x, y, true);
+                    p.translate(HEX_W  / 2, HEX_H  / 2);   
+                    Coords c = new Coords(x, y);
+                    
+                    if(cba.contains(c)) {
+                        
+                        drawHexBorder(g, p, Color.PINK, 0, 6);
+                    }
+                }
+            }
+            
+            Coords d = cba.getEdges()[2].getIntersection(cba.getEdges()[3]);
+            
+            for(Integer x = 0; x < 6; x++) {
+                Coords c = cba.getVertexNum(x);
+
+                Point p = getCentreHexLocation(c.getX(), c.getY(), true);
+                p.translate(HEX_W / 2, HEX_H  / 2);
+                
+                drawHexBorder(g, p, Color.yellow, 0, 3);
+                String s = x.toString();
+                this.drawCenteredText((Graphics2D) g, s, p, Color.yellow, false);
+            }
         }
     }
     

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -720,6 +720,9 @@ public class MovePath implements Cloneable, Serializable {
      */
     public Coords getFinalCoords() {
         if (getLastStep() != null) {
+            if(getGame().useVectorMove()) {
+                return Compute.getFinalPosition(getStartCoords(), getFinalVectors());
+            }
             return getLastStep().getPosition();
         }
         return getEntity().getPosition();

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -719,12 +719,14 @@ public class MovePath implements Cloneable, Serializable {
      * this path.
      */
     public Coords getFinalCoords() {
+        if(getGame().useVectorMove()) {
+            return Compute.getFinalPosition(getEntity().getPosition(), getFinalVectors());
+        }
+        
         if (getLastStep() != null) {
-            if(getGame().useVectorMove()) {
-                return Compute.getFinalPosition(getStartCoords(), getFinalVectors());
-            }
             return getLastStep().getPosition();
         }
+        
         return getEntity().getPosition();
     }
 

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -375,6 +375,8 @@ public class MoveStep implements Serializable {
                 return "Evade";
             case CONVERT_MODE:
                 return "ConvMode";
+            case THRUST:
+                return "Thrust";
             default:
                 return "???";
         }

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -377,6 +377,8 @@ public class MoveStep implements Serializable {
                 return "ConvMode";
             case THRUST:
                 return "Thrust";
+            case YAW:
+                return "Yaw";
             default:
                 return "???";
         }

--- a/megamek/src/megamek/common/pathfinder/MovePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/MovePathFinder.java
@@ -70,16 +70,6 @@ public class MovePathFinder<C> extends AbstractPathFinder<MovePathFinder.CoordsW
         public CoordsWithFacing(MovePath mp) {
             this(mp.getFinalCoords(), mp.getFinalFacing());
         }
-        
-        /** 
-         * Constructs a "coords with facing" object, given a starting position, thrust vectors and ending facing.
-         * @param startCoords Where the object started
-         * @param thrustVectors How much thrust was applied in what directions
-         * @param facing The direction in which the object is facing at the end of the procedure
-         */
-        public CoordsWithFacing(Coords startCoords, int[] thrustVectors, int facing) {
-            this(Compute.getFinalPosition(startCoords, thrustVectors), facing);
-        }
 
         @Override
         public boolean equals(Object obj) {

--- a/megamek/src/megamek/common/pathfinder/MovePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/MovePathFinder.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import megamek.client.bot.princess.AeroPathUtil;
+import megamek.common.Compute;
 import megamek.common.Coords;
 import megamek.common.Entity;
 import megamek.common.EntityMovementType;
@@ -68,6 +69,16 @@ public class MovePathFinder<C> extends AbstractPathFinder<MovePathFinder.CoordsW
 
         public CoordsWithFacing(MovePath mp) {
             this(mp.getFinalCoords(), mp.getFinalFacing());
+        }
+        
+        /** 
+         * Constructs a "coords with facing" object, given a starting position, thrust vectors and ending facing.
+         * @param startCoords Where the object started
+         * @param thrustVectors How much thrust was applied in what directions
+         * @param facing The direction in which the object is facing at the end of the procedure
+         */
+        public CoordsWithFacing(Coords startCoords, int[] thrustVectors, int facing) {
+            this(Compute.getFinalPosition(startCoords, thrustVectors), facing);
         }
 
         @Override

--- a/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
@@ -1,0 +1,168 @@
+package megamek.common.pathfinder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import megamek.client.bot.princess.FireControl;
+import megamek.common.Compute;
+import megamek.common.Coords;
+import megamek.common.IGame;
+import megamek.common.IHex;
+import megamek.common.MovePath;
+import megamek.common.MovePath.MoveStepType;
+import megamek.common.Terrains;
+import megamek.common.logging.DefaultMmLogger;
+import megamek.common.logging.LogLevel;
+import megamek.common.logging.MMLogger;
+import megamek.common.pathfinder.MovePathFinder.CoordsWithFacing;
+
+/**
+ * This set of classes is intended to be used by AI players to generate paths for infantry units.
+ * This includes both foot and jump paths.
+ * @author NickAragua
+ *
+ */
+public class NewtonianAerospacePathFinder {
+    private IGame game;
+    private List<MovePath> aerospacePaths;
+    private MovePath offBoardPath;
+    private MMLogger logger;
+    private static final String LOGGER_CATEGORY = "megamek.common.pathfinder.NewtonianAerospacePathFinder";
+    
+    // This is a map containing coordinates-with-facing, and the length of the path it took to get there
+    private Map<CoordsWithFacing, Integer> visitedCoords = new HashMap<>();
+    private List<MoveStepType> moves;
+    
+    private NewtonianAerospacePathFinder(IGame game) {
+        this.game = game;
+        getLogger().setLogLevel(LOGGER_CATEGORY, LogLevel.DEBUG);
+        
+        // put together a pre-defined array of possible moves
+        moves = new ArrayList<>();
+        //moves.add(MoveStepType.TURN_RIGHT);
+        moves.add(MoveStepType.TURN_LEFT);
+        moves.add(MoveStepType.THRUST);
+    }
+
+    public Collection<MovePath> getAllComputedPathsUncategorized() {
+        return aerospacePaths;
+    }
+    
+    private MMLogger getLogger() {
+        return logger == null ? logger = DefaultMmLogger.getInstance() : logger;
+    }
+    
+    /**
+     * Computes paths to nodes in the graph.
+     * 
+     * @param startingEdge the starting node. Should be empty.
+     */
+    public void run(MovePath startingEdge) {
+        final String METHOD_NAME = "run";
+        
+        try {
+            aerospacePaths = new ArrayList<MovePath>();
+            // add an option to stand still
+            aerospacePaths.add(startingEdge);
+            
+            /*MovePath testPath = startingEdge.clone();
+            testPath.addStep(MoveStepType.TURN_LEFT);
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            aerospacePaths.add(testPath);*/
+            
+            aerospacePaths.addAll(generateChildren(startingEdge));
+            
+            visitedCoords.clear();
+        } catch (OutOfMemoryError e) {
+            /*
+             * Some implementations can run out of memory if they consider and
+             * save in memory too many paths. Usually we can recover from this
+             * by ending prematurely while preserving already computed results.
+             */
+
+            final String memoryMessage = "Not enough memory to analyse all options."//$NON-NLS-1$
+                    + " Try setting time limit to lower value, or "//$NON-NLS-1$
+                    + "increase java memory limit.";
+            
+            getLogger().log(this.getClass(), METHOD_NAME, LogLevel.ERROR, memoryMessage, e);
+        } catch(Exception e) {
+            getLogger().log(this.getClass(), METHOD_NAME, e); //do something, don't just swallow the exception, good lord
+        }
+    }
+    
+    public static NewtonianAerospacePathFinder getInstance(IGame game) {
+        NewtonianAerospacePathFinder npf = new NewtonianAerospacePathFinder(game);
+
+        return npf;
+    }
+    
+    /**
+     * Recursive method that generates the possible child paths from the given path.
+     * Eliminates paths to hexes we've already visited.
+     * Generates *shortest* paths to destination hexes, because, look, infantry isn't going to get beyond a move 1 mod anyway.
+     * @param startingPath
+     * @return
+     */
+    private List<MovePath> generateChildren(MovePath startingPath) {
+        List<MovePath> retval = new ArrayList<>();
+        
+        CoordsWithFacing pathDestination = new CoordsWithFacing(startingPath.getEntity().getPosition(), 
+                                                                startingPath.getFinalVectors(), 
+                                                                startingPath.getFinalFacing());
+        
+        
+        
+        // terminator conditions:
+        // we've visited this hex already and the path we are considering is longer than the previous path that visited this hex
+        // OR we have used all our MP
+        if((visitedCoords.containsKey(pathDestination) && visitedCoords.get(pathDestination).intValue() < startingPath.getMpUsed()) ||
+                (startingPath.getMpUsed() >= startingPath.getEntity().getRunMP())) {
+            return retval;
+        }
+        
+        // keep track of a single path that takes us off board, if there is such a thing
+        // this should always be the shortest one.
+        if(game.getBoard().getHex(pathDestination.getCoords()) == null &&
+                (offBoardPath == null || startingPath.getMpUsed() < offBoardPath.getMpUsed())) {        
+            offBoardPath = startingPath;
+        }
+        
+        visitedCoords.put(pathDestination, startingPath.getMpUsed());
+        
+        // generate all possible children, add them to list
+        // for aerospace units, these are:
+        // turn left
+        // turn right
+        // thrust
+        for(int moveType = 0; moveType < moves.size(); moveType++) {
+            MovePath childPath = startingPath.clone();
+
+            // ensure we're not repeatedly turning back and forth
+            MoveStepType nextStepType = moves.get(moveType);
+            if((childPath.getLastStep() != null) &&
+                    (((nextStepType == MoveStepType.TURN_LEFT) && (childPath.getLastStep().getType() == MoveStepType.TURN_RIGHT)) ||
+                    ((nextStepType == MoveStepType.TURN_RIGHT) && (childPath.getLastStep().getType() == MoveStepType.TURN_LEFT)))) {
+                continue;
+            }
+            
+            childPath.addStep(nextStepType);
+            
+            // having generated the child, we add it and (recursively) any of its children to the list of children to be returned            
+            // of course, if it winds up not being legal anyway for some other reason, then we discard it and move on
+            if(!childPath.isMoveLegal()) {
+                continue;
+            }
+            
+            retval.add(childPath.clone());
+            retval.addAll(generateChildren(childPath));
+        }
+                
+        return retval;
+    }
+}

--- a/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
@@ -37,7 +37,7 @@ public class NewtonianAerospacePathFinder {
         
         // put together a pre-defined array of possible moves
         moves = new ArrayList<>();
-        //moves.add(MoveStepType.TURN_RIGHT);
+        moves.add(MoveStepType.TURN_RIGHT);
         moves.add(MoveStepType.TURN_LEFT);
         moves.add(MoveStepType.THRUST);
     }
@@ -65,6 +65,31 @@ public class NewtonianAerospacePathFinder {
             
             /*MovePath testPath = startingEdge.clone();
             testPath.addStep(MoveStepType.TURN_LEFT);
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            aerospacePaths.add(testPath);
+            
+            testPath = startingEdge.clone();
+            testPath.addStep(MoveStepType.TURN_RIGHT);
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            aerospacePaths.add(testPath);
+            
+            testPath = startingEdge.clone();
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            testPath.addStep(MoveStepType.THRUST);
+            aerospacePaths.add(testPath);
+            
+            testPath = startingEdge.clone();
+            testPath.addStep(MoveStepType.YAW);
+            testPath.addStep(MoveStepType.THRUST);
             testPath.addStep(MoveStepType.THRUST);
             testPath.addStep(MoveStepType.THRUST);
             aerospacePaths.add(testPath);*/

--- a/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
@@ -3,19 +3,12 @@ package megamek.common.pathfinder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import megamek.client.bot.princess.FireControl;
-import megamek.common.Compute;
-import megamek.common.Coords;
 import megamek.common.IGame;
-import megamek.common.IHex;
 import megamek.common.MovePath;
 import megamek.common.MovePath.MoveStepType;
-import megamek.common.Terrains;
 import megamek.common.logging.DefaultMmLogger;
 import megamek.common.logging.LogLevel;
 import megamek.common.logging.MMLogger;
@@ -112,11 +105,7 @@ public class NewtonianAerospacePathFinder {
     private List<MovePath> generateChildren(MovePath startingPath) {
         List<MovePath> retval = new ArrayList<>();
         
-        CoordsWithFacing pathDestination = new CoordsWithFacing(startingPath.getEntity().getPosition(), 
-                                                                startingPath.getFinalVectors(), 
-                                                                startingPath.getFinalFacing());
-        
-        
+        CoordsWithFacing pathDestination = new CoordsWithFacing(startingPath);
         
         // terminator conditions:
         // we've visited this hex already and the path we are considering is longer than the previous path that visited this hex

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -203,6 +203,7 @@ public class BasicPathRankerTest {
         final Entity mockAero = Mockito.mock(Aero.class);
         Mockito.when(mockAero.getId()).thenReturn(2);
         Mockito.when(mockAero.isAero()).thenReturn(true);
+        Mockito.when(mockAero.isAirborne()).thenReturn(true);
         EntityEvaluationResponse expected = new EntityEvaluationResponse();
         EntityEvaluationResponse actual = testRanker.evaluateUnmovedEnemy(mockAero, mockPath, false, false);
         assertEntityEvaluationResponseEquals(expected, actual);

--- a/megamek/unittests/megamek/client/bot/princess/PhysicalInfoTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PhysicalInfoTest.java
@@ -37,7 +37,7 @@ public class PhysicalInfoTest {
         Mockito.when(mockPrincess.getLogger()).thenReturn(fakeLogger);
 
         FireControl mockFireControl = Mockito.mock(FireControl.class);
-        Mockito.when(mockPrincess.getFireControl(FireControlType.Basic)).thenReturn(mockFireControl);
+        Mockito.when(mockPrincess.getFireControl(Mockito.any(Entity.class))).thenReturn(mockFireControl);
 
         ToHitData mockToHit = Mockito.mock(ToHitData.class);
         Mockito.when(mockFireControl.guessToHitModifierPhysical(Mockito.any(Entity.class),

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -66,6 +66,7 @@ public class PrincessTest {
         Mockito.doNothing().when(mockPrincess).log(Mockito.any(Class.class), Mockito.anyString(),
                                                    Mockito.any(LogLevel.class), Mockito.anyString());
         Mockito.when(mockPrincess.getPathRanker(PathRankerType.Basic)).thenReturn(mockPathRanker);
+        Mockito.when(mockPrincess.getPathRanker(Mockito.any(Entity.class))).thenReturn(mockPathRanker);
         Mockito.when(mockPrincess.getMoralUtil()).thenReturn(mockMoralUtil);
         Mockito.when(mockPrincess.getMyFleeingEntities()).thenReturn(new HashSet<>(0));
         Mockito.when(mockPrincess.getLogger()).thenReturn(fakeLogger);
@@ -426,7 +427,7 @@ public class PrincessTest {
         BasicPathRanker mockRanker = Mockito.mock(BasicPathRanker.class);
         Mockito.when(mockRanker.distanceToHomeEdge(Mockito.any(Coords.class), Mockito.any(HomeEdge.class),
                                                    Mockito.any(IGame.class))).thenReturn(0);
-        Mockito.when(mockPrincess.getPathRanker(PathRankerType.Basic)).thenReturn(mockRanker);
+        Mockito.when(mockPrincess.getPathRanker(Mockito.any(Entity.class))).thenReturn(mockRanker);
 
         // Mock objects so we don't have nulls.
         Coords mockCoords = Mockito.mock(Coords.class);


### PR DESCRIPTION
Features include:
- Fixing a long-standing bug with bot geometry where she was incorrectly evaluating the "closest coordinates" of a movable area.
- Fixing a bot cheat where an out-of-control aircraft could still issue orders and evade
- Oh yeah, and allowing the bot to fly spacecraft on space maps, using the stratops advanced newtonian spaceflight rules. This includes all spacecraft without restriction.