### PR TITLE
Split sponson turret weight between the two turrets.

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -520,20 +520,19 @@ public class MiscType extends EquipmentType {
             weaponWeight /= 10;
             return Math.ceil(weaponWeight * 2.0f) / 2.0f;
         } else if (hasFlag(F_SPONSON_TURRET)) {
-            double weaponWeight = 0;
             /* The sponson turret mechanism is equal to 10% of the weight of all mounted weapons, rounded
              * up to the half ton. Since the turrets come in pairs, splitting the weight between them
              * may result in a quarter-ton result for a single turret, but the overall unit weight will
              * be correct.
              */
+            double weaponWeight = 0;
             for (Mounted m : entity.getWeaponList()) {
                 if (m.isSponsonTurretMounted()) {
                     weaponWeight += m.getType().getTonnage(entity);
                 }
             }
             weaponWeight /= 10.0;
-            return Math.ceil(weaponWeight * 2.0) / 4.0;
-
+            return Math.ceil(weaponWeight * 2.0) / 2.0 / entity.countWorkingMisc(MiscType.F_SPONSON_TURRET);
         } else if (hasFlag(F_PINTLE_TURRET)) {
             double weaponWeight = 0;
             // 5% of linked weapons' weight

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -521,16 +521,18 @@ public class MiscType extends EquipmentType {
             return Math.ceil(weaponWeight * 2.0f) / 2.0f;
         } else if (hasFlag(F_SPONSON_TURRET)) {
             double weaponWeight = 0;
-            // 10% of linked weapons' weight
+            /* The sponson turret mechanism is equal to 10% of the weight of all mounted weapons, rounded
+             * up to the half ton. Since the turrets come in pairs, splitting the weight between them
+             * may result in a quarter-ton result for a single turret, but the overall unit weight will
+             * be correct.
+             */
             for (Mounted m : entity.getWeaponList()) {
-                if ((m.isSponsonTurretMounted()
-                        && ((m.getLocation() == Tank.LOC_LEFT) || (m.getLocation() == Tank.LOC_RIGHT)))) {
+                if (m.isSponsonTurretMounted()) {
                     weaponWeight += m.getType().getTonnage(entity);
                 }
             }
-            // round to half ton
-            weaponWeight /= 10;
-            return Math.ceil(weaponWeight * 2.0f) / 2.0f;
+            weaponWeight /= 10.0;
+            return Math.ceil(weaponWeight * 2.0) / 4.0;
 
         } else if (hasFlag(F_PINTLE_TURRET)) {
             double weaponWeight = 0;


### PR DESCRIPTION
Sponson turrets weigh 10% of the total weight of the weapons mounted in them, rounded up to the half ton. Currently the entire weight is allocated to each turret in the pair. Only counting the weapons in the given turret could add an extra half ton from rounding them up individually, so instead I made it halve the weight after rounding, which makes the overall vehicle weight come out correctly.

Fixes MegaMek/megameklab#304: Double Sponson Weight