### PR TITLE
Use correct value when validating BA tube ammo amounts.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -876,12 +876,19 @@ public class TestBattleArmor extends TestEntity {
                 correct = false;
             }
 
-            if ((m.getType() instanceof AmmoType)
-                    && (m.getBaseShotsLeft() > NUM_SHOTS_PER_CRIT)) {
-                buff.append(m.getName() + "has " + m.getBaseShotsLeft()
-                        + " shots, but BattleArmor may only have at most "
-                        + NUM_SHOTS_PER_CRIT + " shots per slot.\n");
-                correct = false;
+            if (m.getType() instanceof AmmoType) {
+                final int maxShots;
+                if (((AmmoType) m.getType()).getAmmoType() != AmmoType.T_BA_TUBE) {
+                    maxShots = NUM_SHOTS_PER_CRIT;
+                } else {
+                    maxShots = NUM_SHOTS_PER_CRIT_TA;
+                }
+                if (m.getBaseShotsLeft() > maxShots) {
+                    buff.append(m.getName()).append(" has ").append(m.getBaseShotsLeft())
+                        .append(" shots, but BattleArmor may only have at most ")
+                        .append(maxShots).append(" shots per slot.\n");
+                    correct = false;
+                }
             }
 
             // Ensure that jump boosters are mounted in the body


### PR DESCRIPTION
BA tube artillery is an exception to the general rule that BA only track ammo for missile weapons. It also comes in two-round clips, which means that a slot is required for every eight shots rather than every four as for missile weapons. From TacOps errata 3.01:
>>>BA Tube artillery ammunition is treated in the same way as battle armor missile ammunition, with one slot required for every four two-round clips.

MM and MML both handle setting the ammo levels in pairs, but during unit validation MM fails to check for ammo type before flagging the unit as illegal if a slot contains more than four shots. This PR adds the missing check.

Fixes MegaMek/megameklab#185.