### PR TITLE
Fix for issue #1213 

### DIFF
--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -33,7 +33,7 @@ import megamek.common.options.OptionsConstants;
  * @author Jay Lawson Fighter squadrons are basically "containers" for a bunch
  *         of fighters.
  */
-public class FighterSquadron extends Aero {
+public class FighterSquadron extends Aero implements IAero {
     private static final long serialVersionUID = 3491212296982370726L;
 
     public static int MAX_SIZE = 6;
@@ -139,6 +139,14 @@ public class FighterSquadron extends Aero {
         return fighters.stream().map(fid -> game.getEntity(fid))
                 .filter(ACTIVE_CHECK)
                 .mapToInt(ent -> ent.getWalkMP(gravity, ignoreheat)).min()
+                .orElse(0);
+    }
+    
+    @Override
+    public int getCurrentThrust() {
+        return fighters.stream().map(fid -> game.getEntity(fid))
+                .filter(ACTIVE_CHECK)
+                .mapToInt(ent -> ((IAero) ent).getCurrentThrust()).min()
                 .orElse(0);
     }
 

--- a/megamek/src/megamek/common/pathfinder/AeroSpacePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroSpacePathFinder.java
@@ -106,6 +106,11 @@ public class AeroSpacePathFinder extends NewtonianAerospacePathFinder {
             return true;
         }
         
+        // there's no reason to consider off-board paths in the standard flight model.
+        if(!path.getGame().getBoard().contains(pathDestination.getCoords())) {
+            return true;
+        }
+        
         return false;
     }
 }

--- a/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/NewtonianAerospacePathFinder.java
@@ -24,7 +24,7 @@ import megamek.common.pathfinder.MovePathFinder.CoordsWithFacing;
 public class NewtonianAerospacePathFinder {
     private IGame game;
     protected List<MovePath> aerospacePaths;
-    private MovePath offBoardPath;
+    protected MovePath offBoardPath;
     private MMLogger logger;
     protected static final String LOGGER_CATEGORY = "megamek.common.pathfinder.NewtonianAerospacePathFinder";
     


### PR DESCRIPTION
An endless recursion (leading to stack overflow) occurs under standard aerospace rules when a path goes off board. It should be impossible for a unit to leave the board under those rules, so we simply eliminate such paths from consideration.