### PR TITLE
Fix potential ArrayIndexOutOfBoundsException

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
+++ b/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
@@ -1454,7 +1454,8 @@ public class ForceDescriptor {
         FactionRecord fRec = getFactionRec();
         if ((null != fRec)
                 && !fRec.getRatingLevels().contains(rating)
-                && (getRatingLevel() >= 0)) {
+                && (getRatingLevel() >= 0)
+                && !fRec.getRatingLevels().isEmpty()) {
             return fRec.getRatingLevels().get(Math.min(getRatingLevel(), fRec.getRatingLevels().size() - 1));
         }
         return rating;


### PR DESCRIPTION
This fixes an exception that Hammer found that stems from incorrectly assuming that a particular List is not empty.