### PR TITLE
Allow for possibility of circular references in Mounted#getLinked

### DIFF
--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -22,7 +22,9 @@
 package megamek.common;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Vector;
 
 import megamek.common.actions.WeaponAttackAction;
@@ -1791,8 +1793,22 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
      * @return
      */
     public boolean isOneShot(){
-        return (isOneShotWeapon()
-                || ((getLinkedBy() != null) && getLinkedBy().isOneShot()));
+        if (isOneShotWeapon()) {
+            return true;
+        } else if ((getType() instanceof AmmoType) && getLinkedBy() != null) {
+            // There should not be any circular references, but we should track where we've been just in case.
+            // Do a couple checks first to avoid instantiating a set unnecessarily.
+            Set<Mounted> checked = new HashSet<>();
+            for (Mounted current = getLinkedBy(); current != null; current = current.getLinkedBy()) {
+                if (checked.contains(current)) {
+                    return false;
+                }
+                if (current.isOneShotWeapon()) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
     
     /**


### PR DESCRIPTION
The implementation of the protomech fusillade introduced the possibility of a chain of ammo mounts, and the check for a one-shot weapon moves along the chain to find the weapon at the end to check the flag. This failed to account for the possibility of circular references, such as BA AP weapons, in which the weapon and the AP mount or armored glove are linked to each other.

Replaced recursion with a loop that tracks what mounts have already been checked. Uses some short-circuit logic to avoid more expensive operations where it will not be necessary.

Fixes Megamek/megameklab#231: Stack Overflow Exception while saving
Battle Armor