### PR TITLE
Fix annoying auto-flee behavior when setting destination edge to none

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
@@ -551,9 +551,11 @@ public class BotConfigDialog extends JDialog implements ActionListener, KeyListe
             setPrincessFields();
         } else if (destinationEdgeCombo.equals(e.getSource())) {
             if (CardinalEdge.getCardinalEdge(destinationEdgeCombo.getSelectedIndex()) == CardinalEdge.NEAREST_OR_NONE) {
+                autoFleeCheck.setSelected(false);
                 autoFleeCheck.setEnabled(false);
             } else {
                 autoFleeCheck.setEnabled(true);
+                autoFleeCheck.setSelected(true);
             }
         } else if (princessHelpButton.equals(e.getSource())) {
             launchPrincessHelp();


### PR DESCRIPTION
Fixes a behavior where, if the user switched a bot's destination edge to 'none', the auto-flee box would "stick", resulting in units running off the board whenever they reached any edge.