### PR TITLE
Fix for sensor and bot bugs

### DIFF
--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -152,7 +152,7 @@ public abstract class PathRanker implements IPathRanker {
             if(path == null) {
                 continue;
             }
-            
+
             StringBuilder msg = new StringBuilder("Validating Path: ").append(path.toString());
 
             try {
@@ -411,6 +411,11 @@ public abstract class PathRanker implements IPathRanker {
      * @return True if there is a building in our path that might collapse.
      */
     private boolean willBuildingCollapse(MovePath path, IGame game) {
+        // airborne aircraft cannot collapse buildings
+        if(path.getEntity().isAero() || path.getEntity().hasETypeFlag(Entity.ETYPE_VTOL)) {
+            return false;
+        }
+        
         // If we're jumping onto a building, make sure it can support our weight.
         if (path.isJumping()) {
             final Coords finalCoords = path.getFinalCoords();

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4520,6 +4520,11 @@ public class Compute {
     
     public static boolean inSensorRange(IGame game, LosEffects los, Entity ae, 
             Targetable target, List<ECMInfo> allECMInfo) {
+        // This is not applicable to objects on the same team. 
+        if(!target.isEnemyOf(ae)) {
+            return false;
+        }
+        
         //For Space games with this option, return something different
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)
                 && target.getTargetType() == Targetable.TYPE_ENTITY
@@ -4542,7 +4547,8 @@ public class Compute {
         
         //A bit of a hack here. "Spacecraft Sensors" return the ground range, because Sensor doesn't know about Game or Entity
         //to do otherwise. We need to use the ground range instead.
-        if (ae.getActiveSensor().getType() == Sensor.TYPE_SPACECRAFT_RADAR) {
+        if ((ae.getActiveSensor() != null) &&
+                ae.getActiveSensor().getType() == Sensor.TYPE_SPACECRAFT_RADAR) {
             range = Sensor.LC_RADAR_GROUND_RANGE;
         }
 

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -132,6 +132,7 @@ public class MovePath implements Cloneable, Serializable {
         sb.append(this.getKey().hashCode());
         sb.append(' '); // it's useful to know for debugging purposes which path you're looking at.
         sb.append("Length: " + this.length());
+        sb.append("Final Coords: " + this.getFinalCoords());
         sb.append(System.lineSeparator());
         
         for (final Enumeration<MoveStep> i = steps.elements(); i.hasMoreElements(); ) {
@@ -685,6 +686,27 @@ public class MovePath implements Cloneable, Serializable {
      */
     private boolean getFliesOverEnemy() {
     	return fliesOverEnemy;
+    }
+    
+    /**
+     * Method that determines whether a given path goes through a given set of x/y coordinates
+     * Useful for debugging mainly.
+     * Note that battletech map coordinates begin at 1, while the internal representation begins at 0
+     * so subtract 1 from each axis to get the actual coordinates.
+     * @param x X-coordinate
+     * @param y Y-coordinate
+     * @return Whether this path goes through the set of coordinates.
+     */
+    public boolean goesThroughCoords(int x, int y) {
+        Enumeration<MoveStep> steps = getSteps();
+        while(steps.hasMoreElements()) {
+            MoveStep step = steps.nextElement();
+            if(step.getPosition().getX() == x && step.getPosition().getY() == y) {
+                return true;
+            }
+        }
+        
+        return false;
     }
     
     /**


### PR DESCRIPTION
This PR covers the following issues:

- inSensorRange was checking friendly entities, which is a waste of time
- inSensorRange was crashing if the entity in question didn't have active sensors
- the bot was discarding paths that took airborne (VTOL and ASF) units over buildings as if those units would collapse the buildings.