### PR TITLE
Fix typo in PlanetaryConditions

### DIFF
--- a/megamek/src/megamek/common/PlanetaryConditions.java
+++ b/megamek/src/megamek/common/PlanetaryConditions.java
@@ -96,7 +96,7 @@ public class PlanetaryConditions implements Serializable {
     private boolean runOnce = false;
 
     //set up the specific conditions
-    private int lightConditions = WI_NONE;
+    private int lightConditions = L_DAY;
     private int weatherConditions = WE_NONE;
     private int oldWeatherConditions = WE_NONE;
     private int windStrength = WI_NONE;


### PR DESCRIPTION
Both `WI_NONE` and `L_DAY` have value 0 - so there is no bugs and this introduces no functional changes.

I thought I could ignore it, but it's bothering me since I first noticed it :-)