### PR TITLE
Updated hardpoint cost for naval repair facility.

### DIFF
--- a/megamek/src/megamek/common/NavalRepairFacility.java
+++ b/megamek/src/megamek/common/NavalRepairFacility.java
@@ -134,7 +134,7 @@ public class NavalRepairFacility extends Bay {
     
     @Override
     public int hardpointCost() {
-        return 2;
+        return (int) Math.ceil(totalSpace / 50000);
     }
     
     public static TechAdvancement techAdvancement() {

--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -338,7 +338,7 @@ public class TestAdvancedAerospace extends TestAero {
         for (Bay bay : vessel.getTransportBays()) {
             max -= bay.hardpointCost();
         }
-        return max;
+        return Math.max(max, 0);
     }
     
     /**


### PR DESCRIPTION
Fixes a bug I ran across while working on space station record sheet printing. TestAdvancedAerospace was returning a negative value for getMaximumDockingHardpoints for some space stations. I discovered the docking hardpoint reduction for naval repair facilities changed from a flat 2 each in the 2012 printing of TacOps to 1/50k tons in the 2018 printing. Besides changing the calculation I added a code to prevent returning a negative value so an illegal design won't crash MML.