### PR TITLE
Fixes for Post-Battle Handling of Capital Fighters

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -4055,7 +4055,40 @@ public class Aero extends Entity implements IAero, IBomber {
     // StratOps pg. 32 & 34
     @Override
     public void doDisbandDamage() {
-
+        // Damage Weapons. WeaponGroups are damaged, and this needs to match up with the fighter's
+        // actual Mounted equipment for MHQ resolution.
+        for (Mounted weaponGroup : getWeaponList()) {
+            int loc = weaponGroup.getLocation();
+            if (weaponGroup.isHit() || areWingsHit()) {
+                // Loop through and find all weapons with the same location as the group
+                
+                // Handle both wings. If the weaponGroup has been hit, both wings were hit.
+                // Otherwise just the areWingsHit flag indicates that only 1 wing was hit.
+                if (loc == Aero.LOC_WINGS && weaponGroup.isHit()) {
+                    for (Mounted weapon : weaponList) {
+                        if (weapon.getLocation() == Aero.LOC_LWING || weapon.getLocation() == Aero.LOC_RWING) {
+                            weapon.setHit(true);
+                        }
+                    }
+                } else {
+                    if (loc == Aero.LOC_WINGS) {
+                        int roll = Compute.d6();
+                        if (roll >= 4) {
+                            loc = Aero.LOC_RWING;
+                        } else {
+                            loc = Aero.LOC_LWING;
+                        }
+                    }
+                    for (Mounted weapon : weaponList) {
+                        if (weapon.getLocation() == loc) {
+                            weapon.setHit(true);
+                        }
+                    }
+                }
+            }
+        }
+        
+        // Now deal with armor and SI
         int dealt = 0;
 
         // Check for critical threshold and if so damage all armor on one facing

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -4055,90 +4055,7 @@ public class Aero extends Entity implements IAero, IBomber {
     // StratOps pg. 32 & 34
     @Override
     public void doDisbandDamage() {
-        // Damage Weapons. WeaponGroups are damaged, and this needs to match up with the fighter's
-        // actual Mounted equipment for MHQ resolution.
-        for (Mounted weaponGroup : getWeaponList()) {
-            int loc = weaponGroup.getLocation();
-            // Loop through and find all weapons with the same location as the group
-            if (areWingsHit()) {
-                // Handle both wings. If the weaponGroup has been hit, both wings were hit.
-                // Otherwise just the areWingsHit flag indicates that only 1 wing was hit.
-                if (loc == Aero.LOC_WINGS && weaponGroup.isHit()) {
-                    for (Mounted weapon : weaponList) {
-                        if (weapon.getLocation() == Aero.LOC_LWING || weapon.getLocation() == Aero.LOC_RWING) {
-                            weapon.setHit(true);
-                            //Taharqa: We should also damage the critical slot, or
-                            //MM and MHQ won't remember that this weapon is damaged on the MUL
-                            //file
-                            for (int i = 0; i < getNumberOfCriticals(weapon.getLocation()); i++) {
-                                CriticalSlot slot1 = getCritical(weapon.getLocation(), i);
-                                if ((slot1 == null) ||
-                                        (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
-                                    continue;
-                                }
-                                Mounted mounted = slot1.getMount();
-                                if (mounted.equals(weapon)) {
-                                    hitAllCriticals(weapon.getLocation(), i);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    if (loc == Aero.LOC_WINGS) {
-                        int roll = Compute.d6();
-                        if (roll >= 4) {
-                            loc = Aero.LOC_RWING;
-                        } else {
-                            loc = Aero.LOC_LWING;
-                        }
-                    }
-                    for (Mounted weapon : weaponList) {
-                        if (weapon.getLocation() == loc) {
-                            weapon.setHit(true);
-                            //Taharqa: We should also damage the critical slot, or
-                            //MM and MHQ won't remember that this weapon is damaged on the MUL
-                            //file
-                            for (int i = 0; i < getNumberOfCriticals(loc); i++) {
-                                CriticalSlot slot1 = getCritical(loc, i);
-                                if ((slot1 == null) ||
-                                        (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
-                                    continue;
-                                }
-                                Mounted mounted = slot1.getMount();
-                                if (mounted.equals(weapon)) {
-                                    hitAllCriticals(loc, i);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            } else if (weaponGroup.isHit()) {
-                for (Mounted weapon : weaponList) {
-                    if (weapon.getLocation() == loc) {
-                        weapon.setHit(true);
-                        //Taharqa: We should also damage the critical slot, or
-                        //MM and MHQ won't remember that this weapon is damaged on the MUL
-                        //file
-                        for (int i = 0; i < getNumberOfCriticals(loc); i++) {
-                            CriticalSlot slot1 = getCritical(loc, i);
-                            if ((slot1 == null) ||
-                                    (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
-                                continue;
-                            }
-                            Mounted mounted = slot1.getMount();
-                            if (mounted.equals(weapon)) {
-                                hitAllCriticals(loc, i);
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        }
         
-        // Now deal with armor and SI
         int dealt = 0;
 
         // Check for critical threshold and if so damage all armor on one facing
@@ -4182,6 +4099,34 @@ public class Aero extends Entity implements IAero, IBomber {
                 setArmor(0, loc);
             }
             damage -= damPerHit;
+        }
+    }
+    
+    /**
+     * Damage a capital fighter's weapons. WeaponGroups are damaged by critical hits. 
+     * This matches up the individual fighter's weapons and critical slots and damages those
+     * for MHQ resolution
+     * @param loc - Int corresponding to the location struck
+     */
+    public void damageCapFighterWeapons(int loc) {
+        for (Mounted weapon : weaponList) {
+            if (weapon.getLocation() == loc) {
+                //Damage the weapon
+                weapon.setHit(true);
+                //Damage the critical slot
+                for (int i = 0; i < getNumberOfCriticals(loc); i++) {
+                    CriticalSlot slot1 = getCritical(loc, i);
+                    if ((slot1 == null) ||
+                            (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
+                        continue;
+                    }
+                    Mounted mounted = slot1.getMount();
+                    if (mounted.equals(weapon)) {
+                        hitAllCriticals(loc, i);
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -4073,7 +4073,8 @@ public class Aero extends Entity implements IAero, IBomber {
 
         // Move on to actual damage...
         int damage = getCap0Armor() - getCapArmor();
-        if ((null != game) || !game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
+        // Fix for #587. Only multiply if Aero Sanity is off
+        if ((null != game) && !game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             damage *= 10;
         }
         damage -= dealt; // We already dealt a bunch of damage, move on.
@@ -4084,7 +4085,8 @@ public class Aero extends Entity implements IAero, IBomber {
         int damPerHit = 5;
         for (int i = 0; i < hits; i++) {
             int loc = Compute.randomInt(4);
-            setArmor(getArmor(loc) - Math.max(damPerHit, damage), loc);
+            // Fix for #587. Apply in 5 point groups unless damage remainder is less.
+            setArmor(getArmor(loc) - Math.min(damPerHit, damage), loc);
             // We did too much damage, so we need to damage the SI, but we wont
             // reduce the SI below 1 here
             // unless the fighter is destroyed.

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -4059,15 +4059,29 @@ public class Aero extends Entity implements IAero, IBomber {
         // actual Mounted equipment for MHQ resolution.
         for (Mounted weaponGroup : getWeaponList()) {
             int loc = weaponGroup.getLocation();
-            if (weaponGroup.isHit() || areWingsHit()) {
-                // Loop through and find all weapons with the same location as the group
-                
+            // Loop through and find all weapons with the same location as the group
+            if (areWingsHit()) {
                 // Handle both wings. If the weaponGroup has been hit, both wings were hit.
                 // Otherwise just the areWingsHit flag indicates that only 1 wing was hit.
                 if (loc == Aero.LOC_WINGS && weaponGroup.isHit()) {
                     for (Mounted weapon : weaponList) {
                         if (weapon.getLocation() == Aero.LOC_LWING || weapon.getLocation() == Aero.LOC_RWING) {
                             weapon.setHit(true);
+                            //Taharqa: We should also damage the critical slot, or
+                            //MM and MHQ won't remember that this weapon is damaged on the MUL
+                            //file
+                            for (int i = 0; i < getNumberOfCriticals(weapon.getLocation()); i++) {
+                                CriticalSlot slot1 = getCritical(weapon.getLocation(), i);
+                                if ((slot1 == null) ||
+                                        (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
+                                    continue;
+                                }
+                                Mounted mounted = slot1.getMount();
+                                if (mounted.equals(weapon)) {
+                                    hitAllCriticals(weapon.getLocation(), i);
+                                    break;
+                                }
+                            }
                         }
                     }
                 } else {
@@ -4082,6 +4096,42 @@ public class Aero extends Entity implements IAero, IBomber {
                     for (Mounted weapon : weaponList) {
                         if (weapon.getLocation() == loc) {
                             weapon.setHit(true);
+                            //Taharqa: We should also damage the critical slot, or
+                            //MM and MHQ won't remember that this weapon is damaged on the MUL
+                            //file
+                            for (int i = 0; i < getNumberOfCriticals(loc); i++) {
+                                CriticalSlot slot1 = getCritical(loc, i);
+                                if ((slot1 == null) ||
+                                        (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
+                                    continue;
+                                }
+                                Mounted mounted = slot1.getMount();
+                                if (mounted.equals(weapon)) {
+                                    hitAllCriticals(loc, i);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            } else if (weaponGroup.isHit()) {
+                for (Mounted weapon : weaponList) {
+                    if (weapon.getLocation() == loc) {
+                        weapon.setHit(true);
+                        //Taharqa: We should also damage the critical slot, or
+                        //MM and MHQ won't remember that this weapon is damaged on the MUL
+                        //file
+                        for (int i = 0; i < getNumberOfCriticals(loc); i++) {
+                            CriticalSlot slot1 = getCritical(loc, i);
+                            if ((slot1 == null) ||
+                                    (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
+                                continue;
+                            }
+                            Mounted mounted = slot1.getMount();
+                            if (mounted.equals(weapon)) {
+                                hitAllCriticals(loc, i);
+                                break;
+                            }
                         }
                     }
                 }

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -4055,7 +4055,7 @@ public class Aero extends Entity implements IAero, IBomber {
     // StratOps pg. 32 & 34
     @Override
     public void doDisbandDamage() {
-        
+
         int dealt = 0;
 
         // Check for critical threshold and if so damage all armor on one facing

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -34572,6 +34572,13 @@ public class Server implements Runnable {
         if (target instanceof FighterSquadron) {
             return;
         }
+        // If a squadron scores a kill, assign it randomly to one of the member fighters
+        if (attacker instanceof FighterSquadron) {
+            Entity killer = attacker.getLoadedUnits().get(Compute.randomInt(attacker.getLoadedUnits().size()));
+            if (killer != null) {
+                attacker = killer;
+            }
+        }
         if ((target.isDoomed() || target.getCrew().isDoomed())
             && !target.getGaveKillCredit() && (attacker != null)) {
             attacker.addKill(target);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -26847,7 +26847,7 @@ public class Server implements Runnable {
                     for (Mounted weap : aero.getWeaponList()) {
                         if (weap.getLocation() == loc) {
                             if (destroyAll) {
-                                weap.setHit(true);                                
+                                weap.setHit(true);
                             } else {
                                 weap.setNWeapons(weap.getNWeapons() / 2);
                             }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -26824,13 +26824,19 @@ public class Server implements Runnable {
             case Aero.CRIT_WEAPON:
                 if (aero.isCapitalFighter()) {
                     boolean destroyAll = false;
+                    // CRIT_WEAPON damages the capital fighter/squadron's weapon groups
+                    // Go ahead and map damage for the fighter's weapon criticals for MHQ
+                    // resolution.
+                    aero.damageCapFighterWeapons(loc);
+                    if ((loc == Aero.LOC_NOSE) || (loc == Aero.LOC_AFT)) {
+                        destroyAll = true;
+                    }
+                    
                     // Convert L/R wing location to wings, else wing weapons never get hit
                     if (loc == Aero.LOC_LWING || loc == Aero.LOC_RWING) {
                         loc = Aero.LOC_WINGS;
                     }
-                    if ((loc == Aero.LOC_NOSE) || (loc == Aero.LOC_AFT)) {
-                        destroyAll = true;
-                    }
+                    
                     if (loc == Aero.LOC_WINGS) {
                         if (aero.areWingsHit()) {
                             destroyAll = true;
@@ -26841,13 +26847,13 @@ public class Server implements Runnable {
                     for (Mounted weap : aero.getWeaponList()) {
                         if (weap.getLocation() == loc) {
                             if (destroyAll) {
-                                weap.setHit(true);
+                                weap.setHit(true);                                
                             } else {
                                 weap.setNWeapons(weap.getNWeapons() / 2);
                             }
                         }
                     }
-                    // also destroy any ECM or BAP in this location
+                    // also destroy any ECM or BAP in the location hit
                     for (Mounted misc : aero.getMisc()) {
                         if ((misc.getType().hasFlag(MiscType.F_ECM)
                             || misc.getType().hasFlag(MiscType.F_ANGEL_ECM)

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -26854,6 +26854,21 @@ public class Server implements Runnable {
                             || misc.getType().hasFlag(MiscType.F_BAP))
                                 && misc.getLocation() == loc) {
                             misc.setHit(true);
+                            //Taharqa: We should also damage the critical slot, or
+                            //MM and MHQ won't remember that this weapon is damaged on the MUL
+                            //file
+                            for (int i = 0; i < aero.getNumberOfCriticals(loc); i++) {
+                                CriticalSlot slot1 = aero.getCritical(loc, i);
+                                if ((slot1 == null) ||
+                                        (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
+                                    continue;
+                                }
+                                Mounted mounted = slot1.getMount();
+                                if (mounted.equals(misc)) {
+                                    aero.hitAllCriticals(loc, i);
+                                    break;
+                                }
+                            }
                         }
                     }
                     r = new Report(9152);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -2756,6 +2756,12 @@ public class Server implements Runnable {
                     if (currentSI > 0) {
                         a.setSI(currentSI);
                     }
+                    //Fix for #587. MHQ tracks fighters at standard scale and doesn't (currently)
+                    //track squadrons. Squadrons don't save to MUL either, so... only convert armor for JS/WS/SS?
+                    //Do we ever need to save capital fighter armor to the final MUL or entityStatus?
+                    if (!entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+                        scale = 1;
+                    }
                     if (scale > 1) {
                         for (int loc = 0; loc < entity.locations(); loc++) {
                             int currentArmor = entity.getArmor(loc) / scale;

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -26845,9 +26845,10 @@ public class Server implements Runnable {
                     }
                     // also destroy any ECM or BAP in this location
                     for (Mounted misc : aero.getMisc()) {
-                        if (misc.getType().hasFlag(MiscType.F_ECM)
+                        if ((misc.getType().hasFlag(MiscType.F_ECM)
                             || misc.getType().hasFlag(MiscType.F_ANGEL_ECM)
-                            || misc.getType().hasFlag(MiscType.F_BAP)) {
+                            || misc.getType().hasFlag(MiscType.F_BAP))
+                                && misc.getLocation() == loc) {
                             misc.setHit(true);
                         }
                     }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -26824,6 +26824,10 @@ public class Server implements Runnable {
             case Aero.CRIT_WEAPON:
                 if (aero.isCapitalFighter()) {
                     boolean destroyAll = false;
+                    // Convert L/R wing location to wings, else wing weapons never get hit
+                    if (loc == Aero.LOC_LWING || loc == Aero.LOC_RWING) {
+                        loc = Aero.LOC_WINGS;
+                    }
                     if ((loc == Aero.LOC_NOSE) || (loc == Aero.LOC_AFT)) {
                         destroyAll = true;
                     }


### PR DESCRIPTION
+ Post-battle armor scale conversion for capital fighters
+ Mapping of squadron weapon/equipment critical hits to individual fighters
Fixes bug #587 
Also, allows weapon and BAP/ECM critical hits taken by squadrons to be recorded and repaired in MHQ