### PR TITLE
Update for PlanetaryConditions.

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1938,6 +1938,7 @@ PlanetaryConditionsDialog.labMaxWind=Maximum Wind
 PlanetaryConditionsDialog.NumberFormatError=Number Format Error
 PlanetaryConditionsDialog.title=Planetary Conditions
 PlanetaryConditionsDialog.EnterValidTemperature=Temperature must be between -200 and 200 degrees Celsius.
+PlanetaryConditionsDialog.EnterValidTemperatureExtreme=Temperature must be less than 30 degrees Celsius when using Hail or Snow.
 PlanetaryConditionsDialog.EnterValidGravity=Gravity must be between 0.1 and 10 G's.
 PlanetaryConditionsDialog.VacuumWind=No wind is allowed in a vacuum.
 PlanetaryConditionsDialog.VacuumWeather=Atmosphere cannot support weather.

--- a/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
@@ -57,6 +57,7 @@ public class PlanetaryConditionsDialog extends JDialog implements
     private ClientGUI client;
     private JFrame frame;
     private PlanetaryConditions conditions;
+    private int currentWeather;
     public PlanetaryConditions getConditions() {
         return conditions;
     }
@@ -145,6 +146,23 @@ public class PlanetaryConditionsDialog extends JDialog implements
             @Override
             public void windowClosing(WindowEvent e) {
                 setVisible(false);
+            }
+        });
+
+        choWeather.addItemListener(e -> {
+            int index = choWeather.getSelectedIndex();
+            if (currentWeather != index && 
+                    (index == PlanetaryConditions.WE_LIGHT_HAIL ||
+                     index == PlanetaryConditions.WE_HEAVY_HAIL ||
+                     index == PlanetaryConditions.WE_LIGHT_SNOW || 
+                     index == PlanetaryConditions.WE_SLEET ||
+                     index == PlanetaryConditions.WE_SNOW_FLURRIES ||
+                     index == PlanetaryConditions.WE_HEAVY_SNOW ||
+                     index == PlanetaryConditions.WE_ICE_STORM || 
+                     index == PlanetaryConditions.WE_BLIZZARD ||
+                     index == PlanetaryConditions.WE_MOD_SNOW)) {
+                currentWeather = index;
+                conditions.setRunOnce(false);
             }
         });
 
@@ -301,6 +319,7 @@ public class PlanetaryConditionsDialog extends JDialog implements
                     .addItem(PlanetaryConditions.getWeatherDisplayableName(i));
         }
         choWeather.setSelectedIndex(conditions.getWeather());
+        currentWeather = conditions.getWeather();
 
         choWind.removeAllItems();
         choMinWind.removeAllItems();
@@ -365,7 +384,6 @@ public class PlanetaryConditionsDialog extends JDialog implements
         conditions.setGravity(Float.parseFloat(fldGrav.getText()));
         conditions.setEMI(cEMI.isSelected());
         conditions.setTerrainAffected(cTerrainAffected.isSelected());
-        conditions.setRunOnce(true);
 
         if (client != null) {
             send();
@@ -418,6 +436,25 @@ public class PlanetaryConditionsDialog extends JDialog implements
                                 Messages
                                         .getString("PlanetaryConditionsDialog.NumberFormatError"),
                                 JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+
+            int weather = currentWeather = choWeather.getSelectedIndex();
+            if (temper >= 30 && (weather == PlanetaryConditions.WE_LIGHT_HAIL ||
+                    weather == PlanetaryConditions.WE_HEAVY_HAIL ||
+                    weather == PlanetaryConditions.WE_LIGHT_SNOW || 
+                    weather == PlanetaryConditions.WE_SLEET ||
+                    weather == PlanetaryConditions.WE_SNOW_FLURRIES ||
+                    weather == PlanetaryConditions.WE_HEAVY_SNOW ||
+                    weather == PlanetaryConditions.WE_ICE_STORM || 
+                    weather == PlanetaryConditions.WE_BLIZZARD ||
+                    weather == PlanetaryConditions.WE_MOD_SNOW)) {
+                JOptionPane
+                        .showMessageDialog(
+                            frame, 
+                            Messages.getString("PlanetaryConditionsDialog.EnterValidTemperatureExtreme"), 
+                            Messages.getString("PlanetaryConditionsDialog.NumberFormatError"), 
+                            JOptionPane.ERROR_MESSAGE);
                 return;
             }
 
@@ -482,7 +519,6 @@ public class PlanetaryConditionsDialog extends JDialog implements
             }
 
             // can't combine certain weather conditions with certain atmospheres
-            int weather = choWeather.getSelectedIndex();
             if ((atmo == PlanetaryConditions.ATMO_VACUUM
                     || atmo == PlanetaryConditions.ATMO_TRACE
                     || atmo == PlanetaryConditions.ATMO_THIN)

--- a/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
@@ -371,7 +371,7 @@ public class PlanetaryConditionsDialog extends JDialog implements
             setConditions(true);
     }
 
-    private void setConditions(boolean shouldSendToClient) {
+    private void setConditions(boolean shouldSendToServer) {
         // make the changes to the planetary conditions
         conditions.setLight(choLight.getSelectedIndex());
         conditions.setWeather(choWeather.getSelectedIndex());
@@ -389,7 +389,7 @@ public class PlanetaryConditionsDialog extends JDialog implements
         conditions.setEMI(cEMI.isSelected());
         conditions.setTerrainAffected(cTerrainAffected.isSelected());
 
-        if (client != null && shouldSendToClient) {
+        if (client != null && shouldSendToServer) {
             send();
         }
     }

--- a/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
@@ -149,7 +149,7 @@ public class PlanetaryConditionsDialog extends JDialog implements
             }
         });
 
-        choWeather.addItemListener(e -> {
+        choWeather.addActionListener(e -> {
             int index = choWeather.getSelectedIndex();
             if (currentWeather != index && 
                     (index == PlanetaryConditions.WE_LIGHT_HAIL ||

--- a/megamek/src/megamek/common/PlanetaryConditions.java
+++ b/megamek/src/megamek/common/PlanetaryConditions.java
@@ -142,6 +142,7 @@ public class PlanetaryConditions implements Serializable {
         fog = other.fog;
         terrainAffected = other.terrainAffected;
         blowingSand = other.blowingSand;
+        runOnce = other.runOnce;
     }
 
     /** clone! */
@@ -964,11 +965,11 @@ public class PlanetaryConditions implements Serializable {
         blowingSand = conditions.blowingSand;
         runOnce = conditions.runOnce;
 
-        if (runOnce) {
+        if (!runOnce) {
             setTempFromWeather();
             setWindFromWeather();
             setSandStorm();
-            runOnce = false;
+            runOnce = true;
         }
 
     }
@@ -994,7 +995,6 @@ public class PlanetaryConditions implements Serializable {
     private void setWindFromWeather() {
         switch (weatherConditions) {
             case WE_SLEET:
-                windStrength = WI_MOD_GALE;
                 setSleet(true);
                 break;
             case WE_ICE_STORM:
@@ -1060,6 +1060,6 @@ public class PlanetaryConditions implements Serializable {
     }
 
     public void setRunOnce(boolean run) {
-        runOnce = true;
+        runOnce = run;
     }
 }


### PR DESCRIPTION
This updates `PlanetaryConditions.java` to fix a couple pieces of errata, and to allow a user to edit the temperature field after setting a weather condition.

Here's a list of changes to `PlanetaryConditions.java`:

* The logic in the `PlanetaryConditions::alterConditions(PlanetaryConditions)` method that was using `runOnce` seemed backwards to me. I flipped the logic so it seems more "correct"
* The `setRunOnce(boolean)` method takes a `boolean` paramter, but was setting the `runOnce` field explicitly to `true`. I corrected the method to set `runOnce` to whatever the value of the parameter is.
* The `clone()` method wasn't coping the `runOnce` field, which caused some issues.

Changes made to `PlanetaryConditionsDialog.java`:

* `setConditions()` was setting `conditions.setRunOnce(true)` on every call, so the `PlanetaryConditions::alterConditions(PlanetaryConditions)` method was always calling the `PlanetaryConditions::setTempFromWeather()`, `PlanetaryConditions::setWindFromWeather()`, and `PlanetaryConditions::setSandStorm()` methods.
* Added a `currentWeather` field to the class, to keep track of the currently selected weather condition is.
* Added an `ItemListener` to the `choWeather` combo box.
* Added a check to make sure that the inputted temperature isn't above 30 degrees Celsius when using snow or hail.

This fixes issue #1352