### PR TITLE
Expose MULParser.parse(Element) for MekHQ perf improvements

### DIFF
--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -281,11 +281,15 @@ public class MULParser {
         }
         
         Element element = xmlDoc.getDocumentElement();
-
+        
         // Get rid of empty text nodes and adjacent text nodes...
         // Stupid weird parsing of XML. At least this cleans it up.
         element.normalize();
 
+        parse(element);
+    }
+
+    public void parse(Element element) {
         String version = element.getAttribute(VERSION);
         if (version.equals("")){
             warning.append("Warning: No version specified, correct parsing " +


### PR DESCRIPTION
This PR simply exposes `MULParser.parse(Element)` for specific performance improvements in MekHQ (which predominately loads units embedded in another XML file).