### PR TITLE
Restrict one-shot weapons to their own bin when configuring ammo.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1293,9 +1293,15 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 ammoBins = new JComboBox<>();
                 matchingAmmoBins = new ArrayList<>();
                 
-                for(Mounted ammoBin : weapon.getEntity().getAmmo()) {
-                    if(((WeaponType) weapon.getType()).getAmmoType() == ((AmmoType) ammoBin.getType()).getAmmoType()) {
-                        matchingAmmoBins.add(ammoBin);
+                if (m_mounted.isOneShot()) {
+                    // One-shot weapons can only access their own bin
+                    matchingAmmoBins.add(m_mounted.getLinked());
+                } else {
+                    for(Mounted ammoBin : weapon.getEntity().getAmmo()) {
+                        if((ammoBin.getLocation() != Entity.LOC_NONE)
+                            && ((WeaponType) weapon.getType()).getAmmoType() == ((AmmoType) ammoBin.getType()).getAmmoType()) {
+                            matchingAmmoBins.add(ammoBin);
+                        }
                     }
                 }
                 


### PR DESCRIPTION
The previous behavior is to get a list of all compatible ammo bins for
the weapon and link to the first in the list. This resulted in multiple
types of one-shot launchers all sharing the same shot of ammo and could
also allow non one-shot launchers to be linked to one shot ammo if both
varieties of launcher were on the same unit.

Fixes #1177: Rocket Launcher bug after configuring unit

The Ostsol OST-5D is a good test unit, with four RL/10s.