### PR TITLE
Fix for #1027: Off-board Infantry Field Artillery "Target Out of Arc"

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3873,7 +3873,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         // Weapon in arc?
         if (!Compute.isInArc(game, attackerId, weaponId, target)
                 && (!Compute.isAirToGround(ae, target) || isArtilleryIndirect)
-                && !ae.isMakingVTOLGroundAttack()) {
+                && !ae.isMakingVTOLGroundAttack()
+                && !ae.isOffBoard()) {
             return "Target not in arc.";
         }
 


### PR DESCRIPTION
When deploying an entity offboard its position is set as the designated number of hexes from the middle of the indicated edge. When placed east or west, the facing is not directly toward the middle of the map due to the hex constraints. If placed close enough, this can cause part of the play area to be out of the firing arc. The player has no control over the facing, or the ability to rotate turret-mounted weapons during play (which includes field artillery). There is also no mention in the off-board rules in TacOps about checking firing arcs.

Added a line that ignores out of arc computation for offboard attacks.