### PR TITLE
Fix integer overflow in JS/WS cost calculation.

### DIFF
--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -1751,17 +1751,17 @@ public class Jumpship extends Aero {
         int driveIdx = 0;
         double driveCosts = 0;
         // Drive Coil
-        driveCost[driveIdx++] += 60000000 + (75000000 * getDocks());
+        driveCost[driveIdx++] += 60000000.0 + (75000000.0 * getDocks());
         // Initiator
-        driveCost[driveIdx++] += 25000000 + (5000000 * getDocks());
+        driveCost[driveIdx++] += 25000000.0 + (5000000.0 * getDocks());
         // Controller
-        driveCost[driveIdx++] += 50000000;
+        driveCost[driveIdx++] += 50000000.0;
         // Tankage
-        driveCost[driveIdx++] += 50000 * getKFIntegrity();
+        driveCost[driveIdx++] += 50000.0 * getKFIntegrity();
         // Sail
-        driveCost[driveIdx++] += 50000 * (30 + (weight / 7500));
+        driveCost[driveIdx++] += 50000.0 * (30 + (weight / 7500.0));
         // Charging System
-        driveCost[driveIdx++] += 500000 + (200000 * getDocks()); 
+        driveCost[driveIdx++] += 500000.0 + (200000.0 * getDocks()); 
         
         for (int i = 0; i < driveIdx; i++) {
             driveCosts += driveCost[i];

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -244,17 +244,17 @@ public class Warship extends Jumpship {
         int driveIdx = 0;
         double driveCosts = 0;
         // Drive Coil
-        driveCost[driveIdx++] += 60000000 + (75000000 * getDocks());
+        driveCost[driveIdx++] += 60000000.0 + (75000000.0 * getDocks());
         // Initiator
-        driveCost[driveIdx++] += 25000000 + (5000000 * getDocks());
+        driveCost[driveIdx++] += 25000000.0 + (5000000.0 * getDocks());
         // Controller
-        driveCost[driveIdx++] += 50000000;
+        driveCost[driveIdx++] += 50000000.0;
         // Tankage
-        driveCost[driveIdx++] += 50000 * getKFIntegrity();
+        driveCost[driveIdx++] += 50000.0 * getKFIntegrity();
         // Sail
-        driveCost[driveIdx++] += 50000 * (30 + (weight / 20000));
+        driveCost[driveIdx++] += 50000.0 * (30 + (weight / 20000.0));
         // Charging System
-        driveCost[driveIdx++] += 500000 + (200000 * getDocks()); 
+        driveCost[driveIdx++] += 500000.0 + (200000.0 * getDocks()); 
         
         for (int i = 0; i < driveIdx; i++) {
             driveCosts += driveCost[i];


### PR DESCRIPTION
The cost of the drive coil is 60,000,000 + (75,000,000 * [number of docking hardpoints]). This calculation is performed with `int` values and a large number of hardpoints can result in integer overflow, resulting in a negative value for the cost of the ship. The intermediate calculation could be done with `long` but since the result is cast to `double` I made all the constants in that section explicit doubles.

Fixes MegaMek/megameklab#283.