### PR TITLE
fix npe when fleeing with phantom picked up mechwarrior

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -6920,6 +6920,10 @@ public class Server implements Runnable {
         // Handle any picked up MechWarriors
         for (Integer mechWarriorId : entity.getPickedUpMechWarriors()) {
             Entity mw = game.getEntity(mechWarriorId.intValue());
+            
+            if(mw == null) {
+            	continue;
+            }
 
             // Is the MechWarrior an enemy?
             int condition = IEntityRemovalConditions.REMOVE_IN_RETREAT;


### PR DESCRIPTION
Fixes #1400. Pretty straightforward, apparently sometimes a mechwarrior entity is removed from the game when picked up, so when the carrying unit flees, that causes an NPE.