### PR TITLE
enable evaluation of arm-flip firing plans

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2040,7 +2040,7 @@ public class FireControl {
 
         // Start with an alpha strike.
         FiringPlan alphaStrike = getFullFiringPlan(shooter, target,
-                                                         ammoConservation, game);
+                                                    ammoConservation, game);
         
         if(shooter.canFlipArms()) {
             shooter.setArmsFlipped(true);
@@ -2103,12 +2103,12 @@ public class FireControl {
 
         // Start with an alpha strike. If it falls under our heat limit, use it.
         FiringPlan alphaStrike = guessFullFiringPlan(shooter, shooterState,
-                                                           target, targetState, game);
+                                                       target, targetState, game);
         
         if(shooter.canFlipArms()) {
             shooter.setArmsFlipped(true);
             FiringPlan betaStrike = guessFullFiringPlan(shooter, shooterState,
-                    target, targetState, game);
+                                                        target, targetState, game);
             betaStrike.setFlipArms(true);
             if(betaStrike.getUtility() > alphaStrike.getUtility()) {
                 alphaStrike = betaStrike;

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1922,7 +1922,8 @@ public class FireControl {
 
         // First plan is a plan that fires only heatless weapons.
         // The remaining plans will build at least some heat.
-        bestPlans[0] = new FiringPlan(target);
+        // we include arm flip information into the regular heat plans, but infantry don't flip arms so we don't bother.
+        bestPlans[0] = new FiringPlan(target, alphaStrike.getFlipArms());
         final FiringPlan nonZeroHeatOptions = new FiringPlan(target);
         final FiringPlan swarmAttack = new FiringPlan(target);
         final FiringPlan legAttack = new FiringPlan(target);
@@ -1989,7 +1990,8 @@ public class FireControl {
                 if ((0 <= leftoverHeatCapacity) &&
                     !bestPlans[leftoverHeatCapacity].containsWeapon(weaponFireInfo.getWeapon())) {
 
-                    final FiringPlan testPlan = new FiringPlan(target);
+                    // make sure to pass along arm flip state from the alpha strike, if any
+                    final FiringPlan testPlan = new FiringPlan(target, alphaStrike.getFlipArms());
                     testPlan.addAll(bestPlans[heatLevel - weaponFireInfo.getHeat()]);
                     testPlan.add(weaponFireInfo);
                     calculateUtility(testPlan, heatTolerance, isAero);
@@ -2037,8 +2039,19 @@ public class FireControl {
                                  final Map<Mounted, Double> ammoConservation) {
 
         // Start with an alpha strike.
-        final FiringPlan alphaStrike = getFullFiringPlan(shooter, target,
+        FiringPlan alphaStrike = getFullFiringPlan(shooter, target,
                                                          ammoConservation, game);
+        
+        if(shooter.canFlipArms()) {
+            shooter.setArmsFlipped(true);
+            FiringPlan betaStrike = getFullFiringPlan(shooter, target, ammoConservation, game);
+            betaStrike.setFlipArms(true);
+            if(betaStrike.getUtility() > alphaStrike.getUtility()) {
+                alphaStrike = betaStrike;
+            }
+            
+            shooter.setArmsFlipped(false);
+        }
         
         // Although they don't track heat, infantry/BA do need to make tradeoffs
         // between firing different weapons, because swarm/leg attacks are
@@ -2089,8 +2102,21 @@ public class FireControl {
         }
 
         // Start with an alpha strike. If it falls under our heat limit, use it.
-        final FiringPlan alphaStrike = guessFullFiringPlan(shooter, shooterState,
+        FiringPlan alphaStrike = guessFullFiringPlan(shooter, shooterState,
                                                            target, targetState, game);
+        
+        if(shooter.canFlipArms()) {
+            shooter.setArmsFlipped(true);
+            FiringPlan betaStrike = guessFullFiringPlan(shooter, shooterState,
+                    target, targetState, game);
+            betaStrike.setFlipArms(true);
+            if(betaStrike.getUtility() > alphaStrike.getUtility()) {
+                alphaStrike = betaStrike;
+            }
+            
+            shooter.setArmsFlipped(false);
+        }
+        
         // Infantry and BA may have alternative options, so we need to consider
         // different firing options.
         if (alphaStrike.getHeat() <= maxHeat && !(shooter instanceof Infantry)) {

--- a/megamek/src/megamek/client/bot/princess/FiringPlan.java
+++ b/megamek/src/megamek/client/bot/princess/FiringPlan.java
@@ -18,6 +18,7 @@ import megamek.common.Mounted;
 import megamek.common.Targetable;
 import megamek.common.WeaponType;
 import megamek.common.actions.EntityAction;
+import megamek.common.actions.FlipArmsAction;
 import megamek.common.actions.TorsoTwistAction;
 import megamek.common.util.StringUtil;
 
@@ -41,11 +42,17 @@ public class FiringPlan extends ArrayList<WeaponFireInfo> implements
     private double utility; // calculated elsewhere
     private Targetable target;
     private int twist;
+    private boolean flipArms;
 
     FiringPlan(Targetable target) {
         setTwist(0);
         setUtility(0);
         this.target = target;
+    }
+    
+    FiringPlan(Targetable target, boolean flipArms) {
+        this(target);
+        this.flipArms = flipArms;
     }
 
     /**
@@ -132,6 +139,10 @@ public class FiringPlan extends ArrayList<WeaponFireInfo> implements
         		FireControl.correctFacing(get(0).getShooter().getFacing() + getTwist())));
         }
         
+        if(flipArms) {
+            actionVector.addElement(new FlipArmsAction(get(0).getShooter().getId(), flipArms));
+        }
+        
         for (WeaponFireInfo weaponFireInfo : this) {
             actionVector.add(weaponFireInfo.getWeaponAttackAction());
         }
@@ -177,6 +188,14 @@ public class FiringPlan extends ArrayList<WeaponFireInfo> implements
 
     public void setTwist(int twist) {
         this.twist = twist;
+    }
+    
+    public boolean getFlipArms() {
+        return flipArms;
+    }
+    
+    public void setFlipArms(boolean flipArms) {
+        this.flipArms = flipArms;
     }
 
     /**


### PR DESCRIPTION
Pretty simple set of changes, enables the bot to use the "arm flip" function when evaluating its moves. Great for Jenners and Riflemen desperate to get that last bit of firepower out before someone cores them out via back shot.