### PR TITLE
Fix for high-heat aeros refusing to fire on ground targets

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1854,7 +1854,9 @@ public class FireControl {
             final FiringPlan bombingPlan = this.getDiveBombPlan(shooter, null, target, game, shooter.passedOver(target), false);
             calculateUtility(bombingPlan, DOES_NOT_TRACK_HEAT, true); // bomb drops never cause heat
             
-            if(bombingPlan.getUtility() > myPlan.getUtility()) {
+            // if the bombing plan actually involves doing something
+            if((bombingPlan.size() > 0) && 
+                    (bombingPlan.getUtility() > myPlan.getUtility())) {
                 return bombingPlan;
             }
         }


### PR DESCRIPTION
Fix an issue where aeros that have more guns than heat capacity would refuse to fire on ground targets.

Basically, the "alpha strike" would come back with a utility of -4000 or whatever because aeros don't like overheating, and then the getFullFiringPlan method would return the no-action bombing run as the alpha strike instead. Whoops!

Now we check whether the bombing plan actually involves doing something before considering it as the alpha strike.