### PR TITLE
SO ammo explosions

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -765,6 +765,7 @@
 6125=remaining <data> damage prevented by CASE.
 6126=remaining <data> damage redirected by CASE II.
 6127=critical hit nullified by CASE II on an 8+ rolls <data>. 
+6128=<data> damage redirected to <data> armor.
 6130=<data> damage transfers to <data>.
 6135=<font color='C00000'>Movement system damaged!</font>
 6140=<font color='C00000'>Movement system destroyed!</font>

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -1007,6 +1007,8 @@
 9152=\ <font color='C00000'>Critical hit on weapons in the <data>.</font>
 9153=\ (but attack includes nuclear warheads, resolved first)<newline>
 9155=\ No functioning weapons in location.
+9156=\ <font color='C00000'>Checking for ammo explosion...<msg:9121,9157>
+9157=\ </font><font color='1CB0FF'>It does not explode!</font>
 9160=\ <font color='C00000'>Thrusters hit!</font>
 9165=\ <font color='C00000'>Cargo bay #<data> hit! <data> tons of cargo is lost.</font>
 9166=\ <font color='C00000'>Transport bay #<data> hit! <data> units destroyed.</font>

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1038,8 +1038,19 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
                     && (((BombType)type).getBombType() == BombType.B_ASEW)) {
                 damagePerShot = 5;
             }
+            
+            //Capital missiles need a racksize for this
+            if (type.hasFlag(AmmoType.F_CAP_MISSILE)) {
+                rackSize = 1;
+            }
 
             long mType = atype.getMunitionType();
+            //Screen launchers need a racksize. Damage is 15 per TW p251
+            if (mType == AmmoType.T_SCREEN_LAUNCHER) {
+                rackSize = 1;
+                damagePerShot = 15;
+            }
+            
             // both Dead-Fire and Tandem-charge SRM's do 3 points of damage per
             // shot when critted
             // Dead-Fire LRM's do 2 points of damage per shot when critted.

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1043,14 +1043,14 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
             if (type.hasFlag(AmmoType.F_CAP_MISSILE)) {
                 rackSize = 1;
             }
-
-            long mType = atype.getMunitionType();
+            
             //Screen launchers need a racksize. Damage is 15 per TW p251
-            if (mType == AmmoType.T_SCREEN_LAUNCHER) {
+            if (atype.getAmmoType() == AmmoType.T_SCREEN_LAUNCHER) {
                 rackSize = 1;
                 damagePerShot = 15;
             }
             
+            long mType = atype.getMunitionType();
             // both Dead-Fire and Tandem-charge SRM's do 3 points of damage per
             // shot when critted
             // Dead-Fire LRM's do 2 points of damage per shot when critted.

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3871,7 +3871,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                 }
             }
             if (!networkFiringSolution) {
-                if (!Compute.hasFiringSolution(game, ae, te)) {
+                //If we don't check for target type here, we can't fire screens and missiles at hexes...
+                if (!Compute.hasFiringSolution(game, ae, te) && target.getTargetType() == Targetable.TYPE_ENTITY) {
                     return "no firing solution to target";
                 }
             }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -23810,9 +23810,9 @@ public class Server implements Runnable {
                 if (te instanceof Aero) {
                     Aero a = (Aero) te;
                     
-                    // check for ammo explosions here: damage vented through armor, excess
+                    // check for large craft ammo explosions here: damage vented through armor, excess
                     // dissipating, much like Tank CASE.
-                    if (ammoExplosion) {
+                    if (ammoExplosion && te.isLargeCraft()) {
                         te.damageThisPhase += damage;
                         r = new Report(6128);
                         r.subject = te_n;
@@ -23911,6 +23911,10 @@ public class Server implements Runnable {
                     r.newlines = 1;
                     if (!ammoExplosion) {
                         r.messageId = 9005;
+                    }
+                    //Only for fighters
+                    if (ammoExplosion && !a.isLargeCraft()) {
+                        r.messageId = 9006;
                     }
                     r.add(damage);
                     r.add(Math.max(a.getSI(), 0));

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -26416,6 +26416,25 @@ public class Server implements Runnable {
                     if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AMMO_EXPLOSIONS)
                         && !(aero instanceof FighterSquadron)
                         && (weapon.getType() instanceof WeaponType)) {
+                        //Bay Weapons
+                        if (aero.usesWeaponBays()) {
+                            //Pick a random weapon in the bay and get the stats
+                            int wId = Compute.randomInt(weapon.getBayWeapons().size());
+                            Mounted bayW = aero.getEquipment(wId);
+                            Mounted bayWAmmo = bayW.getLinked();
+                            if (bayWAmmo != null) {
+                                int ammoroll = Compute.d6(2);
+                                if (ammoroll >= 10) {
+                                    r = new Report(9151);
+                                    r.subject = aero.getId();
+                                    r.add(bayWAmmo.getName());
+                                    r.newlines = 0;
+                                    reports.add(r);
+                                    reports.addAll(explodeEquipment(aero, loc, bayWAmmo));
+                                    break;
+                                }
+                            }
+                        }
                         // does it use Ammo?
                         WeaponType wtype = (WeaponType) weapon.getType();
                         if (wtype.getAmmoType() != AmmoType.T_NA) {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -22375,8 +22375,8 @@ public class Server implements Runnable {
             return vDesc;
         }
 
-        // no consciousness roll for capital fighter pilots
-        if (e.isCapitalFighter()) {
+        // no consciousness roll for capital fighter pilots or large craft crews
+        if (e.isCapitalFighter() || e.isLargeCraft()) {
             return vDesc;
         }
 

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -26478,13 +26478,9 @@ public class Server implements Runnable {
                                 int ammoRoll = Compute.d6(2);
                                 boomTarget = 10;
                                 r.choose(ammoRoll >= boomTarget);
+                                reports.add(r);
                                 if (ammoRoll >= boomTarget) {
-                                    r.choose(true);
-                                    reports.add(r);
                                     reports.addAll(explodeEquipment(aero, loc, bayWAmmo));
-                                } else {
-                                    r.choose(false);
-                                    reports.add(r);
                                 }
                             }
                             //Hit the weapon then also hit all the other weapons in the bay

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -26469,7 +26469,7 @@ public class Server implements Runnable {
                             int wId = weapon.getBayWeapons().get(Compute.randomInt(weapon.getBayWeapons().size()));
                             Mounted bayW = aero.getEquipment(wId);
                             Mounted bayWAmmo = bayW.getLinked();
-                            if (bayWAmmo != null) {
+                            if (bayWAmmo != null && bayWAmmo.getType().isExplosive(bayWAmmo)) {
                                 r = new Report(9156);
                                 r.subject = aero.getId();
                                 r.newlines = 1;


### PR DESCRIPTION
Implements large craft/bay weapon ammo explosions per SO. 
Fighters still explode per TW rules.

Also removes consciousness check for large craft crew hits - TW states that only units up to small craft size make these, and ammo explosions generate a lot more crew hits.