### PR TITLE
Tro display fixes

### DIFF
--- a/megamek/src/megamek/common/templates/AeroTROView.java
+++ b/megamek/src/megamek/common/templates/AeroTROView.java
@@ -241,7 +241,7 @@ public class AeroTROView extends TROView {
             final Map<String, Object> ammoEntry = new HashMap<>();
             ammoEntry.put("name", aList.get(0).getType().getName().replaceAll("\\s+Ammo", ""));
             ammoEntry.put("shots", aList.stream().mapToInt(Mounted::getUsableShotsLeft).sum());
-            ammoEntry.put("tonnage", aList.stream().mapToDouble(m -> m.getType().getTonnage(aero)).sum());
+            ammoEntry.put("tonnage", aList.stream().mapToDouble(m -> m.getAmmoCapacity()).sum());
             ammo.add(ammoEntry);
         }
         setModelData("ammo", ammo);

--- a/megamek/src/megamek/common/templates/SmallCraftDropshipTROView.java
+++ b/megamek/src/megamek/common/templates/SmallCraftDropshipTROView.java
@@ -57,7 +57,7 @@ public class SmallCraftDropshipTROView extends AeroTROView {
         setModelData("usesWeaponBays", aero.usesWeaponBays());
         if (aero.usesWeaponBays()) {
             final int nameWidth = addWeaponBays(aero.isSpheroid() ? SPHEROID_ARCS : AERODYNE_ARCS);
-            setModelData("formatBayRow",
+            setModelData("formatWeaponBayRow",
                     new FormatTableRowMethod(new int[] { nameWidth, 5, 8, 8, 8, 8, 12 },
                             new Justification[] { Justification.LEFT, Justification.CENTER, Justification.CENTER,
                                     Justification.CENTER, Justification.CENTER, Justification.CENTER,


### PR DESCRIPTION
Fixes two problems with TRO-style summaries:
1. Dropship/Small craft throws an exception when attempting to output to plain text due to confusion between the table layout functions for weapon bays and transport bays
Fixes MegaMek/megameklab#290: problems with the export to clipboard (text) function
2. The ammo summary for large craft reports the ammo tonnage based on number of slots rather than taking into account how many shots are located in the slot.
Fixes MegaMek/megameklab#291: Problem with ammunition display in the text tech readout output for large spacecraft.