### PR TITLE
Fix for #1028: Infantry TAG has 0 range

### DIFF
--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
@@ -77,7 +77,10 @@ public abstract class InfantryWeapon extends Weapon {
      */
     @Override
     public int getLongRange() {
-        return infantryRange * 3;
+        if (longRange == 0) {
+            return infantryRange * 3;
+        }
+        return longRange;
     }
 
     /**
@@ -86,7 +89,10 @@ public abstract class InfantryWeapon extends Weapon {
      */
     @Override
     public int getExtremeRange() {
-        return infantryRange * 4;
+        if (extremeRange == 0) {
+            return infantryRange * 4;
+        }
+        return extremeRange;
     }
 
     /*


### PR DESCRIPTION
InfantryWeapon overrides getLongRange and getExtremeRange to provide values calculated from the infantry weapon range. This does not work for infantry TAG, which uses standard unit ranges.