### PR TITLE
Heat weapons

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -787,7 +787,7 @@ public class Aero extends Entity implements IAero, IBomber {
     }
 
     @Override
-    public boolean tracksHeatBuildup() {
+    public boolean tracksHeat() {
         return true;
     }
 

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -786,6 +786,11 @@ public class Aero extends Entity implements IAero, IBomber {
         podHeatSinks = hs;
     }
 
+    @Override
+    public boolean tracksHeatBuildup() {
+        return true;
+    }
+
     public void setLeftThrustHits(int hits) {
         leftThrustHits = hits;
     }

--- a/megamek/src/megamek/common/ConvFighter.java
+++ b/megamek/src/megamek/common/ConvFighter.java
@@ -51,6 +51,11 @@ public class ConvFighter extends Aero {
     }
     
     @Override
+    public boolean tracksHeatBuildup() {
+        return false;
+    }
+
+    @Override
     public double getFuelPointsPerTon() {
         return 160;
     }

--- a/megamek/src/megamek/common/ConvFighter.java
+++ b/megamek/src/megamek/common/ConvFighter.java
@@ -51,7 +51,7 @@ public class ConvFighter extends Aero {
     }
     
     @Override
-    public boolean tracksHeatBuildup() {
+    public boolean tracksHeat() {
         return false;
     }
 

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -83,6 +83,11 @@ public class Dropship extends SmallCraft {
     private int collarType = COLLAR_STANDARD;
 
     @Override
+    public boolean tracksHeatBuildup() {
+        return false;
+    }
+
+    @Override
     public int getUnitType() {
         return UnitType.DROPSHIP;
     }

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -84,6 +84,8 @@ public class Dropship extends SmallCraft {
 
     @Override
     public boolean tracksHeat() {
+        // While large craft perform heat calculations, they are not considered heat-tracking units
+        // because they cannot generate more heat than they can dissipate in the same turn.
         return false;
     }
 

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -83,7 +83,7 @@ public class Dropship extends SmallCraft {
     private int collarType = COLLAR_STANDARD;
 
     @Override
-    public boolean tracksHeatBuildup() {
+    public boolean tracksHeat() {
         return false;
     }
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3352,6 +3352,15 @@ public abstract class Entity extends TurnOrdered implements Transporter,
 
         return mod;
     }
+    
+    /**
+     * Used to identify an Entity that tracks heat buildup (Mechs, ASFs, and small craft).
+     * 
+     * @return Whether the unit tracks heat buildup.
+     */
+    public boolean tracksHeatBuildup() {
+        return false;
+    }
 
     /**
      * Creates a new mount for this equipment and adds it in.

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3352,7 +3352,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
 
         return mod;
     }
-    
+
     /**
      * Creates a new mount for this equipment and adds it in.
      */

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3354,15 +3354,6 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     }
     
     /**
-     * Used to identify an Entity that tracks heat buildup (Mechs, ASFs, and small craft).
-     * 
-     * @return Whether the unit tracks heat buildup.
-     */
-    public boolean tracksHeatBuildup() {
-        return false;
-    }
-
-    /**
      * Creates a new mount for this equipment and adds it in.
      */
     public Mounted addEquipment(EquipmentType etype, int loc)

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -104,7 +104,7 @@ public class Jumpship extends Aero {
     }
 
     @Override
-    public boolean tracksHeatBuildup() {
+    public boolean tracksHeat() {
         return false;
     }
 

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -110,6 +110,8 @@ public class Jumpship extends Aero {
 
     @Override
     public int getUnitType() {
+        // While large craft perform heat calculations, they are not considered heat-tracking units
+        // because they cannot generate more heat than they can dissipate in the same turn.
         return UnitType.JUMPSHIP;
     }
 

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -104,6 +104,11 @@ public class Jumpship extends Aero {
     }
 
     @Override
+    public boolean tracksHeatBuildup() {
+        return false;
+    }
+
+    @Override
     public int getUnitType() {
         return UnitType.JUMPSHIP;
     }

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -1832,6 +1832,11 @@ public abstract class Mech extends Entity {
         }
         return sinksUnderwater;
     }
+    
+    @Override
+    public boolean tracksHeatBuildup() {
+        return true;
+    }
 
     /**
      * Returns the name of the type of movement used. This is mech-specific.

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -1834,7 +1834,7 @@ public abstract class Mech extends Entity {
     }
     
     @Override
-    public boolean tracksHeatBuildup() {
+    public boolean tracksHeat() {
         return true;
     }
 

--- a/megamek/src/megamek/common/Targetable.java
+++ b/megamek/src/megamek/common/Targetable.java
@@ -134,6 +134,15 @@ public interface Targetable extends Serializable {
                 getTargetType() == TYPE_HEX_BOMB;
     }
 
+    /**
+     * Used to identify an target that tracks heat buildup (Mechs, ASFs, and small craft).
+     * 
+     * @return Whether the target tracks heat buildup.
+     */
+    default boolean tracksHeat() {
+        return false;
+    }
+    
     @Override
     int hashCode();
 }

--- a/megamek/src/megamek/common/weapons/FlamerHeatHandler.java
+++ b/megamek/src/megamek/common/weapons/FlamerHeatHandler.java
@@ -26,7 +26,6 @@ import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.IGame;
 import megamek.common.Infantry;
-import megamek.common.Mech;
 import megamek.common.Report;
 import megamek.common.TargetRoll;
 import megamek.common.ToHitData;
@@ -58,7 +57,7 @@ public class FlamerHeatHandler extends WeaponHandler {
     protected void handleEntityDamage(Entity entityTarget,
             Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
             int bldgAbsorbs) {
-        if ((entityTarget.tracksHeatBuildup())
+        if ((entityTarget.tracksHeat())
                 && game.getOptions().booleanOption(OptionsConstants.BASE_FLAMER_HEAT)) {
             // heat
             hit = entityTarget.rollHitLocation(toHit.getHitTable(),

--- a/megamek/src/megamek/common/weapons/FlamerHeatHandler.java
+++ b/megamek/src/megamek/common/weapons/FlamerHeatHandler.java
@@ -58,7 +58,7 @@ public class FlamerHeatHandler extends WeaponHandler {
     protected void handleEntityDamage(Entity entityTarget,
             Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
             int bldgAbsorbs) {
-        if ((entityTarget instanceof Mech)
+        if ((entityTarget.tracksHeatBuildup())
                 && game.getOptions().booleanOption(OptionsConstants.BASE_FLAMER_HEAT)) {
             // heat
             hit = entityTarget.rollHitLocation(toHit.getHitTable(),

--- a/megamek/src/megamek/common/weapons/PlasmaCannonHandler.java
+++ b/megamek/src/megamek/common/weapons/PlasmaCannonHandler.java
@@ -15,7 +15,6 @@ package megamek.common.weapons;
 
 import java.util.Vector;
 
-import megamek.common.Aero;
 import megamek.common.BattleArmor;
 import megamek.common.Building;
 import megamek.common.BuildingTarget;
@@ -216,7 +215,7 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
             Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
             int bldgAbsorbs) {
 
-        if (entityTarget.tracksHeatBuildup()) {
+        if (entityTarget.tracksHeat()) {
             hit = entityTarget.rollHitLocation(toHit.getHitTable(),
                     toHit.getSideTable(), waa.getAimedLocation(),
                     waa.getAimingMode(), toHit.getCover());
@@ -281,7 +280,7 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
      */
     @Override
     protected int calcDamagePerHit() {
-        if ((target instanceof Mech) || (target instanceof Aero)) {
+        if (target.tracksHeat()) {
             return 0;
         }
         int toReturn = 1;
@@ -310,7 +309,7 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
      */
     @Override
     protected int calcnCluster() {
-        if ((target instanceof Mech) || (target instanceof Aero)) {
+        if (target.tracksHeat()) {
             bSalvo = false;
             return 1;
         }
@@ -330,7 +329,7 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
         if ((target instanceof Infantry) && !(target instanceof BattleArmor)) {
             return 1;
         }
-        if ((target instanceof Mech) || (target instanceof Aero)) {
+        if (target.tracksHeat()) {
             return 1;
         }
         if ((target instanceof BattleArmor)

--- a/megamek/src/megamek/common/weapons/PlasmaCannonHandler.java
+++ b/megamek/src/megamek/common/weapons/PlasmaCannonHandler.java
@@ -72,6 +72,7 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
      *      entityTarget, Vector<Report> vPhaseReport, HitData hit, Building
      *      bldg, int hits, int nCluster, int bldgAbsorbs)
      */
+    @Override
     protected void handlePartialCoverHit(Entity entityTarget,
             Vector<Report> vPhaseReport, HitData hit, Building bldg, int hits,
             int nCluster, int bldgAbsorbs) {
@@ -215,7 +216,7 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
             Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
             int bldgAbsorbs) {
 
-        if ((entityTarget instanceof Mech) || (entityTarget instanceof Aero)) {
+        if (entityTarget.tracksHeatBuildup()) {
             hit = entityTarget.rollHitLocation(toHit.getHitTable(),
                     toHit.getSideTable(), waa.getAimedLocation(),
                     waa.getAimingMode(), toHit.getCover());

--- a/megamek/src/megamek/common/weapons/PlasmaRifleHandler.java
+++ b/megamek/src/megamek/common/weapons/PlasmaRifleHandler.java
@@ -65,7 +65,7 @@ public class PlasmaRifleHandler extends AmmoWeaponHandler {
             int bldgAbsorbs) {
         super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
                 nCluster, bldgAbsorbs);
-        if (!missed && entityTarget.tracksHeatBuildup()) {
+        if (!missed && entityTarget.tracksHeat()) {
             Report r = new Report(3400);
             r.subject = subjectId;
             r.indent(2);
@@ -137,7 +137,7 @@ public class PlasmaRifleHandler extends AmmoWeaponHandler {
      */
     @Override
     protected int calcnCluster() {
-        if ((target instanceof Mech) || (target instanceof Aero)) {
+        if (target.tracksHeat()) {
             bSalvo = false;
             return 1;
         }
@@ -163,7 +163,7 @@ public class PlasmaRifleHandler extends AmmoWeaponHandler {
     protected int calcHits(Vector<Report> vPhaseReport) {
         int toReturn;
         // against mechs, 1 hit with 10 damage, plus heat
-        if ((target instanceof Mech) || (target instanceof Aero)) {
+        if (target.tracksHeat()) {
             toReturn = 1;
             // otherwise, 10+2d6 damage
             // but fireresistant BA armor gets no damage from heat, and half the

--- a/megamek/src/megamek/common/weapons/PlasmaRifleHandler.java
+++ b/megamek/src/megamek/common/weapons/PlasmaRifleHandler.java
@@ -65,8 +65,7 @@ public class PlasmaRifleHandler extends AmmoWeaponHandler {
             int bldgAbsorbs) {
         super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits,
                 nCluster, bldgAbsorbs);
-        if (!missed
-                && ((entityTarget instanceof Mech) || (entityTarget instanceof Aero))) {
+        if (!missed && entityTarget.tracksHeatBuildup()) {
             Report r = new Report(3400);
             r.subject = subjectId;
             r.indent(2);

--- a/megamek/src/megamek/common/weapons/VehicleFlamerHeatHandler.java
+++ b/megamek/src/megamek/common/weapons/VehicleFlamerHeatHandler.java
@@ -27,7 +27,6 @@ import megamek.common.EquipmentType;
 import megamek.common.HitData;
 import megamek.common.IGame;
 import megamek.common.Infantry;
-import megamek.common.Mech;
 import megamek.common.Report;
 import megamek.common.TargetRoll;
 import megamek.common.ToHitData;
@@ -68,7 +67,7 @@ public class VehicleFlamerHeatHandler extends AmmoWeaponHandler {
     protected void handleEntityDamage(Entity entityTarget,
             Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
             int bldgAbsorbs) {
-        if ((entityTarget.tracksHeatBuildup())
+        if ((entityTarget.tracksHeat())
                 && game.getOptions().booleanOption(OptionsConstants.BASE_FLAMER_HEAT)) {
 
             hit = entityTarget.rollHitLocation(toHit.getHitTable(),

--- a/megamek/src/megamek/common/weapons/VehicleFlamerHeatHandler.java
+++ b/megamek/src/megamek/common/weapons/VehicleFlamerHeatHandler.java
@@ -68,7 +68,7 @@ public class VehicleFlamerHeatHandler extends AmmoWeaponHandler {
     protected void handleEntityDamage(Entity entityTarget,
             Vector<Report> vPhaseReport, Building bldg, int hits, int nCluster,
             int bldgAbsorbs) {
-        if ((entityTarget instanceof Mech)
+        if ((entityTarget.tracksHeatBuildup())
                 && game.getOptions().booleanOption(OptionsConstants.BASE_FLAMER_HEAT)) {
 
             hit = entityTarget.rollHitLocation(toHit.getHitTable(),

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11167,7 +11167,7 @@ public class Server implements Runnable {
                     vPhaseReport.addElement(r);
                 }
                 vPhaseReport.addAll(tryClearHex(t.getPosition(), missiles * 4,
-                                                ae.getId()));
+                                                attId));
                 tryIgniteHex(t.getPosition(), attId, false, true,
                              new TargetRoll(0, "inferno"), -1, vPhaseReport);
                 break;

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11116,6 +11116,10 @@ public class Server implements Runnable {
         IHex hex = game.getBoard().getHex(t.getPosition());
         Report r;
         Vector<Report> vPhaseReport = new Vector<Report>();
+        int attId = Entity.NONE;
+        if (null != ae) {
+            attId = ae.getId();
+        }
         switch (t.getTargetType()) {
             case Targetable.TYPE_HEX_ARTILLERY:
                 // used for BA inferno explosion
@@ -11145,7 +11149,7 @@ public class Server implements Runnable {
                                                                         .getBuildingAt(t.getPosition()), 2 * missiles,
                                                                     t.getPosition());
                     for (Report report : vBuildingReport) {
-                        report.subject = ae.getId();
+                        report.subject = attId;
                     }
                     vPhaseReport.addAll(vBuildingReport);
                 }
@@ -11157,14 +11161,14 @@ public class Server implements Runnable {
                 if ((h != null) && h.hasTerrainfactor()) {
                     r = new Report(3384);
                     r.indent(2);
-                    r.subject = ae.getId();
+                    r.subject = attId;
                     r.add(t.getPosition().getBoardNum());
                     r.add(missiles * 4);
                     vPhaseReport.addElement(r);
                 }
                 vPhaseReport.addAll(tryClearHex(t.getPosition(), missiles * 4,
                                                 ae.getId()));
-                tryIgniteHex(t.getPosition(), ae.getId(), false, true,
+                tryIgniteHex(t.getPosition(), attId, false, true,
                              new TargetRoll(0, "inferno"), -1, vPhaseReport);
                 break;
             case Targetable.TYPE_BLDG_IGNITE:
@@ -11173,7 +11177,7 @@ public class Server implements Runnable {
                                                                     .getBuildingAt(t.getPosition()), 2 * missiles,
                                                                 t.getPosition());
                 for (Report report : vBuildingReport) {
-                    report.subject = ae.getId();
+                    report.subject = attId;
                 }
                 vPhaseReport.addAll(vBuildingReport);
 
@@ -11207,7 +11211,7 @@ public class Server implements Runnable {
                 if ((te instanceof Mech) && (!areaEffect)) {
                     // Bug #1585497: Check for partial cover
                     int m = missiles;
-                    LosEffects le = LosEffects.calculateLos(game, ae.getId(), t);
+                    LosEffects le = LosEffects.calculateLos(game, attId, t);
                     int cover = le.getTargetCover();
                     Vector<Report> coverDamageReports = new Vector<Report>();
                     int heatDamage = 0;

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11337,9 +11337,12 @@ public class Server implements Runnable {
                     te.heatFromExternal += 2 * missiles;
                     Report.addNewline(vPhaseReport);
                 } else if (te instanceof ConvFighter) {
-                    // CFs take damage to SI. Other aerospace units ignore infernos.
-                    int siDamage = missiles / 3;
-                    if (siDamage > 0) {
+                    // CFs take a point SI damage for every three missiles that hit.
+                    // Use the heatFromExternal field to carry the remainder in case of multiple inferno hits.
+                    te.heatFromExternal += missiles;
+                    if (te.heatFromExternal >= 3) {
+                        int siDamage = te.heatFromExternal / 3;
+                        te.heatFromExternal %= 3;
                         final ConvFighter ftr = (ConvFighter) te;
                         int remaining = Math.max(0,  ftr.getSI() - siDamage);
                         r = new Report(9146);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11384,11 +11384,11 @@ public class Server implements Runnable {
                                                          ToHitData.SIDE_FRONT);
                         if (hit.getLocation() == Protomech.LOC_NMISS) {
                             Protomech proto = (Protomech) te;
-                            r = new Report(6305);
+                            r = new Report(6035);
                             r.subject = te.getId();
                             r.indent(2);
                             if (proto.isGlider()) {
-                                r.messageId = 6306;
+                                r.messageId = 6036;
                                 proto.setWingHits(proto.getWingHits() + 1);
                             }
                             vPhaseReport.add(r);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11326,7 +11326,8 @@ public class Server implements Runnable {
                     }
                     vPhaseReport.addAll(coverDamageReports);
                     Report.addNewline(vPhaseReport);
-                } else if (te instanceof Aero) {
+                } else if (te.tracksHeat()) {
+                    // ASFs and small craft
                     r = new Report(3400);
                     r.add(2 * missiles);
                     r.subject = te.getId();
@@ -11335,18 +11336,37 @@ public class Server implements Runnable {
                     vPhaseReport.add(r);
                     te.heatFromExternal += 2 * missiles;
                     Report.addNewline(vPhaseReport);
+                } else if (te instanceof ConvFighter) {
+                    // CFs take damage to SI. Other aerospace units ignore infernos.
+                    int siDamage = missiles / 3;
+                    if (siDamage > 0) {
+                        final ConvFighter ftr = (ConvFighter) te;
+                        int remaining = Math.max(0,  ftr.getSI() - siDamage);
+                        r = new Report(9146);
+                        r.subject = te.getId();
+                        r.indent(2);
+                        r.add(siDamage);
+                        r.add(remaining);
+                        vPhaseReport.add(r);
+                        ftr.setSI(remaining);
+                        te.damageThisPhase += siDamage;
+                        if (remaining <= 0) {
+                            vPhaseReport.addAll(destroyEntity(te,
+                                    "Structural Integrity Collapse"));
+                            ftr.setSI(0);
+                            if (null != ae) {
+                                creditKill(te, ae);
+                            }
+                        }
+                    }
                 } else if (te instanceof Tank) {
-                    boolean targetIsSupportVee = (te instanceof SupportTank)
-                                                 || (te instanceof LargeSupportTank)
-                                                 || (te instanceof SupportVTOL);
                     int direction = Compute.targetSideTable(ae, te, called);
                     while (missiles-- > 0) {
                         HitData hit = te.rollHitLocation(ToHitData.HIT_NORMAL,
                                                          direction);
                         int critRollMod = 0;
-                        if (!targetIsSupportVee
-                            || (te.hasArmoredChassis() && (te.getBARRating(hit
-                                                                                   .getLocation()) > 9))) {
+                        if (!te.isSupportVehicle()
+                            || (te.hasArmoredChassis() && (te.getBARRating(hit.getLocation()) > 9))) {
                             critRollMod -= 2;
                         }
                         if ((te.getArmorType(hit.getLocation()) == EquipmentType.T_ARMOR_HARDENED)
@@ -11441,8 +11461,7 @@ public class Server implements Runnable {
                         creditKill(te, ae);
                         Report.addNewline(vPhaseReport);
                     }
-                } else {
-                    // gun emplacements
+                } else if (te instanceof GunEmplacement){
                     int direction = Compute.targetSideTable(ae, te, called);
                     while (missiles-- > 0) {
                         HitData hit = te.rollHitLocation(ToHitData.HIT_NORMAL,

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11359,6 +11359,12 @@ public class Server implements Runnable {
                             }
                         }
                     }
+                } else if (te instanceof Aero) {
+                    // Large craft ignore infernos
+                    r = new Report(1242);
+                    r.subject = te.getId();
+                    r.indent(2);
+                    vPhaseReport.add(r);
                 } else if (te instanceof Tank) {
                     int direction = Compute.targetSideTable(ae, te, called);
                     while (missiles-- > 0) {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11336,6 +11336,30 @@ public class Server implements Runnable {
                     vPhaseReport.add(r);
                     te.heatFromExternal += 2 * missiles;
                     Report.addNewline(vPhaseReport);
+                } else if (te instanceof GunEmplacement){
+                    int direction = Compute.targetSideTable(ae, te, called);
+                    while (missiles-- > 0) {
+                        HitData hit = te.rollHitLocation(ToHitData.HIT_NORMAL,
+                                                         direction);
+                        vPhaseReport.addAll(damageEntity(te, hit, 2));
+                    }
+                } else if ((te instanceof Tank) || te.isSupportVehicle()) {
+                    int direction = Compute.targetSideTable(ae, te, called);
+                    while (missiles-- > 0) {
+                        HitData hit = te.rollHitLocation(ToHitData.HIT_NORMAL,
+                                                         direction);
+                        int critRollMod = 0;
+                        if (!te.isSupportVehicle()
+                            || (te.hasArmoredChassis() && (te.getBARRating(hit.getLocation()) > 9))) {
+                            critRollMod -= 2;
+                        }
+                        if ((te.getArmorType(hit.getLocation()) == EquipmentType.T_ARMOR_HARDENED)
+                            && (te.getArmor(hit.getLocation()) > 0)) {
+                            critRollMod -= 2;
+                        }
+                        vPhaseReport.addAll(criticalEntity(te, hit.getLocation(),
+                                                           hit.isRear(), critRollMod, 0, true));
+                    }
                 } else if (te instanceof ConvFighter) {
                     // CFs take a point SI damage for every three missiles that hit.
                     // Use the heatFromExternal field to carry the remainder in case of multiple inferno hits.
@@ -11362,29 +11386,12 @@ public class Server implements Runnable {
                             }
                         }
                     }
-                } else if (te instanceof Aero) {
+                } else if (te.isLargeCraft()) {
                     // Large craft ignore infernos
                     r = new Report(1242);
                     r.subject = te.getId();
                     r.indent(2);
                     vPhaseReport.add(r);
-                } else if (te instanceof Tank) {
-                    int direction = Compute.targetSideTable(ae, te, called);
-                    while (missiles-- > 0) {
-                        HitData hit = te.rollHitLocation(ToHitData.HIT_NORMAL,
-                                                         direction);
-                        int critRollMod = 0;
-                        if (!te.isSupportVehicle()
-                            || (te.hasArmoredChassis() && (te.getBARRating(hit.getLocation()) > 9))) {
-                            critRollMod -= 2;
-                        }
-                        if ((te.getArmorType(hit.getLocation()) == EquipmentType.T_ARMOR_HARDENED)
-                            && (te.getArmor(hit.getLocation()) > 0)) {
-                            critRollMod -= 2;
-                        }
-                        vPhaseReport.addAll(criticalEntity(te, hit.getLocation(),
-                                                           hit.isRear(), critRollMod, 0, true));
-                    }
                 } else if (te instanceof Protomech) {
                     te.heatFromExternal += missiles;
                     while (te.heatFromExternal >= 3) {
@@ -11469,13 +11476,6 @@ public class Server implements Runnable {
                         vPhaseReport.addAll(destroyEntity(te, "damage", false));
                         creditKill(te, ae);
                         Report.addNewline(vPhaseReport);
-                    }
-                } else if (te instanceof GunEmplacement){
-                    int direction = Compute.targetSideTable(ae, te, called);
-                    while (missiles-- > 0) {
-                        HitData hit = te.rollHitLocation(ToHitData.HIT_NORMAL,
-                                                         direction);
-                        vPhaseReport.addAll(damageEntity(te, hit, 2));
                     }
                 }
         }


### PR DESCRIPTION
Corrections to the way damage is applied to certain unit types from flamers, plasma weapons, and infernos. Adds a `tracksHeat()` method to the `Targetable` interface to remove the need for filtering based on `instanceof` checks. This returns true for mechs, aerospace fighters, and small craft, and false for all other unit types.

The following behaviors are changed to conform to the rules:
1. Flamers in heat mode will now raise the heat levels of aerospace fighters and small craft in addition to mechs.
2. Instead of mechs and all aerospace units, plasma weapons will raise heat levels only for mechs, asfs, and small craft. Those that don't track heat ignore the external heat levels, but they are supposed to have additional damage applied to them as for vehicles, protomechs, and infantry (TW, 139-140).
3. Instead of raising heat levels for all aerospace units, conventional fighters take a point of damage directly to SI for every three missiles that hit. The effect on large craft does not change, since they ignore external heat buildup, but the report will now be correct.

I also discovered that some digits were transposed in the report ids for Protomechs with a near miss.

Fixes #1375: Heat damage not correctly applied to all unit types