### PR TITLE
Check for valid Entities when advancing turn

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -3449,8 +3449,8 @@ public class Server implements Runnable {
             nextEntity = game.getEntity(game.getFirstEntityNum(nextTurn));
         }
         
-        // if there aren't any more turns, end the phase
-        if (!game.hasMoreTurns()) {
+        // if there aren't any more valid turns, end the phase
+        if (null == nextEntity) {
             endCurrentPhase();
             return;
         }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -3442,14 +3442,18 @@ public class Server implements Runnable {
      * allow the other players to skip that player.
      */
     private void changeToNextTurn(int prevPlayerId) {
+        GameTurn nextTurn = null;
+        Entity nextEntity = null;
+        while (game.hasMoreTurns() && (null == nextEntity)) {
+            nextTurn = game.changeToNextTurn();
+            nextEntity = game.getEntity(game.getFirstEntityNum(nextTurn));
+        }
+        
         // if there aren't any more turns, end the phase
         if (!game.hasMoreTurns()) {
             endCurrentPhase();
             return;
         }
-
-        // okay, well next turn then!
-        GameTurn nextTurn = game.changeToNextTurn();
 
         IPlayer player = getPlayer(nextTurn.getPlayerNum());
 


### PR DESCRIPTION
In some situations an Entity may finish a phase before its turn, such as disembarking from a transport while using individual initiative. In this case the server advances to a turn that leaves the player with no valid action. I've added a few lines that checks for a valid Entity and skips any turns that do not have one.

Fixes #1172 