### PR TITLE
Account for Nova CEWS in computing vehicle/CF HS requirement.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -667,6 +667,9 @@ public class TestAero extends TestEntity {
             if (mtype.hasFlag(MiscType.F_VIRAL_JAMMER_DECOY)||mtype.hasFlag(MiscType.F_VIRAL_JAMMER_DECOY)) {
                 heat += 12;
             }
+            if (mtype.hasFlag(MiscType.F_NOVA)) {
+            	heat += 2;
+            }
         }
         if (aero.hasStealth()) {
             heat += 10;

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -284,6 +284,9 @@ public class TestTank extends TestEntity {
             if (mtype.hasFlag(MiscType.F_VIRAL_JAMMER_DECOY)||mtype.hasFlag(MiscType.F_VIRAL_JAMMER_DECOY)) {
                 heat += 12;
             }
+            if (mtype.hasFlag(MiscType.F_NOVA)) {
+            	heat += 2;
+            }
         }
         if (tank.hasStealth()) {
             heat += 10;


### PR DESCRIPTION
Fixes MegaMek/megameklab#198: Nova CEWS & heat sinks on vehicles

Nova CEWS generates two points of heat, and heat-neutral units require enough heat sinks in construction.