### PR TITLE
Fix bug where the wrong type was chosen for equals in CommonSettingsDialog (lgtm)

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -967,12 +967,12 @@ public class CommonSettingsDialog extends ClientDialog implements
         }
 
         if (tileSetChoice.getSelectedIndex() >= 0) {
-            if (!cs.getMapTileset().equals(tileSets.get(tileSetChoice.getSelectedIndex())) &&
+            String tileSetFileName = tileSets.get(tileSetChoice.getSelectedIndex()).getName();
+            if (!cs.getMapTileset().equals(tileSetFileName) &&
                     (clientgui != null) && (clientgui.bv != null))  {
                 clientgui.bv.clearShadowMap();
             }
-            cs.setMapTileset(tileSets.get(tileSetChoice.getSelectedIndex())
-                    .getName());
+            cs.setMapTileset(tileSetFileName);
         }
 
         ToolTipManager.sharedInstance().setInitialDelay(


### PR DESCRIPTION
Fixes bug where String::equals was called against a File object instead of its file name. Part of #1242.