### PR TITLE
Aero Sanity update

### DIFF
--- a/megamek/i18n/megamek/common/options/messages.properties
+++ b/megamek/i18n/megamek/common/options/messages.properties
@@ -452,8 +452,8 @@ GameOptionsInfo.option.single_no_cap.displayableName=(Unofficial) Single Fighter
 GameOptionsInfo.option.single_no_cap.description=When checked, single fighters are not treated as Capital Fighters when using the StratOps Capital Fighters rules.
 GameOptionsInfo.option.allow_large_squadrons.displayableName=(Unofficial) Allow large (up to 10) fighter squadrons
 GameOptionsInfo.option.allow_large_squadrons.description=Allow up to 10 fighters in a squadron instead of the arbitrary 6 of the official record sheets.
-GameOptionsInfo.option.aero_sanity.displayableName=(Unofficial)(VERY BUGGY) Aero Sanity Mod for damage 
-GameOptionsInfo.option.aero_sanity.description= A modification of aero damage rules to make damage consistent across different unit types.\nSee document in the docs folder for details. USE AT YOUR OWN RISK.
+GameOptionsInfo.option.aero_sanity.displayableName=(Unofficial) Aero Sanity Mod for damage 
+GameOptionsInfo.option.aero_sanity.description= A modification of aero damage rules to make damage consistent across different unit types.\nSee document in the docs folder for details.
 GameOptionsInfo.option.cargo_bay_damage.displayableName=(Unofficial) Damage Cargo/Transport Bays on Cargo Critical Hit
 GameOptionsInfo.option.cargo_bay_damage.description= If a Cargo critical hit is taken, the cargo/transport bay itself suffers damage in addition to the cargo/units inside.
 

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -366,7 +366,7 @@
 3361=<B>Systems overheating. Point defenses shutting down!</B>
 3362=Point defenses engaging!
 3365=\ Attack deals zero damage.
-3366=Point Defense engaged (-<data> modifier to each launcher in bay)!
+3366=Point Defense engaged (Distributing <data> damage as cluster modifier to bay attack)!
 3370=<font color='008000'><B>hits</B></font> with <data> inferno missile(s).
 3371=<data> (<data>) is hit by incendiary grenades!
 3372=<data> is hit by incendiary grenades!

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -366,7 +366,8 @@
 3361=<B>Systems overheating. Point defenses shutting down!</B>
 3362=Point defenses engaging!
 3365=\ Attack deals zero damage.
-3366=Point Defense engaged (Distributing <data> damage as cluster modifier to bay attack)!
+3366=Point Defense engaged (Distributing <data> damage as cluster modifier to bay attack)!  
+3367=Point Defense engaged (Distributing <data> damage as cluster modifier to missile attack)!  
 3370=<font color='008000'><B>hits</B></font> with <data> inferno missile(s).
 3371=<data> (<data>) is hit by incendiary grenades!
 3372=<data> is hit by incendiary grenades!

--- a/megamek/src/megamek/common/weapons/AR10Handler.java
+++ b/megamek/src/megamek/common/weapons/AR10Handler.java
@@ -94,177 +94,177 @@ public class AR10Handler extends AmmoWeaponHandler {
             }
             vPhaseReport.addElement(r);
                 
-        //Point Defense fire vs Capital Missiles
+            //Point Defense fire vs Capital Missiles
         
-        // are we a glancing hit?  Check for this here, report it later
-        if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GLANCING_BLOWS)) {
-            if (roll == toHit.getValue()) {
-                bGlancing = true;
-            } else {
-                bGlancing = false;
+            // are we a glancing hit?  Check for this here, report it later
+            if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GLANCING_BLOWS)) {
+                if (roll == toHit.getValue()) {
+                    bGlancing = true;
+                } else {
+                    bGlancing = false;
+                }
             }
-        }
         
-        // Set Margin of Success/Failure and check for Direct Blows
-        toHit.setMoS(roll - Math.max(2, toHit.getValue()));
-        bDirect = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_DIRECT_BLOW)
-                && ((toHit.getMoS() / 3) >= 1) && (entityTarget != null);
+            // Set Margin of Success/Failure and check for Direct Blows
+            toHit.setMoS(roll - Math.max(2, toHit.getValue()));
+            bDirect = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_DIRECT_BLOW)
+                    && ((toHit.getMoS() / 3) >= 1) && (entityTarget != null);
 
-        //This has to be up here so that we don't screw up glancing/direct blow reports
-        attackValue = calcAttackValue();
+            //This has to be up here so that we don't screw up glancing/direct blow reports
+            attackValue = calcAttackValue();
         
-        //CalcAttackValue triggers counterfire, so now we can safely get this
-        CapMissileAMSMod = getCapMissileAMSMod();
+            //CalcAttackValue triggers counterfire, so now we can safely get this
+            CapMissileAMSMod = getCapMissileAMSMod();
         
-        //Only do this if the missile wasn't destroyed
-        if (CapMissileAMSMod > 0 && CapMissileArmor > 0) {
-            toHit.addModifier(CapMissileAMSMod, "Damage from Point Defenses");
-            if (roll < toHit.getValue()) {
-                CapMissileMissed = true;
+            //Only do this if the missile wasn't destroyed
+            if (CapMissileAMSMod > 0 && CapMissileArmor > 0) {
+                toHit.addModifier(CapMissileAMSMod, "Damage from Point Defenses");
+                if (roll < toHit.getValue()) {
+                    CapMissileMissed = true;
+                }
             }
-        }
         
-        // Report any AMS bay action against Capital missiles that doesn't destroy them all.
-        if (amsBayEngagedCap && CapMissileArmor > 0) {
-            r = new Report(3358);
-            r.add(CapMissileAMSMod);
-            r.subject = subjectId;
-            vPhaseReport.addElement(r);
+            // Report any AMS bay action against Capital missiles that doesn't destroy them all.
+            if (amsBayEngagedCap && CapMissileArmor > 0) {
+                r = new Report(3358);
+                r.add(CapMissileAMSMod);
+                r.subject = subjectId;
+                vPhaseReport.addElement(r);
                     
-        // Report any PD bay action against Capital missiles that doesn't destroy them all.
-        } else if (pdBayEngagedCap && CapMissileArmor > 0) {
-            r = new Report(3357);
-            r.add(CapMissileAMSMod);
-            r.subject = subjectId;
-            vPhaseReport.addElement(r);
-        }
+                // Report any PD bay action against Capital missiles that doesn't destroy them all.
+            } else if (pdBayEngagedCap && CapMissileArmor > 0) {
+                r = new Report(3357);
+                r.add(CapMissileAMSMod);
+                r.subject = subjectId;
+                vPhaseReport.addElement(r);
+            }
         
-        if (toHit.getValue() == TargetRoll.IMPOSSIBLE) {
-            r = new Report (3135);
-            r.subject = subjectId;
-            r.add(" " + target.getPosition(), true);
-            vPhaseReport.addElement(r);
-            return false;
-        } else if (toHit.getValue() == TargetRoll.AUTOMATIC_FAIL) {
-            r = new Report(3140);
-            r.newlines = 0;
-            r.subject = subjectId;
-            r.add(toHit.getDesc());
-            vPhaseReport.addElement(r);
-        } else if (toHit.getValue() == TargetRoll.AUTOMATIC_SUCCESS) {
-            r = new Report(3145);
-            r.newlines = 0;
-            r.subject = subjectId;
-            r.add(toHit.getDesc());
-            vPhaseReport.addElement(r);
-        } else {
+            if (toHit.getValue() == TargetRoll.IMPOSSIBLE) {
+                r = new Report (3135);
+                r.subject = subjectId;
+                r.add(" " + target.getPosition(), true);
+                vPhaseReport.addElement(r);
+                return false;
+            } else if (toHit.getValue() == TargetRoll.AUTOMATIC_FAIL) {
+                r = new Report(3140);
+                r.newlines = 0;
+                r.subject = subjectId;
+                r.add(toHit.getDesc());
+                vPhaseReport.addElement(r);
+            } else if (toHit.getValue() == TargetRoll.AUTOMATIC_SUCCESS) {
+                r = new Report(3145);
+                r.newlines = 0;
+                r.subject = subjectId;
+                r.add(toHit.getDesc());
+                vPhaseReport.addElement(r);
+            } else {
             // roll to hit
             r = new Report(3150);
             r.newlines = 0;
             r.subject = subjectId;
             r.add(toHit.getValue());
             vPhaseReport.addElement(r);
-        }
-
-        // dice have been rolled, thanks
-        r = new Report(3155);
-        r.newlines = 0;
-        r.subject = subjectId;
-        r.add(roll);
-        vPhaseReport.addElement(r);
-
-        // do we hit?
-        bMissed = roll < toHit.getValue();
-
-        //Report Glancing/Direct Blow here because of Capital Missile weirdness
-        if ((bGlancing) && !(amsBayEngagedCap || pdBayEngagedCap)) {
-            r = new Report(3186);
-            r.subject = ae.getId();
-            r.newlines = 0;
-            vPhaseReport.addElement(r);
-        } 
-
-        if ((bDirect) && !(amsBayEngagedCap || pdBayEngagedCap)) {
-            r = new Report(3189);
-            r.subject = ae.getId();
-            r.newlines = 0;
-            vPhaseReport.addElement(r);
-        }
-        
-        CounterAV = getCounterAV();
-        //use this if AMS counterfire destroys all the Capital missiles
-        if (amsBayEngagedCap && (CapMissileArmor <= 0)) {
-            r = new Report(3356);
-            r.indent();
-            r.subject = subjectId;
-            vPhaseReport.addElement(r);
-        }
-        //use this if PD counterfire destroys all the Capital missiles
-        if (pdBayEngagedCap && (CapMissileArmor <= 0)) {
-            r = new Report(3355);
-            r.indent();
-            r.subject = subjectId;
-            vPhaseReport.addElement(r);
-        }
-
-        // Any necessary PSRs, jam checks, etc.
-        // If this boolean is true, don't report
-        // the miss later, as we already reported
-        // it in doChecks
-        boolean missReported = doChecks(vPhaseReport);
-        if (missReported) {
-            bMissed = true;
-        }
-        if (bMissed && !missReported) {
-            reportMiss(vPhaseReport);
-        }
-        // Handle damage.
-        int nCluster = calcnCluster();
-        int id = vPhaseReport.size();
-        int hits = calcHits(vPhaseReport);
-
-        if (target.isAirborne() || game.getBoard().inSpace() || ae.usesWeaponBays()) {
-            // if we added a line to the phase report for calc hits, remove
-            // it now
-            while (vPhaseReport.size() > id) {
-                vPhaseReport.removeElementAt(vPhaseReport.size() - 1);
             }
-            int[] aeroResults = calcAeroDamage(entityTarget, vPhaseReport);
-            hits = aeroResults[0];
-            // If our capital missile was destroyed, it shouldn't hit
-            if ((amsBayEngagedCap || pdBayEngagedCap) && (CapMissileArmor <= 0)) {
-                hits = 0;
+
+            // dice have been rolled, thanks
+            r = new Report(3155);
+            r.newlines = 0;
+            r.subject = subjectId;
+            r.add(roll);
+            vPhaseReport.addElement(r);
+
+            // do we hit?
+            bMissed = roll < toHit.getValue();
+
+            //Report Glancing/Direct Blow here because of Capital Missile weirdness
+            if ((bGlancing) && !(amsBayEngagedCap || pdBayEngagedCap)) {
+                r = new Report(3186);
+                r.subject = ae.getId();
+                r.newlines = 0;
+                vPhaseReport.addElement(r);
+            } 
+
+            if ((bDirect) && !(amsBayEngagedCap || pdBayEngagedCap)) {
+                r = new Report(3189);
+                r.subject = ae.getId();
+                r.newlines = 0;
+                vPhaseReport.addElement(r);
             }
-            nCluster = aeroResults[1];
-        }
-        
-        //Capital missiles shouldn't be able to target buildings, being space-only weapons
-        //but if they aren't defined, handleEntityDamage() doesn't work.
-        int bldgAbsorbs = 0;
 
-        // We have to adjust the reports on a miss, so they line up
-        if (bMissed && id != vPhaseReport.size()) {
-            vPhaseReport.get(id - 1).newlines--;
-            vPhaseReport.get(id).indent(2);
-            vPhaseReport.get(vPhaseReport.size() - 1).newlines++;
-        }
+            CounterAV = getCounterAV();
+            //use this if AMS counterfire destroys all the Capital missiles
+            if (amsBayEngagedCap && (CapMissileArmor <= 0)) {
+                r = new Report(3356);
+                r.indent();
+                r.subject = subjectId;
+                vPhaseReport.addElement(r);
+            }
+            //use this if PD counterfire destroys all the Capital missiles
+            if (pdBayEngagedCap && (CapMissileArmor <= 0)) {
+                r = new Report(3355);
+                r.indent();
+                r.subject = subjectId;
+                vPhaseReport.addElement(r);
+            }
 
-        // Make sure the player knows when his attack causes no damage.
-        if (nDamPerHit == 0) {
-            r = new Report(3365);
-            r.subject = subjectId;
-            vPhaseReport.addElement(r);
-            return false;
-        }
-        if (!bMissed && (entityTarget != null)) {
-            handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
-                    nCluster, bldgAbsorbs);
-            server.creditKill(entityTarget, ae);
-        } else if (!bMissed) { // Hex is targeted, need to report a hit
-            r = new Report(3390);
-            r.subject = subjectId;
-            vPhaseReport.addElement(r);
-        }
+            // Any necessary PSRs, jam checks, etc.
+            // If this boolean is true, don't report
+            // the miss later, as we already reported
+            // it in doChecks
+            boolean missReported = doChecks(vPhaseReport);
+            if (missReported) {
+                bMissed = true;
+            }
+            if (bMissed && !missReported) {
+                reportMiss(vPhaseReport);
+            }
+            // Handle damage.
+            int nCluster = calcnCluster();
+            int id = vPhaseReport.size();
+            int hits = calcHits(vPhaseReport);
+
+            if (target.isAirborne() || game.getBoard().inSpace() || ae.usesWeaponBays()) {
+                // if we added a line to the phase report for calc hits, remove
+                // it now
+                while (vPhaseReport.size() > id) {
+                    vPhaseReport.removeElementAt(vPhaseReport.size() - 1);
+                }
+                int[] aeroResults = calcAeroDamage(entityTarget, vPhaseReport);
+                hits = aeroResults[0];
+                // If our capital missile was destroyed, it shouldn't hit
+                if ((amsBayEngagedCap || pdBayEngagedCap) && (CapMissileArmor <= 0)) {
+                    hits = 0;
+                }
+                nCluster = aeroResults[1];
+            }
+
+            //Capital missiles shouldn't be able to target buildings, being space-only weapons
+            //but if they aren't defined, handleEntityDamage() doesn't work.
+            int bldgAbsorbs = 0;
+
+            // We have to adjust the reports on a miss, so they line up
+            if (bMissed && id != vPhaseReport.size()) {
+                vPhaseReport.get(id - 1).newlines--;
+                vPhaseReport.get(id).indent(2);
+                vPhaseReport.get(vPhaseReport.size() - 1).newlines++;
+            }
+
+            // Make sure the player knows when his attack causes no damage.
+            if (nDamPerHit == 0) {
+                r = new Report(3365);
+                r.subject = subjectId;
+                vPhaseReport.addElement(r);
+                return false;
+            }
+            if (!bMissed && (entityTarget != null)) {
+                handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
+                        nCluster, bldgAbsorbs);
+                server.creditKill(entityTarget, ae);
+            } else if (!bMissed) { // Hex is targeted, need to report a hit
+                r = new Report(3390);
+                r.subject = subjectId;
+                vPhaseReport.addElement(r);
+            }
         }
         Report.addNewline(vPhaseReport);
         return false;

--- a/megamek/src/megamek/common/weapons/AR10Handler.java
+++ b/megamek/src/megamek/common/weapons/AR10Handler.java
@@ -13,10 +13,18 @@
  */
 package megamek.common.weapons;
 
+import java.util.Vector;
+
 import megamek.common.AmmoType;
+import megamek.common.Building;
+import megamek.common.Entity;
 import megamek.common.IGame;
+import megamek.common.Report;
+import megamek.common.TargetRoll;
+import megamek.common.Targetable;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 
 /**
@@ -37,6 +45,229 @@ public class AR10Handler extends AmmoWeaponHandler {
      */
     public AR10Handler(ToHitData t, WeaponAttackAction w, IGame g, Server s) {
         super(t, w, g, s);
+    }
+    
+    /*
+     * (non-Javadoc)
+     *
+     * @see megamek.common.weapons.AttackHandler#handle(int, java.util.Vector)
+     */
+    @Override
+    public boolean handle(IGame.Phase phase, Vector<Report> vPhaseReport) {
+        if (!cares(phase)) {
+            return true;
+        }
+        
+        int numAttacks = 1;
+        
+        Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
+                : null;
+        
+        if (entityTarget != null) {
+            ae.setLastTarget(entityTarget.getId());
+            ae.setLastTargetDisplayName(entityTarget.getDisplayName());
+        }
+        // Which building takes the damage?
+        Building bldg = game.getBoard().getBuildingAt(target.getPosition());
+        String number = nweapons > 1 ? " (" + nweapons + ")" : "";
+        for (int i = numAttacks; i > 0; i--) {
+            // Report weapon attack and its to-hit value.
+            Report r = new Report(3115);
+            r.indent();
+            r.newlines = 0;
+            r.subject = subjectId;
+            r.add(wtype.getName() + number);
+            if (entityTarget != null) {
+                if ((wtype.getAmmoType() != AmmoType.T_NA)
+                        && (weapon.getLinked() != null)
+                        && (weapon.getLinked().getType() instanceof AmmoType)) {
+                    AmmoType atype = (AmmoType) weapon.getLinked().getType();
+                    if (atype.getMunitionType() != AmmoType.M_STANDARD) {
+                        r.messageId = 3116;
+                        r.add(atype.getSubMunitionName());
+                    }
+                }
+                r.addDesc(entityTarget);
+            } else {
+                r.messageId = 3120;
+                r.add(target.getDisplayName(), true);
+            }
+            vPhaseReport.addElement(r);
+                
+        //Point Defense fire vs Capital Missiles
+        
+        // are we a glancing hit?  Check for this here, report it later
+        if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GLANCING_BLOWS)) {
+            if (roll == toHit.getValue()) {
+                bGlancing = true;
+            } else {
+                bGlancing = false;
+            }
+        }
+        
+        // Set Margin of Success/Failure and check for Direct Blows
+        toHit.setMoS(roll - Math.max(2, toHit.getValue()));
+        bDirect = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_DIRECT_BLOW)
+                && ((toHit.getMoS() / 3) >= 1) && (entityTarget != null);
+
+        //This has to be up here so that we don't screw up glancing/direct blow reports
+        attackValue = calcAttackValue();
+        
+        //CalcAttackValue triggers counterfire, so now we can safely get this
+        CapMissileAMSMod = getCapMissileAMSMod();
+        
+        //Only do this if the missile wasn't destroyed
+        if (CapMissileAMSMod > 0 && CapMissileArmor > 0) {
+            toHit.addModifier(CapMissileAMSMod, "Damage from Point Defenses");
+            if (roll < toHit.getValue()) {
+                CapMissileMissed = true;
+            }
+        }
+        
+        // Report any AMS bay action against Capital missiles that doesn't destroy them all.
+        if (amsBayEngagedCap && CapMissileArmor > 0) {
+            r = new Report(3358);
+            r.add(CapMissileAMSMod);
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+                    
+        // Report any PD bay action against Capital missiles that doesn't destroy them all.
+        } else if (pdBayEngagedCap && CapMissileArmor > 0) {
+            r = new Report(3357);
+            r.add(CapMissileAMSMod);
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+        }
+        
+        if (toHit.getValue() == TargetRoll.IMPOSSIBLE) {
+            r = new Report (3135);
+            r.subject = subjectId;
+            r.add(" " + target.getPosition(), true);
+            vPhaseReport.addElement(r);
+            return false;
+        } else if (toHit.getValue() == TargetRoll.AUTOMATIC_FAIL) {
+            r = new Report(3140);
+            r.newlines = 0;
+            r.subject = subjectId;
+            r.add(toHit.getDesc());
+            vPhaseReport.addElement(r);
+        } else if (toHit.getValue() == TargetRoll.AUTOMATIC_SUCCESS) {
+            r = new Report(3145);
+            r.newlines = 0;
+            r.subject = subjectId;
+            r.add(toHit.getDesc());
+            vPhaseReport.addElement(r);
+        } else {
+            // roll to hit
+            r = new Report(3150);
+            r.newlines = 0;
+            r.subject = subjectId;
+            r.add(toHit.getValue());
+            vPhaseReport.addElement(r);
+        }
+
+        // dice have been rolled, thanks
+        r = new Report(3155);
+        r.newlines = 0;
+        r.subject = subjectId;
+        r.add(roll);
+        vPhaseReport.addElement(r);
+
+        // do we hit?
+        bMissed = roll < toHit.getValue();
+
+        //Report Glancing/Direct Blow here because of Capital Missile weirdness
+        if ((bGlancing) && !(amsBayEngagedCap || pdBayEngagedCap)) {
+            r = new Report(3186);
+            r.subject = ae.getId();
+            r.newlines = 0;
+            vPhaseReport.addElement(r);
+        } 
+
+        if ((bDirect) && !(amsBayEngagedCap || pdBayEngagedCap)) {
+            r = new Report(3189);
+            r.subject = ae.getId();
+            r.newlines = 0;
+            vPhaseReport.addElement(r);
+        }
+        
+        CounterAV = getCounterAV();
+        //use this if AMS counterfire destroys all the Capital missiles
+        if (amsBayEngagedCap && (CapMissileArmor <= 0)) {
+            r = new Report(3356);
+            r.indent();
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+        }
+        //use this if PD counterfire destroys all the Capital missiles
+        if (pdBayEngagedCap && (CapMissileArmor <= 0)) {
+            r = new Report(3355);
+            r.indent();
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+        }
+
+        // Any necessary PSRs, jam checks, etc.
+        // If this boolean is true, don't report
+        // the miss later, as we already reported
+        // it in doChecks
+        boolean missReported = doChecks(vPhaseReport);
+        if (missReported) {
+            bMissed = true;
+        }
+        if (bMissed && !missReported) {
+            reportMiss(vPhaseReport);
+        }
+        // Handle damage.
+        int nCluster = calcnCluster();
+        int id = vPhaseReport.size();
+        int hits = calcHits(vPhaseReport);
+
+        if (target.isAirborne() || game.getBoard().inSpace() || ae.usesWeaponBays()) {
+            // if we added a line to the phase report for calc hits, remove
+            // it now
+            while (vPhaseReport.size() > id) {
+                vPhaseReport.removeElementAt(vPhaseReport.size() - 1);
+            }
+            int[] aeroResults = calcAeroDamage(entityTarget, vPhaseReport);
+            hits = aeroResults[0];
+            // If our capital missile was destroyed, it shouldn't hit
+            if ((amsBayEngagedCap || pdBayEngagedCap) && (CapMissileArmor <= 0)) {
+                hits = 0;
+            }
+            nCluster = aeroResults[1];
+        }
+        
+        //Capital missiles shouldn't be able to target buildings, being space-only weapons
+        //but if they aren't defined, handleEntityDamage() doesn't work.
+        int bldgAbsorbs = 0;
+
+        // We have to adjust the reports on a miss, so they line up
+        if (bMissed && id != vPhaseReport.size()) {
+            vPhaseReport.get(id - 1).newlines--;
+            vPhaseReport.get(id).indent(2);
+            vPhaseReport.get(vPhaseReport.size() - 1).newlines++;
+        }
+
+        // Make sure the player knows when his attack causes no damage.
+        if (nDamPerHit == 0) {
+            r = new Report(3365);
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+            return false;
+        }
+        if (!bMissed && (entityTarget != null)) {
+            handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
+                    nCluster, bldgAbsorbs);
+            server.creditKill(entityTarget, ae);
+        } else if (!bMissed) { // Hex is targeted, need to report a hit
+            r = new Report(3390);
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+        }
+        }
+        Report.addNewline(vPhaseReport);
+        return false;
     }
 
     /**

--- a/megamek/src/megamek/common/weapons/ATMHandler.java
+++ b/megamek/src/megamek/common/weapons/ATMHandler.java
@@ -135,6 +135,7 @@ public class ATMHandler extends MissileWeaponHandler {
     @Override
     protected int calcAttackValue() {
         int av = 0;
+        int counterAV = 0;
         int range = RangeType.rangeBracket(nRange, wtype.getATRanges(), true, false);
         AmmoType atype = (AmmoType) ammo.getType();
         if (atype.getMunitionType() == AmmoType.M_HIGH_EXPLOSIVE) {
@@ -164,6 +165,11 @@ public class ATMHandler extends MissileWeaponHandler {
                 av = wtype.getRoundExtAV();
             }
         }
+        
+        //Point Defenses engage the missiles still aimed at us
+        counterAV = calcCounterAV();
+        av = av - counterAV;
+        
         if (bDirect) {
             av = Math.min(av + (toHit.getMoS() / 3), av * 2);
         }

--- a/megamek/src/megamek/common/weapons/ATMHandler.java
+++ b/megamek/src/megamek/common/weapons/ATMHandler.java
@@ -298,8 +298,7 @@ public class ATMHandler extends MissileWeaponHandler {
         nMissilesModifier += getAMSHitsMod(vPhaseReport);
         
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
-                && (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
-                        || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP))) {
+                && entityTarget.isLargeCraft()) {
             nMissilesModifier -= getAeroSanityAMSHitsMod();
         }
 

--- a/megamek/src/megamek/common/weapons/ATMHandler.java
+++ b/megamek/src/megamek/common/weapons/ATMHandler.java
@@ -304,7 +304,11 @@ public class ATMHandler extends MissileWeaponHandler {
         }
 
         if (allShotsHit()) {
-            missilesHit = wtype.getRackSize();
+            // We want buildings and large craft to be able to affect this number with AMS
+            // treat as a Streak launcher (cluster roll 11) to make this happen
+            missilesHit = Compute.missilesHit(wtype.getRackSize(),
+                    nMissilesModifier, weapon.isHotLoaded(), true,
+                    isAdvancedAMS());
         } else {
             if (ae instanceof BattleArmor) {
                 missilesHit = Compute.missilesHit(wtype.getRackSize()

--- a/megamek/src/megamek/common/weapons/ATMHandler.java
+++ b/megamek/src/megamek/common/weapons/ATMHandler.java
@@ -298,7 +298,7 @@ public class ATMHandler extends MissileWeaponHandler {
         nMissilesModifier += getAMSHitsMod(vPhaseReport);
         
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
-                && entityTarget.isLargeCraft()) {
+                && entityTarget != null && entityTarget.isLargeCraft()) {
             nMissilesModifier -= getAeroSanityAMSHitsMod();
         }
 

--- a/megamek/src/megamek/common/weapons/AmmoWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/AmmoWeaponHandler.java
@@ -95,10 +95,4 @@ public class AmmoWeaponHandler extends WeaponHandler {
                 (int) Math.floor((double) totalShots
                         / (double) weapon.getCurrentShots()));
     }
-    
-    //Check for Thunderbolt. We'll use this for single AMS resolution
-    protected boolean isTbolt() {
-        return false;
-    }
-    
 }

--- a/megamek/src/megamek/common/weapons/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BayWeaponHandler.java
@@ -143,8 +143,8 @@ public class BayWeaponHandler extends WeaponHandler {
                 &&  target.getTargetType() != Targetable.TYPE_BUILDING)) 
         		|| game.getBoard().inSpace()
         		// Capital missile launchers should return the root handler...
-        		|| (wtype.getAtClass() == (19))
-        		|| (wtype.getAtClass() == (20))) {
+        		|| (wtype.getAtClass() == (WeaponType.CLASS_CAPITAL_MISSILE))
+        		|| (wtype.getAtClass() == (WeaponType.CLASS_AR10))) {
             return super.handle(phase, vPhaseReport);
         }
 

--- a/megamek/src/megamek/common/weapons/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BayWeaponHandler.java
@@ -548,8 +548,8 @@ public class BayWeaponHandler extends WeaponHandler {
                         WeaponHandler wHandler = (WeaponHandler) bayWHandler;
                         wHandler.setParentBayHandler(this);
                     } else {
-                        logDebug(METHOD_NAME,
-                                "bayWHandler is not a weapon handler! How did you manage that?");
+                        logError(METHOD_NAME,
+                                "bayWHandler " +  bayWHandler.getClass() + " is not a weapon handler! Cannot set parent bay handler.");
                         continue;
                     }
                     bayWHandler.handle(phase, vPhaseReport);

--- a/megamek/src/megamek/common/weapons/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BayWeaponHandler.java
@@ -366,6 +366,7 @@ public class BayWeaponHandler extends WeaponHandler {
     }
 
     public boolean handleAeroSanity(IGame.Phase phase, Vector<Report> vPhaseReport) {
+        final String METHOD_NAME = "handleAeroSanity(Phase, vPhaseReport)";
         if (!cares(phase)) {
             return true;
         }
@@ -542,10 +543,14 @@ public class BayWeaponHandler extends WeaponHandler {
                     WeaponAttackAction bayWaa = new WeaponAttackAction(waa.getEntityId(), waa.getTargetType(), waa.getTargetId(), wId);
                     AttackHandler bayWHandler = ((Weapon)bayWType).getCorrectHandler(autoHit, bayWaa, game, server);
                     bayWHandler.setAnnouncedEntityFiring(false);
-                    // This should always be true. Maybe there's a better way to write this?
+                    // This should always be true
                     if (bayWHandler instanceof WeaponHandler) {
                         WeaponHandler wHandler = (WeaponHandler) bayWHandler;
                         wHandler.setParentBayHandler(this);
+                    } else {
+                        logDebug(METHOD_NAME,
+                                "bayWHandler is not a weapon handler! How did you manage that?");
+                        continue;
                     }
                     bayWHandler.handle(phase, vPhaseReport);
                     if(vPhaseReport.size() > replaceReport) {

--- a/megamek/src/megamek/common/weapons/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BayWeaponHandler.java
@@ -528,7 +528,10 @@ public class BayWeaponHandler extends WeaponHandler {
         //Large missiles
 
         Report.addNewline(vPhaseReport);
-        toHit.addModifier(TargetRoll.AUTOMATIC_SUCCESS, "if the bay hits, all bay weapons hit");
+        //New toHit data to hold our bay auto hit. We want to be able to get glacing/direct blow
+        //data from the 'real' toHit data of this bay handler
+        ToHitData autoHit = new ToHitData();
+        autoHit.addModifier(TargetRoll.AUTOMATIC_SUCCESS, "if the bay hits, all bay weapons hit");
         int replaceReport;
         for (int wId : weapon.getBayWeapons()) {
             Mounted m = ae.getEquipment(wId);

--- a/megamek/src/megamek/common/weapons/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BayWeaponHandler.java
@@ -540,7 +540,7 @@ public class BayWeaponHandler extends WeaponHandler {
                 if(bayWType instanceof Weapon) {
                     replaceReport = vPhaseReport.size();
                     WeaponAttackAction bayWaa = new WeaponAttackAction(waa.getEntityId(), waa.getTargetType(), waa.getTargetId(), wId);
-                    AttackHandler bayWHandler = ((Weapon)bayWType).getCorrectHandler(toHit, bayWaa, game, server);
+                    AttackHandler bayWHandler = ((Weapon)bayWType).getCorrectHandler(autoHit, bayWaa, game, server);
                     bayWHandler.setAnnouncedEntityFiring(false);
                     // This should always be true. Maybe there's a better way to write this?
                     if (bayWHandler instanceof WeaponHandler) {

--- a/megamek/src/megamek/common/weapons/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BayWeaponHandler.java
@@ -493,7 +493,7 @@ public class BayWeaponHandler extends WeaponHandler {
         
         //Report point defense effects
         //Set up a cluster hits table modifier
-        double counterAVMod = (getCounterAV());
+        double counterAVMod = getCounterAV();
         //Report a failure due to overheating
         if (pdOverheated
                 && (!(amsBayEngaged

--- a/megamek/src/megamek/common/weapons/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/BayWeaponHandler.java
@@ -493,7 +493,7 @@ public class BayWeaponHandler extends WeaponHandler {
         
         //Report point defense effects
         //Set up a cluster hits table modifier
-        double counterAVMod = (getCounterAV() / weapon.getBayWeapons().size());
+        double counterAVMod = (getCounterAV());
         //Report a failure due to overheating
         if (pdOverheated
                 && (!(amsBayEngaged

--- a/megamek/src/megamek/common/weapons/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/CLIATMHandler.java
@@ -274,8 +274,7 @@ public class CLIATMHandler extends ATMHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
-                    || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+            if (entityTarget.isLargeCraft()) {
                 nMissilesModifier -= getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/CLIATMHandler.java
@@ -281,12 +281,11 @@ public class CLIATMHandler extends ATMHandler {
         }
 
         if (allShotsHit()) {
-            if (amsMod == 0) {
-                missilesHit = wtype.getRackSize();
-            } else {
-                missilesHit = Compute.missilesHit(wtype.getRackSize(), amsMod,
-                        weapon.isHotLoaded(), allShotsHit(), isAdvancedAMS());
-            }
+            // We want buildings and large craft to be able to affect this number with AMS
+            // treat as a Streak launcher (cluster roll 11) to make this happen
+            missilesHit = Compute.missilesHit(wtype.getRackSize(),
+                    nMissilesModifier, weapon.isHotLoaded(), true,
+                    isAdvancedAMS());
         } else {
             if (ae instanceof BattleArmor) {
                 missilesHit = Compute.missilesHit(wtype.getRackSize()

--- a/megamek/src/megamek/common/weapons/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/CLIATMHandler.java
@@ -274,7 +274,7 @@ public class CLIATMHandler extends ATMHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.isLargeCraft()) {
+            if (entityTarget != null && entityTarget.isLargeCraft()) {
                 nMissilesModifier -= getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -641,8 +641,7 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
             r.subject = subjectId;
             vPhaseReport.addElement(r);
         }
-        
-        vPhaseReport.addElement(r);
+
         if (toHit.getValue() == TargetRoll.IMPOSSIBLE) {
             r = new Report(3135);
             r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -756,8 +756,8 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
                         WeaponHandler wHandler = (WeaponHandler) bayWHandler;
                         wHandler.setParentBayHandler(this);
                     } else {
-                        logDebug(METHOD_NAME,
-                                "bayWHandler is not a weapon handler! How did you manage that?");
+                        logError(METHOD_NAME,
+                                "bayWHandler " +  bayWHandler.getClass() + " is not a weapon handler! Cannot set parent bay handler.");
                         continue;
                     }
                     bayWHandler.handle(phase, vPhaseReport);

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -552,6 +552,7 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
     
     @Override
     public boolean handleAeroSanity(IGame.Phase phase, Vector<Report> vPhaseReport) {
+        final String METHOD_NAME = "handleAeroSanity(Phase, vPhaseReport)";
         if (!cares(phase)) {
             return true;
         }
@@ -754,6 +755,10 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
                     if (bayWHandler instanceof WeaponHandler) {
                         WeaponHandler wHandler = (WeaponHandler) bayWHandler;
                         wHandler.setParentBayHandler(this);
+                    } else {
+                        logDebug(METHOD_NAME,
+                                "bayWHandler is not a weapon handler! How did you manage that?");
+                        continue;
                     }
                     bayWHandler.handle(phase, vPhaseReport);
                     if(vPhaseReport.size() > replaceReport) {

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -359,15 +359,6 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
                         }
                     }
                 }
-                
-                // check for tele-missiles and if they are there then
-                // I will need to
-                // add them to an inserted attack list and reset the av
-                //TODO: Telemissiles are broken with the PD changes. I'll fix this soon.
-                /* if (atype.hasFlag(AmmoType.F_TELE_MISSILE)) {
-                    insertedAttacks.addElement(wId);
-                    av = av - current_av;
-                } */
             }
         }
         

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -656,6 +656,11 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
                     WeaponAttackAction bayWaa = new WeaponAttackAction(waa.getEntityId(), waa.getTargetType(), waa.getTargetId(), wId);
                     AttackHandler bayWHandler = ((Weapon)bayWType).getCorrectHandler(toHit, bayWaa, game, server);
                     bayWHandler.setAnnouncedEntityFiring(false);
+                    // This should always be true. Maybe there's a better way to write this?
+                    if (bayWHandler instanceof WeaponHandler) {
+                        WeaponHandler wHandler = (WeaponHandler) bayWHandler;
+                        wHandler.setParentBayHandler(this);
+                    }
                     bayWHandler.handle(phase, vPhaseReport);
                     if(vPhaseReport.size() > replaceReport) {
                         //fix the reporting - is there a better way to do this

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -66,13 +66,13 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
         if (!cares(phase)) {
             return true;
         }
-        /*
+
         if(game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             return handleAeroSanity(phase, vPhaseReport);
-        } */
+        }
         
         int numAttacks = 1;
-                
+        
         Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                 : null;
         
@@ -125,8 +125,6 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
 
         //This has to be up here so that we don't screw up glancing/direct blow reports
         attackValue = calcAttackValue();
-        //Needed for Aero Sanity to work
-        nDamPerHit = calcDamagePerHit();
         
         //CalcAttackValue triggers counterfire, so now we can safely get this
         CapMissileAMSMod = getCapMissileAMSMod();

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -63,10 +63,7 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
      */
     @Override
     public boolean handle(IGame.Phase phase, Vector<Report> vPhaseReport) {
-        if (!cares(phase)) {
-            return true;
-        }
-
+        
         if(game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             return handleAeroSanity(phase, vPhaseReport);
         }
@@ -525,8 +522,6 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
         if (!cares(phase)) {
             return true;
         }
-
-        insertAttacks(phase, vPhaseReport);
 
         Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                 : null;

--- a/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBayHandler.java
@@ -736,7 +736,10 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
         }
 
         Report.addNewline(vPhaseReport);
-        toHit.addModifier(TargetRoll.AUTOMATIC_SUCCESS, "if the bay hits, all bay weapons hit");
+        //New toHit data to hold our bay auto hit. We want to be able to get glacing/direct blow
+        //data from the 'real' toHit data of this bay handler
+        ToHitData autoHit = new ToHitData();
+        autoHit.addModifier(TargetRoll.AUTOMATIC_SUCCESS, "if the bay hits, all bay weapons hit");
         int replaceReport;
         for (int wId : weapon.getBayWeapons()) {
             Mounted m = ae.getEquipment(wId);
@@ -745,7 +748,7 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
                 if(bayWType instanceof Weapon) {
                     replaceReport = vPhaseReport.size();
                     WeaponAttackAction bayWaa = new WeaponAttackAction(waa.getEntityId(), waa.getTargetType(), waa.getTargetId(), wId);
-                    AttackHandler bayWHandler = ((Weapon)bayWType).getCorrectHandler(toHit, bayWaa, game, server);
+                    AttackHandler bayWHandler = ((Weapon)bayWType).getCorrectHandler(autoHit, bayWaa, game, server);
                     bayWHandler.setAnnouncedEntityFiring(false);
                     // This should always be true. Maybe there's a better way to write this?
                     if (bayWHandler instanceof WeaponHandler) {

--- a/megamek/src/megamek/common/weapons/CapitalMissileBearingsOnlyHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBearingsOnlyHandler.java
@@ -54,10 +54,14 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
      */
     private static final long serialVersionUID = -1277549123532227298L;
     boolean handledAmmoAndReport = false;
-    boolean detRangeShort = weapon.curMode().equals("Bearings-Only Short Detection Range");
-    boolean detRangeMedium = weapon.curMode().equals("Bearings-Only Medium Detection Range");
-    boolean detRangeLong = weapon.curMode().equals("Bearings-Only Long Detection Range");
-    boolean detRangeExtreme = weapon.curMode().equals("Bearings-Only Extreme Detection Range");
+    boolean detRangeShort = (weapon.curMode().equals(Weapon.Mode_CapMissile_Bearing_Short) 
+            || weapon.curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Short));
+    boolean detRangeMedium = (weapon.curMode().equals(Weapon.Mode_CapMissile_Bearing_Med) 
+            || weapon.curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Med));
+    boolean detRangeLong = (weapon.curMode().equals(Weapon.Mode_CapMissile_Bearing_Long) 
+            || weapon.curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Long));
+    boolean detRangeExtreme = (weapon.curMode().equals(Weapon.Mode_CapMissile_Bearing_Ext) 
+            || weapon.curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Ext));
 
     /**
      * This constructor may only be used for deserialization.

--- a/megamek/src/megamek/common/weapons/CapitalMissileBearingsOnlyHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBearingsOnlyHandler.java
@@ -830,6 +830,52 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
             return (int) Math.ceil(av);
     }
     
+    /**
+     * Calculate the damage per hit.
+     *
+     * @return an <code>int</code> representing the damage dealt per hit.
+     */
+    @Override
+    protected int calcDamagePerHit() {
+        AmmoType atype = (AmmoType) ammo.getType();
+        double toReturn = wtype.getDamage(nRange);
+        
+        //AR10 munitions
+        if (atype != null) {
+            if (atype.getAmmoType() == AmmoType.T_AR10) {
+                if (atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)) {
+                    toReturn = 4;
+                } else if (atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)) {
+                    toReturn = 3;
+                } else if (atype.hasFlag(AmmoType.F_PEACEMAKER)) {
+                    toReturn = 1000;
+                } else if (atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
+                    toReturn = 100;
+                } else {
+                    toReturn = 2;
+                }
+            }
+            //Nuclear Warheads for non-AR10 missiles
+            if (atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
+                toReturn = 100;
+            } else if (atype.hasFlag(AmmoType.F_PEACEMAKER)) {
+                toReturn = 1000;
+            } 
+            nukeS2S = atype.hasFlag(AmmoType.F_NUCLEAR);
+        }
+        
+        // we default to direct fire weapons for anti-infantry damage
+        if (bDirect) {
+            toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
+        }
+
+        if (bGlancing) {
+            toReturn = (int) Math.floor(toReturn / 2.0);
+        }
+
+        return (int) toReturn;
+    }
+    
     @Override
     protected int calcCapMissileAMSMod() {
         CapMissileAMSMod = (int) Math.ceil(CounterAV / 10.0);

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -105,10 +105,17 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
         
         // are we a glancing hit?  Check for this here, report it later
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GLANCING_BLOWS)) {
-            if (roll == toHit.getValue()) {
-                bGlancing = true;
+            if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
+                if (getParentBayHandler() != null) {
+                    WeaponHandler bayHandler = getParentBayHandler();
+                    bGlancing = bayHandler.bGlancing;
+                }
             } else {
+                if (roll == toHit.getValue()) {
+                    bGlancing = true;
+                } else {
                 bGlancing = false;
+                }
             }
         }
         
@@ -118,11 +125,11 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
                 && ((toHit.getMoS() / 3) >= 1) && (entityTarget != null);
         
         //Point Defense fire vs Capital Missiles
-        if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
-            if (getParentBayHandler() != null) {
-                WeaponHandler bayHandler = getParentBayHandler();
-                CounterAV = bayHandler.getCounterAV();
-            }
+        if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
+                && getParentBayHandler() != null) {
+            WeaponHandler bayHandler = getParentBayHandler();
+            CounterAV = bayHandler.getCounterAV();
+            CapMissileArmor = bayHandler.CapMissileArmor;
             nDamPerHit = calcDamagePerHit();
         } else {
             // Should only be used when using a grounded dropship with individual weapons
@@ -130,6 +137,7 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
             attackValue = calcAttackValue();
         }
         //CalcAttackValue triggers counterfire, so now we can safely get this
+        //If Aero Sanity is on we get it from the parent Bay
         CapMissileAMSMod = getCapMissileAMSMod();
         
         //Only do this if the missile wasn't destroyed

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -415,33 +415,8 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
     @Override
     protected int getCapMisMod() {
         AmmoType atype = (AmmoType) ammo.getType();
-        if (atype == null || atype.getAmmoType() == AmmoType.T_PIRANHA) {
-            return 0;
-        }
-        if (atype.getAmmoType() == AmmoType.T_WHITE_SHARK
-                || atype.getAmmoType() == AmmoType.T_WHITE_SHARK_T
-                || atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)
-                // Santa Anna, per IO rules
-                || atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
-            return 9;
-        } else if (atype.getAmmoType() == AmmoType.T_KRAKEN_T
-                || atype.getAmmoType() == AmmoType.T_KRAKENM
-                // Peacemaker, per IO rules
-                || atype.hasFlag(AmmoType.F_PEACEMAKER)) {
-            return 8;
-        } else if (atype.getAmmoType() == AmmoType.T_KILLER_WHALE
-                || atype.getAmmoType() == AmmoType.T_KILLER_WHALE_T
-                || atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)
-                || atype.getAmmoType() == AmmoType.T_MANTA_RAY
-                || atype.getAmmoType() == AmmoType.T_ALAMO) {
-            return 10;
-        } else if (atype.getAmmoType() == AmmoType.T_STINGRAY) {
-            return 12;
-        } else {
-            return 11;
-        }
+        return getCritMod(atype);
     }
-
 
     /*
      * get the cap mis mod given a single ammo type

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -434,17 +434,17 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
                 // Santa Anna, per IO rules
                 || atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
             return 9;
+        } else if (atype.getAmmoType() == AmmoType.T_KRAKEN_T
+                || atype.getAmmoType() == AmmoType.T_KRAKENM
+                // Peacemaker, per IO rules
+                || atype.hasFlag(AmmoType.F_PEACEMAKER)) {
+            return 8;
         } else if (atype.getAmmoType() == AmmoType.T_KILLER_WHALE
                 || atype.getAmmoType() == AmmoType.T_KILLER_WHALE_T
                 || atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)
                 || atype.getAmmoType() == AmmoType.T_MANTA_RAY
                 || atype.getAmmoType() == AmmoType.T_ALAMO) {
             return 10;
-        } else if (atype.getAmmoType() == AmmoType.T_KRAKEN_T
-                || atype.getAmmoType() == AmmoType.T_KRAKENM
-                // Peacemaker, per IO rules
-                || atype.hasFlag(AmmoType.F_PEACEMAKER)) {
-            return 8;
         } else if (atype.getAmmoType() == AmmoType.T_STINGRAY) {
             return 12;
         } else {

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -101,7 +101,7 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
             }
             vPhaseReport.addElement(r);
                 
-        //Point Defense fire vs Capital Missiles
+        
         
         // are we a glancing hit?  Check for this here, report it later
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GLANCING_BLOWS)) {
@@ -116,10 +116,19 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
         toHit.setMoS(roll - Math.max(2, toHit.getValue()));
         bDirect = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_DIRECT_BLOW)
                 && ((toHit.getMoS() / 3) >= 1) && (entityTarget != null);
-
-        //This has to be up here so that we don't screw up glancing/direct blow reports
-        nDamPerHit = calcDamagePerHit();
         
+        //Point Defense fire vs Capital Missiles
+        if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
+            if (getParentBayHandler() != null) {
+                WeaponHandler bayHandler = getParentBayHandler();
+                CounterAV = bayHandler.getCounterAV();
+            }
+            nDamPerHit = calcDamagePerHit();
+        } else {
+            // Should only be used when using a grounded dropship with individual weapons
+            // Otherwise we're using CapitalMissileBayHandler
+            attackValue = calcAttackValue();
+        }
         //CalcAttackValue triggers counterfire, so now we can safely get this
         CapMissileAMSMod = getCapMissileAMSMod();
         
@@ -363,9 +372,7 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
             } else if (atype.hasFlag(AmmoType.F_PEACEMAKER)) {
                 toReturn = 1000;
             } 
-            if (atype.hasFlag(AmmoType.F_NUCLEAR)) {
-                nukeS2S = true;
-            }
+            nukeS2S = atype.hasFlag(AmmoType.F_NUCLEAR);
         }
         
         // we default to direct fire weapons for anti-infantry damage

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -120,7 +120,13 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
         }
         
         // Set Margin of Success/Failure and check for Direct Blows
-        toHit.setMoS(roll - Math.max(2, toHit.getValue()));
+        if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
+                && getParentBayHandler() != null) {
+            WeaponHandler bayHandler = getParentBayHandler();
+            toHit.setMoS(roll - Math.max(2, bayHandler.toHit.getValue()));
+        } else {
+            toHit.setMoS(roll - Math.max(2, toHit.getValue()));
+        }
         bDirect = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_DIRECT_BLOW)
                 && ((toHit.getMoS() / 3) >= 1) && (entityTarget != null);
         

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -118,7 +118,7 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
                 && ((toHit.getMoS() / 3) >= 1) && (entityTarget != null);
 
         //This has to be up here so that we don't screw up glancing/direct blow reports
-        attackValue = calcAttackValue();
+        nDamPerHit = calcAttackValue();
         
         //CalcAttackValue triggers counterfire, so now we can safely get this
         CapMissileAMSMod = getCapMissileAMSMod();

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -100,9 +100,7 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
                 r.add(target.getDisplayName(), true);
             }
             vPhaseReport.addElement(r);
-                
-        
-        
+
         // are we a glancing hit?  Check for this here, report it later
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GLANCING_BLOWS)) {
             if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -16,12 +16,9 @@ package megamek.common.weapons;
 import java.util.Vector;
 
 import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
 import megamek.common.Building;
-import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.IGame;
-import megamek.common.Infantry;
 import megamek.common.Mounted;
 import megamek.common.RangeType;
 import megamek.common.Report;

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -13,10 +13,17 @@
  */
 package megamek.common.weapons;
 
+import java.util.Vector;
+
 import megamek.common.AmmoType;
+import megamek.common.Building;
+import megamek.common.Entity;
 import megamek.common.IGame;
 import megamek.common.Mounted;
 import megamek.common.RangeType;
+import megamek.common.Report;
+import megamek.common.TargetRoll;
+import megamek.common.Targetable;
 import megamek.common.ToHitData;
 import megamek.common.WeaponType;
 import megamek.common.actions.WeaponAttackAction;
@@ -45,6 +52,229 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
             Server s) {
         super(t, w, g, s);
         advancedPD = g.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADV_POINTDEF);
+    }
+    
+    /*
+     * (non-Javadoc)
+     *
+     * @see megamek.common.weapons.AttackHandler#handle(int, java.util.Vector)
+     */
+    @Override
+    public boolean handle(IGame.Phase phase, Vector<Report> vPhaseReport) {
+        if (!cares(phase)) {
+            return true;
+        }
+        
+        int numAttacks = 1;
+        
+        Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
+                : null;
+        
+        if (entityTarget != null) {
+            ae.setLastTarget(entityTarget.getId());
+            ae.setLastTargetDisplayName(entityTarget.getDisplayName());
+        }
+        // Which building takes the damage?
+        Building bldg = game.getBoard().getBuildingAt(target.getPosition());
+        String number = nweapons > 1 ? " (" + nweapons + ")" : "";
+        for (int i = numAttacks; i > 0; i--) {
+            // Report weapon attack and its to-hit value.
+            Report r = new Report(3115);
+            r.indent();
+            r.newlines = 0;
+            r.subject = subjectId;
+            r.add(wtype.getName() + number);
+            if (entityTarget != null) {
+                if ((wtype.getAmmoType() != AmmoType.T_NA)
+                        && (weapon.getLinked() != null)
+                        && (weapon.getLinked().getType() instanceof AmmoType)) {
+                    AmmoType atype = (AmmoType) weapon.getLinked().getType();
+                    if (atype.getMunitionType() != AmmoType.M_STANDARD) {
+                        r.messageId = 3116;
+                        r.add(atype.getSubMunitionName());
+                    }
+                }
+                r.addDesc(entityTarget);
+            } else {
+                r.messageId = 3120;
+                r.add(target.getDisplayName(), true);
+            }
+            vPhaseReport.addElement(r);
+                
+        //Point Defense fire vs Capital Missiles
+        
+        // are we a glancing hit?  Check for this here, report it later
+        if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GLANCING_BLOWS)) {
+            if (roll == toHit.getValue()) {
+                bGlancing = true;
+            } else {
+                bGlancing = false;
+            }
+        }
+        
+        // Set Margin of Success/Failure and check for Direct Blows
+        toHit.setMoS(roll - Math.max(2, toHit.getValue()));
+        bDirect = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_DIRECT_BLOW)
+                && ((toHit.getMoS() / 3) >= 1) && (entityTarget != null);
+
+        //This has to be up here so that we don't screw up glancing/direct blow reports
+        attackValue = calcAttackValue();
+        
+        //CalcAttackValue triggers counterfire, so now we can safely get this
+        CapMissileAMSMod = getCapMissileAMSMod();
+        
+        //Only do this if the missile wasn't destroyed
+        if (CapMissileAMSMod > 0 && CapMissileArmor > 0) {
+            toHit.addModifier(CapMissileAMSMod, "Damage from Point Defenses");
+            if (roll < toHit.getValue()) {
+                CapMissileMissed = true;
+            }
+        }
+        
+        // Report any AMS bay action against Capital missiles that doesn't destroy them all.
+        if (amsBayEngagedCap && CapMissileArmor > 0) {
+            r = new Report(3358);
+            r.add(CapMissileAMSMod);
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+                    
+        // Report any PD bay action against Capital missiles that doesn't destroy them all.
+        } else if (pdBayEngagedCap && CapMissileArmor > 0) {
+            r = new Report(3357);
+            r.add(CapMissileAMSMod);
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+        }
+        
+        if (toHit.getValue() == TargetRoll.IMPOSSIBLE) {
+            r = new Report (3135);
+            r.subject = subjectId;
+            r.add(" " + target.getPosition(), true);
+            vPhaseReport.addElement(r);
+            return false;
+        } else if (toHit.getValue() == TargetRoll.AUTOMATIC_FAIL) {
+            r = new Report(3140);
+            r.newlines = 0;
+            r.subject = subjectId;
+            r.add(toHit.getDesc());
+            vPhaseReport.addElement(r);
+        } else if (toHit.getValue() == TargetRoll.AUTOMATIC_SUCCESS) {
+            r = new Report(3145);
+            r.newlines = 0;
+            r.subject = subjectId;
+            r.add(toHit.getDesc());
+            vPhaseReport.addElement(r);
+        } else {
+            // roll to hit
+            r = new Report(3150);
+            r.newlines = 0;
+            r.subject = subjectId;
+            r.add(toHit.getValue());
+            vPhaseReport.addElement(r);
+        }
+
+        // dice have been rolled, thanks
+        r = new Report(3155);
+        r.newlines = 0;
+        r.subject = subjectId;
+        r.add(roll);
+        vPhaseReport.addElement(r);
+
+        // do we hit?
+        bMissed = roll < toHit.getValue();
+
+        //Report Glancing/Direct Blow here because of Capital Missile weirdness
+        if ((bGlancing) && !(amsBayEngagedCap || pdBayEngagedCap)) {
+            r = new Report(3186);
+            r.subject = ae.getId();
+            r.newlines = 0;
+            vPhaseReport.addElement(r);
+        } 
+
+        if ((bDirect) && !(amsBayEngagedCap || pdBayEngagedCap)) {
+            r = new Report(3189);
+            r.subject = ae.getId();
+            r.newlines = 0;
+            vPhaseReport.addElement(r);
+        }
+        
+        CounterAV = getCounterAV();
+        //use this if AMS counterfire destroys all the Capital missiles
+        if (amsBayEngagedCap && (CapMissileArmor <= 0)) {
+            r = new Report(3356);
+            r.indent();
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+        }
+        //use this if PD counterfire destroys all the Capital missiles
+        if (pdBayEngagedCap && (CapMissileArmor <= 0)) {
+            r = new Report(3355);
+            r.indent();
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+        }
+
+        // Any necessary PSRs, jam checks, etc.
+        // If this boolean is true, don't report
+        // the miss later, as we already reported
+        // it in doChecks
+        boolean missReported = doChecks(vPhaseReport);
+        if (missReported) {
+            bMissed = true;
+        }
+        if (bMissed && !missReported) {
+            reportMiss(vPhaseReport);
+        }
+        // Handle damage.
+        int nCluster = calcnCluster();
+        int id = vPhaseReport.size();
+        int hits = calcHits(vPhaseReport);
+
+        if (target.isAirborne() || game.getBoard().inSpace() || ae.usesWeaponBays()) {
+            // if we added a line to the phase report for calc hits, remove
+            // it now
+            while (vPhaseReport.size() > id) {
+                vPhaseReport.removeElementAt(vPhaseReport.size() - 1);
+            }
+            int[] aeroResults = calcAeroDamage(entityTarget, vPhaseReport);
+            hits = aeroResults[0];
+            // If our capital missile was destroyed, it shouldn't hit
+            if ((amsBayEngagedCap || pdBayEngagedCap) && (CapMissileArmor <= 0)) {
+                hits = 0;
+            }
+            nCluster = aeroResults[1];
+        }
+        
+        //Capital missiles shouldn't be able to target buildings, being space-only weapons
+        //but if they aren't defined, handleEntityDamage() doesn't work.
+        int bldgAbsorbs = 0;
+
+        // We have to adjust the reports on a miss, so they line up
+        if (bMissed && id != vPhaseReport.size()) {
+            vPhaseReport.get(id - 1).newlines--;
+            vPhaseReport.get(id).indent(2);
+            vPhaseReport.get(vPhaseReport.size() - 1).newlines++;
+        }
+
+        // Make sure the player knows when his attack causes no damage.
+        if (nDamPerHit == 0) {
+            r = new Report(3365);
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+            return false;
+        }
+        if (!bMissed && (entityTarget != null)) {
+            handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
+                    nCluster, bldgAbsorbs);
+            server.creditKill(entityTarget, ae);
+        } else if (!bMissed) { // Hex is targeted, need to report a hit
+            r = new Report(3390);
+            r.subject = subjectId;
+            vPhaseReport.addElement(r);
+        }
+        }
+        Report.addNewline(vPhaseReport);
+        return false;
     }
     
     /**

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -107,8 +107,9 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_GLANCING_BLOWS)) {
             if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
                 if (getParentBayHandler() != null) {
+                    //Use the to-hit value for the bay handler, otherwise toHit is set to Automatic Success
                     WeaponHandler bayHandler = getParentBayHandler();
-                    bGlancing = bayHandler.bGlancing;
+                    bGlancing = (roll == bayHandler.toHit.getValue());
                 }
             } else {
                 if (roll == toHit.getValue()) {
@@ -122,6 +123,7 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
         // Set Margin of Success/Failure and check for Direct Blows
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
                 && getParentBayHandler() != null) {
+            //Use the to-hit value for the bay handler, otherwise toHit is set to Automatic Success
             WeaponHandler bayHandler = getParentBayHandler();
             toHit.setMoS(roll - Math.max(2, bayHandler.toHit.getValue()));
         } else {
@@ -135,7 +137,6 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
                 && getParentBayHandler() != null) {
             WeaponHandler bayHandler = getParentBayHandler();
             CounterAV = bayHandler.getCounterAV();
-            CapMissileArmor = bayHandler.CapMissileArmor;
             nDamPerHit = calcDamagePerHit();
         } else {
             // Should only be used when using a grounded dropship with individual weapons
@@ -143,7 +144,6 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
             attackValue = calcAttackValue();
         }
         //CalcAttackValue triggers counterfire, so now we can safely get this
-        //If Aero Sanity is on we get it from the parent Bay
         CapMissileAMSMod = getCapMissileAMSMod();
         
         //Only do this if the missile wasn't destroyed

--- a/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileHandler.java
@@ -414,8 +414,32 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
     
     @Override
     protected int getCapMisMod() {
-        return getCritMod((AmmoType) ammo.getType());
-
+        AmmoType atype = (AmmoType) ammo.getType();
+        if (atype == null || atype.getAmmoType() == AmmoType.T_PIRANHA) {
+            return 0;
+        }
+        if (atype.getAmmoType() == AmmoType.T_WHITE_SHARK
+                || atype.getAmmoType() == AmmoType.T_WHITE_SHARK_T
+                || atype.hasFlag(AmmoType.F_AR10_WHITE_SHARK)
+                // Santa Anna, per IO rules
+                || atype.hasFlag(AmmoType.F_SANTA_ANNA)) {
+            return 9;
+        } else if (atype.getAmmoType() == AmmoType.T_KRAKEN_T
+                || atype.getAmmoType() == AmmoType.T_KRAKENM
+                // Peacemaker, per IO rules
+                || atype.hasFlag(AmmoType.F_PEACEMAKER)) {
+            return 8;
+        } else if (atype.getAmmoType() == AmmoType.T_KILLER_WHALE
+                || atype.getAmmoType() == AmmoType.T_KILLER_WHALE_T
+                || atype.hasFlag(AmmoType.F_AR10_KILLER_WHALE)
+                || atype.getAmmoType() == AmmoType.T_MANTA_RAY
+                || atype.getAmmoType() == AmmoType.T_ALAMO) {
+            return 10;
+        } else if (atype.getAmmoType() == AmmoType.T_STINGRAY) {
+            return 12;
+        } else {
+            return 11;
+        }
     }
 
 

--- a/megamek/src/megamek/common/weapons/LRMAntiTSMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMAntiTSMHandler.java
@@ -90,7 +90,11 @@ public class LRMAntiTSMHandler extends LRMHandler {
         }
         
         if (allShotsHit()) {
-            missilesHit = wtype.getRackSize();
+            // We want buildings and large craft to be able to affect this number with AMS
+            // treat as a Streak launcher (cluster roll 11) to make this happen
+            missilesHit = Compute.missilesHit(wtype.getRackSize(),
+                    nMissilesModifier, weapon.isHotLoaded(), true,
+                    isAdvancedAMS());
         } else {
             // anti tsm hit with half the normal number, round up
             missilesHit = Compute.missilesHit(wtype.getRackSize(),

--- a/megamek/src/megamek/common/weapons/LRMAntiTSMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMAntiTSMHandler.java
@@ -83,8 +83,7 @@ public class LRMAntiTSMHandler extends LRMHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
-                    || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+            if (entityTarget.isLargeCraft()) {
                 nMissilesModifier -= getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/LRMAntiTSMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMAntiTSMHandler.java
@@ -83,7 +83,7 @@ public class LRMAntiTSMHandler extends LRMHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.isLargeCraft()) {
+            if (entityTarget != null && entityTarget.isLargeCraft()) {
                 nMissilesModifier -= getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/LRMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMHandler.java
@@ -267,8 +267,7 @@ public class LRMHandler extends MissileWeaponHandler {
         nMissilesModifier += getAMSHitsMod(vPhaseReport);
         
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
-                && (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
-                        || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP))) {
+                && entityTarget.isLargeCraft()) {
             nMissilesModifier -= getAeroSanityAMSHitsMod();
         }
 

--- a/megamek/src/megamek/common/weapons/LRMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMHandler.java
@@ -267,7 +267,7 @@ public class LRMHandler extends MissileWeaponHandler {
         nMissilesModifier += getAMSHitsMod(vPhaseReport);
         
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
-                && entityTarget.isLargeCraft()) {
+                && entityTarget != null && entityTarget.isLargeCraft()) {
             nMissilesModifier -= getAeroSanityAMSHitsMod();
         }
 

--- a/megamek/src/megamek/common/weapons/LRMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMHandler.java
@@ -283,7 +283,11 @@ public class LRMHandler extends MissileWeaponHandler {
         }
         
         if (allShotsHit()) {
-            missilesHit = rackSize;
+            // We want buildings and large craft to be able to affect this number with AMS
+            // treat as a Streak launcher (cluster roll 11) to make this happen
+            missilesHit = Compute.missilesHit(wtype.getRackSize(),
+                    nMissilesModifier, weapon.isHotLoaded(), true,
+                    isAdvancedAMS());
         } else {
             if (ae instanceof BattleArmor) {
                 missilesHit = Compute.missilesHit(rackSize

--- a/megamek/src/megamek/common/weapons/LRMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMHandler.java
@@ -276,7 +276,9 @@ public class LRMHandler extends MissileWeaponHandler {
         boolean minRangeELRMAttack = false;
         
         // ELRMs only hit with half their rack size rounded up at minimum range.
+        // Ignore this for space combat. 1 hex is 18km across.
         if (wtype instanceof ExtendedLRMWeapon
+                && !game.getBoard().inSpace()
                 && (nRange <= wtype.getMinimumRange())) {
             rackSize = rackSize / 2 + rackSize % 2;
             minRangeELRMAttack = true;
@@ -285,7 +287,7 @@ public class LRMHandler extends MissileWeaponHandler {
         if (allShotsHit()) {
             // We want buildings and large craft to be able to affect this number with AMS
             // treat as a Streak launcher (cluster roll 11) to make this happen
-            missilesHit = Compute.missilesHit(wtype.getRackSize(),
+            missilesHit = Compute.missilesHit(rackSize,
                     nMissilesModifier, weapon.isHotLoaded(), true,
                     isAdvancedAMS());
         } else {

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -452,7 +452,7 @@ public class LRMSwarmHandler extends LRMHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.isLargeCraft()) {
+            if (entityTarget != null && entityTarget.isLargeCraft()) {
                 amsMod = (int) -getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -452,8 +452,7 @@ public class LRMSwarmHandler extends LRMHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
-                    || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+            if (entityTarget.isLargeCraft()) {
                 amsMod = (int) -getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -448,22 +448,24 @@ public class LRMSwarmHandler extends LRMHandler {
         int nMissilesModifier = getClusterModifiers(false);
 
         // add AMS mods
-        nMissilesModifier += getAMSHitsMod(vPhaseReport);
-        
+        int amsMod = getAMSHitsMod(vPhaseReport);
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
             if (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
                     || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
-                nMissilesModifier -= getAeroSanityAMSHitsMod();
+                amsMod = (int) -getAeroSanityAMSHitsMod();
             }
         }
+        nMissilesModifier += amsMod;
+        
+        
 
         int swarmMissilesLeft = waa.getSwarmMissiles();
         // swarm or swarm-I shots may just hit with the remaining missiles
         if (swarmMissilesLeft > 0) {
             if (allShotsHit()) {
-                missilesHit = swarmMissilesLeft;
+                missilesHit = (swarmMissilesLeft - amsMod);
             } else {
                 missilesHit = Compute.missilesHit(swarmMissilesLeft,
                         nMissilesModifier, weapon.isHotLoaded(), false,

--- a/megamek/src/megamek/common/weapons/MissileBayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileBayWeaponHandler.java
@@ -155,6 +155,12 @@ public class MissileBayWeaponHandler extends AmmoBayWeaponHandler {
     protected void setPDBayReportingFlag() {
         pdBayEngaged = true;
     }
+    
+    //Check for Thunderbolt. We'll use this for single AMS resolution
+    @Override
+    protected boolean isTbolt() {
+        return wtype.hasFlag(WeaponType.F_LARGEMISSILE);
+    }
 
     /*
      * check for special munitions and their effect on av 

--- a/megamek/src/megamek/common/weapons/MissileBayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileBayWeaponHandler.java
@@ -145,7 +145,11 @@ public class MissileBayWeaponHandler extends AmmoBayWeaponHandler {
      */
     @Override
     protected void setAMSBayReportingFlag() {
-        amsBayEngaged = true;
+        if (isTbolt()) {
+            amsBayEngagedMissile = true;
+        } else {
+            amsBayEngaged = true;
+        }
     }
     
     /**
@@ -153,7 +157,11 @@ public class MissileBayWeaponHandler extends AmmoBayWeaponHandler {
      */
     @Override
     protected void setPDBayReportingFlag() {
-        pdBayEngaged = true;
+        if (isTbolt()) {
+            pdBayEngagedMissile = true;
+        } else {
+            pdBayEngaged = true;
+        }
     }
     
     //Check for Thunderbolt. We'll use this for single AMS resolution

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -502,7 +502,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         } else if (getCounterAV() > 0) {
             // Good for squadron missile fire. This may get divided up against too many missile racks to produce a result.
             // Set a minimum -4 (default AMS mod)
-            return Math.min((getCounterAV() / nweaponsHit),4);
+            return Math.max((getCounterAV() / nweaponsHit),4);
         }
         return 0;
     }

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -492,7 +492,8 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
             }
             //Now report and apply the effect, if any
             if (bayHandler.amsBayEngaged || bayHandler.pdBayEngaged) {
-                return counterAVMod;
+                // Let's try to mimc reduced AMS effectiveness against higher munition attack values
+                return (counterAVMod / calcDamagePerHit());
             }
         }
         return 0;
@@ -1110,8 +1111,11 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
      * @return
      */
     protected boolean isAdvancedAMS() {
-        if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
-            return advancedPD && (amsBayEngaged || pdBayEngaged);
+        //Cluster hits calculation in Compute needs this to be on
+        if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
+                && getParentBayHandler() != null) {
+            WeaponHandler bayHandler = getParentBayHandler();
+            return advancedPD && (bayHandler.amsBayEngaged || bayHandler.pdBayEngaged);
         }
         return advancedAMS && (amsEngaged || apdsEngaged);
     }
@@ -1119,9 +1123,6 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
     //Check for Thunderbolt. We'll use this for single AMS resolution
     @Override
     protected boolean isTbolt() {
-        if (wtype.hasFlag(WeaponType.F_LARGEMISSILE)) {
-            return true;
-        }
-        return false;
+        return wtype.hasFlag(WeaponType.F_LARGEMISSILE);
     }
 }

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -494,8 +494,9 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
             }
             //Now report and apply the effect, if any
             if (bayHandler.amsBayEngaged || bayHandler.pdBayEngaged) {
-                // Let's try to mimc reduced AMS effectiveness against higher munition attack values
-                return (counterAVMod / calcDamagePerHit());
+                // Let's try to mimic reduced AMS effectiveness against higher munition attack values
+                // Set a minimum -4 (default AMS mod)
+                return Math.max((counterAVMod / calcDamagePerHit()),2);
             }
         } else if (getCounterAV() > 0) {
             // Good for squadron missile fire. This may get divided up against too many missile racks to produce a result.

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -873,7 +873,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         if (game.getBoard().inSpace() 
                     || waa.isAirToAir(game)
                     || waa.isAirToGround(game)) {
-            // Ensures AMS state is properly updated
+            // Ensures single AMS state is properly updated
             getAMSHitsMod(new Vector<Report>());
             int[] aeroResults = calcAeroDamage(entityTarget, vPhaseReport);
             hits = aeroResults[0];
@@ -897,16 +897,8 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
                 r.indent();
                 vPhaseReport.addElement(r); 
             }
-            if (!bMissed && amsEngaged && !isTbolt() && !ae.isCapitalFighter()) {
-                // handle single AMS action against standard missiles
-                // Thunderbolts get handled by calcHits below
-                int amsRoll = Compute.d6();
-                r = new Report(3352);
-                r.subject = subjectId;
-                r.add(amsRoll);
-                vPhaseReport.add(r);
-                hits = Math.max(0, hits - amsRoll);
-            } else if (!bMissed && amsEngaged && isTbolt() && !ae.isCapitalFighter()) {
+            if (!bMissed && amsEngaged && isTbolt() && !ae.isCapitalFighter()) {
+                // Thunderbolts are destroyed by AMS 50% of the time whether Aero Sanity is on or not
                 hits = calcHits(vPhaseReport);
             } else if (!bMissed && nweaponsHit == 1)  {
                 r = new Report(3390);
@@ -915,6 +907,15 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
             }
             // This is for aero attacks as attack value. Does not apply if Aero Sanity is on
             if (!game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
+                if (!bMissed && amsEngaged && !isTbolt() && !ae.isCapitalFighter()) {
+                    // handle single AMS action against standard missiles
+                    int amsRoll = Compute.d6();
+                    r = new Report(3352);
+                    r.subject = subjectId;
+                    r.add(amsRoll);
+                    vPhaseReport.add(r);
+                    hits = Math.max(0, hits - amsRoll);
+                }
                 // Report any AMS bay action against standard missiles.
                 if (amsBayEngaged && (attackValue <= 0)) {
                     //use this if AMS counterfire destroys all the missiles
@@ -949,7 +950,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
                 }
             } 
         } else {
-            //If none of the above apply, or Aero Sanity is on, use this
+            //If none of the above apply
             hits = calcHits(vPhaseReport);
         }
 

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -49,8 +49,6 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
      *
      */
     private static final long serialVersionUID = -4801130911083653548L;
-    boolean amsEngaged = false;
-    boolean apdsEngaged = false;
     boolean advancedAMS = false;
     boolean advancedPD = false;
     boolean multiAMS = false;

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -245,7 +245,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         nMissilesModifier += getAMSHitsMod(vPhaseReport);
         
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
-                && entityTarget.isLargeCraft()) {
+                && entityTarget != null && entityTarget.isLargeCraft()) {
             nMissilesModifier -= getAeroSanityAMSHitsMod();
         }
 

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -245,8 +245,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         nMissilesModifier += getAMSHitsMod(vPhaseReport);
         
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
-                && (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
-                        || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP))) {
+                && entityTarget.isLargeCraft()) {
             nMissilesModifier -= getAeroSanityAMSHitsMod();
         }
 

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -870,10 +870,9 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         int nCluster = calcnCluster();
         int id = vPhaseReport.size();
         int hits;
-        if (!game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
-                && (game.getBoard().inSpace() 
-                        || waa.isAirToAir(game)
-                        || waa.isAirToGround(game))) {
+        if (game.getBoard().inSpace() 
+                    || waa.isAirToAir(game)
+                    || waa.isAirToGround(game)) {
             // Ensures AMS state is properly updated
             getAMSHitsMod(new Vector<Report>());
             int[] aeroResults = calcAeroDamage(entityTarget, vPhaseReport);
@@ -907,38 +906,6 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
                 r.add(amsRoll);
                 vPhaseReport.add(r);
                 hits = Math.max(0, hits - amsRoll);
-            
-            // Report any AMS bay action against standard missiles.          
-            } else if (amsBayEngaged && (attackValue <= 0)) {
-                //use this if AMS counterfire destroys all the missiles
-                r = new Report(3356);
-                r.indent();
-                r.subject = subjectId;
-                vPhaseReport.addElement(r);
-            } else if (amsBayEngaged) {
-                //use this if AMS counterfire destroys some of the missiles
-                CounterAV = getCounterAV();
-                r = new Report(3354);
-                r.indent();
-                r.add(CounterAV);
-                r.subject = subjectId;
-                vPhaseReport.addElement(r);
-                
-             // Report any Point Defense bay action against standard missiles.
- 
-            } else if (pdBayEngaged && (attackValue <= 0)) {
-                //use this if PD counterfire destroys all the missiles
-                r = new Report(3355);
-                r.subject = subjectId;
-                vPhaseReport.addElement(r);
-            } else if (pdBayEngaged) {
-                //use this if PD counterfire destroys some of the missiles
-                r = new Report(3353);
-                r.add(CounterAV);
-                r.subject = subjectId;
-                vPhaseReport.addElement(r);
-            } else if (amsBayEngagedMissile || pdBayEngagedMissile) {
-            //This is reported elsewhere. Don't do anything else.   
             } else if (!bMissed && amsEngaged && isTbolt() && !ae.isCapitalFighter()) {
                 hits = calcHits(vPhaseReport);
             } else if (!bMissed && nweaponsHit == 1)  {
@@ -946,6 +913,41 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
                 r.subject = subjectId;
                 vPhaseReport.addElement(r);
             }
+            // This is for aero attacks as attack value. Does not apply if Aero Sanity is on
+            if (!game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
+                // Report any AMS bay action against standard missiles.
+                if (amsBayEngaged && (attackValue <= 0)) {
+                    //use this if AMS counterfire destroys all the missiles
+                    r = new Report(3356);
+                    r.indent();
+                    r.subject = subjectId;
+                    vPhaseReport.addElement(r);
+                } else if (amsBayEngaged) {
+                    //use this if AMS counterfire destroys some of the missiles
+                    CounterAV = getCounterAV();
+                    r = new Report(3354);
+                    r.indent();
+                    r.add(CounterAV);
+                    r.subject = subjectId;
+                    vPhaseReport.addElement(r);
+                    
+                // Report any Point Defense bay action against standard missiles.
+     
+                } else if (pdBayEngaged && (attackValue <= 0)) {
+                    //use this if PD counterfire destroys all the missiles
+                    r = new Report(3355);
+                    r.subject = subjectId;
+                    vPhaseReport.addElement(r);
+                } else if (pdBayEngaged) {
+                    //use this if PD counterfire destroys some of the missiles
+                    r = new Report(3353);
+                    r.add(CounterAV);
+                    r.subject = subjectId;
+                    vPhaseReport.addElement(r);
+                } else if (amsBayEngagedMissile || pdBayEngagedMissile) {
+                //This is reported elsewhere. Don't do anything else.   
+                }
+            } 
         } else {
             //If none of the above apply, or Aero Sanity is on, use this
             hits = calcHits(vPhaseReport);

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -499,6 +499,10 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
                 // Let's try to mimc reduced AMS effectiveness against higher munition attack values
                 return (counterAVMod / calcDamagePerHit());
             }
+        } else if (getCounterAV() > 0) {
+            // Good for squadron missile fire. This may get divided up against too many missile racks to produce a result.
+            // Set a minimum -4 (default AMS mod)
+            return Math.min((getCounterAV() / nweaponsHit),4);
         }
         return 0;
     }

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -253,7 +253,11 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         }
 
         if (allShotsHit()) {
-            missilesHit = wtype.getRackSize();
+            // We want buildings and large craft to be able to affect this number with AMS
+            // treat as a Streak launcher (cluster roll 11) to make this happen
+            missilesHit = Compute.missilesHit(wtype.getRackSize(),
+                    nMissilesModifier, weapon.isHotLoaded(), true,
+                    isAdvancedAMS());
         } else {
             if (ae instanceof BattleArmor) {
                 int shootingStrength = 1;

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -870,9 +870,10 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         int nCluster = calcnCluster();
         int id = vPhaseReport.size();
         int hits;
-        if (game.getBoard().inSpace() 
-                || waa.isAirToAir(game)
-                || waa.isAirToGround(game)) {
+        if (!game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
+                && (game.getBoard().inSpace() 
+                        || waa.isAirToAir(game)
+                        || waa.isAirToGround(game))) {
             // Ensures AMS state is properly updated
             getAMSHitsMod(new Vector<Report>());
             int[] aeroResults = calcAeroDamage(entityTarget, vPhaseReport);
@@ -946,6 +947,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
                 vPhaseReport.addElement(r);
             }
         } else {
+            //If none of the above apply, or Aero Sanity is on, use this
             hits = calcHits(vPhaseReport);
         }
 

--- a/megamek/src/megamek/common/weapons/NarcHandler.java
+++ b/megamek/src/megamek/common/weapons/NarcHandler.java
@@ -26,8 +26,10 @@ import megamek.common.Mech;
 import megamek.common.NarcPod;
 import megamek.common.Protomech;
 import megamek.common.Report;
+import megamek.common.Targetable;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 
 /**
@@ -59,7 +61,20 @@ public class NarcHandler extends MissileWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         bSalvo = true;
         getAMSHitsMod(vPhaseReport);
-        calcCounterAV();
+        if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
+            // Or bay AMS if Aero Sanity is on
+            Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
+                    : null;
+            if (entityTarget.isLargeCraft()) {
+                if (getParentBayHandler() != null) {
+                    WeaponHandler bayHandler = getParentBayHandler();
+                    amsBayEngagedMissile = bayHandler.amsBayEngagedMissile;
+                    pdBayEngagedMissile = bayHandler.pdBayEngagedMissile;
+                }
+            }
+        } else {
+            calcCounterAV();
+        }
         // Report AMS/Pointdefense failure due to Overheating.
         if (pdOverheated 
                 && (!(amsBayEngaged

--- a/megamek/src/megamek/common/weapons/NarcHandler.java
+++ b/megamek/src/megamek/common/weapons/NarcHandler.java
@@ -65,7 +65,7 @@ public class NarcHandler extends MissileWeaponHandler {
             // Or bay AMS if Aero Sanity is on
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.isLargeCraft()) {
+            if (entityTarget != null && entityTarget.isLargeCraft()) {
                 if (getParentBayHandler() != null) {
                     WeaponHandler bayHandler = getParentBayHandler();
                     amsBayEngagedMissile = bayHandler.amsBayEngagedMissile;

--- a/megamek/src/megamek/common/weapons/PiranhaHandler.java
+++ b/megamek/src/megamek/common/weapons/PiranhaHandler.java
@@ -40,7 +40,7 @@ public class PiranhaHandler extends AmmoWeaponHandler {
 
     @Override
     protected int getCapMisMod() {
-        return 13;
+        return 0;
     }
 
 }

--- a/megamek/src/megamek/common/weapons/SRMAntiTSMHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMAntiTSMHandler.java
@@ -76,7 +76,7 @@ public class SRMAntiTSMHandler extends SRMHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.isLargeCraft()) {
+            if (entityTarget != null && entityTarget.isLargeCraft()) {
                 nMissilesModifier -= getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/SRMAntiTSMHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMAntiTSMHandler.java
@@ -83,7 +83,11 @@ public class SRMAntiTSMHandler extends SRMHandler {
         }
         
         if (allShotsHit()) {
-            missilesHit = wtype.getRackSize();
+            // We want buildings and large craft to be able to affect this number with AMS
+            // treat as a Streak launcher (cluster roll 11) to make this happen
+            missilesHit = Compute.missilesHit(wtype.getRackSize(),
+                    nMissilesModifier, weapon.isHotLoaded(), true,
+                    isAdvancedAMS());
         } else {
             // anti tsm hit with half the normal number, round up
             missilesHit = Compute.missilesHit(wtype.getRackSize(),

--- a/megamek/src/megamek/common/weapons/SRMAntiTSMHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMAntiTSMHandler.java
@@ -76,8 +76,7 @@ public class SRMAntiTSMHandler extends SRMHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
-                    || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+            if (entityTarget.isLargeCraft()) {
                 nMissilesModifier -= getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
@@ -234,7 +234,7 @@ public class SRMInfernoHandler extends SRMHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.isLargeCraft()) {
+            if (entityTarget != null && entityTarget.isLargeCraft()) {
                 nMissilesModifier -= getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
@@ -234,8 +234,7 @@ public class SRMInfernoHandler extends SRMHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
-                    || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+            if (entityTarget.isLargeCraft()) {
                 nMissilesModifier -= getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
@@ -241,7 +241,11 @@ public class SRMInfernoHandler extends SRMHandler {
         }
 
         if (allShotsHit()) {
-            missilesHit = wtype.getRackSize();
+            // We want buildings and large craft to be able to affect this number with AMS
+            // treat as a Streak launcher (cluster roll 11) to make this happen
+            missilesHit = Compute.missilesHit(wtype.getRackSize(),
+                    nMissilesModifier, weapon.isHotLoaded(), true,
+                    isAdvancedAMS());
         } else {
             if (ae instanceof BattleArmor) {
                 missilesHit = Compute.missilesHit(wtype.getRackSize()

--- a/megamek/src/megamek/common/weapons/StreakHandler.java
+++ b/megamek/src/megamek/common/weapons/StreakHandler.java
@@ -111,7 +111,7 @@ public class StreakHandler extends MissileWeaponHandler {
                     : null;
             if (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
                     || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
-                nMissilesModifier -= getAeroSanityAMSHitsMod();
+                amsMod = (int) -getAeroSanityAMSHitsMod();
             }
         }
         

--- a/megamek/src/megamek/common/weapons/StreakHandler.java
+++ b/megamek/src/megamek/common/weapons/StreakHandler.java
@@ -109,8 +109,7 @@ public class StreakHandler extends MissileWeaponHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.hasETypeFlag(Entity.ETYPE_DROPSHIP)
-                    || entityTarget.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+            if (entityTarget.isLargeCraft()) {
                 amsMod = (int) -getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/StreakHandler.java
+++ b/megamek/src/megamek/common/weapons/StreakHandler.java
@@ -109,7 +109,7 @@ public class StreakHandler extends MissileWeaponHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.isLargeCraft()) {
+            if (entityTarget != null && entityTarget.isLargeCraft()) {
                 amsMod = (int) -getAeroSanityAMSHitsMod();
             }
         }

--- a/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
@@ -18,13 +18,16 @@ import java.util.Vector;
 import megamek.common.AmmoType;
 import megamek.common.BattleArmor;
 import megamek.common.Compute;
+import megamek.common.Entity;
 import megamek.common.IGame;
 import megamek.common.Infantry;
 import megamek.common.RangeType;
 import megamek.common.Report;
+import megamek.common.Targetable;
 import megamek.common.ToHitData;
 import megamek.common.WeaponType;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 
 /**
@@ -125,7 +128,20 @@ public class ThunderBoltWeaponHandler extends MissileWeaponHandler {
      */
     @Override
     protected int calcHits(Vector<Report> vPhaseReport) {
+        // Activate single AMS
         getAMSHitsMod(vPhaseReport);
+        if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
+            // Or bay AMS if Aero Sanity is on
+            Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
+                    : null;
+            if (entityTarget.isLargeCraft()) {
+                if (getParentBayHandler() != null) {
+                    WeaponHandler bayHandler = getParentBayHandler();
+                    amsBayEngagedMissile = bayHandler.amsBayEngagedMissile;
+                    pdBayEngagedMissile = bayHandler.pdBayEngagedMissile;
+                }
+            }
+        }
         bSalvo = true;
         // Report AMS/Pointdefense failure due to Overheating.
         if (pdOverheated 

--- a/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
@@ -135,7 +135,7 @@ public class ThunderBoltWeaponHandler extends MissileWeaponHandler {
             // Or bay AMS if Aero Sanity is on
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;
-            if (entityTarget.isLargeCraft()) {
+            if (entityTarget != null && entityTarget.isLargeCraft()) {
                 if (getParentBayHandler() != null) {
                     WeaponHandler bayHandler = getParentBayHandler();
                     amsBayEngagedMissile = bayHandler.amsBayEngagedMissile;

--- a/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ThunderBoltWeaponHandler.java
@@ -23,6 +23,7 @@ import megamek.common.IGame;
 import megamek.common.Infantry;
 import megamek.common.RangeType;
 import megamek.common.Report;
+import megamek.common.TargetRoll;
 import megamek.common.Targetable;
 import megamek.common.ToHitData;
 import megamek.common.WeaponType;
@@ -203,7 +204,7 @@ public class ThunderBoltWeaponHandler extends MissileWeaponHandler {
         if (wtype.hasFlag(WeaponType.F_ANTI_SHIP)) {
             return 11;
         } else {
-            return 20;
+            return 0;
         }
     }
 

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -146,6 +146,40 @@ public class WeaponHandler implements AttackHandler, Serializable {
         getLogger().log(getClass(), methodName, LogLevel.DEBUG, message);
     }
     
+    /**
+     * Write errors to the logs
+     *
+     * @param methodName Name of the method logging is coming from
+     * @param message Message to log
+     */
+    protected void logError(String methodName, String message) {
+        logError(methodName, message, null);
+    }
+
+    /**
+     * Write errors to the logs.
+     *
+     * @param methodName Name of the method logging is coming from
+     * @param message Message to log
+     * @param e The exception that caused the error
+     */
+    protected void logError(String methodName, String message, Throwable e) {
+        if (null != e) {
+            getLogger().log(getClass(), methodName, LogLevel.ERROR, message, e);
+        } else {
+            getLogger().log(getClass(), methodName, LogLevel.ERROR, message);
+        }
+    }
+
+    /**
+     * Write errors to the log.
+     * @param methodName Name of the method logging is coming from
+     * @param e The exception that caused the error
+     */
+    protected void logError(String methodName, Throwable e) {
+        getLogger().log(getClass(), methodName, LogLevel.ERROR, e);
+    }
+    
     protected MMLogger getLogger() {
         if (null == logger) {
             logger = DefaultMmLogger.getInstance();

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1658,6 +1658,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
             return true;
         }
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
+                && !ae.isCapitalFighter()
                 && target.getTargetType() == Targetable.TYPE_ENTITY
                 && ((Entity) target).isCapitalScale()
                 && !((Entity) target).isCapitalFighter()) {

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -245,6 +245,13 @@ public class WeaponHandler implements AttackHandler, Serializable {
     }
     
     /**
+     * Sets whether or not this weapon is considered a single, large missile for AMS resolution
+     */
+    protected boolean isTbolt() {
+        return false;
+    }
+    
+    /**
      * Calculates the attack value of point defense weapons used against a missile bay attack
      * This is the main large craft point defense method
      * See also TeleMissileAttackAction, which contains a modified version of this to work against 

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -567,6 +567,15 @@ public class WeaponHandler implements AttackHandler, Serializable {
                         for (int i = 0; i < nweaponsHit; i++) {
                             hits += calcHits(throwAwayReport);
                         }
+                        //Report point defense fire
+                        if (pdBayEngaged || amsBayEngaged) {
+                            Report r = new Report(3367);
+                            r.indent();
+                            r.subject = subjectId;
+                            r.add(getCounterAV());
+                            r.newlines = 0;
+                            vPhaseReport.addElement(r);
+                        }
                         Report r = new Report(3325);
                         r.subject = subjectId;
                         r.add(hits);
@@ -1658,10 +1667,10 @@ public class WeaponHandler implements AttackHandler, Serializable {
             return true;
         }
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)
-                && !ae.isCapitalFighter()
                 && target.getTargetType() == Targetable.TYPE_ENTITY
                 && ((Entity) target).isCapitalScale()
-                && !((Entity) target).isCapitalFighter()) {
+                && !((Entity) target).isCapitalFighter()
+                && !ae.isCapitalFighter()) {
             return true;
         }
         return false;

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -599,6 +599,73 @@ public class WeaponHandler implements AttackHandler, Serializable {
                         r.newlines = 0;
                         vPhaseReport.add(r);
                     } else {
+                        //If point defenses engage Large, single missiles
+                        if (pdBayEngagedMissile || amsBayEngagedMissile) {
+                            int AMSHits = 0;
+                            Report r = new Report(3236);
+                            r.subject = subjectId;
+                            r.add(nweaponsHit);
+                            vPhaseReport.add(r);
+                            r = new Report(3230);
+                            r.indent(1);
+                            r.subject = subjectId;
+                            vPhaseReport.add(r);
+                            for (int i = 0; i < nweaponsHit; i++) {
+                                int destroyRoll = Compute.d6();
+                                if (destroyRoll <= 3) {
+                                    r = new Report(3240);
+                                    r.subject = subjectId;
+                                    r.add("missile");
+                                    r.add(destroyRoll);
+                                    vPhaseReport.add(r);
+                                    AMSHits += 1;
+                                } else {
+                                    r = new Report(3241);
+                                    r.add("missile");
+                                    r.add(destroyRoll);
+                                    r.subject = subjectId;
+                                    vPhaseReport.add(r);                                
+                                }
+                            }
+                            nweaponsHit = nweaponsHit - AMSHits;
+                        } else if (amsEngaged || apdsEngaged) {
+                            //If you're shooting at a target using single AMS
+                            //Too many variables here as far as AMS numbers
+                            //Just allow 1 missile to be shot down
+                            int AMSHits = 0;
+                            Report r = new Report(3236);
+                            r.subject = subjectId;
+                            r.add(nweaponsHit);
+                            vPhaseReport.add(r);
+                            if (amsEngaged) {
+                                r = new Report(3230);
+                                r.indent(1);
+                                r.subject = subjectId;
+                                vPhaseReport.add(r);
+                            }
+                            if (apdsEngaged) {
+                                r = new Report(3231);
+                                r.indent(1);
+                                r.subject = subjectId;
+                                vPhaseReport.add(r);
+                            }
+                            int destroyRoll = Compute.d6();
+                            if (destroyRoll <= 3) {
+                                r = new Report(3240);
+                                r.subject = subjectId;
+                                r.add("missile");
+                                r.add(destroyRoll);
+                                vPhaseReport.add(r);
+                                AMSHits = 1;
+                            } else {
+                                r = new Report(3241);
+                                r.add("missile");
+                                r.add(destroyRoll);
+                                r.subject = subjectId;
+                                vPhaseReport.add(r);                                
+                            }
+                            nweaponsHit = nweaponsHit - AMSHits;
+                        }
                         nCluster = 1;
                         Report r = new Report(3325);
                         r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -554,6 +554,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
             int reportSize = vPhaseReport.size();
             int hits = calcHits(vPhaseReport);
             int nCluster = calcnCluster();
+            int AMSHits = 0;
             if (ae.isCapitalFighter()) {
                 Vector<Report> throwAwayReport = new Vector<Report>();
                 // for capital scale fighters, each non-cluster weapon hits a
@@ -606,7 +607,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
                             while (vPhaseReport.size() > reportSize) {
                                 vPhaseReport.remove(vPhaseReport.size() - 1);
                             }
-                            int AMSHits = 0;
+                            AMSHits = 0;
                             Report r = new Report(3236);
                             r.subject = subjectId;
                             r.add(nweaponsHit);
@@ -642,7 +643,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
                             //If you're shooting at a target using single AMS
                             //Too many variables here as far as AMS numbers
                             //Just allow 1 missile to be shot down
-                            int AMSHits = 0;
+                            AMSHits = 0;
                             Report r = new Report(3236);
                             r.subject = subjectId;
                             r.add(nweaponsHit);

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -563,7 +563,6 @@ public class WeaponHandler implements AttackHandler, Serializable {
                         while (vPhaseReport.size() > reportSize) {
                             vPhaseReport.remove(vPhaseReport.size() - 1);
                         }
-                        // nDamPerHit = 1;
                         hits = 0;
                         for (int i = 0; i < nweaponsHit; i++) {
                             hits += calcHits(throwAwayReport);

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -390,7 +390,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
      * Sets the parent handler for each sub-weapon handler called when looping through bay weapons
      * Used with Aero Sanity to pass counterAV through to the individual missile handler from the bay handler
      * 
-     * @param ah - The <code>AttackHandler</code> for the BayWeapon this individual weapon belongs to
+     * @param bh - The <code>AttackHandler</code> for the BayWeapon this individual weapon belongs to
      */ 
     protected void setParentBayHandler(WeaponHandler bh) {
         parentBayHandler = bh;

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -133,6 +133,9 @@ public class WeaponHandler implements AttackHandler, Serializable {
     protected boolean advancedPD = false; //true if advanced StratOps game rule is on
     protected WeaponHandler parentBayHandler = null; //Used for weapons bays when Aero Sanity is on
     
+    protected boolean amsEngaged = false;
+    protected boolean apdsEngaged = false;
+    
     /**
      * Write debug information to the logs.
      *
@@ -575,6 +578,11 @@ public class WeaponHandler implements AttackHandler, Serializable {
                             r.add(getCounterAV());
                             r.newlines = 0;
                             vPhaseReport.addElement(r);
+                        } else if (amsEngaged) {
+                            Report r = new Report(3350);
+                            r.subject = entityTarget.getId();
+                            r.newlines = 0;
+                            vPhaseReport.add(r);
                         }
                         Report r = new Report(3325);
                         r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -601,6 +601,11 @@ public class WeaponHandler implements AttackHandler, Serializable {
                     } else {
                         //If point defenses engage Large, single missiles
                         if (pdBayEngagedMissile || amsBayEngagedMissile) {
+                            // remove the last reports because they showed the
+                            // number of shots that hit
+                            while (vPhaseReport.size() > reportSize) {
+                                vPhaseReport.remove(vPhaseReport.size() - 1);
+                            }
                             int AMSHits = 0;
                             Report r = new Report(3236);
                             r.subject = subjectId;
@@ -629,6 +634,11 @@ public class WeaponHandler implements AttackHandler, Serializable {
                             }
                             nweaponsHit = nweaponsHit - AMSHits;
                         } else if (amsEngaged || apdsEngaged) {
+                            // remove the last reports because they showed the
+                            // number of shots that hit
+                            while (vPhaseReport.size() > reportSize) {
+                                vPhaseReport.remove(vPhaseReport.size() - 1);
+                            }
                             //If you're shooting at a target using single AMS
                             //Too many variables here as far as AMS numbers
                             //Just allow 1 missile to be shot down

--- a/megamek/src/megamek/common/weapons/bayweapons/ThunderboltBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/ThunderboltBayWeapon.java
@@ -49,7 +49,7 @@ public class ThunderboltBayWeapon extends AmmoBayWeapon {
         this.tonnage = 0.0;
         this.bv = 0;
         this.cost = 0;
-        this.flags = flags.or(F_MISSILE);
+        this.flags = flags.or(F_MISSILE).or(F_LARGEMISSILE);
         this.atClass = CLASS_THUNDERBOLT;
     }
     

--- a/megamek/src/megamek/common/weapons/capitalweapons/AR10Weapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/AR10Weapon.java
@@ -22,7 +22,6 @@ import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AR10Handler;
 import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.TeleMissileHandler;
 import megamek.server.Server;
 
 /**
@@ -87,11 +86,6 @@ public class AR10Weapon extends CapitalMissileWeapon {
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, IGame game, Server server) {
-        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
-                .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace()) {
-            return new TeleMissileHandler(toHit, waa, game, server);
-        }
         return new AR10Handler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/AR10Weapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/AR10Weapon.java
@@ -17,12 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AR10Handler;
-import megamek.common.weapons.AttackHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -74,18 +68,5 @@ public class AR10Weapon extends CapitalMissileWeapon {
             .setPrototypeFactions(F_TH)
             .setProductionFactions(F_TH)
             .setReintroductionFactions(F_FS,F_LC);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        return new AR10Handler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissBarracudaWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissBarracudaWeapon.java
@@ -17,12 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.BarracudaHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -73,18 +67,5 @@ public class CapMissBarracudaWeapon extends CapitalMissileWeapon {
             .setPrototypeFactions(F_TA)
             .setProductionFactions(F_TA)
             .setReintroductionFactions(F_FS,F_LC);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        return new BarracudaHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissKillerWhaleWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissKillerWhaleWeapon.java
@@ -17,13 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.KillerWhaleHandler;
-import megamek.common.weapons.TeleMissileHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -73,23 +66,5 @@ public class CapMissKillerWhaleWeapon extends CapitalMissileWeapon {
             .setPrototypeFactions(F_TA)
             .setProductionFactions(F_TA)
             .setReintroductionFactions(F_FS,F_LC);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
-                .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace()) {
-            return new TeleMissileHandler(toHit, waa, game, server);
-        }
-        return new KillerWhaleHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissKrakenWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissKrakenWeapon.java
@@ -17,13 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.CapitalMissileHandler;
-import megamek.common.weapons.TeleMissileHandler;
-import megamek.server.Server;
 
 /**
  * @author Ben Grills
@@ -71,23 +64,5 @@ public class CapMissKrakenWeapon extends CapitalMissileWeapon {
         .setPrototypeFactions(F_CS,F_DC)
         .setProductionFactions(F_DC);
         
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
-                .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace()) {
-            return new TeleMissileHandler(toHit, waa, game, server);
-        }
-        return new CapitalMissileHandler (toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleBarracudaWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleBarracudaWeapon.java
@@ -17,13 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.BarracudaHandler;
-import megamek.common.weapons.BarracudaTHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -74,22 +67,5 @@ public class CapMissTeleBarracudaWeapon extends CapitalMissileWeapon {
             .setISApproximate(false, false, false,false, false)
             .setPrototypeFactions(F_CS,F_DC)
             .setProductionFactions(F_DC);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
-                .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace())
-            return new BarracudaTHandler(toHit, waa, game, server);
-        return new BarracudaHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKillerWhaleWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKillerWhaleWeapon.java
@@ -17,13 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.KillerWhaleHandler;
-import megamek.common.weapons.KillerWhaleTHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -73,22 +66,5 @@ public class CapMissTeleKillerWhaleWeapon extends CapitalMissileWeapon {
             .setISApproximate(false, false, false,false, false)
             .setPrototypeFactions(F_CS,F_DC)
             .setProductionFactions(F_DC);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
-                .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace())
-            return new KillerWhaleTHandler(toHit, waa, game, server);
-        return new KillerWhaleHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKrakenWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleKrakenWeapon.java
@@ -17,13 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.CapitalMissileHandler;
-import megamek.common.weapons.KrakenTHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -74,22 +67,5 @@ public class CapMissTeleKrakenWeapon extends CapitalMissileWeapon {
             .setISApproximate(false, false, false,false, false)
             .setPrototypeFactions(F_CS,F_DC)
             .setProductionFactions(F_DC);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame,
-     * megamek.server.Server)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        if (game.getBoard().inSpace()) {
-            return new KrakenTHandler(toHit, waa, game, server);
-        }
-        return new CapitalMissileHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleWhiteSharkWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissTeleWhiteSharkWeapon.java
@@ -17,13 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.WhiteSharkHandler;
-import megamek.common.weapons.WhiteSharkTHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -74,22 +67,5 @@ public class CapMissTeleWhiteSharkWeapon extends CapitalMissileWeapon {
             .setPrototypeFactions(F_CS,F_DC)
             .setProductionFactions(F_DC);
 
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
-                .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.hasFlag(AmmoType.F_TELE_MISSILE) && game.getBoard().inSpace())
-            return new WhiteSharkTHandler(toHit, waa, game, server);
-        return new WhiteSharkHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapMissWhiteSharkWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapMissWhiteSharkWeapon.java
@@ -17,12 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.WhiteSharkHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -72,18 +66,5 @@ public class CapMissWhiteSharkWeapon extends CapitalMissileWeapon {
             .setPrototypeFactions(F_TA)
             .setProductionFactions(F_TA)
             .setReintroductionFactions(F_FS,F_LC);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        return new WhiteSharkHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/CapitalMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/CapitalMissileWeapon.java
@@ -17,11 +17,15 @@
  */
 package megamek.common.weapons.capitalweapons;
 
+import megamek.common.Entity;
 import megamek.common.IGame;
+import megamek.common.Mounted;
+import megamek.common.RangeType;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AmmoWeapon;
 import megamek.common.weapons.AttackHandler;
+import megamek.common.weapons.CapitalMissileBearingsOnlyHandler;
 import megamek.common.weapons.CapitalMissileHandler;
 import megamek.server.Server;
 
@@ -50,6 +54,14 @@ public abstract class CapitalMissileWeapon extends AmmoWeapon {
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, IGame game, Server server) {
+        Mounted weapon = game.getEntity(waa.getEntityId())
+                .getEquipment(waa.getWeaponId());
+        Entity attacker = game.getEntity(waa.getEntityId());
+        int rangeToTarget = attacker.getPosition().distance(waa.getTarget(game).getPosition());
+        if (weapon.isInBearingsOnlyMode()
+                && rangeToTarget >= RangeType.RANGE_BEARINGS_ONLY_MINIMUM) {
+            return new CapitalMissileBearingsOnlyHandler(toHit, waa, game, server);
+        }
         return new CapitalMissileHandler(toHit, waa, game, server);
     }
     

--- a/megamek/src/megamek/common/weapons/capitalweapons/SubCapMissileMantaRayWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/SubCapMissileMantaRayWeapon.java
@@ -17,12 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.MantaRayHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -69,18 +63,5 @@ public class SubCapMissileMantaRayWeapon extends SubCapMissileWeapon {
             .setISApproximate(true, false, false, false, false)
             .setPrototypeFactions(F_WB)
             .setProductionFactions(F_WB);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        return new MantaRayHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/SubCapMissilePiranhaWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/SubCapMissilePiranhaWeapon.java
@@ -17,12 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.PiranhaHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -70,18 +64,5 @@ public class SubCapMissilePiranhaWeapon extends SubCapMissileWeapon {
             .setISApproximate(true, false, false, false, false)
             .setPrototypeFactions(F_WB)
             .setProductionFactions(F_WB);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        return new PiranhaHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/SubCapMissileStingrayWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/SubCapMissileStingrayWeapon.java
@@ -17,12 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.StingrayHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -70,18 +64,5 @@ public class SubCapMissileStingrayWeapon extends SubCapMissileWeapon {
             .setISApproximate(true, false, false, false, false)
             .setPrototypeFactions(F_WB)
             .setProductionFactions(F_WB);
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-     */
-    @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, IGame game, Server server) {
-        return new StingrayHandler(toHit, waa, game, server);
     }
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/SubCapMissileSwordfishWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/SubCapMissileSwordfishWeapon.java
@@ -17,12 +17,6 @@
 package megamek.common.weapons.capitalweapons;
 
 import megamek.common.AmmoType;
-import megamek.common.IGame;
-import megamek.common.ToHitData;
-import megamek.common.actions.WeaponAttackAction;
-import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.SwordfishHandler;
-import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -69,17 +63,5 @@ public class SubCapMissileSwordfishWeapon extends SubCapMissileWeapon {
             .setPrototypeFactions(F_WB)
             .setProductionFactions(F_WB);
 		
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see
-	 * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-	 * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
-	 */
-	@Override
-	protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, IGame game, Server server) {
-		return new SwordfishHandler(toHit, waa, game, server);
 	}
 }

--- a/megamek/src/megamek/common/weapons/capitalweapons/SubCapMissileWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/SubCapMissileWeapon.java
@@ -17,7 +17,13 @@
  */
 package megamek.common.weapons.capitalweapons;
 
+import megamek.common.IGame;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AmmoWeapon;
+import megamek.common.weapons.AttackHandler;
+import megamek.common.weapons.CapitalMissileHandler;
+import megamek.server.Server;
 
 /**
  * @author Jay Lawson
@@ -34,6 +40,19 @@ public abstract class SubCapMissileWeapon extends AmmoWeapon {
         capital = true;
         subCapital = true;
         flags = flags.or(F_AERO_WEAPON).or(F_MISSILE).andNot(F_PROTO_WEAPON);;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
+     * megamek.common.actions.WeaponAttackAction, megamek.common.IGame)
+     */
+    @Override
+    protected AttackHandler getCorrectHandler(ToHitData toHit,
+            WeaponAttackAction waa, IGame game, Server server) {
+        return new CapitalMissileHandler(toHit, waa, game, server);
     }
     
     @Override


### PR DESCRIPTION
+ Aero Sanity 2.0!
+ Allow targeting for waypoint launch bearings-only capital missile bay modes
+ Remove spurious Capital Missile critical roll for thunderbolt type missiles

This is an update and rework of aero sanity. Fixes a number of reporting bugs and adds full support for Advanced Point Defense, Glancing/Direct blows, S2S nuclear weapons and Bearings-Only Capital Missiles.
This supercedes PR#1190.