### PR TITLE
Implementation of bot logic for handling aircraft standard space and low-altitude aero maps

### DIFF
--- a/megamek/src/megamek/client/bot/princess/AeroPathUtil.java
+++ b/megamek/src/megamek/client/bot/princess/AeroPathUtil.java
@@ -1,11 +1,18 @@
 package megamek.client.bot.princess;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import megamek.common.IAero;
 import megamek.common.MovePath;
 import megamek.common.UnitType;
 import megamek.common.MovePath.MoveStepType;
 
-// Helper class that contains functionality relating exclusively to aero units
+/**
+ * Helper class that contains functionality relating exclusively to aero unit paths.
+ * @author Andrew
+ *
+ */
 public class AeroPathUtil 
 {	
 	/**
@@ -70,4 +77,60 @@ public class AeroPathUtil
 		        (movePath.getEntity().isAero() && (movePath.getMpUsed() <= ((IAero) movePath.getEntity()).getSI()));
 	}
 
+	/**
+     * Generates paths that begin with all valid acceleration sequences for this aircraft.
+     * @param startingPath
+     * @return
+     */
+    public static Collection<MovePath> generateValidAccelerations(MovePath startingPath, int lowerBound, int upperBound) {
+        Collection<MovePath> paths = new ArrayList<MovePath>();
+        
+        // sanity check: if we've already done something else with the path, there's no acceleration to be done
+        if(startingPath.length() > 0) {
+            return paths;
+        }
+        
+        int currentVelocity = startingPath.getFinalVelocity();
+        
+        // we go from the lower bound to the current velocity and generate paths with the required number of DECs to get to
+        // the desired velocity
+        for(int desiredVelocity = lowerBound; desiredVelocity < currentVelocity; desiredVelocity++) {
+            MovePath path = startingPath.clone();
+            for(int deltaVelocity = 0; deltaVelocity < currentVelocity - desiredVelocity; deltaVelocity++) {
+                path.addStep(MoveStepType.DEC);
+            }
+            
+            paths.add(path);
+        }
+        
+        // If the unaltered starting path is within acceptable velocity bounds, it's also a valid "acceleration".
+        if(startingPath.getFinalVelocity() <= upperBound &&
+           startingPath.getFinalVelocity() >= lowerBound) {
+            paths.add(startingPath.clone());
+        }
+        
+        // we go from the current velocity to the upper bound and generate paths with the required number of DECs to get to
+        // the desired velocity
+        for(int desiredVelocity = currentVelocity; desiredVelocity < upperBound; desiredVelocity++) {
+            MovePath path = startingPath.clone();
+            for(int deltaVelocity = 0; deltaVelocity < upperBound - desiredVelocity; deltaVelocity++) {
+                path.addStep(MoveStepType.ACC);
+            }
+            
+            paths.add(path);
+        }
+        
+        return paths;
+    }
+    
+    /**
+     * Helper function to calculate the maximum thrust we should use for a particular aircraft
+     * We limit ourselves to the lowest of "safe thrust" and "structural integrity", as anything further is unsafe, meaning it requires a PSR.
+     * @param aero The aero entity for which to calculate max thrust.
+     * @return The max thrust.
+     */
+    public static int calculateMaxSafeThrust(IAero aero) {
+        int maxThrust = Math.min(aero.getCurrentThrust(), aero.getSI());    // we should only thrust up to our SI
+        return maxThrust;
+    }
 }

--- a/megamek/src/megamek/client/bot/princess/AeroPathUtil.java
+++ b/megamek/src/megamek/client/bot/princess/AeroPathUtil.java
@@ -146,6 +146,14 @@ public class AeroPathUtil
         // clone path add UP
         // if path uses more MP than entity has available or altitude higher than 10, stop
         for(int altChange = 0; ; altChange++) {
+            int altChangeCost = altChange * 2;
+            
+            // if we are going to attempt to change altitude but won't actually be able to, break out.
+            if((path.getFinalAltitude() + altChange > 10) ||
+                    path.getMpUsed() + altChangeCost > path.getEntity().getRunMP()) {
+                break;
+            }
+            
             MovePath childPath = path.clone();
             
             for(int numSteps = 0; numSteps < altChange; numSteps++) {
@@ -161,20 +169,23 @@ public class AeroPathUtil
         }
         
         // clone path add DOWN
+        // if the path is already at minimum altitude, skip this
         // if path uses more MP than entity has available or altitude lower than 1, stop
-        for(int altChange = 1; ; altChange++) {
-            MovePath childPath = path.clone();
-            
-            for(int numSteps = 0; numSteps < altChange; numSteps++) {
-                childPath.addStep(MoveStepType.DOWN);
+        if(path.getFinalAltitude() > 1) {
+            for(int altChange = 1; ; altChange++) {
+                MovePath childPath = path.clone();
+                
+                for(int numSteps = 0; numSteps < altChange; numSteps++) {
+                    childPath.addStep(MoveStepType.DOWN);
+                }
+                
+                if((childPath.getFinalAltitude() < 1) ||
+                        childPath.getMpUsed() > path.getEntity().getRunMP()) {
+                    break;
+                }
+                
+                paths.add(childPath);
             }
-            
-            if((childPath.getFinalAltitude() < 1) ||
-                    childPath.getMpUsed() > path.getEntity().getRunMP()) {
-                break;
-            }
-            
-            paths.add(childPath);
         }
         
         return paths;

--- a/megamek/src/megamek/client/bot/princess/AeroPathUtil.java
+++ b/megamek/src/megamek/client/bot/princess/AeroPathUtil.java
@@ -2,6 +2,7 @@ package megamek.client.bot.princess;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import megamek.common.IAero;
 import megamek.common.MovePath;
@@ -10,7 +11,7 @@ import megamek.common.MovePath.MoveStepType;
 
 /**
  * Helper class that contains functionality relating exclusively to aero unit paths.
- * @author Andrew
+ * @author NickAragua
  *
  */
 public class AeroPathUtil 
@@ -79,8 +80,8 @@ public class AeroPathUtil
 
 	/**
      * Generates paths that begin with all valid acceleration sequences for this aircraft.
-     * @param startingPath
-     * @return
+     * @param startingPath The initial path, hopefully empty.
+     * @return The child paths with all the accelerations this unit possibly can undertake.
      */
     public static Collection<MovePath> generateValidAccelerations(MovePath startingPath, int lowerBound, int upperBound) {
         Collection<MovePath> paths = new ArrayList<MovePath>();
@@ -132,5 +133,50 @@ public class AeroPathUtil
     public static int calculateMaxSafeThrust(IAero aero) {
         int maxThrust = Math.min(aero.getCurrentThrust(), aero.getSI());    // we should only thrust up to our SI
         return maxThrust;
+    }
+    
+    /**
+     * Given a move path, generate all possible increases and decreases in elevation.
+     * @param path The move path to process.
+     * @return Collection of generated paths.
+     */
+    public static List<MovePath> generateValidAltitudeChanges(MovePath path) {
+        List<MovePath> paths = new ArrayList<MovePath>();
+        
+        // clone path add UP
+        // if path uses more MP than entity has available or altitude higher than 10, stop
+        for(int altChange = 0; ; altChange++) {
+            MovePath childPath = path.clone();
+            
+            for(int numSteps = 0; numSteps < altChange; numSteps++) {
+                childPath.addStep(MoveStepType.UP);
+            }
+            
+            if((childPath.getFinalAltitude() > 10) ||
+                    childPath.getMpUsed() > path.getEntity().getRunMP()) {
+                break;
+            }
+            
+            paths.add(childPath);
+        }
+        
+        // clone path add DOWN
+        // if path uses more MP than entity has available or altitude lower than 1, stop
+        for(int altChange = 1; ; altChange++) {
+            MovePath childPath = path.clone();
+            
+            for(int numSteps = 0; numSteps < altChange; numSteps++) {
+                childPath.addStep(MoveStepType.DOWN);
+            }
+            
+            if((childPath.getFinalAltitude() < 1) ||
+                    childPath.getMpUsed() > path.getEntity().getRunMP()) {
+                break;
+            }
+            
+            paths.add(childPath);
+        }
+        
+        return paths;
     }
 }

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -622,12 +622,9 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                    .append(LOG_DECIMAL.format(expectedDamageTaken)).append("]");
             utility += braveryMod;
 
-            //noinspection StatementWithEmptyBody
-            if (path.getEntity().isAero() && !path.getEntity().isSpaceborne()) {
-                // No idea what original implementation was meant to be.
-
-            } else {
-
+            // the only critters not subject to aggression and herding mods are
+            // airborne aeros on ground maps, as they move incredibly fast
+            if (!path.getEntity().isAirborneAeroOnGroundMap()) {
                 // The further I am from a target, the lower this path ranks 
                 // (weighted by Hyper Aggression.
                 utility -= calculateAggressionMod(movingUnit, pathCopy, game,

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -164,10 +164,10 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             EntityEvaluationResponse returnResponse =
                     new EntityEvaluationResponse();
 
-            //Airborne aeros always move after other units, and would require an 
+            //Airborne aeros on ground maps always move after other units, and would require an 
             // entirely different evaluation
             //TODO (low priority) implement a way to see if I can dodge aero units
-            if (enemy.isAero() && enemy.isAirborne()) {
+            if (enemy.isAirborneAeroOnGroundMap()) {
                 return returnResponse;
             }
             
@@ -669,7 +669,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
     protected boolean evaluateAsMoved(Entity enemy) {
         // Aerospace units on ground maps can go pretty much anywhere they want, so it's
         // somewhat pointless to try to predict their movement.
-        return !enemy.isSelectableThisTurn() || enemy.isImmobile() || (enemy.isAero() && enemy.isAirborne());
+        return !enemy.isSelectableThisTurn() || enemy.isImmobile() || enemy.isAirborneAeroOnGroundMap();
     }
     
     /**

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1646,7 +1646,9 @@ public class FireControl {
         // Rank how useful this plan is.
         calculateUtility(myPlan, calcHeatTolerance(shooter, null), shooterState.isAero());
         
-        if(shooter.isAero()) {
+        // if we're in a position to drop bombs because we're an aircraft on a ground map, then
+        // the "alpha strike" may be a bombing plan.
+        if(shooter.isAirborneAeroOnGroundMap()) {
             final FiringPlan bombingPlan = this.getDiveBombPlan(shooter, null, target, game, shooter.passedOver(target), true);
             calculateUtility(bombingPlan, DOES_NOT_TRACK_HEAT, true); // bomb drops never cause heat
             

--- a/megamek/src/megamek/client/bot/princess/InfantryPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryPathRanker.java
@@ -131,7 +131,7 @@ public class InfantryPathRanker extends BasicPathRanker implements IPathRanker {
             //Aeros always move after other units, and would require an 
             // entirely different evaluation
             //TODO (low priority) implement a way to see if I can dodge aero units
-            if (enemy.isAirborne()) {
+            if (enemy.isAirborneAeroOnGroundMap()) {
                 return returnResponse;
             }
             

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -39,6 +39,7 @@ import megamek.common.Terrains;
 import megamek.common.pathfinder.AbstractPathFinder.Filter;
 import megamek.common.pathfinder.AeroGroundPathFinder;
 import megamek.common.pathfinder.AeroGroundPathFinder.AeroGroundOffBoardFilter;
+import megamek.common.pathfinder.AeroLowAltitudePathFinder;
 import megamek.common.pathfinder.AeroSpacePathFinder;
 import megamek.common.pathfinder.InfantryPathFinder;
 import megamek.common.pathfinder.LongestPathFinder;
@@ -250,7 +251,12 @@ public class PathEnumerator {
                 apf.run(new MovePath(game, mover));
                 paths.addAll(apf.getAllComputedPathsUncategorized());
             // this handles the case of the mover being an infantry unit of some kind
-            } else if(mover.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
+            } else if(mover.isAero() && game.getBoard().inAtmosphere()) {
+                AeroLowAltitudePathFinder apf = AeroLowAltitudePathFinder.getInstance(getGame());
+                apf.run(new MovePath(game, mover));
+                paths.addAll(apf.getAllComputedPathsUncategorized());
+            // this handles the case of the mover being an infantry unit of some kind
+            }else if(mover.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
                 InfantryPathFinder ipf = InfantryPathFinder.getInstance(getGame());
                 ipf.run(new MovePath(game, mover));
                 paths.addAll(ipf.getAllComputedPathsUncategorized());

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -39,6 +39,7 @@ import megamek.common.Terrains;
 import megamek.common.pathfinder.AbstractPathFinder.Filter;
 import megamek.common.pathfinder.AeroGroundPathFinder;
 import megamek.common.pathfinder.AeroGroundPathFinder.AeroGroundOffBoardFilter;
+import megamek.common.pathfinder.AeroSpacePathFinder;
 import megamek.common.pathfinder.InfantryPathFinder;
 import megamek.common.pathfinder.LongestPathFinder;
 import megamek.common.pathfinder.MovePathFinder;
@@ -196,10 +197,7 @@ public class PathEnumerator {
             
             // Aero movement on atmospheric ground maps
             // currently only applies to a) conventional aircraft, b) aerotech units, c) lams in air mode
-            if(mover.isAirborne() &&
-               mover.isOnAtmosphericGroundMap() &&
-               mover.isAero() &&                    // guards against the edge case of airborne non-aero units
-               !((IAero) mover).isSpheroid()) {
+            if(mover.isAirborneAeroOnGroundMap() && !((IAero) mover).isSpheroid()) {
                 AeroGroundPathFinder apf = AeroGroundPathFinder.getInstance(getGame());
                 MovePath startPath = new MovePath(getGame(), mover);
                 apf.run(startPath);
@@ -241,45 +239,22 @@ public class PathEnumerator {
                 for(Integer length : pathLengths.keySet()) {
                     this.owner.log(this.getClass(), METHOD_NAME, LogLevel.DEBUG, "Paths of length " + length + ": " + pathLengths.get(length));
                 }
+            // this handles the case of the mover being an aerospace unit and "advances space flight" rules being on
             } else if(mover.isAero() && game.useVectorMove()) {
                 NewtonianAerospacePathFinder npf = NewtonianAerospacePathFinder.getInstance(getGame());
                 npf.run(new MovePath(game, mover));
                 paths.addAll(npf.getAllComputedPathsUncategorized());
-            } else if (mover.isAero()) {
-                IAero aeroMover = (IAero)mover;
-                // Get the shortest paths possible.
-                ShortestPathFinder spf;
-                
-                if (aeroMover.isSpheroid()) {
-                    spf = ShortestPathFinder.newInstanceOfOneToAllSpheroid(
-                            MoveStepType.FORWARDS, getGame());
-                } else { // Aerodynes must expend all velocity
-                    spf = ShortestPathFinder.newInstanceOfOneToAllAerodyne(
-                            MoveStepType.FORWARDS, getGame());
-                }
-                spf.setAdjacencyMap(new MovePathFinder.NextStepsAeroAdjacencyMap(
-                        MoveStepType.FORWARDS));
-                
-                // Make sure we accelerate to avoid stalling as needed.
-                MovePath startPath = new MovePath(getGame(), mover);
-                spf.run(startPath);
-                paths.addAll(spf.getAllComputedPathsUncategorized());
-
-                // Remove illegal paths.
-                Filter<MovePath> filter = new Filter<MovePath>() {
-                    @Override
-                    public boolean shouldStay(MovePath movePath) {
-                        return isLegalAeroMove(movePath);
-                    }
-                };
-                paths = new ArrayList<>(filter.doFilter(paths));
+            // this handles the case of the mover being an aerospace unit on a space map
+            } else if(mover.isAero() && game.getBoard().inSpace()) {
+                AeroSpacePathFinder apf = AeroSpacePathFinder.getInstance(getGame());
+                apf.run(new MovePath(game, mover));
+                paths.addAll(apf.getAllComputedPathsUncategorized());
+            // this handles the case of the mover being an infantry unit of some kind
             } else if(mover.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
                 InfantryPathFinder ipf = InfantryPathFinder.getInstance(getGame());
                 ipf.run(new MovePath(game, mover));
                 paths.addAll(ipf.getAllComputedPathsUncategorized());
-            }
-            else { // Non-Aero movement
-                //add running moves
+            } else { // Non-Aero movement
                 // TODO: Will this cause Princess to never use MASC?
                 LongestPathFinder lpf = LongestPathFinder
                         .newInstanceOfLongestPath(mover.getRunMPwithoutMASC(),

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -145,7 +145,7 @@ public abstract class PathRanker implements IPathRanker {
         CardinalEdge homeEdge = getOwner().getHomeEdge(mover);
         boolean fleeing = getOwner().isFallingBack(mover);
         
-        boolean isAirborneAeroOnAtmosphericGroundMap = mover.isAirborne() && mover.isOnAtmosphericGroundMap();
+        boolean isAirborneAeroOnGroundMap = mover.isAirborneAeroOnGroundMap();
         
         for (MovePath path : startingPathList) {
             // just in case
@@ -157,7 +157,7 @@ public abstract class PathRanker implements IPathRanker {
 
             try {
                 // if we are an aero unit on the ground map, we want to discard paths that keep us at altitude 1 with no bombs
-            	if(isAirborneAeroOnAtmosphericGroundMap) {
+            	if(isAirborneAeroOnGroundMap) {
             		// if we have no bombs, we want to make sure our altitude is above 1
             		// if we do have bombs, we may consider altitude bombing (in the future)
             		if((path.getEntity().getBombs(BombType.F_GROUND_BOMB).size() == 0) &&
@@ -178,7 +178,7 @@ public abstract class PathRanker implements IPathRanker {
 
                 // Make sure I'm trying to get/stay in range of a target.
                 // Skip this part if I'm an aero on the ground map, as it's kind of irrelevant
-                if(!isAirborneAeroOnAtmosphericGroundMap) {
+                if(!isAirborneAeroOnGroundMap) {
                     Targetable closestToEnd = findClosestEnemy(mover, finalCoords, game);
                     String validation = validRange(finalCoords, closestToEnd, startingTargetDistance, maxRange, inRange);
                     if (!StringUtil.isNullOrEmpty(validation)) {
@@ -261,7 +261,7 @@ public abstract class PathRanker implements IPathRanker {
             for (Entity e : enemies) {
                 // Skip airborne aero units as they're further away than they seem and hard to catch.
                 // Also, skip withdrawing enemy bot units, to avoid humping disabled tanks and ejected mechwarriors
-                if ((e.isAero() && e.isAirborne()) || 
+                if (e.isAirborneAeroOnGroundMap() || 
                         getOwner().getHonorUtil().isEnemyBroken(e.getTargetId(), e.getOwnerId(), getOwner().getForcedWithdrawal())) {
                     continue;
                 }

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -149,7 +149,7 @@ public abstract class PathRanker implements IPathRanker {
         
         for (MovePath path : startingPathList) {
             // just in case
-            if(path == null) {
+            if((path == null) || !path.isMoveLegal()) {
                 continue;
             }
 

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1826,7 +1826,7 @@ public class Princess extends BotClient {
         // then evade
         if(pathEntity.isAirborne() &&
            !possibleToInflictDamage &&
-           (path.getMpUsed() <= AeroGroundPathFinder.calculateMaxSafeThrust((IAero) path.getEntity()) - 2)) {
+           (path.getMpUsed() <= AeroPathUtil.calculateMaxSafeThrust((IAero) path.getEntity()) - 2)) {
             path.addStep(MoveStepType.EVADE);
         }
     }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -459,8 +459,6 @@ public class Compute {
         final IHex srcHex = game.getBoard().getHex(src);
         final IHex destHex = game.getBoard().getHex(dest);
         final boolean isInfantry = (entity instanceof Infantry);
-        final boolean isPavementStep = Compute.canMoveOnPavement(game, src,
-                dest, moveStep);
         int delta_alt = (destElevation + destHex.getLevel())
                         - (srcElevation + srcHex.getLevel());
 
@@ -476,6 +474,9 @@ public class Compute {
         if (src.equals(dest)) {
             return false;
         }
+        
+        // airborne aircraft do not require pavement-related checks
+        final boolean isPavementStep = entity.isAirborne() ? false : Compute.canMoveOnPavement(game, src, dest, moveStep);
 
         // check for rubble
         if ((movementType != EntityMovementType.MOVE_JUMP)

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2296,6 +2296,14 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     }
     
     /**
+     * Convenience method to determine whether this entity should be treated as an airborne aero on a ground map.
+     * @return True if this is an airborne aircraft on a ground map.
+     */
+    public boolean isAirborneAeroOnGroundMap() {
+        return isAero() && isAirborne() && getGame().getBoard().onGround();
+    }
+    
+    /**
      * Returns the display name for this entity.
      */
     @Override

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -465,8 +465,7 @@ public class MoveStep implements Serializable {
         IHex destHex = game.getBoard().getHex(getPosition());
 
         // Check for pavement movement.
-        if (Compute.canMoveOnPavement(game, prev.getPosition(), getPosition(),
-                this)) {
+        if (!entity.isAirborne() && Compute.canMoveOnPavement(game, prev.getPosition(), getPosition(), this)) {
             setPavementStep(true);
         } else {
             setPavementStep(false);
@@ -762,8 +761,7 @@ public class MoveStep implements Serializable {
             case TURN_LEFT:
             case TURN_RIGHT:
                 // Check for pavement movement.
-                if (Compute.canMoveOnPavement(game, prev.getPosition(),
-                        getPosition(), this)) {
+                if (!entity.isAirborne() && Compute.canMoveOnPavement(game, prev.getPosition(), getPosition(), this)) {
                     setPavementStep(true);
                 } else {
                     setPavementStep(false);

--- a/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
@@ -3,7 +3,6 @@ package megamek.common.pathfinder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -36,10 +35,10 @@ public class AeroGroundPathFinder {
     
     private IGame game;
     private List<MovePath> aeroGroundPaths;
-    private int maxThrust;
+    protected int maxThrust;
     private MMLogger logger;
     
-    private AeroGroundPathFinder(IGame game) {
+    protected AeroGroundPathFinder(IGame game) {
         this.game = game;
         getLogger().setLogLevel(LOGGER_CATEGORY, LogLevel.DEBUG);
     }
@@ -68,9 +67,14 @@ public class AeroGroundPathFinder {
                 return;
             }
             
-            // recalculate max thrust for the given path's entity
-            maxThrust = calculateMaxSafeThrust((IAero) startingEdge.getEntity());                
-            Collection<MovePath> validAccelerations = generateValidAccelerations(startingEdge);
+            // calculate maximum and minimum safe velocity
+            // in the case of aerospace units on ground maps, we want a velocity of at least 1 so we don't stall
+            // and at least 3 so we don't pointlessly fly around in circles or consume all available memory
+            IAero aero = (IAero) startingEdge.getEntity();
+            int maxThrust = AeroPathUtil.calculateMaxSafeThrust(aero);  
+            int maxVelocity = Math.min(3, aero.getCurrentVelocity() + maxThrust);
+            int minVelocity = Math.max(1, aero.getCurrentVelocity() - maxThrust);
+            Collection<MovePath> validAccelerations = AeroPathUtil.generateValidAccelerations(startingEdge, minVelocity, maxVelocity);
             
             for(MovePath acceleratedPath : validAccelerations) {
                 aeroGroundPaths.addAll(getAltitudeAdjustedPaths(GenerateAllPaths(acceleratedPath)));
@@ -96,37 +100,6 @@ public class AeroGroundPathFinder {
         AeroGroundPathFinder apf = new AeroGroundPathFinder(game);
 
         return apf;
-    }
-    
-    /**
-     * Worker function that indicates if there is an enemy aircraft on the board for the current path.
-     * Assumes we are on a ground map
-     * @param path the current path we're evaluating
-     * @return Whether or not there's an enemy airborne entity on the board.
-     */
-    @SuppressWarnings("unused")
-    private static boolean airborneEnemiesOnBoard(Entity mover) {
-        for(Iterator<Entity> entityIter = mover.getGame().getAllEnemyEntities((Entity) mover); entityIter.hasNext();) {
-            Entity currentEntity = entityIter.next();
-            if(currentEntity.isAero()) {
-                return true;
-            }
-        }
-        
-        return false;
-    }
-    
-    /**
-     * Helper function to calculate the maximum thrust we should use for a particular aircraft
-     * We limit ourselves to the lowest of "safe thrust" and "structural integrity"...
-     *  ... or something a little lower to prevent using gigabyte after gigabyte of memory on high-thrust paths
-     *  that don't do anything useful.
-     * @param aero The aero entity for which to calculate max thrust.
-     * @return The max thrust.
-     */
-    public static int calculateMaxSafeThrust(IAero aero) {
-        int maxThrust = Math.min(aero.getCurrentThrust(), aero.getSI());    // we should only thrust up to our SI
-        return maxThrust;
     }
     
     /**
@@ -191,68 +164,11 @@ public class AeroGroundPathFinder {
     Map<Coords, MovePath> visitedHexes;
     
     /**
-     * Generates paths that begin with all valid acceleration sequences for this aircraft.
-     * Avoids sequences that will cause a PSR (just no)
-     * @param startingPath
-     * @return
-     */
-    private Collection<MovePath> generateValidAccelerations(MovePath startingPath) {
-        // the possible velocities at ground level are 1 - 12 (we ignore "0" velocity as that will just stall our aircraft)
-        // with an additional lower and upper bound of "current velocity" -/+ walk MP (investigate utility of adjusting it to be run MP instead)
-
-        Collection<MovePath> paths = new ArrayList<MovePath>();
-        
-        // sanity check: if we've already done something else with the path, there's no acceleration to be done
-        if(startingPath.length() > 0) {
-            return paths;
-        }
-        
-        int currentVelocity = startingPath.getFinalVelocity();
-        int lowerBound = Math.max(1, currentVelocity - maxThrust);
-        // put a governor on that engine
-        // while the rulebook max velocity on ground map is 12, in reality we want to limit ourselves to velocity 3, for two reasons:
-        // 1: velocity 3 lets us do a 360 degree turn, so any further turning is superfluous
-        // 2: velocity 4 generates about 6,000 paths which is pretty painful for performance, although we can probably improve
-        //      that by updating PathRanker.getMovePathSuccessProbability() to skip most non-aero related checks
-        int upperBound = Math.min(3, currentVelocity + maxThrust); 
-        
-        // we go from the lower bound to the current velocity and generate paths with the required number of DECs to get to
-        // the desired velocity
-        for(int desiredVelocity = lowerBound; desiredVelocity < currentVelocity; desiredVelocity++) {
-            MovePath path = startingPath.clone();
-            for(int deltaVelocity = 0; deltaVelocity < currentVelocity - desiredVelocity; deltaVelocity++) {
-                path.addStep(MoveStepType.DEC);
-            }
-            
-            paths.add(path);
-        }
-        
-        // If the unaltered starting path is within acceptable velocity bounds, it's also a valid "acceleration".
-        if(startingPath.getFinalVelocity() <= upperBound &&
-           startingPath.getFinalVelocity() >= lowerBound) {
-            paths.add(startingPath.clone());
-        }
-        
-        // we go from the current velocity to the upper bound and generate paths with the required number of DECs to get to
-        // the desired velocity
-        for(int desiredVelocity = currentVelocity; desiredVelocity < upperBound; desiredVelocity++) {
-            MovePath path = startingPath.clone();
-            for(int deltaVelocity = 0; deltaVelocity < upperBound - desiredVelocity; deltaVelocity++) {
-                path.addStep(MoveStepType.ACC);
-            }
-            
-            paths.add(path);
-        }
-        
-        return paths;
-    }
-    
-    /**
      * Given a list of MovePaths, applies adjustTowardsDesiredAltitude to each of them.
      * @param startingPaths The collection of paths to process
      * @return The new collection of resulting paths.
      */
-    private List<MovePath> getAltitudeAdjustedPaths(List<MovePath> startingPaths) {
+    protected List<MovePath> getAltitudeAdjustedPaths(List<MovePath> startingPaths) {
         List<MovePath> desiredAltitudes = new ArrayList<MovePath>();
         
         for(MovePath start : startingPaths) {
@@ -326,7 +242,7 @@ public class AeroGroundPathFinder {
     // if a branch runs off board, we discard it unless it's the shortest one so far, we'll want to keep one of those around
     // if a branch runs out of velocity, then we make note of all the hexes it has visited so far.
     // if a hex has already been visited by another branch, then we set the current one as the visitor only if it's shorter
-    private List<MovePath> GenerateAllPaths(MovePath mp) {
+    protected List<MovePath> GenerateAllPaths(MovePath mp) {
         List<MovePath> retval = new ArrayList<MovePath>();
         
         for(MovePath path : generateSidePaths(mp, MoveStepType.TURN_RIGHT)) {
@@ -354,7 +270,7 @@ public class AeroGroundPathFinder {
     }
     
     // generates and returns all paths that stick straight lines out of the current path to the right or left
-    private List<MovePath> generateSidePaths(MovePath mp, MoveStepType stepType) {
+    protected List<MovePath> generateSidePaths(MovePath mp, MoveStepType stepType) {
         List<MovePath> retval = new ArrayList<MovePath>();
         MovePath straightLine = mp.clone();
         
@@ -403,7 +319,7 @@ public class AeroGroundPathFinder {
     
     // helper function to move the path forward until we run out of velocity or off the board
     // "respect" board edges by attempting a turn 
-    private void ForwardToTheEnd(MovePath mp) {
+    protected void ForwardToTheEnd(MovePath mp) {
         while(mp.getFinalVelocityLeft() > 0) {
                 // don't generate an illegal move that flies off the board
                 if(!mp.nextForwardStepOffBoard()) {

--- a/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
@@ -79,7 +79,7 @@ public class AeroGroundPathFinder {
             // in the case of aerospace units on ground maps, we want a velocity of at least 1 so we don't stall
             // and at least 3 so we don't pointlessly fly around in circles or consume all available memory
             IAero aero = (IAero) startingEdge.getEntity();
-            int maxThrust = AeroPathUtil.calculateMaxSafeThrust(aero);  
+            maxThrust = AeroPathUtil.calculateMaxSafeThrust(aero);  
             int maxVelocity = Math.min(getMaximumVelocity(aero), aero.getCurrentVelocity() + maxThrust);
             int minVelocity = Math.max(getMinimumVelocity(aero), aero.getCurrentVelocity() - maxThrust);
             Collection<MovePath> validAccelerations = AeroPathUtil.generateValidAccelerations(startingEdge, minVelocity, maxVelocity);

--- a/megamek/src/megamek/common/pathfinder/AeroLowAltitudePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroLowAltitudePathFinder.java
@@ -1,0 +1,11 @@
+package megamek.common.pathfinder;
+
+/**
+ * This class is intended to be used by the bot for generating possible paths for 
+ * aerospace units on a low-altitude atmospheric map.
+ * @author NickAragua
+ *
+ */
+public class AeroLowAltitudePathFinder {
+
+}

--- a/megamek/src/megamek/common/pathfinder/AeroLowAltitudePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroLowAltitudePathFinder.java
@@ -1,11 +1,98 @@
 package megamek.common.pathfinder;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import megamek.client.bot.princess.AeroPathUtil;
+import megamek.common.Coords;
+import megamek.common.IAero;
+import megamek.common.IGame;
+import megamek.common.MovePath;
+import megamek.common.MoveStep;
+import megamek.common.pathfinder.MovePathFinder.CoordsWithFacing;
+
 /**
  * This class is intended to be used by the bot for generating possible paths for 
  * aerospace units on a low-altitude atmospheric map.
  * @author NickAragua
  *
  */
-public class AeroLowAltitudePathFinder {
+public class AeroLowAltitudePathFinder extends AeroGroundPathFinder {
 
+    protected static final String LOGGER_CATEGORY = "megamek.common.pathfinder.AeroLowAltitudePathFinder";
+    
+    protected AeroLowAltitudePathFinder(IGame game) {
+        super(game);
+    }
+
+    public static AeroLowAltitudePathFinder getInstance(IGame game) {
+        AeroLowAltitudePathFinder alf = new AeroLowAltitudePathFinder(game);
+
+        return alf;
+    }
+    
+    @Override
+    protected int getMinimumVelocity(IAero mover) {
+        return 1;
+    }
+    
+    @Override
+    protected int getMaximumVelocity(IAero mover) {
+        return mover.getCurrentThrust() * 2;
+    }
+    
+    /**
+     * Generate all possible paths given a starting movement path.
+     * This includes increases and decreases in elevation.
+     */
+    @Override
+    protected List<MovePath> GenerateAllPaths(MovePath mp) {
+        List<MovePath> altitudePaths = AeroPathUtil.generateValidAltitudeChanges(mp);
+        List<MovePath> fullMovePaths = new ArrayList<>();
+        
+        for(MovePath altitudePath : altitudePaths) {
+            fullMovePaths.addAll(super.GenerateAllPaths(altitudePath.clone()));
+        }
+        
+        return fullMovePaths;
+    }
+    
+    /**
+     * Get a list of movement paths with end-of-path altitude adjustments.
+     * Irrelevant for low-atmo maps, so simply returns the passed-in list.
+     */
+    @Override
+    protected List<MovePath> getAltitudeAdjustedPaths(List<MovePath> startingPaths) {
+        return startingPaths;
+    }
+    
+    // this data structure maps a set of coordinates with facing
+    // to a map between height and "used MP".
+    private Map<CoordsWithFacing, Map<Integer, Integer>> visitedCoords = new HashMap<CoordsWithFacing, Map<Integer, Integer>>();
+    /**
+     * Determines whether or not the given move path is "redundant".
+     * In this situation, "redundant" means "there is already a shorter path that goes to the ending coordinates/facing/height" combo.
+     */
+    @Override
+    protected boolean pathIsRedundant(MovePath mp) {
+        if(!mp.fliesOffBoard()) {
+            CoordsWithFacing destinationCoords = new CoordsWithFacing(mp);
+            if(!visitedCoords.containsKey(destinationCoords)) {
+                visitedCoords.put(destinationCoords, new HashMap<>());
+            }
+            
+            // we may or may not have been to these coordinates before, but we haven't been to this height. Not redundant. 
+            if(!visitedCoords.get(destinationCoords).containsKey(mp.getFinalAltitude())) {
+                visitedCoords.get(destinationCoords).put(mp.getFinalAltitude(), mp.getMpUsed());
+                return false;
+            // we *have* been to these coordinates and height before. This is redundant if the previous visit used less MP.
+            } else {
+                return visitedCoords.get(destinationCoords).get(mp.getFinalAltitude()) < mp.getMpUsed();
+            }
+        } else {
+            return false;
+        }
+    }
 }

--- a/megamek/src/megamek/common/pathfinder/AeroSpacePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroSpacePathFinder.java
@@ -1,0 +1,111 @@
+package megamek.common.pathfinder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import megamek.client.bot.princess.AeroPathUtil;
+import megamek.common.IAero;
+import megamek.common.IGame;
+import megamek.common.MovePath;
+import megamek.common.MovePath.MoveStepType;
+import megamek.common.pathfinder.MovePathFinder.CoordsWithFacing;
+
+/**
+ * This class generates move paths suitable for use by an aerospace unit
+ * operating on a space map, with 'advanced flight' turned off.
+ * @author NickAragua
+ *
+ */
+public class AeroSpacePathFinder extends NewtonianAerospacePathFinder {
+
+    protected static final String LOGGER_CATEGORY = "megamek.common.pathfinder.AeroSpacePathFinder";
+    
+    protected AeroSpacePathFinder(IGame game) {
+        super(game);
+    }
+    
+    /**
+     * Worker method to put together a pre-defined array of possible moves
+     */
+    @Override
+    protected void initializeMoveList() {
+        moves = new ArrayList<>();
+        moves.add(MoveStepType.TURN_RIGHT);
+        moves.add(MoveStepType.TURN_LEFT);
+        moves.add(MoveStepType.FORWARDS);
+    }
+    
+    public static AeroSpacePathFinder getInstance(IGame game) {
+        AeroSpacePathFinder asf = new AeroSpacePathFinder(game);
+
+        return asf;
+    }
+    
+    /** 
+     * Generates a list of possible step combinations that should be done at the beginning of a path
+     * This implementation generates exactly one path, which is either no moves or one hex forward when velocity > 0
+     * @return "List" of all possible "starting" paths
+     */
+    @Override
+    protected List<MovePath> generateStartingPaths(MovePath startingEdge) {
+        List<MovePath> startingPaths = new ArrayList<>();
+        
+        // calculate max and min safe velocity
+        // in space, we can go as slow or as fast as we want.
+        IAero aero = (IAero) startingEdge.getEntity();
+        int maxThrust = AeroPathUtil.calculateMaxSafeThrust(aero);  
+        int maxVelocity = aero.getCurrentVelocity() + maxThrust;
+        int minVelocity = Math.max(0, aero.getCurrentVelocity() - maxThrust);
+        startingPaths.addAll(AeroPathUtil.generateValidAccelerations(startingEdge, minVelocity, maxVelocity));
+        
+        // all non-zero-velocity paths must move at least one hex forward
+        for(MovePath path : startingPaths) {
+            if(path.getFinalVelocity() > 0) {
+                path.addStep(MoveStepType.FORWARDS);
+            }
+        }
+        
+        
+        return startingPaths;
+    }
+    
+    /**
+     * "Worker" function to determine whether the path being examined is an intermediate path.
+     * This means that the path, as is, is not a valid path, but its children may be.
+     * This mainly applies to aero paths that have not used all their velocity.
+     * @param path The move path to consider.
+     * @return Whether it is an intermediate path or not.
+     */
+    @Override
+    protected boolean isIntermediatePath(MovePath path) {
+        return path.getFinalVelocityLeft() > 0;
+    }
+    
+    /**
+     * Worker function to determine whether we should discard the current path 
+     * (due to it being illegal or redundant) or keep generating child nodes
+     * @param path The move path to consider
+     * @return Whether to keep or dicsard.
+     */
+    @Override
+    protected boolean discardPath(MovePath path, CoordsWithFacing pathDestination) {
+        boolean maxMPExceeded = path.getMpUsed() > path.getEntity().getRunMP();
+        
+        // having generated the child, we add it and (recursively) any of its children to the list of children to be returned            
+        // unless it moves too far or exceeds max thrust
+        if(path.getFinalVelocityLeft() < 0 || maxMPExceeded) {
+            return true;
+        }
+        
+        // terminator conditions:
+        // we've visited this hex already and the path we are considering is longer than the previous path that visited this hex
+        if(visitedCoords.containsKey(pathDestination) && visitedCoords.get(pathDestination).intValue() < path.getMpUsed()) {
+            return true;
+        }
+        
+        return false;
+    }
+}

--- a/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
@@ -23,20 +23,27 @@ import megamek.common.pathfinder.MovePathFinder.CoordsWithFacing;
  */
 public class NewtonianAerospacePathFinder {
     private IGame game;
-    private List<MovePath> aerospacePaths;
+    protected List<MovePath> aerospacePaths;
     private MovePath offBoardPath;
     private MMLogger logger;
-    private static final String LOGGER_CATEGORY = "megamek.common.pathfinder.NewtonianAerospacePathFinder";
+    protected static final String LOGGER_CATEGORY = "megamek.common.pathfinder.NewtonianAerospacePathFinder";
     
     // This is a map containing coordinates-with-facing, and the length of the path it took to get there
-    private Map<CoordsWithFacing, Integer> visitedCoords = new HashMap<>();
-    private List<MoveStepType> moves;
+    protected Map<CoordsWithFacing, Integer> visitedCoords = new HashMap<>();
+    // This is a list of all possible moves
+    protected List<MoveStepType> moves;
     
-    private NewtonianAerospacePathFinder(IGame game) {
+    protected NewtonianAerospacePathFinder(IGame game) {
         this.game = game;
         getLogger().setLogLevel(LOGGER_CATEGORY, LogLevel.DEBUG);
         
-        // put together a pre-defined array of possible moves
+        initializeMoveList();
+    }
+    
+    /**
+     * Worker method to put together a pre-defined array of possible moves
+     */
+    protected void initializeMoveList() {
         moves = new ArrayList<>();
         moves.add(MoveStepType.TURN_RIGHT);
         moves.add(MoveStepType.TURN_LEFT);
@@ -61,20 +68,15 @@ public class NewtonianAerospacePathFinder {
         
         try {
             aerospacePaths = new ArrayList<MovePath>();
-            // add an option to stand still
-            aerospacePaths.add(startingEdge);
             
             // can't do anything if the unit is out of control.
             if(((IAero) startingEdge.getEntity()).isOutControlTotal()) {
                 return;
             }
             
-            aerospacePaths.addAll(generateChildren(startingEdge));
-            
-            MovePath reverseEdge = startingEdge.clone();
-            reverseEdge.addStep(MoveStepType.YAW);
-            aerospacePaths.add(reverseEdge);
-            aerospacePaths.addAll(generateChildren(reverseEdge));
+            for(MovePath path : generateStartingPaths(startingEdge)) {
+                aerospacePaths.addAll(generateChildren(path));
+            }
             
             // it's possible that we generated some number of paths that go off-board
             // now is the time to clean those out.
@@ -107,6 +109,28 @@ public class NewtonianAerospacePathFinder {
 
         return npf;
     }
+        
+    /** 
+     * Generates a list of possible step combinations that should be done at the beginning of a path
+     * Has side effect of updating the visited coordinates map and adding it to the list of generated paths
+     * @return List of all possible "starting" paths
+     */
+    protected List<MovePath> generateStartingPaths(MovePath startingEdge) {
+        List<MovePath> startingPaths = new ArrayList<>();
+        
+        MovePath defaultPath = startingEdge.clone();
+        aerospacePaths.add(defaultPath);
+        visitedCoords.put(new CoordsWithFacing(defaultPath), defaultPath.getMpUsed());
+        startingPaths.add(defaultPath);
+        
+        MovePath reverseEdge = startingEdge.clone();
+        reverseEdge.addStep(MoveStepType.YAW);
+        aerospacePaths.add(reverseEdge);
+        visitedCoords.put(new CoordsWithFacing(reverseEdge), reverseEdge.getMpUsed());
+        startingPaths.add(defaultPath);
+        
+        return startingPaths;
+    }
     
     /**
      * Recursive method that generates the possible child paths from the given path.
@@ -136,21 +160,8 @@ public class NewtonianAerospacePathFinder {
             
             childPath.addStep(nextStepType);
             
-            boolean maxMPUsed = childPath.getMpUsed() >= childPath.getEntity().getRunMP();
-            
-            // having generated the child, we add it and (recursively) any of its children to the list of children to be returned            
-            // of course, if it winds up not being legal anyway for some other reason, then we discard it and move on
-            if(!childPath.isMoveLegal() && maxMPUsed) {
-                continue;
-            }
-            
             CoordsWithFacing pathDestination = new CoordsWithFacing(childPath);
-            
-            // terminator conditions:
-            // we've visited this hex already and the path we are considering is longer than the previous path that visited this hex
-            // OR we have used all our MP
-            if((visitedCoords.containsKey(pathDestination) && visitedCoords.get(pathDestination).intValue() < childPath.getMpUsed()) 
-                    || maxMPUsed) {
+            if(discardPath(childPath, pathDestination)) {
                 continue;
             }
             
@@ -161,15 +172,62 @@ public class NewtonianAerospacePathFinder {
                 offBoardPath = childPath;
             }
             
-            visitedCoords.put(pathDestination, childPath.getMpUsed());
+            if(!isIntermediatePath(childPath)) {
+                visitedCoords.put(pathDestination, childPath.getMpUsed());
             
-            retval.add(childPath.clone());
+                retval.add(childPath.clone());
+            }
+            
             retval.addAll(generateChildren(childPath));
         }
                 
         return retval;
     }
     
+    /**
+     * "Worker" function to determine whether the path being examined is an intermediate path.
+     * This means that the path, as is, is not a valid path, but its children may be.
+     * This mainly applies to aero paths that have not used all their velocity.
+     * For newtonian space flight, it is never an intermediate path.
+     * @param path The move path to consider.
+     * @return Whether it is an intermediate path or not.
+     */
+    protected boolean isIntermediatePath(MovePath path) {
+        return false;
+    }
+    
+    /**
+     * Worker function to determine whether we should discard the current path 
+     * (due to it being illegal or redundant) or keep generating child nodes
+     * @param path The move path to consider
+     * @return Whether to keep or dicsard.
+     */
+    protected boolean discardPath(MovePath path, CoordsWithFacing pathDestination) {
+        boolean maxMPExceeded = path.getMpUsed() > path.getEntity().getRunMP();
+        
+        // having generated the child, we add it and (recursively) any of its children to the list of children to be returned            
+        // unless it is illegal or exceeds max MP, in which case we discard it
+        // (max mp is maybe redundant)?
+        if(!path.isMoveLegal() || maxMPExceeded) {
+            return true;
+        }
+        
+        // terminator conditions:
+        // we've visited this hex already and the path we are considering is longer than the previous path that visited this hex
+        if(visitedCoords.containsKey(pathDestination) && visitedCoords.get(pathDestination).intValue() < path.getMpUsed()) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Worker function to calculate whether, if the given move step is added to the given move path, there will be
+     * "too much turning", where a turn of 180 degrees or more is considered too much (we can yaw instead)
+     * @param path The move path to consider
+     * @param stepType The step type to consider
+     * @return Whether we're turning too much
+     */
     private boolean tooMuchTurning(MovePath path, MoveStepType stepType) {
         if(path.getLastStep() == null || path.getSecondLastStep() == null) {
             return false;

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -204,6 +204,7 @@ public class BasicPathRankerTest {
         Mockito.when(mockAero.getId()).thenReturn(2);
         Mockito.when(mockAero.isAero()).thenReturn(true);
         Mockito.when(mockAero.isAirborne()).thenReturn(true);
+        Mockito.when(mockAero.isAirborneAeroOnGroundMap()).thenReturn(true);
         EntityEvaluationResponse expected = new EntityEvaluationResponse();
         EntityEvaluationResponse actual = testRanker.evaluateUnmovedEnemy(mockAero, mockPath, false, false);
         assertEntityEvaluationResponseEquals(expected, actual);
@@ -1049,6 +1050,7 @@ public class BasicPathRankerTest {
         final Entity mockAero = Mockito.mock(ConvFighter.class);
         Mockito.when(mockAero.isAero()).thenReturn(true);
         Mockito.when(mockAero.isAirborne()).thenReturn(true);
+        Mockito.when(mockAero.isAirborneAeroOnGroundMap()).thenReturn(true);
         Mockito.when(mockAero.getPosition()).thenReturn(new Coords(1, 1)); // Right on top of me, but being an aero, it
         // shouldn't count.
         Mockito.when(mockAero.isSelectableThisTurn()).thenReturn(false);


### PR DESCRIPTION
As per title. 

Notable changes: dedicated pathfinder classes for low altitude atmo maps and space maps (non-newtonian).

Minor changes:
- Bug fix where aeros were overwriting their negative-value firing plans with empty bomb drops when considering paths.
- Minor optimization to avoid "pavement checks" for airborne aircraft.