### PR TITLE
Fix for aerospace lateral weapon symmetry validation

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -902,7 +902,7 @@ public class TestAdvancedAerospace extends TestAero {
         boolean lateralMatch = true;
         // Forward weapons
         for (EquipmentType eq : leftFwd.keySet()) {
-            if (!rightFwd.containsKey(eq) || (leftFwd.get(eq) != rightFwd.get(eq))) {
+            if (!rightFwd.containsKey(eq) || !leftFwd.get(eq).equals(rightFwd.get(eq))) {
                 lateralMatch = false;
                 break;
             }
@@ -920,7 +920,7 @@ public class TestAdvancedAerospace extends TestAero {
         // Aft weapons
         if (lateralMatch) {
             for (EquipmentType eq : leftAft.keySet()) {
-                if (!rightAft.containsKey(eq) || (leftAft.get(eq) != rightAft.get(eq))) {
+                if (!rightAft.containsKey(eq) || !leftAft.get(eq).equals(rightAft.get(eq))) {
                     lateralMatch = false;
                     break;
                 }
@@ -937,7 +937,7 @@ public class TestAdvancedAerospace extends TestAero {
         // Broadside (warships)
         if (lateralMatch) {
             for (EquipmentType eq : leftBroad.keySet()) {
-                if (!rightBroad.containsKey(eq) || (leftBroad.get(eq) != rightBroad.get(eq))) {
+                if (!rightBroad.containsKey(eq) || !leftBroad.get(eq).equals(rightBroad.get(eq))) {
                     lateralMatch = false;
                     break;
                 }

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -690,7 +690,7 @@ public class TestSmallCraft extends TestAero {
         }
         boolean lateralMatch = true;
         for (EquipmentType eq : leftFwd.keySet()) {
-            if (!rightFwd.containsKey(eq) || (leftFwd.get(eq) != rightFwd.get(eq))) {
+            if (!rightFwd.containsKey(eq) || !leftFwd.get(eq).equals(rightFwd.get(eq))) {
                 lateralMatch = false;
                 break;
             }
@@ -707,7 +707,7 @@ public class TestSmallCraft extends TestAero {
         }
         if (lateralMatch) {
             for (EquipmentType eq : leftAft.keySet()) {
-                if (!rightAft.containsKey(eq) || (leftAft.get(eq) != rightAft.get(eq))) {
+                if (!rightAft.containsKey(eq) || !leftAft.get(eq).equals(rightAft.get(eq))) {
                     lateralMatch = false;
                     break;
                 }


### PR DESCRIPTION
Fixed incorrect use of == instead of equals() for comparing value of Integer. Because Java caches values of Integer between -128 and 127, == works for those values the same way as a primitive int and this only showed up when somebody created a warship with more than 127 of the same weapon in an arc.

Fixes Megamek/megameklab#249: Warship Validation error