### PR TITLE
Enable princess to unjam weapons

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -543,7 +543,14 @@ public class Princess extends BotClient {
             // get the first entity that can act this turn make sure weapons 
             // are loaded
             final Entity shooter = game.getFirstEntity(getMyTurn());
-
+            
+            // if I have jammed weapons, I am going to consider unjamming them instead of firing
+            Vector<EntityAction> unjamPlan = getFireControl(shooter).getUnjamWeaponPlan(shooter);
+            if(unjamPlan != null) {
+                sendAttackData(shooter.getId(), unjamPlan);
+                return;
+            }
+            
             // If my unit is forced to withdraw, don't fire unless I've been 
             // fired on.
             if (getForcedWithdrawal() && shooter.isCrippled()) {


### PR DESCRIPTION
Sometimes, a tank or a turret will take damage and a weapon will become jammed. This pull request enables the bot to consider unjamming its weapons rather than sitting there with jammed weapons and not doing anything.