### PR TITLE
fix game-stopping NPE encountered when adding units to observer player mid-game

### DIFF
--- a/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
@@ -67,6 +67,7 @@ import megamek.client.ui.Messages;
 import megamek.common.Entity;
 import megamek.common.EntityMovementMode;
 import megamek.common.IGame.Phase;
+import megamek.common.IPlayer;
 import megamek.common.event.GameListener;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GameSettingsChangeEvent;
@@ -823,7 +824,12 @@ WindowListener, TreeSelectionListener {
         m_chPlayer.addItem(clientName);
         for (Iterator<Client> i = m_clientgui.getBots().values().iterator(); i
         .hasNext();) {
-            m_chPlayer.addItem(i.next().getName());
+            Client client = i.next();
+            IPlayer player = m_client.getGame().getPlayer(client.getLocalPlayerNumber());
+            
+            if(!player.isObserver()) {
+                m_chPlayer.addItem(client.getName());
+            }
         }
         if (m_chPlayer.getItemCount() == 1) {
             m_chPlayer.setEnabled(false);

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -672,10 +672,18 @@ public class Server implements Runnable {
             getGame().addGameListener(listener);
         }
 
+        List<Integer> orphanEntities = new ArrayList<>();
+                
         // reattach the transient fields and ghost the players
         for (Iterator<Entity> e = game.getEntities(); e.hasNext(); ) {
             Entity ent = e.next();
             ent.setGame(game);
+            
+            if(ent.getOwner() == null) {
+                orphanEntities.add(ent.getId());
+                continue;
+            }
+            
             if (ent instanceof Mech) {
                 ((Mech) ent).setBAGrabBars();
                 ((Mech) ent).setProtomechClampMounts();
@@ -684,6 +692,9 @@ public class Server implements Runnable {
                 ((Tank) ent).setBAGrabBars();
             }
         }
+        
+        game.removeEntities(orphanEntities, IEntityRemovalConditions.REMOVE_UNKNOWN);
+        
         game.setOutOfGameEntitiesVector(game.getOutOfGameEntitiesVector());
         for (Enumeration<IPlayer> e = game.getPlayers(); e.hasMoreElements(); ) {
             IPlayer p = e.nextElement();


### PR DESCRIPTION
I had eliminated all units from a bot then foolishly decided to add some more reinforcements to it via RAT generator. That locked up the game for good.

So, to prevent future foolishness of this sort, two changes:
1) Prevent players from adding units to 'observer' bots
2) Clean up units that don't have an actual owner when loading a game.