### PR TITLE
Fix #1218: initialize pilot damage taken array to correct size

### DIFF
--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -64,7 +64,7 @@ public class Protomech extends Entity {
 
     // Crew damage caused so far by crits to this location.
     // Needed for location destruction pilot damage.
-    private int pilotDamageTaken[] = { 0, 0, 0, 0, 0, 0 };
+    private int pilotDamageTaken[] = { 0, 0, 0, 0, 0, 0, 0 };
 
     /**
      * Not every Protomech has a main gun. N.B. Regardless of the value set


### PR DESCRIPTION
Fix for #1218 

Can't really reproduce the defect itself, but the log file indicates that something was looking for pilot damage at location 6, which doesn't exist in the backing array. So, the idea is to make the array match all the other location arrays in the class.