### PR TITLE
A bridge too far - bot edition

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -544,7 +544,6 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             // look at all of my enemies          
             FiringPhysicalDamage damageEstimate = new FiringPhysicalDamage();
             
-            int alpha = 1;
             double expectedDamageTaken = checkPathForHazards(pathCopy,
                                                              movingUnit,
                                                              game);


### PR DESCRIPTION
Fix for #1119, allowing the bot to cross bridges with tanks. And probably infantry and anything else that needs to be able to cross them. Also, allow surface naval units not to treat water hexes as hazards.