### PR TITLE
Remove spot for LRM indirect fire penalty for the unit that was successfully designated TAG on the same turn.

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -354,6 +354,8 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     private boolean evading = false;
 
     public boolean spotting;
+    public boolean spottingWithoutPenalty; // the unit has spotted for LRM indirect fire but suffers no penalty for it
+
     private boolean clearingMinefield = false;
     protected int killerId = Entity.NONE;
     private int offBoardDistance = 0;
@@ -6085,6 +6087,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         setDisplacementAttack(null);
         setFindingClub(false);
         setSpotting(false);
+	setSpottingWithoutPenalty(false);
         spotTargetId = Entity.NONE;
         setClearingMinefield(false);
         setUnjammingRAC(false);
@@ -9063,6 +9066,15 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     public void setSpotting(boolean spotting) {
         this.spotting = spotting;
     }
+    
+    //spottingWithoutPenalty
+    public boolean isSpottingWithoutPenalty() {
+        return spottingWithoutPenalty;
+    }//isSpottingWithoutPenalty
+
+    public void setSpottingWithoutPenalty(boolean spottingWithoutPenalty) {
+        this.spottingWithoutPenalty = spottingWithoutPenalty;
+    }//setSpottingWithoutPenalty
 
     /**
      * Um, basically everything can spot for LRM indirect fire.

--- a/megamek/src/megamek/common/actions/PhysicalAttackAction.java
+++ b/megamek/src/megamek/common/actions/PhysicalAttackAction.java
@@ -211,7 +211,8 @@ public class PhysicalAttackAction extends AbstractAttackAction {
         }
 
         // if we're spotting for indirect fire, add +1
-        if (ae.isSpotting() && !ae.getCrew().hasActiveCommandConsole()) {
+        // also no penalty if the unit will not suffer the penalty by the other means.
+        if (ae.isSpotting() && !ae.getCrew().hasActiveCommandConsole() && !ae.isSpottingWithoutPenalty()) {
             toHit.addModifier(+1, "attacker is spotting for indirect LRM fire");
         }
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -788,7 +788,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
 
         // if we're spotting for indirect fire, add +1 (no penalty with second pilot in command console)
-        if (ae.isSpotting() && !ae.getCrew().hasActiveCommandConsole()) {
+	// also no penalty if the unit will not suffer the penalty by the other means.
+        if (ae.isSpotting() && !ae.getCrew().hasActiveCommandConsole() && !ae.isSpottingWithoutPenalty()) {
             toHit.addModifier(+1, "attacker is spotting for indirect LRM fire");
         }
 

--- a/megamek/src/megamek/common/weapons/TAGHandler.java
+++ b/megamek/src/megamek/common/weapons/TAGHandler.java
@@ -92,6 +92,7 @@ public class TAGHandler extends WeaponHandler {
             // per errata, being painted by a TAG also spots the target for indirect fire
             ae.setSpotting(true);
             ae.setSpotTargetId(entityTarget.getId());
+            ae.setSpottingWithoutPenalty //allows the unit to not suffer the penalty
             
             Report r = new Report(3188);
             r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/TAGHandler.java
+++ b/megamek/src/megamek/common/weapons/TAGHandler.java
@@ -92,7 +92,7 @@ public class TAGHandler extends WeaponHandler {
             // per errata, being painted by a TAG also spots the target for indirect fire
             ae.setSpotting(true);
             ae.setSpotTargetId(entityTarget.getId());
-            ae.setSpottingWithoutPenalty //allows the unit to not suffer the penalty
+            ae.setSpottingWithoutPenalty(true); //allows the unit to not suffer the penalty
             
             Report r = new Report(3188);
             r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1207,6 +1207,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
                         
                         ae.setSpotting(true);
                         ae.setSpotTargetId(target.getTargetId());
+			ae.setSpottingWithoutPenalty(true); //allows the unit to not suffer the penalty
                         
                         r = new Report(3390);
                         r.subject = subjectId;


### PR DESCRIPTION
Fix for issue #1388 .

I was reviewed the pull request #1296 before making a fix for the problem, because I think that the problem is related with this. 

Actually, pull request #1296 was intended to fix for it. But, it seems that it wasn't fully cover the problem. Anyway my solution is just adding something to that.

It is simple - add a flag on Entity that notes the entity spots without penalty, and see if the unit will not suffer the penalty before put it.

But, because I am not familiar to MegaMek's code, and I am not fully understand the structure, so I think that it may cause a bug. So please check it with care. Also, I fear that I might cause a serious problem because I have touched Entity class, which seems one of the most used class in the application. But, after search through Entity.Java it seems that a new flag was needed to solve the problem.