### PR TITLE
Don't try to combine non-existent armor location in TRO view.

### DIFF
--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -357,7 +357,8 @@ public class TROView {
                     if ((locs[i] < entity.locations())
                             && ((!provider.apply(entity, locs[i]).equals(provider.apply(entity, locs[0])))
                                     || !entity.hasETypeFlag(Entity.ETYPE_MECH))) {
-                        val = Arrays.stream(locs).mapToObj(l -> String.valueOf(provider.apply(entity, l)))
+                        val = Arrays.stream(locs).filter(l -> l < entity.locations())
+                                .mapToObj(l -> String.valueOf(provider.apply(entity, l)))
                                 .collect(Collectors.joining("/"));
                         break;
                     }


### PR DESCRIPTION
Found in log attached to Megamek/megameklab#278 but not the main issue reported there.

When constructing the TRO view, symmetric locations (such as R/L arm, R/L wing) that don't have the same values are shown separated as slashes. If one of the locations on that row does not exist it is not getting filtered out. Thus a mech with matching R/L leg armor is fine. If the leg armor differs, then unless it's a tripod we get an ArrayIndexOutOfRange exception when it tries to include the center leg armor in the report. I added a filter to skip non-existent sections.