### PR TITLE
Fix partial wing weight calculation

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -463,10 +463,10 @@ public class MiscType extends EquipmentType {
                 }
             }
         } else if (hasFlag(F_PARTIAL_WING) && hasFlag(F_MECH_EQUIPMENT)) {
-            if (TechConstants.isClan(getTechLevel(entity.getTechLevelYear()))) {
-                return Math.floor((entity.getWeight() * 0.05f) * 2.0f) / 2.0;
+            if (isClan()) {
+                return Math.ceil((entity.getWeight() * 0.05) * 2.0) / 2.0;
             } else {
-                return Math.floor((entity.getWeight() * 0.07f) * 2.0f) / 2.0;
+                return Math.ceil((entity.getWeight() * 0.07) * 2.0) / 2.0;
             }
         } else if (hasFlag(F_PARTIAL_WING) && hasFlag(F_PROTOMECH_EQUIPMENT)) {
             return Math.ceil((entity.getWeight() / 5.0f) * 1000.0) / 1000.0;


### PR DESCRIPTION
Round partial wing weight up to half ton instead of down. Also compute weight based on tech base of equipment rather than the unit, which may not be correct for mixed tech units.

Fixes Megamek/megameklab#280: Wrong rounding for Partial Wing