### PR TITLE
Added prototype IS omnivehicle intro date of 3008.

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -1221,6 +1221,14 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             .setPrototypeFactions(F_CCY, F_CSF).setProductionFactions(F_CCY, F_DC)
             .setTechRating(RATING_E).setAvailability(RATING_X, RATING_E, RATING_E, RATING_D)
             .setStaticTechLevel(SimpleTechLevel.STANDARD);
+    // This is not in the rules anywhere, but is implied by the existence of the Badger and Bandit
+    // tanks used by Wolf's Dragoons and sold to the merc market as early as 3008.
+    private static final TechAdvancement TA_OMNIVEHICLE = new TechAdvancement(TECH_BASE_ALL)
+            .setISAdvancement(3008, DATE_NONE, 3052).setISApproximate(true)
+            .setClanAdvancement(2854, 2856, 2864).setClanApproximate(true)
+            .setPrototypeFactions(F_CCY, F_CSF, F_MERC).setProductionFactions(F_CCY, F_DC)
+            .setTechRating(RATING_E).setAvailability(RATING_X, RATING_E, RATING_E, RATING_D)
+            .setStaticTechLevel(SimpleTechLevel.STANDARD);
     protected final static TechAdvancement TA_PATCHWORK_ARMOR = new TechAdvancement(TECH_BASE_ALL)
             .setAdvancement(DATE_PS, 3075, 3080).setApproximate(false, false, true)
             .setTechRating(RATING_A)
@@ -1239,7 +1247,15 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
 
     public static TechAdvancement getOmniAdvancement() {
-        return new TechAdvancement(TA_OMNI);
+        return getOmniAdvancement(null);
+    }
+    
+    public static TechAdvancement getOmniAdvancement(Entity en) {
+        if (en instanceof Tank) {
+            return new TechAdvancement(TA_OMNIVEHICLE);
+        } else {
+            return new TechAdvancement(TA_OMNI);
+        }
     }
 
     public static TechAdvancement getPatchworkArmorAdvancement() {

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1139,7 +1139,7 @@ public abstract class TestEntity implements TestEntityOption {
         }
         int useIntroYear = getEntity().getYear() + getIntroYearMargin();
         if (getEntity().isOmni()) {
-            int introDate = Entity.getOmniAdvancement()
+            int introDate = Entity.getOmniAdvancement(getEntity())
                     .getIntroductionDate(getEntity().isClan() || getEntity().isMixedTech());
             if (useIntroYear < introDate) {
                 retVal = true;


### PR DESCRIPTION
The rules (strictly applied) say you can't, the fluff says you can. Wolf's Dragoons were using omni tech on vehicles as early as 3008, though the tech does not become available to the IS until ~3052. I modified the intro dates for omni tech to include an IS prototype date of ~3008 for vehicles for mercs (WD sold the vehicles on the merc market). This allows the Bandit and the Badger to validate and to undergo refits in MekHQ. Using default options it does not make podded equipment available for purchase in MekHQ or allow omnivehicles to be constructed in MML prior to the general omni intro date, but it there are options that can be changed to allow it.

Fixes MegaMek/mekhq#1110: Badger / Bandit vehicles can't be customized
prior to 3047