### PR TITLE
Server no longer recycles dead connections' ids

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -895,12 +895,7 @@ public class Server implements Runnable {
      * Returns a free connection id.
      */
     public int getFreeConnectionId() {
-        while ((getPendingConnection(connectionCounter) != null)
-               || (getConnection(connectionCounter) != null)
-               || (getPlayer(connectionCounter) != null)) {
-            connectionCounter++;
-        }
-        return connectionCounter;
+        return connectionCounter++;
     }
 
     /**


### PR DESCRIPTION
This PR prevents `Server` from recycling the ids of connections/players that have disconnected.

The motivation for this change is that if a client disconnects and another one quickly connects, it may happen that the `COMMAND_CLOSE_CONNECTION` of the "old" client is processed _after_ the new connection has been accepted, which in turn causes the server to no longer recognise the new client in subsequent exchanges (because its player has been removed from the game when the "old" `COMMAND_CLOSE_CONNECTION` was processed).

Unfortunately I don't have a test case to replicate the issue (which only manifests sporadically anyways): I bumped into it while working on some experimental code for the Story Arcs thing.