### PR TITLE
Add improved AC/20 ammo to EquipmentType hash after creating it.

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -784,6 +784,7 @@ public class AmmoType extends EquipmentType {
         EquipmentType.addType(base);
         base = AmmoType.createCLImprovedAC20Ammo();
         clanImprovedAcAmmo.add(base);
+        EquipmentType.addType(base);
         
         base = AmmoType.createCLPROAC2Ammo();
         clanProtoAcAmmo.add(base);


### PR DESCRIPTION
Fixes Megamek/megameklab#202: Clan Improved Autocannon 20 has no
standard ammunition