### PR TITLE
prevent exception when bot considers movement out of bounds

### DIFF
--- a/megamek/src/megamek/common/pathfinder/MovePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/MovePathFinder.java
@@ -379,9 +379,10 @@ public class MovePathFinder<C> extends AbstractPathFinder<MovePathFinder.CoordsW
                 }
             }
 
-            if (backwardsStep) {
+            if (backwardsStep &&
+                    mp.getGame().getBoard().contains(mp.getFinalCoords().translated((mp.getFinalFacing() + 3) % 6))) {
                 result.add(mp.clone().addStep(MoveStepType.BACKWARDS));
-            } else {
+            } else if(mp.getGame().getBoard().contains(mp.getFinalCoords().translated(mp.getFinalFacing()))) {
                 result.add(mp.clone().addStep(MoveStepType.FORWARDS));
             }
 


### PR DESCRIPTION
Pretty straightforward, this section of code was generating a significant amount of NPEs that were all getting logged but not technically stopping the game. 

A call to addStep that results in the coordinates being off-board throws an exception, so we avoid doing that to save time and effort.