### PR TITLE
Map annotations and description

### DIFF
--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -32,15 +32,19 @@ import java.io.StreamTokenizer;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import megamek.common.Building.BasementType;
+import megamek.common.annotations.Nullable;
 import megamek.common.event.BoardEvent;
 import megamek.common.event.BoardListener;
 import megamek.common.util.MegaMekFile;
@@ -140,6 +144,16 @@ public class Board implements Serializable, IBoard {
      * Option to turn have roads auto-exiting to pavement.
      */
     private boolean roadsAutoExit = true;
+
+    /**
+     * A description of the map.
+     */
+    private String description;
+
+    /**
+     * Per-hex annotations on the map.
+     */
+    private Map<Coords, Collection<String>> annotations = new HashMap<>();
 
     /**
      * Creates a new board with zero as its width and height parameters.
@@ -1718,5 +1732,54 @@ public class Board implements Serializable, IBoard {
 
     public boolean hasBoardBackground() {
         return (backgroundPaths != null) && backgroundPaths.size() > 0;
+    }
+
+    /**
+     * Gets the description of the map.
+     * @return The description of the map, if one exists, otherwise null.
+     */
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the description of the map.
+     * @param s The description of the map; may be null.
+     */
+    public void setDescription(@Nullable String s) {
+        description = s;
+    }
+
+    /**
+     * Gets the annotations associated with a hex.
+     * @param x The X-Coordinate of the hex.
+     * @param y The Y-Coordinate of the hex.
+     * @return A collection of annotations for the hex.
+     */
+    public Collection<String> getAnnotations(int x, int y) {
+        return getAnnotations(new Coords(x, y));
+    }
+
+    /**
+     * Gets the annotations associated with a hex.
+     * @param c Coordinates of the hex.
+     * @return A collection of annotations for the hex.
+     */
+    public Collection<String> getAnnotations(Coords c) {
+        return annotations.getOrDefault(c, Collections.emptyList());
+    }
+
+    /**
+     * Sets annotations on a given hex.
+     * @param c Coordinates of the hex to apply the annotations to.
+     * @param a A collection of annotations to assign to the hex. This may be null.
+     */
+    public void setAnnotations(Coords c, @Nullable Collection<String> a) {
+        if (null == a || a.isEmpty()) {
+            annotations.remove(c);
+        } else {
+            annotations.put(c, a);
+        }
     }
 }

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -1781,6 +1781,14 @@ public class Board implements Serializable, IBoard {
     }
 
     /**
+     * Gets every annotations on the map.
+     * @return A read-only map of per-hex annotations.
+     */
+    public Map<Coords, Collection<String>> getAnnotations() {
+        return Collections.unmodifiableMap(annotations);
+    }
+
+    /**
      * Gets the annotations associated with a hex.
      * @param x The X-Coordinate of the hex.
      * @param y The Y-Coordinate of the hex.

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -894,6 +894,35 @@ public class Board implements Serializable, IBoard {
                         System.err.println("Board specified background image, " + "but path couldn't be found! Path: "
                                 + bgFile.getPath());
                     }
+                } else if ((st.ttype == StreamTokenizer.TT_WORD) && st.sval.equalsIgnoreCase("description")) {
+                    st.nextToken();
+                    if (st.ttype == '"') {
+                        String d = getDescription();
+                        if (null == d) {
+                            setDescription(st.sval);
+                        } else {
+                            setDescription(d + "\n\n" + st.sval);
+                        }
+                    }
+                } else if ((st.ttype == StreamTokenizer.TT_WORD) && st.sval.equalsIgnoreCase("note")) {
+                    st.nextToken();
+                    if (st.ttype == StreamTokenizer.TT_NUMBER) {
+                        int x, y, coordWidth = 100;
+                        int coords = (int)st.nval;
+                        if (coords > 9999) {
+                            coordWidth = 1000;
+                        }
+                        y = coords % coordWidth;
+                        coords /= coordWidth;
+                        x = coords;
+                        st.nextToken();
+                        Coords c = new Coords(x, y);
+                        if (st.ttype == '"') {
+                            Collection<String> a = new ArrayList<>(getAnnotations(c));
+                            a.add(st.sval);
+                            setAnnotations(c, a);
+                        }
+                    }
                 } else if ((st.ttype == StreamTokenizer.TT_WORD) && st.sval.equalsIgnoreCase("end")) {
                     break;
                 }

--- a/megamek/src/megamek/common/IBoard.java
+++ b/megamek/src/megamek/common/IBoard.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import megamek.common.annotations.Nullable;
@@ -553,6 +554,12 @@ public interface IBoard {
      * @param s The description of the map; may be null.
      */
     public abstract void setDescription(@Nullable String s);
+
+    /**
+     * Gets every annotations on the map.
+     * @return A read-only map of per-hex annotations.
+     */
+    public abstract Map<Coords, Collection<String>> getAnnotations();
 
     /**
      * Gets the annotations associated with a hex.

--- a/megamek/src/megamek/common/IBoard.java
+++ b/megamek/src/megamek/common/IBoard.java
@@ -539,4 +539,40 @@ public interface IBoard {
     public abstract boolean isValid();
 
     public abstract boolean isValid(StringBuffer errBuff);
+
+
+    /**
+     * Gets the description of the map.
+     * @return The description of the map, if one exists, otherwise null.
+     */
+    @Nullable
+    public abstract String getDescription();
+
+    /**
+     * Sets the description of the map.
+     * @param s The description of the map; may be null.
+     */
+    public abstract void setDescription(@Nullable String s);
+
+    /**
+     * Gets the annotations associated with a hex.
+     * @param x The X-Coordinate of the hex.
+     * @param y The Y-Coordinate of the hex.
+     * @return A collection of annotations for the hex.
+     */
+    public abstract Collection<String> getAnnotations(int x, int y);
+
+    /**
+     * Gets the annotations associated with a hex.
+     * @param c Coordinates of the hex.
+     * @return A collection of annotations for the hex.
+     */
+    public abstract Collection<String> getAnnotations(Coords c);
+
+    /**
+     * Sets annotations on a given hex.
+     * @param c Coordinates of the hex to apply the annotations to.
+     * @param a A collection of annotations to assign to the hex. This may be null.
+     */
+    public abstract void setAnnotations(Coords c, @Nullable Collection<String> a);
 }


### PR DESCRIPTION
This extends the board files to support an overall description and hex annotations per #1315 . This feature serves two purposes:
1. Allows text descriptions of the map and certain hexes to be available to visually impaired players.
2. Allows fluff to be added to scenario maps.

The board files now support:
```
description "This is the first paragraph of the description."
description "This is the second paragraph."
note 0716 "This is a note about hex (7, 16)"
note 0716 "This is another note about hex (7, 16)"
```

This is not currently wired up into the GUI in any way.