### PR TITLE
Don't use conventional infantry VTOL/SCUBA motion type in BA blk.

### DIFF
--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -2316,12 +2316,14 @@ public class Infantry extends Entity {
     
     @Override
     public String getMovementModeAsString() {
-    	if (getMovementMode().equals(EntityMovementMode.VTOL)) {
-    		return hasMicrolite()? "Microlite" : "Microcopter";
-    	}
-    	if (getMovementMode() == EntityMovementMode.INF_UMU) {
-    		return getOriginalJumpMP() > 1? "Motorized SCUBA" : "SCUBA";
-    	}
+        if (!hasETypeFlag(Entity.ETYPE_BATTLEARMOR)) {
+            if (getMovementMode().equals(EntityMovementMode.VTOL)) {
+                return hasMicrolite()? "Microlite" : "Microcopter";
+            }
+            if (getMovementMode() == EntityMovementMode.INF_UMU) {
+                return getOriginalJumpMP() > 1? "Motorized SCUBA" : "SCUBA";
+            }
+        }
     	return super.getMovementModeAsString();
     }
 


### PR DESCRIPTION
Conventional infantry have multiple options for VTOL and UMU movement, necessitating different values for the motion_type field in the blk file. This behavior is incorrectly inherited by `BattleArmor`.

Fixes Megamek/megameklab#228: BA VTOL and UMU movement types