### PR TITLE
Primitive js armor

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -182,7 +182,7 @@ public class TestAdvancedAerospace extends TestAero {
      */
     public static double maxArmorWeight(Jumpship vessel){
         // max armor tonnage is based on SI weight, which is vessel mass * SI / 1000
-        if (vessel.hasETypeFlag(Entity.ETYPE_WARSHIP) && !vessel.isPrimitive()) {
+        if (vessel.hasETypeFlag(Entity.ETYPE_WARSHIP)) {
             // SI weight / 50
             return floor(vessel.get0SI() * vessel.getWeight() / 50000.0, Ceil.HALFTON);
         } else if (vessel.hasETypeFlag(Entity.ETYPE_SPACE_STATION)) {

--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -181,15 +181,16 @@ public class TestAdvancedAerospace extends TestAero {
      *   
      */
     public static double maxArmorWeight(Jumpship vessel){
+        // max armor tonnage is based on SI weight, which is vessel mass * SI / 1000
         if (vessel.hasETypeFlag(Entity.ETYPE_WARSHIP) && !vessel.isPrimitive()) {
             // SI weight / 50
             return floor(vessel.get0SI() * vessel.getWeight() / 50000.0, Ceil.HALFTON);
         } else if (vessel.hasETypeFlag(Entity.ETYPE_SPACE_STATION)) {
             // SI weight / 3 + 60
-            return floor(vessel.get0SI() * vessel.getWeight() / 300.0 + 60, Ceil.HALFTON);
+            return floor(vessel.get0SI() * vessel.getWeight() / 3000.0 + 60, Ceil.HALFTON);
         } else {
             // SI weight / 12
-            return floor(vessel.get0SI() * vessel.getWeight() / 1800.0, Ceil.HALFTON);
+            return floor(vessel.get0SI() * vessel.getWeight() / 12000.0, Ceil.HALFTON);
         }
     }
     


### PR DESCRIPTION
Fix calculation for max armor tonnage for space stations and jumpships. Per errata, primitive jumpships use the warship calculation (as they are constructed using warship rules anyway), so fixed that also.

Erratum post: https://bg.battletech.com/forums/index.php?topic=50926.msg1279444#msg1279444

Fixes MegaMek/megameklab#288: Maximum armor on a primitive jumpship is too high.