### PR TITLE
Quads and Extended Torso Twist quirk

### DIFF
--- a/megamek/src/megamek/common/QuadMech.java
+++ b/megamek/src/megamek/common/QuadMech.java
@@ -209,25 +209,22 @@ public class QuadMech extends Mech {
         return getWalkMP(gravity, ignoreheat);
     }
     
-    /**
+    /*
      * Normally Quads can't torso twist. Extended torso twist allows regular bipedal mech twisting
      */
     @Override
     public boolean canChangeSecondaryFacing() {
-    	if (hasQuirk(OptionsConstants.QUIRK_POS_EXT_TWIST)) {
-    		return !isProne();
-    	}
-    	return false;
+    	return hasQuirk(OptionsConstants.QUIRK_POS_EXT_TWIST) && !isProne();
     }
     
     @Override
     public boolean isValidSecondaryFacing(int dir) {
         int rotate = dir - getFacing();
-        if (hasQuirk(OptionsConstants.QUIRK_POS_EXT_TWIST)) {
-            return (rotate == 0) || (rotate == 1) || (rotate == -1)
-            		|| (rotate == -5) || (rotate == 5);
+        if (canChangeSecondaryFacing()) {
+            return (rotate <= 1) || (rotate == 5);
         }
-        return rotate == 0;
+        else
+        	return rotate == 0;
     }
     
     @Override

--- a/megamek/src/megamek/common/QuadMech.java
+++ b/megamek/src/megamek/common/QuadMech.java
@@ -208,10 +208,40 @@ public class QuadMech extends Mech {
         }
         return getWalkMP(gravity, ignoreheat);
     }
-
+    
+    /**
+     * Normally Quads can't torso twist. Extended torso twist allows regular bipedal mech twisting
+     */
     @Override
     public boolean canChangeSecondaryFacing() {
-        return false;
+    	if (hasQuirk(OptionsConstants.QUIRK_POS_EXT_TWIST)) {
+    		return !isProne();
+    	}
+    	return false;
+    }
+    
+    @Override
+    public boolean isValidSecondaryFacing(int dir) {
+        int rotate = dir - getFacing();
+        if (hasQuirk(OptionsConstants.QUIRK_POS_EXT_TWIST)) {
+            return (rotate == 0) || (rotate == 1) || (rotate == -1)
+            		|| (rotate == -5) || (rotate == 5);
+        }
+        return rotate == 0;
+    }
+    
+    @Override
+    public int clipSecondaryFacing(int dir) {
+        if (isValidSecondaryFacing(dir)) {
+            return dir;
+        }
+        // can't twist while prone
+        if (!canChangeSecondaryFacing()) {
+            return getFacing();
+        }
+        // otherwise, twist once in the appropriate direction
+        final int rotate = (dir + (6 - getFacing())) % 6;
+        return rotate >= 3 ? (getFacing() + 5) % 6 : (getFacing() + 1) % 6;
     }
 
     /**


### PR DESCRIPTION
Fixes #1259: Extended Torso Twist Quirk not applying to Quads. Borrowed code from megamek/common/Mech.java