### PR TITLE
force warship/space station to use same asew bulletproofing as jumpship

### DIFF
--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -113,14 +113,21 @@ public class Jumpship extends Aero {
     private int asewAffectedTurns[] = { 0, 0, 0, 0, 0, 0};
     
     /*
+     * Accessor for the asewAffectedTurns array, which may be different for inheriting classes.
+     */
+    protected int[] getAsewAffectedTurns() {
+        return asewAffectedTurns;
+    }
+    
+    /*
      * Sets the number of rounds a specified firing arc is affected by an ASEW missile
      * @param arc - integer representing the desired firing arc
      * @param turns - integer specifying the number of end phases that the effects last through
      * Technically, about 1.5 turns elapse per the rules for ASEW missiles in TO
      */
     public void setASEWAffected(int arc, int turns) {
-        if (arc < asewAffectedTurns.length) {
-            asewAffectedTurns[arc] = turns;
+        if (arc < getAsewAffectedTurns().length) {
+            getAsewAffectedTurns()[arc] = turns;
         }
     }
     
@@ -129,8 +136,8 @@ public class Jumpship extends Aero {
      * @param arc - integer representing the desired firing arc
      */
     public int getASEWAffected(int arc) {
-        if (arc < asewAffectedTurns.length) {
-            return asewAffectedTurns[arc];
+        if (arc < getAsewAffectedTurns().length) {
+            return getAsewAffectedTurns()[arc];
         }
         return 0;
     }

--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -33,36 +33,9 @@ public class SpaceStation extends Jumpship {
     // This only affects cost, but may have an effect in a large-scale strategic setting.
     private boolean modular = false;
     
-    //ASEW Missile Effects, per location
-    //Values correspond to Locations, inherited from Jumpship: NOS,FLS,FRS,AFT,ALS,ARS
-    private int asewAffectedTurns[] = { 0, 0, 0, 0, 0, 0};
-
     @Override
     public int getUnitType() {
         return UnitType.SPACE_STATION;
-    }
-
-    /*
-     * Sets the number of rounds a specified firing arc is affected by an ASEW missile
-     * @param arc - integer representing the desired firing arc
-     * @param turns - integer specifying the number of end phases that the effects last through
-     * Technically, about 1.5 turns elapse per the rules for ASEW missiles in TO
-     * Space Stations should use the same method as Jumpships, but because Warships have a different number of arcs
-     * we run into problems if this isn't explicitly specified here.
-     */
-    @Override
-    public void setASEWAffected(int arc, int turns) {
-        asewAffectedTurns[arc] = turns;
-    }
-    
-    /*
-     * Returns the number of rounds a specified firing arc is affected by an ASEW missile
-     * @param arc - integer representing the desired firing arc
-     * Also an override to prevent issues with Warships having a different number of arcs
-     */
-    @Override
-    public int getASEWAffected(int arc) {
-        return asewAffectedTurns[arc];
     }
     
     public SpaceStation() {

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -58,24 +58,11 @@ public class Warship extends Jumpship {
     private int asewAffectedTurns[] = { 0, 0, 0, 0, 0, 0, 0, 0};
     
     /*
-     * Sets the number of rounds a specified firing arc is affected by an ASEW missile
-     * @param arc - integer representing the desired firing arc
-     * @param turns - integer specifying the number of end phases that the effects last through
-     * Technically, about 1.5 turns elapse per the rules for ASEW missiles in TO
-     * Because Warships have 8 arcs instead of 6, this overrides the method in Jumpship
+     * Accessor for the asewAffectedTurns array, which may be different for inheriting classes.
      */
     @Override
-    public void setASEWAffected(int arc, int turns) {
-        asewAffectedTurns[arc] = turns;
-    }
-    
-    /*
-     * Returns the number of rounds a specified firing arc is affected by an ASEW missile
-     * @param arc - integer representing the desired firing arc
-     */
-    @Override
-    public int getASEWAffected(int arc) {
-        return asewAffectedTurns[arc];
+    protected int[] getAsewAffectedTurns() {
+        return asewAffectedTurns;
     }
  
     


### PR DESCRIPTION
Fixes a sensor-related bug that freezes the game at the end phase when a warship or space station is on the board.