### PR TITLE
Fix duplicate internal name for IS/Clan BA ECM.

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -10683,8 +10683,8 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = BattleArmor.SINGLE_HEX_ECM;
-        misc.setInternalName("ECM Suite (Light)");
-        misc.addLookupName("IS BA ECM");
+        misc.setInternalName("IS BA ECM");
+        misc.addLookupName("ECM Suite (Light)");
         misc.addLookupName("ISBAECM");
         misc.addLookupName("IS" + BattleArmor.SINGLE_HEX_ECM);
         misc.tonnage = .1;
@@ -10708,8 +10708,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = BattleArmor.SINGLE_HEX_ECM;
-        misc.setInternalName("ECM Suite (Light)");
-        misc.addLookupName("CL BA ECM");
+        misc.setInternalName("CL BA ECM");
         misc.addLookupName("CLBAECM");
         misc.addLookupName("CL" + BattleArmor.SINGLE_HEX_ECM);
         misc.tonnage = .075;


### PR DESCRIPTION
IS and Clan BA ECM both have their internalname field set to "ECM Suite (Light)", which means that they are not distinguished when saving the unit file and when loaded it will add whichever equipment object was added to the hash later. I changed them to have unique names and retained the old name as an additional lookup for the IS version, since the Shen Long [Interdictor] is the only unit file in the repo where it occurs.

Fixes MegaMek/megameklab#292: BA Saving of IS BA ECM as wrong type