### PR TITLE
Vehicular stealth validation

### DIFF
--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -3494,7 +3494,7 @@ public class Tank extends Entity {
                 case EquipmentType.T_ARMOR_HARDENED:
                     usedSlots++;
                     break;
-                case EquipmentType.T_ARMOR_STEALTH:
+                case EquipmentType.T_ARMOR_STEALTH_VEHICLE:
                     usedSlots += 2;
                     break;
                 case EquipmentType.T_ARMOR_REACTIVE:

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -627,7 +627,7 @@ public class TestAero extends TestEntity {
                 heat += 12;
             }
         }
-        if (aero.getArmorType(1) == EquipmentType.T_ARMOR_STEALTH_VEHICLE) {
+        if (aero.hasStealth()) {
             heat += 10;
         }
         return heat;
@@ -644,7 +644,7 @@ public class TestAero extends TestEntity {
     @Override
     public double getWeightHeatSinks() {
         if (aero.hasETypeFlag(Entity.ETYPE_CONV_FIGHTER)) {
-            int required = countHeatEnergyWeapons();
+            int required = getConventionalCountHeatLaserWeapons();
             return Math.max(0, required - engine.getWeightFreeEngineHeatSinks());
         } else {
             return Math.max(getCountHeatSinks() - engine.getWeightFreeEngineHeatSinks(), 0);
@@ -688,46 +688,6 @@ public class TestAero extends TestEntity {
 
     public Aero getAero() {
         return aero;
-    }
-
-    private int countHeatEnergyWeapons() {
-        int heat = 0;
-        for (Mounted m : aero.getWeaponList()) {
-            WeaponType wt = (WeaponType) m.getType();
-            if ((wt.hasFlag(WeaponType.F_LASER) 
-                    && (wt.getAmmoType() == AmmoType.T_NA))
-                        || wt.hasFlag(WeaponType.F_PPC)
-                        || wt.hasFlag(WeaponType.F_PLASMA)
-                        || wt.hasFlag(WeaponType.F_PLASMA_MFUK)
-                        || (wt.hasFlag(WeaponType.F_FLAMER) 
-                                && (wt.getAmmoType() == AmmoType.T_NA))) {
-                heat += wt.getHeat();
-            }
-            // laser insulator reduce heat by 1, to a minimum of 1
-            Mounted linkedBy = m.getLinkedBy();
-            if (wt.hasFlag(WeaponType.F_LASER) && (linkedBy != null)
-                    && !linkedBy.isInoperable()
-                    && linkedBy.getType().hasFlag(MiscType.F_LASER_INSULATOR)) {
-                heat -= 1;
-                if (heat == 0) {
-                    heat++;
-                }
-            }
-
-            if ((linkedBy != null) && 
-                    (linkedBy.getType() instanceof MiscType) && 
-                    linkedBy.getType().hasFlag(MiscType.F_PPC_CAPACITOR)) {
-                heat += 5;
-            }
-        }
-        for (Mounted m : aero.getMisc()) {
-            MiscType mtype = (MiscType)m.getType();
-            // mobile HPGs count as energy weapons for construction purposes
-            if (mtype.hasFlag(MiscType.F_MOBILE_HPG)) {
-                heat += 20;
-            }
-        }
-        return heat;
     }
 
     public String printArmorLocProp(int loc, int wert) {

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1261,6 +1261,11 @@ public abstract class TestEntity implements TestEntityOption {
             illegal = true;
         }
         
+        if (getEntity().hasStealth() && !getEntity().hasWorkingMisc(MiscType.F_ECM)) {
+            buff.append("Stealth armor requires an ECM generator.\n");
+            illegal = true;
+        }
+        
         if (getEntity().isOmni()) {
             for (Mounted m : getEntity().getEquipment()) {
                 if (m.isOmniPodMounted() && m.getType().isOmniFixedOnly()) {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -396,10 +396,6 @@ public class TestMech extends TestEntity {
             StringBuffer buff) {
         MiscType mt = (MiscType) mounted.getType();
         if (mt.hasFlag(MiscType.F_STEALTH) && !entity.hasPatchworkArmor()) {
-            if (!entity.hasWorkingMisc(MiscType.F_ECM)) {
-                buff.append("stealth armor needs ECM suite\n");
-                return false;
-            }
             // stealth needs to have 2 crits in legs arm and side torso
             if (countCriticalSlotsFromEquipInLocation(entity, mounted,
                     Mech.LOC_LARM) != 2) {

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -285,6 +285,9 @@ public class TestTank extends TestEntity {
                 heat += 12;
             }
         }
+        if (tank.hasStealth()) {
+            heat += 10;
+        }
         return heat;
     }
 
@@ -296,8 +299,7 @@ public class TestTank extends TestEntity {
 
     @Override
     public int getCountHeatSinks() {
-        float heat = getTankCountHeatLaserWeapons();
-        return Math.round(heat);
+        return getTankCountHeatLaserWeapons();
     }
 
     @Override


### PR DESCRIPTION
Fix for MegaMek/megameklab#184

-Requires heat sinks for stealth armor in vehicles as with weapons per rules in TO, p. 280
-Requires ECM generator to pass validation (previously checked only in mechs; now checked in all units)
-Allocates two weapon slots on vehicles with stealth armor (previously checked for mech stealth armor rather than vehicular.
-I also double-checked heat sink calculations for conventional fighters, which follow the same rules as vehicles, and noticed there were two separate methods to compute heat sink requirements and removed the extra (the one that didn't include stealth armor requirements.