### PR TITLE
Handle missing force generator data more gracefully.

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
+++ b/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
@@ -1458,7 +1458,8 @@ public class ForceDescriptor {
     public String ratGeneratorRating() {
         FactionRecord fRec = getFactionRec();
         if ((null != fRec)
-                && !fRec.getRatingLevels().contains(rating)) {
+                && !fRec.getRatingLevels().contains(rating)
+                && (getRatingLevel() >= 0)) {
             return fRec.getRatingLevels().get(Math.min(getRatingLevel(), fRec.getRatingLevels().size() - 1));
         }
         return rating;

--- a/megamek/src/megamek/client/ratgenerator/Ruleset.java
+++ b/megamek/src/megamek/client/ratgenerator/Ruleset.java
@@ -84,12 +84,14 @@ public class Ruleset {
     private HashMap<Integer,String> customRanks;
     private ArrayList<ForceNode> forceNodes;
     private String parent;
-
+    
     private Ruleset() {
         faction = "IS";
         ratingSystem = RatingSystem.IS;
-        forceNodes = new ArrayList<>();
+        defaults = new DefaultsNode();
+        toc = new TOCNode();
         customRanks = new HashMap<>();
+        forceNodes = new ArrayList<>();
         parent = null;
     }
 
@@ -133,7 +135,8 @@ public class Ruleset {
                 }
             }
         }
-        return null;
+        // This shouldn't happen unless the data is missing. Throw out a default ruleset to prevent barfing.
+        return new Ruleset();
     }
 
     public int getCustomRankBase() {


### PR DESCRIPTION
Prevent throwing exceptions if the force generator data is missing. This is most likely to happen when launching MM from MekHQ while running from the repository.