### PR TITLE
Fix lam deployment npe

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2063,8 +2063,9 @@ public class Compute {
 
         } // End attacker-is-Protomech
 
-        // Is the shoulder destroyed?
-        else {
+        // only mechs have arm actuators - for those, we check whether
+        // there is arm actuator damage
+        else if(attacker instanceof Mech) {
             // split weapons need to account for arm actuator hits, too
             // see bug 1363690
             // we don't need to specifically check for weapons split between
@@ -2082,23 +2083,27 @@ public class Compute {
                     default:
                 }
             }
-            if (attacker.getBadCriticals(CriticalSlot.TYPE_SYSTEM,
-                                         Mech.ACTUATOR_SHOULDER, location) > 0) {
-                mods.addModifier(4, "shoulder actuator destroyed");
-            } else {
-                // no shoulder hits, add other arm hits
-                int actuatorHits = 0;
+            
+            // only arms can have damaged arm actuators
+            if(location == Mech.LOC_LARM || location == Mech.LOC_RARM) {
                 if (attacker.getBadCriticals(CriticalSlot.TYPE_SYSTEM,
-                                             Mech.ACTUATOR_UPPER_ARM, location) > 0) {
-                    actuatorHits++;
-                }
-                if (attacker.getBadCriticals(CriticalSlot.TYPE_SYSTEM,
-                                             Mech.ACTUATOR_LOWER_ARM, location) > 0) {
-                    actuatorHits++;
-                }
-                if (actuatorHits > 0) {
-                    mods.addModifier(actuatorHits, actuatorHits
-                                                   + " destroyed arm actuators");
+                                             Mech.ACTUATOR_SHOULDER, location) > 0) {
+                    mods.addModifier(4, "shoulder actuator destroyed");
+                } else {
+                    // no shoulder hits, add other arm hits
+                    int actuatorHits = 0;
+                    if (attacker.getBadCriticals(CriticalSlot.TYPE_SYSTEM,
+                                                 Mech.ACTUATOR_UPPER_ARM, location) > 0) {
+                        actuatorHits++;
+                    }
+                    if (attacker.getBadCriticals(CriticalSlot.TYPE_SYSTEM,
+                                                 Mech.ACTUATOR_LOWER_ARM, location) > 0) {
+                        actuatorHits++;
+                    }
+                    if (actuatorHits > 0) {
+                        mods.addModifier(actuatorHits, actuatorHits
+                                                       + " destroyed arm actuators");
+                    }
                 }
             }
         }

--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -2108,18 +2108,4 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
             }
         }
     }
-    
-    /**
-     * Override of Entity's getBadCriticals which translates the given location
-     * to its aero equivalent if the LAM is in fighter mode.
-     */
-    @Override
-    public int getBadCriticals(int type, int index, int loc) {
-        if(getConversionMode() == CONV_MODE_FIGHTER) {
-            return(super.getBadCriticals(type, index, getAeroLocation(loc)));
-        } else {
-            return(super.getBadCriticals(type,  index, loc));
-        }
-    }
-
 }

--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -2108,5 +2108,18 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
             }
         }
     }
+    
+    /**
+     * Override of Entity's getBadCriticals which translates the given location
+     * to its aero equivalent if the LAM is in fighter mode.
+     */
+    @Override
+    public int getBadCriticals(int type, int index, int loc) {
+        if(getConversionMode() == CONV_MODE_FIGHTER) {
+            return(super.getBadCriticals(type, index, getAeroLocation(loc)));
+        } else {
+            return(super.getBadCriticals(type,  index, loc));
+        }
+    }
 
 }

--- a/megamek/src/megamek/common/pathfinder/MovePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/MovePathFinder.java
@@ -379,9 +379,10 @@ public class MovePathFinder<C> extends AbstractPathFinder<MovePathFinder.CoordsW
                 }
             }
 
-            if (backwardsStep) {
+            if (backwardsStep &&
+                    mp.getGame().getBoard().contains(mp.getFinalCoords().translated((mp.getFinalFacing() + 3) % 6))) {
                 result.add(mp.clone().addStep(MoveStepType.BACKWARDS));
-            } else {
+            } else if(mp.getGame().getBoard().contains(mp.getFinalCoords().translated(mp.getFinalFacing()))) {
                 result.add(mp.clone().addStep(MoveStepType.FORWARDS));
             }
 

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -32,6 +32,7 @@ import megamek.common.Entity;
 import megamek.common.EquipmentMode;
 import megamek.common.EquipmentType;
 import megamek.common.HitData;
+import megamek.common.IAero;
 import megamek.common.IAimingModes;
 import megamek.common.IGame;
 import megamek.common.ITerrain;
@@ -734,7 +735,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
                 bSalvo = false;
                 if (nweapons > 1) {
                     nweaponsHit = Compute.missilesHit(nweapons,
-                            ((Aero) ae).getClusterMods());
+                            ((IAero) ae).getClusterMods());
                     //If point defenses engage Large, single missiles
                     if (pdBayEngagedMissile || amsBayEngagedMissile) {
                         int AMSHits = 0;


### PR DESCRIPTION
This change fixes an NPE when the bot considers deploying a LAM in fighter mode within weapons range of a hostile unit. The number of locations changes between fighter and mech/airmech modes, so we need to translate the location appropriately.

Got lazy and based it off my previous PR, which is why you see the extra file.