### PR TITLE
Fix minefield phase skip

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -3450,12 +3450,13 @@ public class Server implements Runnable {
             nextEntity = game.getEntity(game.getFirstEntityNum(nextTurn));
         }
         
-        boolean nonEntityPhase = game.getPhase() == IGame.Phase.PHASE_DEPLOY_MINEFIELDS;
+        boolean minefieldPhase = game.getPhase() == IGame.Phase.PHASE_DEPLOY_MINEFIELDS;
+        boolean artyPhase = game.getPhase() == IGame.Phase.PHASE_SET_ARTYAUTOHITHEXES;
         
         // if there aren't any more valid turns, end the phase
         // note that some phases don't use entities
-        if (((null == nextEntity) && !nonEntityPhase) ||
-                ((null == nextTurn) && nonEntityPhase)) {
+        if (((null == nextEntity) && !minefieldPhase) ||
+                ((null == nextTurn) && minefieldPhase)) {
             endCurrentPhase();
             return;
         }
@@ -3477,7 +3478,7 @@ public class Server implements Runnable {
             sendGhostSkipMessage(player);
         } else if ((null == game.getFirstEntity())
                 && (null != player)
-                && !nonEntityPhase) {
+                && !minefieldPhase && !artyPhase) {
             sendTurnErrorSkipMessage(player);
         }
     }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -3450,8 +3450,7 @@ public class Server implements Runnable {
             nextEntity = game.getEntity(game.getFirstEntityNum(nextTurn));
         }
         
-        boolean nonEntityPhase = game.getPhase() == IGame.Phase.PHASE_DEPLOY_MINEFIELDS ||
-                game.getPhase() == IGame.Phase.PHASE_SET_ARTYAUTOHITHEXES;
+        boolean nonEntityPhase = game.getPhase() == IGame.Phase.PHASE_DEPLOY_MINEFIELDS;
         
         // if there aren't any more valid turns, end the phase
         // note that some phases don't use entities

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -3450,8 +3450,13 @@ public class Server implements Runnable {
             nextEntity = game.getEntity(game.getFirstEntityNum(nextTurn));
         }
         
+        boolean nonEntityPhase = game.getPhase() == IGame.Phase.PHASE_DEPLOY_MINEFIELDS ||
+                game.getPhase() == IGame.Phase.PHASE_SET_ARTYAUTOHITHEXES;
+        
         // if there aren't any more valid turns, end the phase
-        if (null == nextEntity) {
+        // note that some phases don't use entities
+        if (((null == nextEntity) && !nonEntityPhase) ||
+                ((null == nextTurn) && nonEntityPhase)) {
             endCurrentPhase();
             return;
         }
@@ -3473,9 +3478,7 @@ public class Server implements Runnable {
             sendGhostSkipMessage(player);
         } else if ((null == game.getFirstEntity())
                 && (null != player)
-                && ((game.getPhase() != IGame.Phase.PHASE_DEPLOY_MINEFIELDS)
-                        && (game.getPhase()
-                                != IGame.Phase.PHASE_SET_ARTYAUTOHITHEXES))) {
+                && !nonEntityPhase) {
             sendTurnErrorSkipMessage(player);
         }
     }


### PR DESCRIPTION
Fixes the behavior displayed in issue #1238. During a minefield deployment phase, there are no eligible entities, but there are still turns, so we add a little extra logic to the "changeToNextTurn" method.