### PR TITLE
UnitType.determineUnitTypeCode refactoring

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -212,7 +212,12 @@ public class Aero extends Entity implements IAero, IBomber {
         // need to set altitude to something different than entity
         altitude = 5;
     }
-    
+
+    @Override
+    public int getUnitType() {
+        return UnitType.AERO;
+    }
+
     protected static final TechAdvancement TA_ASF = new TechAdvancement(TECH_BASE_ALL)
             .setAdvancement(DATE_NONE, 2470, 2490).setProductionFactions(F_TH)
             .setTechRating(RATING_D).setAvailability(RATING_C, RATING_E, RATING_D, RATING_C)

--- a/megamek/src/megamek/common/BattleArmor.java
+++ b/megamek/src/megamek/common/BattleArmor.java
@@ -352,7 +352,12 @@ public class BattleArmor extends Infantry {
         // Construction complete.
         isInitialized = true;
     }
-    
+
+    @Override
+    public int getUnitType() {
+        return UnitType.BATTLE_ARMOR;
+    }
+
     protected static final TechAdvancement[] TA_BATTLEARMOR = {
             new TechAdvancement(TECH_BASE_ALL).setISAdvancement(2710, DATE_NONE, 3058, 2766, 2905)
                 .setClanAdvancement(2710, DATE_NONE, 3058).setPrototypeFactions(F_TH)

--- a/megamek/src/megamek/common/ConvFighter.java
+++ b/megamek/src/megamek/common/ConvFighter.java
@@ -31,6 +31,11 @@ public class ConvFighter extends Aero {
     private static final long serialVersionUID = 6297668284292929409L;
 
     @Override
+    public int getUnitType() {
+        return UnitType.CONV_FIGHTER;
+    }
+
+    @Override
     public boolean doomedInVacuum() {
         return true;
     }

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -77,6 +77,11 @@ public class Dropship extends SmallCraft {
     private boolean kfBoomDamaged = false;
     private int collarType = COLLAR_STANDARD;
 
+    @Override
+    public int getUnitType() {
+        return UnitType.DROPSHIP;
+    }
+
     public CrewType defaultCrewType() {
         return CrewType.VESSEL;
     }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -867,6 +867,11 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         externalId = UUID.randomUUID().toString();
         initTechAdvancement();
     }
+
+    /**
+     * @see {@link UnitType}
+     */
+    public abstract int getUnitType();
     
     public CrewType defaultCrewType() {
         return CrewType.SINGLE;

--- a/megamek/src/megamek/common/GunEmplacement.java
+++ b/megamek/src/megamek/common/GunEmplacement.java
@@ -47,6 +47,11 @@ public class GunEmplacement extends Tank {
         setEngine(new Engine(0, Engine.NORMAL_ENGINE, Engine.TANK_ENGINE));
     }
 
+    @Override
+    public int getUnitType() {
+        return UnitType.GUN_EMPLACEMENT;
+    }
+
     public boolean isTurret() {
         return !hasNoTurret();
     }

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -210,7 +210,12 @@ public class Infantry extends Entity {
         // Determine the number of MPs.
         setOriginalWalkMP(1);
     }
-    
+
+    @Override
+    public int getUnitType() {
+        return UnitType.INFANTRY;
+    }
+
     public CrewType defaultCrewType() {
         return CrewType.CREW;
     }

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -100,8 +100,12 @@ public class Jumpship extends Aero {
         super();
         damThresh = new int[] { 0, 0, 0, 0, 0, 0 };
     }
-    
-    
+
+    @Override
+    public int getUnitType() {
+        return UnitType.JUMPSHIP;
+    }
+
     //ASEW Missile Effects, per location
     //Values correspond to Locations: NOS,FLS,FRS,AFT,ALS,ARS
     private int asewAffectedTurns[] = { 0, 0, 0, 0, 0, 0};

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -352,6 +352,11 @@ public abstract class Mech extends Entity {
         }
     }
 
+    @Override
+    public int getUnitType() {
+        return UnitType.MEK;
+    }
+
     /**
      * @return if this mech cannot stand up from hulldown
      */

--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -169,6 +169,11 @@ public class Protomech extends Entity {
     }
 
     @Override
+    public int getUnitType() {
+        return UnitType.PROTOMEK;
+    }
+
+    @Override
     protected int[] getNoOfSlots() {
         return NUM_OF_SLOTS;
     }

--- a/megamek/src/megamek/common/SmallCraft.java
+++ b/megamek/src/megamek/common/SmallCraft.java
@@ -58,6 +58,11 @@ public class SmallCraft extends Aero {
             .setStaticTechLevel(SimpleTechLevel.STANDARD);
 
     @Override
+    public int getUnitType() {
+        return UnitType.SMALL_CRAFT;
+    }
+
+    @Override
     public TechAdvancement getConstructionTechAdvancement() {
         if (isPrimitive()) {
             return TA_SM_CRAFT_PRIMITIVE;

--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -34,8 +34,12 @@ public class SpaceStation extends Jumpship {
     //ASEW Missile Effects, per location
     //Values correspond to Locations, inherited from Jumpship: NOS,FLS,FRS,AFT,ALS,ARS
     private int asewAffectedTurns[] = { 0, 0, 0, 0, 0, 0};
-    
-    
+
+    @Override
+    public int getUnitType() {
+        return UnitType.SPACE_STATION;
+    }
+
     /*
      * Sets the number of rounds a specified firing arc is affected by an ASEW missile
      * @param arc - integer representing the desired firing arc

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -106,6 +106,14 @@ public class Tank extends Entity {
             300, 400, 500, 625 };
 
     @Override
+    public int getUnitType() {
+        EntityMovementMode mm = getMovementMode();
+        return (mm == EntityMovementMode.NAVAL) || (mm == EntityMovementMode.HYDROFOIL) || (mm == EntityMovementMode.SUBMARINE)
+             ? UnitType.NAVAL
+             : UnitType.TANK;
+    }
+
+    @Override
     public String[] getLocationAbbrs() {
         return LOCATION_ABBRS;
     }

--- a/megamek/src/megamek/common/UnitType.java
+++ b/megamek/src/megamek/common/UnitType.java
@@ -42,10 +42,12 @@ public class UnitType {
 
     public static final int SIZE = names.length;
 
+    /** @deprecated use {@code UnitType.getTypeName(e.getUnitType())} instead */
+    @Deprecated
     public static String determineUnitType(Entity e) {
-        return names[determineUnitTypeCode(e)];
+        return getTypeName(e.getUnitType());
     }
-    
+
     /**
      * Reverse lookup for type integer constant from name
      * 
@@ -61,43 +63,10 @@ public class UnitType {
         return -1;
     }
 
+    /** @deprecated use {@link Entity#getUnitType()} instead */
+    @Deprecated
     public static int determineUnitTypeCode(Entity e) {
-        EntityMovementMode mm = e.getMovementMode();
-        if (e instanceof BattleArmor) {
-            return BATTLE_ARMOR;
-        } else if (e instanceof Infantry) {
-            return INFANTRY;
-        } else if (e instanceof VTOL) {
-            return VTOL;
-        } else if ((mm == EntityMovementMode.NAVAL)
-                || (mm == EntityMovementMode.HYDROFOIL)
-                || (mm == EntityMovementMode.SUBMARINE)) {
-            return NAVAL;
-        } else if (e instanceof GunEmplacement) {
-            return GUN_EMPLACEMENT;
-        } else if (e instanceof Tank) {
-            return TANK;
-        } else if (e instanceof Mech) {
-            return MEK;
-        } else if (e instanceof Protomech) {
-            return PROTOMEK;
-        } else if (e instanceof Warship) {
-            return WARSHIP;
-        } else if (e instanceof SpaceStation) {
-            return SPACE_STATION;
-        } else if (e instanceof Jumpship) {
-            return JUMPSHIP;
-        } else if (e instanceof Dropship) {
-            return DROPSHIP;
-        } else if (e instanceof SmallCraft) {
-            return SMALL_CRAFT;
-        } else if (e instanceof ConvFighter) {
-            return CONV_FIGHTER;
-        } else if (e instanceof Aero) {
-            return AERO;
-        }else {
-            throw new IllegalArgumentException("Unknown unit type");
-        }
+        return e.getUnitType();
     }
 
     public static String getTypeName(int type) {

--- a/megamek/src/megamek/common/VTOL.java
+++ b/megamek/src/megamek/common/VTOL.java
@@ -54,6 +54,11 @@ public class VTOL extends Tank implements IBomber {
     public static final int CRIT_FLIGHT_STABILIZER = 19;
 
     @Override
+    public int getUnitType() {
+        return UnitType.VTOL;
+    }
+
+    @Override
     public String[] getLocationAbbrs() {
         return LOCATION_ABBRS;
     }

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -46,7 +46,12 @@ public class Warship extends Jumpship {
         damThresh = new int[] { 0, 0, 0, 0, 0, 0, 0, 0 };
         setDriveCoreType(DRIVE_CORE_COMPACT);
     }
-    
+
+    @Override
+    public int getUnitType() {
+        return UnitType.WARSHIP;
+    }
+
     //ASEW Missile Effects, per location
     //Values correspond to Locations, as seen above: NOS,FLS,FRS,AFT,ALS,ARS,LBS,RBS
     private int asewAffectedTurns[] = { 0, 0, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
`UnitType.determineUnitTypeCode()` used to be implemented as a cascade of
`instanceof` checks. This refactors that into a new method in `Entity`.

This removes 14 `instanceof`: now there are just 3632 remaining ones... :-D :-D

More seriously: I know `UnitType` begs to be made into an enumeration... I didn't touch that because it's also used in MHQ and honestly I didn't want to go through the hassle of submitting coordinated PRs on different repos just for this.

