### PR TITLE
Deprecate BehaviourSettings.getCopy()

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BehaviorSettings.java
+++ b/megamek/src/megamek/client/bot/princess/BehaviorSettings.java
@@ -132,13 +132,20 @@ public class BehaviorSettings {
         this.logger = logger;
     }
 
-    public BehaviorSettings getCopy() throws PrincessException {
+    /**
+     * @return a copy of these settings
+     */
+    public BehaviorSettings copy() {
         final BehaviorSettings copy = new BehaviorSettings();
         copy.setDestinationEdge(getDestinationEdge());
         copy.setRetreatEdge(getRetreatEdge());
         copy.setForcedWithdrawal(isForcedWithdrawal());
         copy.setAutoFlee(shouldAutoFlee());
-        copy.setDescription(getDescription());
+        try {
+            copy.setDescription(getDescription());
+        } catch (PrincessException e) {
+            throw new AssertionError(e);
+        }
         copy.setFallShameIndex(getFallShameIndex());
         copy.setBraveryIndex(getBraveryIndex());
         copy.setHerdMentalityIndex(getHerdMentalityIndex());
@@ -152,6 +159,18 @@ public class BehaviorSettings {
             copy.addPriorityUnit(p);
         }
         return copy;
+    }
+
+    /**
+     * @return a copy of these settings
+     * @throws PrincessException
+     *         despite declaring it, this method never throws
+     *         {@linkplain PrincessException}
+     * @deprecated use {@link #copy()} instead
+     */
+    @Deprecated
+    public BehaviorSettings getCopy() throws PrincessException {
+        return copy();
     }
 
     /**

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -232,14 +232,7 @@ public class Princess extends BotClient {
             LogLevel.INFO,
             "New behavior settings for " + getName() +
             "\n" + behaviorSettings.toLog());
-        try {
-            this.behaviorSettings = behaviorSettings.getCopy();
-        } catch (final PrincessException e) {
-            log(getClass(),
-                "setBehaviorSettings(BehaviorSettings)",
-                e);
-            return;
-        }
+        this.behaviorSettings = behaviorSettings.copy();
         getStrategicBuildingTargets().clear();
         setFallBack(behaviorSettings.shouldGoHome(),
                     "Fall Back Configuration.");


### PR DESCRIPTION

```
public BehaviourSettings getCopy() throws PrincessException
```
is deprecated in favour of a new
```
public BehaviourSettings copy()
```
which doesn't declare `PrincessException`, since it can't actually be thrown (the `PrincessException` declared by `getCopy()` is only thrown via `setDescription()` if the copied settings don't have a valid description - which can't be the case copying from another `BehaviourSettings`).

Note that I don't necessarily endorse that `BehaviourSettings.setDescription()` throw a checked exception instead of `IllegalArgumentException` or that `getCopy()` be implemented in terms of the public getters and setters: I'm proposing this PR just for the sake of MekHQ, where I'm interested in removing the handlers for the impossible `PrincessException`.