### PR TITLE
Ignore hardened armor MP reduction when checking max IJJs.

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2586,7 +2586,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     /**
      * Returns this entity's unmodified running/flank mp.
      */
-    protected int getOriginalRunMP() {
+    public int getOriginalRunMP() {
         return (int) Math.ceil(getOriginalWalkMP() * 1.5);
     }
 

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -1092,6 +1092,10 @@ public abstract class Mech extends Entity {
                 - (hasMPReducingHardenedArmor() ? 1 : 0);
     }
 
+    /**
+     * @return The mech's run MP without MASC or supercharger, but with any reduction
+     *         due to hardened armor.
+     */
     public int getOriginalRunMPwithoutMASC() {
         return super.getOriginalRunMP()
                 - (hasMPReducingHardenedArmor() ? 1 : 0);

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -739,7 +739,7 @@ public class TestMech extends TestEntity {
     public boolean correctMovement(StringBuffer buff) {
         // Mechanical Jump Boosts can be greater then Running as long as
         // the unit can handle the weight.
-        if ((mech.getJumpMP(false) > mech.getOriginalRunMPwithoutMASC())
+        if ((mech.getJumpMP(false) > mech.getOriginalRunMP())
                 && !mech.hasJumpBoosters()
                 && !mech.hasWorkingMisc(MiscType.F_PARTIAL_WING)) {
             buff.append("Jump MP exceeds run MP\n");


### PR DESCRIPTION
Use getOriginalJumpMP() instead of getOriginalRunMPwithoutMASC() when validating maximum number of IJJs, as the latter applies the reduction for hardened armor and the rules (TacOps, p. 281, as of 2012 printing) state that hardened armor does not reduce the maximum number of IJJs. I changed the visibility of Entity#getOriginalJumpMP() from protected to public as I saw no reason for it not to be public and force code duplication.

Fixes Megamek/megameklab#271: Bug of interaction with Partial Wing,
Improved Jump Jet and Hardened Armor