### PR TITLE
Add IS torpedo ammo for BA SRM launchers.

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -1835,7 +1835,7 @@ public class AmmoType extends EquipmentType {
                 .setISAdvancement(DATE_NONE, DATE_NONE, 3052, DATE_NONE, DATE_NONE)
                 .setISApproximate(false,false,false,false,false)
                 .setStaticTechLevel(SimpleTechLevel.STANDARD),"230,TM"));
-        
+
         // Walk through both the base types and the
         // mutators, and create munition types.
         AmmoType.createMunitions(isBaLrmAmmos, munitions);

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -1835,11 +1835,12 @@ public class AmmoType extends EquipmentType {
                 .setISAdvancement(DATE_NONE, DATE_NONE, 3052, DATE_NONE, DATE_NONE)
                 .setISApproximate(false,false,false,false,false)
                 .setStaticTechLevel(SimpleTechLevel.STANDARD),"230,TM"));
-
+        
         // Walk through both the base types and the
         // mutators, and create munition types.
         AmmoType.createMunitions(isBaLrmAmmos, munitions);
-
+        AmmoType.createMunitions(baSrmAmmos,  munitions);
+        
         // Create the munition types for clan BA LRM launchers.
         munitions.clear();
         munitions.add(new MunitionMutator("Multi-Purpose", 1, M_MULTI_PURPOSE,


### PR DESCRIPTION
I noticed this while tracking down equipment that fails to load because of a name change. Rules for BA torpedo ammo are on TM, p. 261-2. While multi-purpose missiles are Clan-only, there is no such statement about torpedoes.

Fixes MegaMek/megameklab#297: BA SRM Torpedo ammo fails to load