### PR TITLE
Fix for flamer heat damage.

### DIFF
--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -605,6 +605,8 @@ public class WeaponType extends EquipmentType {
     
     // Fusillade works like a one-shot weapon but has a second round.
     public static final BigInteger F_DOUBLE_ONESHOT = BigInteger.valueOf(1).shiftLeft(68);
+    // ER flamers do half damage in heat mode
+    public static final BigInteger F_ER_FLAMER = BigInteger.valueOf(1).shiftLeft(69);
     
     // add maximum range for AT2
     public static final int RANGE_SHORT = RangeType.RANGE_SHORT;

--- a/megamek/src/megamek/common/weapons/FlamerHeatHandler.java
+++ b/megamek/src/megamek/common/weapons/FlamerHeatHandler.java
@@ -30,6 +30,7 @@ import megamek.common.Mech;
 import megamek.common.Report;
 import megamek.common.TargetRoll;
 import megamek.common.ToHitData;
+import megamek.common.WeaponType;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
@@ -82,21 +83,27 @@ public class FlamerHeatHandler extends WeaponHandler {
             r = new Report(3400);
             r.subject = subjectId;
             r.indent(2);
-            if (entityTarget.getArmor(hit) > 0 && 
+            int heatDamage = wtype.getDamage();
+            if (wtype.hasFlag(WeaponType.F_ER_FLAMER)) {
+                heatDamage = Math.max(1,  heatDamage / 2);
+            }
+           if (entityTarget.getArmor(hit) > 0 && 
                     ((entityTarget.getArmorType(hit.getLocation()) == 
                         EquipmentType.T_ARMOR_HEAT_DISSIPATING) ||
                      (entityTarget.getArmorType(hit.getLocation()) == 
                         EquipmentType.T_ARMOR_REFLECTIVE))){
-                entityTarget.heatFromExternal += 1;
-                r.add(1);
+               
+               int actual = Math.max(heatDamage,  heatDamage / 2);
+                entityTarget.heatFromExternal += actual;
+                r.add(actual);
                 r.choose(true);
                 r.messageId=3406;
-                r.add(2);
+                r.add(heatDamage);
                 r.add(EquipmentType.armorNames
                         [entityTarget.getArmorType(hit.getLocation())]);
             } else {
-                entityTarget.heatFromExternal += 2;
-                r.add(2);
+                entityTarget.heatFromExternal += heatDamage;
+                r.add(heatDamage);
                 r.choose(true);
             }                        
             vPhaseReport.addElement(r);

--- a/megamek/src/megamek/common/weapons/FlamerHeatHandler.java
+++ b/megamek/src/megamek/common/weapons/FlamerHeatHandler.java
@@ -68,7 +68,7 @@ public class FlamerHeatHandler extends WeaponHandler {
 
             if (entityTarget.removePartialCoverHits(hit.getLocation(), toHit
                     .getCover(), Compute.targetSideTable(ae, entityTarget,
-                    weapon.getCalledShot().getCall()))) {
+                            weapon.getCalledShot().getCall()))) {
                 // Weapon strikes Partial Cover.
                 handlePartialCoverHit(entityTarget, vPhaseReport, hit, bldg,
                         hits, nCluster, bldgAbsorbs);
@@ -79,7 +79,7 @@ public class FlamerHeatHandler extends WeaponHandler {
             r.add(toHit.getTableDesc());
             r.add(entityTarget.getLocationAbbr(hit));
             vPhaseReport.addElement(r);
-            
+
             r = new Report(3400);
             r.subject = subjectId;
             r.indent(2);
@@ -87,13 +87,13 @@ public class FlamerHeatHandler extends WeaponHandler {
             if (wtype.hasFlag(WeaponType.F_ER_FLAMER)) {
                 heatDamage = Math.max(1,  heatDamage / 2);
             }
-           if (entityTarget.getArmor(hit) > 0 && 
+            if (entityTarget.getArmor(hit) > 0 && 
                     ((entityTarget.getArmorType(hit.getLocation()) == 
-                        EquipmentType.T_ARMOR_HEAT_DISSIPATING) ||
-                     (entityTarget.getArmorType(hit.getLocation()) == 
-                        EquipmentType.T_ARMOR_REFLECTIVE))){
-               
-               int actual = Math.max(heatDamage,  heatDamage / 2);
+                    EquipmentType.T_ARMOR_HEAT_DISSIPATING) ||
+                            (entityTarget.getArmorType(hit.getLocation()) == 
+                            EquipmentType.T_ARMOR_REFLECTIVE))){
+
+                int actual = Math.max(heatDamage,  heatDamage / 2);
                 entityTarget.heatFromExternal += actual;
                 r.add(actual);
                 r.choose(true);

--- a/megamek/src/megamek/common/weapons/flamers/CLERFlamer.java
+++ b/megamek/src/megamek/common/weapons/flamers/CLERFlamer.java
@@ -36,6 +36,7 @@ public class CLERFlamer extends FlamerWeapon {
         name = "ER Flamer";
         setInternalName("CLERFlamer");
         addLookupName("CL ER Flamer");
+        flags = flags.or(WeaponType.F_ER_FLAMER);
         heat = 4;
         damage = 2;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;

--- a/megamek/src/megamek/common/weapons/flamers/ISERFlamer.java
+++ b/megamek/src/megamek/common/weapons/flamers/ISERFlamer.java
@@ -37,6 +37,7 @@ public class ISERFlamer extends FlamerWeapon {
         setInternalName(name);
         addLookupName("IS ER Flamer");
         addLookupName("ISERFlamer");
+        flags = flags.or(WeaponType.F_ER_FLAMER);
         heat = 4;
         damage = 2;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;


### PR DESCRIPTION
The flamer weapon handler always applies two points of heat damage. The
BA heavy flamer should get four points, and the ER flamers should do
half damage when used in heat mode (TacOps, 312). The ammo-based flamers
(vehicle, heavy) use a different handler which applies the correct
damage.

Fixes #1353: Battle Armor Heavy Flamer only raise 2 heat per hit