### PR TITLE
fix_npes_and_out_of_control_issues

### DIFF
--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -737,11 +737,12 @@ public class SharedUtility {
                 if(game.getBoard().onGround()) {
                     steps = 16;
                 }
-                while(steps > 0) {
+                while(steps > 0 &&
+                        game.getBoard().contains(md.getFinalCoords())) {
                     md.addStep(MoveStepType.FORWARDS);
                     steps--;
                 }
-                if (!game.getBoard().contains(md.getLastStep().getPosition())) {
+                if (!game.getBoard().contains(md.getFinalCoords())) {
                     md.removeLastStep();
                     if(game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_RETURN_FLYOVER)) {
                         //Telemissiles shouldn't get a return option

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -1336,9 +1336,6 @@ public class MoveStep implements Serializable {
      */
     public void moveInDir(int dir) {
         position = position.translated(dir);
-        if (!getGame().getBoard().contains(position)) {
-            throw getLogger().error(getClass(), "moveInDir(int)", new RuntimeException("Coordinate off the board."));
-        }
     }
 
     /**

--- a/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
@@ -335,7 +335,11 @@ public class AeroGroundPathFinder {
                 firstTurn = false;
             }
 
-            straightLine.addStep(MoveStepType.FORWARDS);
+            if(straightLine.nextForwardStepOffBoard()) {
+                break;
+            } else {
+                straightLine.addStep(MoveStepType.FORWARDS);
+            }
         }
 
         return retval;


### PR DESCRIPTION
Fixed an issue where an out-of-control aircraft whose path would take it off board would cause a soft-lock. Pretty sure it was introduced this release.

The moveInDir exception when moving off board is unnecessary (and resulted in serious log bloat), as "compileIllegal" later declares the move path illegal.

Also minor performance improvement to aero-ground path finding to reduce consideration of paths that go off the board anyway.