### PR TITLE
Client no longer depends on its subclas BotClient

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -39,8 +39,9 @@ import java.util.zip.GZIPInputStream;
 
 import javax.swing.SwingUtilities;
 
+import com.thoughtworks.xstream.XStream;
+
 import megamek.MegaMek;
-import megamek.client.bot.BotClient;
 import megamek.client.commands.AddBotCommand;
 import megamek.client.commands.AssignNovaNetworkCommand;
 import megamek.client.commands.ClientCommand;
@@ -57,7 +58,6 @@ import megamek.common.BoardDimensions;
 import megamek.common.Building;
 import megamek.common.Building.DemolitionCharge;
 import megamek.common.Coords;
-import megamek.common.QuirksHandler;
 import megamek.common.Entity;
 import megamek.common.EntitySelector;
 import megamek.common.FighterSquadron;
@@ -76,6 +76,7 @@ import megamek.common.Minefield;
 import megamek.common.Mounted;
 import megamek.common.MovePath;
 import megamek.common.PlanetaryConditions;
+import megamek.common.QuirksHandler;
 import megamek.common.Report;
 import megamek.common.SpecialHexDisplay;
 import megamek.common.TagInfo;
@@ -108,8 +109,6 @@ import megamek.common.options.IBasicOption;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.StringUtil;
 import megamek.server.SmokeCloud;
-
-import com.thoughtworks.xstream.XStream;
 
 /**
  * This class is instanciated for each client and for each bot running on that
@@ -180,8 +179,6 @@ public class Client implements IClientCommandHandler {
             }
         }
     }
-
-    ;
 
     private Thread connThread;
 
@@ -355,8 +352,13 @@ public class Client implements IClientCommandHandler {
         log.append("<html><body>");
     }
 
-    private boolean keepGameLog() {
-        return PreferenceManager.getClientPreferences().keepGameLog() && !(this instanceof BotClient);
+    /**
+     * Called to determine whether the game log should be kept.
+     * <p>
+     * Default implementation delegates to {@code PreferenceManager.getClientPreferences()}.
+     */
+    protected boolean keepGameLog() {
+        return PreferenceManager.getClientPreferences().keepGameLog();
     }
 
     /**

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -257,6 +257,11 @@ public abstract class BotClient extends Client {
 
     protected abstract void checkMoral();
 
+    @Override
+    protected boolean keepGameLog() {
+        return false;
+    }
+
     /**
      * Helper function that determines which of this bot's entities are stranded inside immobilized transports. 
      * @return Array of entity IDs.


### PR DESCRIPTION
`Client.keepGameLog()` was implemented with a runtime `instanceof` check for a subclass:

```java
private boolean keepGameLog() {
    return PreferenceManager.getClientPreferences().keepGameLog()
        && !(this instanceof BotClient);
}
```