### PR TITLE
Disallow loading trailers during deployment

### DIFF
--- a/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
@@ -1023,12 +1023,15 @@ public class DeploymentDisplay extends StatusBarPhaseDisplay {
         }
         List<Entity> entities = clientgui.getClient().getGame()
                 .getEntitiesVector();
-        for (Entity other : entities) {        
+        for (Entity other : entities) {
             if (other.isSelectableThisTurn() && ce().canLoad(other, false)
                     // We can't depend on the transport id to be set because we sent a server update
                     // before loading on the client side, and the loaded unit may have been reset
                     // by the resulting update from the server.
-                    && !ce().getLoadedUnits().contains(other)) {
+                    && !ce().getLoadedUnits().contains(other)
+                    // If you want to load a trailer into a dropship or large support vee, do it in the lobby
+                    // The 'load' button should not allow trailers - that's what 'tow' is for.
+                    && !other.isTrailer()) {
                 choices.add(other);
             }
         }


### PR DESCRIPTION
Prevents using the 'Load' button to try and attach a trailer to a tractor during the deployment phase, which causes an NPE

This will also prevent loading a trailer into a dropship or a vehicle with a vehicle bay, but you can do either in the lobby or during movement. 