### PR TITLE
Reduce 'mech jump mp by 1/medium shield.

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -1266,11 +1266,13 @@ public abstract class Mech extends Entity {
                 }
             }
         }
+        // Medium shield reduces jump mp by 1/shield
+        jump -= getNumberOfShields(MiscType.S_SHIELD_MEDIUM);
 
         if (hasModularArmor() && !ignoremodulararmor) {
             jump--;
         }
-
+        
         if (gravity) {
             return Math.max(applyGravityEffectsOnMP(jump), 0);
         }


### PR DESCRIPTION
From TacOps, p. 291: [the shield's] Mobility Modifier indicates the shield’s effect on a ’Mech’s Walking, Running and Jumping MPs when carrying a shield." The -1 MP for a medium shield is being applied to walk but not jump. Per rules clarification post (https://bg.battletech.com/forums/index.php?topic=20302.0), this reduction is per shield and the run MP is recalculated from the reduced walk MP, which is what MM already does.

Fixes MegaMek/megameklab#302: Medium Shield doesn't affect Jump MP at
all