### PR TITLE
Removed incorrect tech advancement data for point defense bay.

### DIFF
--- a/megamek/src/megamek/common/weapons/bayweapons/PointDefenseBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/PointDefenseBayWeapon.java
@@ -17,7 +17,6 @@
 package megamek.common.weapons.bayweapons;
 
 import megamek.common.IGame;
-import megamek.common.TechAdvancement;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AmmoBayWeaponHandler;
@@ -54,10 +53,6 @@ public class PointDefenseBayWeapon extends AmmoBayWeapon {
 		flags = flags.or(F_PDBAY).or(F_AERO_WEAPON);
 		setModes(new String[] { "Point Defense", "Normal" });
 		setInstantModeSwitch(false);
-        techAdvancement.setTechBase(TechAdvancement.TECH_BASE_ALL);
-        techAdvancement.setAdvancement(DATE_NONE, DATE_NONE, 3071);
-        techAdvancement.setTechRating(RATING_C);
-        techAdvancement.setAvailability( new int[] { RATING_E, RATING_E, RATING_E, RATING_E });
     }
     
     @Override


### PR DESCRIPTION
This was generated by a utility I wrote to convert the previous tech
level data to IO format. Since the equipment didn't have an intro date
given it used the earliest available date, which was 3071. The tech
advancement is now inherited from WeaponBay, and the dates coincide with
JS/WS tech advancement.

Fixes Megamek/megameklab#237: Large amounts of weapons overtax warship
creation