### PR TITLE
Fix issue where firing display would get stuck

### DIFF
--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -1880,7 +1880,8 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
             boolean hasLos = LosEffects.calculateLos(game, cen, target)
                     .canSee();
             // In double blind, we need to "spot" the target as well as LoS
-            if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)
+            if (hasLos
+                    && game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)
                     && !Compute.inVisualRange(game, ce(), target)
                     && !Compute.inSensorRange(game, ce(), target, null)) {
                 hasLos = false;


### PR DESCRIPTION
This fixes a situation where, if you have double-blind on, and your target ran out of LOS, the client would soft-lock. Now, if we don't have line-of-sight in the first place, we don't bother computing visual/sensor range for the purposes of the enabling/disabling the "spot" button.