### PR TITLE
Support vee cost and weight calculations

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10407,6 +10407,25 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                 }
             }
         }
+        if (isSupportVehicle()) {
+            for (Transporter t : getTransports()) {
+                int seatCost = 0;
+                if (t instanceof PillionSeatCargoBay) {
+                    seatCost += 10;
+                } else if (t instanceof StandardSeatCargoBay) {
+                    seatCost += 100;
+                }
+                if (seatCost > 0) {
+                    bvText.append(startColumn);
+                    bvText.append("Seating");
+                    bvText.append(endColumn);
+                    bvText.append(startColumn);
+                    bvText.append(commafy.format(seatCost));
+                    bvText.append(endColumn);
+                    bvText.append(endRow);
+                }
+            }
+        }
         return cost;
     }
     

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1014,8 +1014,22 @@ public class MiscType extends EquipmentType {
                 default:
                     costValue = 50000;
                 }
+            } else if (hasFlag(F_BASIC_FIRECONTROL)) {
+                // 5% of weapon cost
+                double weaponCost = 0;
+                for (Mounted mount : entity.getWeaponList()) {
+                    weaponCost += mount.getType().getCost(entity, mount.isArmored(), mount.getLocation());
+                }
+                return weaponCost * 0.05;
+            } else if (hasFlag(F_ADVANCED_FIRECONTROL)) {
+                // 10% of weapon cost
+                double weaponCost = 0;
+                for (Mounted mount : entity.getWeaponList()) {
+                    weaponCost += mount.getType().getCost(entity, mount.isArmored(), mount.getLocation());
+                }
+                return weaponCost * 0.1;
             }
-
+            
             if (isArmored) {
                 double armoredCost = costValue;
 
@@ -6399,6 +6413,7 @@ public class MiscType extends EquipmentType {
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 0;
         misc.tankslots = 0;
+        misc.cost = EquipmentType.COST_VARIABLE;
         misc.flags = misc.flags.or(MiscType.F_BASIC_FIRECONTROL).or(MiscType.F_SUPPORT_TANK_EQUIPMENT)
                 .or(MiscType.F_TANK_EQUIPMENT);
         misc.omniFixedOnly = true;
@@ -6420,6 +6435,7 @@ public class MiscType extends EquipmentType {
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 0;
         misc.tankslots = 0;
+        misc.cost = EquipmentType.COST_VARIABLE;
         misc.flags = misc.flags.or(MiscType.F_ADVANCED_FIRECONTROL)
                 .or(MiscType.F_SUPPORT_TANK_EQUIPMENT.or(MiscType.F_TANK_EQUIPMENT));
         misc.omniFixedOnly = true;

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1303,12 +1303,17 @@ public abstract class TestEntity implements TestEntityOption {
     public double getWeightCarryingSpace() {
         double carryingSpace = getEntity().getTroopCarryingSpace();
         double cargoWeight = 0;
+        Ceil rounding = Ceil.HALFTON;
+        if (getEntity().isSupportVehicle()
+                && (getEntity().getWeight() < 5.0)) {
+            rounding = Ceil.KILO;
+        }
         for (Bay bay : getEntity().getTransportBays()) {
             if (!bay.isQuarters()) {
-                cargoWeight += ceil(bay.getWeight(), Ceil.HALFTON);
+                cargoWeight += bay.getWeight();
             }
         }
-        return carryingSpace + cargoWeight;
+        return ceil(carryingSpace + cargoWeight, rounding);
     }
 
     public String printWeightCarryingSpace() {


### PR DESCRIPTION
A few fixes for calculations of support vehicle costs and weight calculations:
- Added cost calculation for basic and advanced fire control.
- Count standard and pillion crew seats in cost.
- Use kilogram standard for carrying capacity for small support vees.