### PR TITLE
Fix #1127 JTable model vs view indices

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CamoChoiceDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CamoChoiceDialog.java
@@ -412,14 +412,17 @@ public class CamoChoiceDialog extends JDialog implements TreeSelectionListener {
         }
         treeCategories.setSelectionPath(new TreePath(node.getPath()));
         fillTable(category);
-        int rowIndex = 0;
+        int modelRowIndex = -1;
         for (int i = 0; i < camoModel.getRowCount(); i++) {
             if (((String) camoModel.getValueAt(i, 0)).equals(filename)) {
-                rowIndex = i;
+                modelRowIndex = i;
                 break;
             }
         }
-        tableCamo.setRowSelectionInterval(rowIndex, rowIndex);
+        int viewRowIndex = modelRowIndex != -1
+                         ? tableCamo.convertRowIndexToView(modelRowIndex)
+                         : 0;
+        tableCamo.setRowSelectionInterval(viewRowIndex, viewRowIndex);
     }
 
     Icon generateIcon(String cat, String item) {


### PR DESCRIPTION
For reference, here's the relevant stack trace from the user's log in #1127 :
```
Exception in thread "AWT-EventQueue-0" java.lang.IllegalArgumentException: Row index out of range
	at javax.swing.JTable.boundRow(Unknown Source)
	at javax.swing.JTable.setRowSelectionInterval(Unknown Source)
	at megamek.client.ui.swing.CamoChoiceDialog.setEntity(CamoChoiceDialog.java:422)
	at megamek.client.ui.swing.ChatLounge.mechCamo(ChatLounge.java:2431)
	at megamek.client.ui.swing.ChatLounge$MekTableMouseAdapter.actionPerformed(ChatLounge.java:3577)
```