### PR TITLE
Indicate which button has focus on the main window

### DIFF
--- a/megamek/src/megamek/client/ui/swing/widget/MegamekButton.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MegamekButton.java
@@ -300,7 +300,7 @@ public class MegamekButton extends JButton implements MouseListener {
             textLabel.setFont(specificFont);
         }
         if (this.isEnabled()) {
-            if (isMousedOver) {
+            if (isMousedOver || hasFocus()) {
                 Font font = textLabel.getFont();
                 if (shouldBold) {
                     // same font but bold


### PR DESCRIPTION
This is a simple update to the main window to visually indicate which button has focus. Simply uses the isMouseOver painting scheme.