### PR TITLE
Include tripod center leg when calculating armored component weight.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1479,7 +1479,7 @@ public abstract class TestEntity implements TestEntityOption {
     }
 
     public double getArmoredComponentWeight() {
-        return 0.0f;
+        return 0.0;
     }
 
     public static boolean usesKgStandard(Entity entity) {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -846,7 +846,7 @@ public class TestMech extends TestEntity {
     public double getArmoredComponentWeight() {
         double weight = 0.0;
 
-        for (int location = Mech.LOC_HEAD; location <= Mech.LOC_LLEG; location++) {
+        for (int location = Mech.LOC_HEAD; location < mech.locations(); location++) {
             for (int slot = 0; slot < mech.getNumberOfCriticals(location); slot++) {
                 CriticalSlot cs = mech.getCritical(location, slot);
                 if ((cs != null) && cs.isArmored()) {


### PR DESCRIPTION
I noticed while working on Megamek/megameklab#250 that when iterating through the locations to check for armored components, the upward bounds of the loop is Mech.LOC_LLEG instead of the more flexible mech.locations(). So the weight of any armored components in a tripod's center leg would not be included.

Also removed an unnecessary type coercion.