### PR TITLE
Fixed NPE when getTonnage is called with null Entity.

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -868,7 +868,7 @@ public class MiscType extends EquipmentType {
             } else {
                 return Math.ceil((entity.getWeight() * 0.02) * 2) / 2.0;
             }
-        }  else if (hasFlag(MiscType.F_MAGNETIC_CLAMP) && entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
+        }  else if (hasFlag(MiscType.F_MAGNETIC_CLAMP) && hasFlag(MiscType.F_PROTOMECH_EQUIPMENT)) {
             if (entity.getWeight() < 6) {
                 return 0.25;
             } else if (entity.getWeight() < 10) {

--- a/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
@@ -58,7 +58,7 @@ public abstract class LRMWeapon extends MissileWeapon {
     
     @Override
     public double getTonnage(Entity entity, int location) {
-        if (entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
+        if ((null != entity) && entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
             return getRackSize() * 0.2;
         } else {
             return super.getTonnage(entity, location);

--- a/megamek/src/megamek/common/weapons/lrms/LRTWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRTWeapon.java
@@ -44,7 +44,7 @@ public abstract class LRTWeapon extends MissileWeapon {
     
     @Override
     public double getTonnage(Entity entity, int location) {
-        if (entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
+        if ((entity != null) && entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
             return getRackSize() * 0.2;
         } else {
             return super.getTonnage(entity, location);

--- a/megamek/src/megamek/common/weapons/lrms/StreakLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/StreakLRMWeapon.java
@@ -43,7 +43,7 @@ public abstract class StreakLRMWeapon extends LRMWeapon {
     
     @Override
     public double getTonnage(Entity entity, int location) {
-        if (entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
+        if ((entity != null) && entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
             return getRackSize() * 0.4;
         } else {
             return super.getTonnage(entity, location);

--- a/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
@@ -55,7 +55,7 @@ public abstract class SRMWeapon extends MissileWeapon {
     
     @Override
     public double getTonnage(Entity entity, int location) {
-        if (entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
+        if ((null != entity) && entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
             return getRackSize() * 0.25;
         } else {
             return super.getTonnage(entity, location);

--- a/megamek/src/megamek/common/weapons/srms/SRTWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/SRTWeapon.java
@@ -44,7 +44,7 @@ public abstract class SRTWeapon extends MissileWeapon {
     
     @Override
     public double getTonnage(Entity entity, int location) {
-        if (entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
+        if ((null != entity) && entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
             return getRackSize() * 0.25;
         } else {
             return super.getTonnage(entity, location);

--- a/megamek/src/megamek/common/weapons/srms/StreakSRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/StreakSRMWeapon.java
@@ -41,7 +41,7 @@ public abstract class StreakSRMWeapon extends SRMWeapon {
     
     @Override
     public double getTonnage(Entity entity, int location) {
-        if (entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
+        if ((null != entity) && entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
             return getRackSize() * 0.5;
         } else {
             return super.getTonnage(entity, location);


### PR DESCRIPTION
I failed to account for the possibility of a null entity when adding some protomech-specific tonnage calculations. I noticed this in warehouse parts while doing some work on MekHQ.