### PR TITLE
Added missing equipment checks to validation.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1345,6 +1345,23 @@ public abstract class TestEntity implements TestEntityOption {
                 hasHarjelIII = true;
             }
         }
+        if ((isMech() || isTank() || isAero())
+                && (!getEntity().hasEngine()
+                        || (!getEntity().getEngine().isFusion()
+                                && (getEntity().getEngine().getEngineType() != Engine.FISSION)))) {
+            for (Mounted m : getEntity().getWeaponList()) {
+                if (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_IGAUSS_HEAVY) {
+                    buff.append("Improved Heavy Gauss requires a fusion or fission engine.\n");
+                    illegal = true;
+                } else if (m.getType().hasFlag(WeaponType.F_FLAMER)
+                        && (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_NA)
+                        && (!getEntity().hasEngine() || (!getEntity().getEngine().isFusion()
+                                && (getEntity().getEngine().getEngineType() != Engine.FISSION)))) {
+                    buff.append("Standard flamers require a fusion or fission engine.\n");
+                    illegal = true;
+                }
+            }
+        }        
 
         if (minesweeperCount > 1) {
             buff.append("Unit has more than one minesweeper!\n");

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1494,16 +1494,42 @@ public class TestMech extends TestEntity {
                 }
             }
         }
+        
+        for (Mounted m : mech.getWeaponList()) {
+            if (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_IGAUSS_HEAVY) {
+                boolean torso = mech.locationIsTorso(m.getLocation());
+                if (m.getSecondLocation() != Entity.LOC_NONE) {
+                    torso = torso && mech.locationIsTorso(m.getSecondLocation());
+                }
+                if (!mech.isSuperHeavy() && !torso) {
+                    buff.append("IHGauss can only be mounted in torso location.\n");
+                    illegal = true;
+                }
+                if (!mech.hasEngine() || (!mech.getEngine().isFusion()
+                        && (mech.getEngine().getEngineType() != Engine.FISSION))) {
+                    buff.append("IHGauss requires a fusion or fission engine.\n");
+                    illegal = true;
+                }
+            }
+            if (m.getType().hasFlag(WeaponType.F_FLAMER)
+                    && (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_NA)
+                    && (!mech.hasEngine() || (!mech.getEngine().isFusion()
+                            && (mech.getEngine().getEngineType() != Engine.FISSION)))) {
+                buff.append("Standard flamers require a fusion or fission engine.\n");
+                illegal = true;
+            }
+            if ((m.getType().hasFlag(WeaponType.F_TASER)
+                    || m.getType().hasFlag(WeaponType.F_HYPER))
+                    && !(mech.hasEngine() && mech.getEngine().isFusion())) {
+                buff.append(m.getType().getName()).append(" needs fusion engine\n");
+                illegal = true;
+            }
+        }
 
-		if (mech.hasWorkingWeapon(WeaponType.F_TASER) && !(mech.hasEngine() && mech.getEngine().isFusion())) {
-			buff.append("Mek Taser needs fusion engine\n");
-			illegal = true;
-		}
-
-		if (mech.hasWorkingWeapon(WeaponType.F_HYPER) && !(mech.hasEngine() && mech.getEngine().isFusion())) {
-			buff.append("RISC Hyper Laser needs fusion engine\n");
-			illegal = true;
-		}
+        if (mech.hasWorkingWeapon(WeaponType.F_HYPER) && !(mech.hasEngine() && mech.getEngine().isFusion())) {
+            buff.append("RISC Hyper Laser needs fusion engine\n");
+            illegal = true;
+        }
         
         if (mech.hasFullHeadEject()) {
             if ((mech.getCockpitType() == Mech.COCKPIT_TORSO_MOUNTED)

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1506,16 +1506,15 @@ public class TestMech extends TestEntity {
                     torso = torso && mech.locationIsTorso(m.getSecondLocation());
                 }
                 if (!mech.isSuperHeavy() && !torso) {
-                    buff.append("IHGauss can only be mounted in torso location.\n");
+                    buff.append("Improved Heavy Gauss can only be mounted in a torso location.\n");
                     illegal = true;
                 }
                 if (!mech.hasEngine() || (!mech.getEngine().isFusion()
                         && (mech.getEngine().getEngineType() != Engine.FISSION))) {
-                    buff.append("IHGauss requires a fusion or fission engine.\n");
+                    buff.append("Improved Heavy Gauss requires a fusion or fission engine.\n");
                     illegal = true;
                 }
-            }
-            if (m.getType().hasFlag(WeaponType.F_FLAMER)
+            } else if (m.getType().hasFlag(WeaponType.F_FLAMER)
                     && (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_NA)
                     && (!mech.hasEngine() || (!mech.getEngine().isFusion()
                             && (mech.getEngine().getEngineType() != Engine.FISSION)))) {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1509,17 +1509,6 @@ public class TestMech extends TestEntity {
                     buff.append("Improved Heavy Gauss can only be mounted in a torso location.\n");
                     illegal = true;
                 }
-                if (!mech.hasEngine() || (!mech.getEngine().isFusion()
-                        && (mech.getEngine().getEngineType() != Engine.FISSION))) {
-                    buff.append("Improved Heavy Gauss requires a fusion or fission engine.\n");
-                    illegal = true;
-                }
-            } else if (m.getType().hasFlag(WeaponType.F_FLAMER)
-                    && (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_NA)
-                    && (!mech.hasEngine() || (!mech.getEngine().isFusion()
-                            && (mech.getEngine().getEngineType() != Engine.FISSION)))) {
-                buff.append("Standard flamers require a fusion or fission engine.\n");
-                illegal = true;
             }
             if ((m.getType().hasFlag(WeaponType.F_TASER)
                     || m.getType().hasFlag(WeaponType.F_HYPER))

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1315,6 +1315,10 @@ public class TestMech extends TestEntity {
                                 || (((WeaponType)m.getType()).getAmmoType() == AmmoType.T_IGAUSS_HEAVY))) {
                     buff.append("LAMs cannot mount heavy gauss rifles.\n");
                     illegal = true;
+                } else if ((m.getType() instanceof MiscType)
+                        && m.getType().hasFlag(MiscType.F_CLUB)) {
+                    buff.append("LAMs cannot be constructed with physical weapons.\n");
+                    illegal = true;
                 } else if (m.getType().isSpreadable()) {
                     if (spread.containsKey(m.getType())) {
                         spread.get(m.getType()).add(m.getLocation());

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -713,6 +713,27 @@ public class TestTank extends TestEntity {
             }
         }
         
+        for (Mounted m : tank.getWeaponList()) {
+            if (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_IGAUSS_HEAVY) {
+                if ((m.getLocation() == Tank.LOC_TURRET)
+                        || (m.getLocation() == Tank.LOC_TURRET_2)) {
+                    buff.append("Improved Heavy Gauss cannot be mounted in a turret.\n");
+                    illegal = true;
+                }
+                if (!tank.hasEngine() || (!tank.getEngine().isFusion()
+                        && (tank.getEngine().getEngineType() != Engine.FISSION))) {
+                    buff.append("Improved Heavy Gauss requires a fusion or fission engine.\n");
+                    illegal = true;
+                }
+            } else if (m.getType().hasFlag(WeaponType.F_FLAMER)
+                    && (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_NA)
+                    && (!tank.hasEngine() || (!tank.getEngine().isFusion()
+                            && (tank.getEngine().getEngineType() != Engine.FISSION)))) {
+                buff.append("Standard flamers require a fusion or fission engine.\n");
+                illegal = true;
+            }
+        }
+        
         if ((tank.getMovementMode() == EntityMovementMode.VTOL)
                 || (tank.getMovementMode() == EntityMovementMode.WIGE)
                 || (tank.getMovementMode() == EntityMovementMode.HOVER)) {

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -714,22 +714,10 @@ public class TestTank extends TestEntity {
         }
         
         for (Mounted m : tank.getWeaponList()) {
-            if (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_IGAUSS_HEAVY) {
-                if ((m.getLocation() == Tank.LOC_TURRET)
-                        || (m.getLocation() == Tank.LOC_TURRET_2)) {
-                    buff.append("Improved Heavy Gauss cannot be mounted in a turret.\n");
-                    illegal = true;
-                }
-                if (!tank.hasEngine() || (!tank.getEngine().isFusion()
-                        && (tank.getEngine().getEngineType() != Engine.FISSION))) {
-                    buff.append("Improved Heavy Gauss requires a fusion or fission engine.\n");
-                    illegal = true;
-                }
-            } else if (m.getType().hasFlag(WeaponType.F_FLAMER)
-                    && (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_NA)
-                    && (!tank.hasEngine() || (!tank.getEngine().isFusion()
-                            && (tank.getEngine().getEngineType() != Engine.FISSION)))) {
-                buff.append("Standard flamers require a fusion or fission engine.\n");
+            if ((((WeaponType) m.getType()).getAmmoType() == AmmoType.T_IGAUSS_HEAVY)
+                    && ((m.getLocation() == Tank.LOC_TURRET)
+                        || (m.getLocation() == Tank.LOC_TURRET_2))) {
+                buff.append("Improved Heavy Gauss cannot be mounted in a turret.\n");
                 illegal = true;
             }
         }


### PR DESCRIPTION
Adds three rules checks to validation:
1. Improved Heavy Gauss requires a fission or fusion engine and cannot be mounted in a non-torso location in a 'Mech (except superheavies) or turret in a vehicle.
2. Standard flamers (including ER but not vehicular or heavy) require a fission or fusion engine.
3. LAMs cannot be constructed with physical weapons per this post: https://bg.battletech.com/forums/index.php?topic=52456.msg1236486

Fixes MegaMek/megameklab#297:  Improved Heavy Gauss Rifle can be mounted on the vehicle turret and can be used by the unit without fusion or fission engine.