### PR TITLE
Mixed tech intro date check

### DIFF
--- a/megamek/src/megamek/common/ITechManager.java
+++ b/megamek/src/megamek/common/ITechManager.java
@@ -90,15 +90,17 @@ public interface ITechManager {
         int faction = getTechFaction();
         boolean clanTech = useClanTechBase();
         
-        boolean introducedIS = tech.getIntroductionDate(false) <= getTechIntroYear();
-        boolean introducedClan = tech.getIntroductionDate(true) <= getTechIntroYear();
+        int isIntroDate = tech.getIntroductionDate(false);
+        int clanIntroDate = tech.getIntroductionDate(true);
+        boolean introducedIS = (isIntroDate != ITechnology.DATE_NONE) && (isIntroDate <= getTechIntroYear());
+        boolean introducedClan = (clanIntroDate != ITechnology.DATE_NONE) && (clanIntroDate <= getTechIntroYear());
         boolean extinctIS = tech.isExtinct(getTechIntroYear(), false);
         boolean extinctClan = tech.isExtinct(getTechIntroYear(), true);
         // A little bit of hard-coded universe detail
         if ((faction == ITechnology.F_CS)
-                && extinctIS && (tech.getReintroductionDate(false) != ITechnology.DATE_NONE)
+                && extinctIS && (isIntroDate != ITechnology.DATE_NONE)
                 && (tech.getBaseAvailability(ITechnology.getTechEra(getTechIntroYear())) < ITechnology.RATING_X)
-                && tech.getIntroductionDate(false) <= getTechIntroYear()) {
+                && isIntroDate <= getTechIntroYear()) {
             // ComStar has access to Star League tech that is otherwise extinct in the Inner Sphere as if TH,
             // unless it has an availability of X (which is SLDF Royal equipment).
             extinctIS = false;


### PR DESCRIPTION
In some cases (usually involving mixed tech) tech will show available before it should because the check whether it was introduced does not account for the possibility that the intro date for the opposite tech base is sometimes -1 (DATE_NONE), which is always less than the current date.

This also can occur during the early Clan era when IS equipment is tweaked to be treated as Clan equipment, which is where I ran across it while working on MegaMek/megameklab#203