### PR TITLE
Account for shielding in CF fusion/fission engine weights.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -545,6 +545,19 @@ public class TestAero extends TestEntity {
         }
         return 0;
     }
+    
+    @Override
+    public double getWeightEngine() {
+        double wt = super.getWeightEngine();
+        // Conventional fighters with fusion engines require extra shielding.
+        // Per TacOps fission engines require extra shielding as well.
+        if (getEntity().hasETypeFlag(Entity.ETYPE_CONV_FIGHTER)
+                && (null != getEntity().getEngine())
+                && (getEntity().getEngine().isFusion() || getEntity().getEngine().hasFlag(Engine.FISSION))) {
+            wt = ceil(wt * 1.5, Ceil.HALFTON);
+        }
+        return wt;
+    }
 
     @Override
     public double getWeightControls() {


### PR DESCRIPTION
MM does not add the extra 50% engine weight for conventional fighter fusion engines, which is surprising given that the rule is displayed prominently in small type tacked at the end of a footnote in a table.

Per TacOps the 50% extra weight is required for fission engines as well. It only mentions vehicles specifically, but as the fusion engine shielding rule is the same for vees and CFs and CFs are basically the vehicles of the sky, it's almost certainly the case for CFs.