### PR TITLE
fix nonsensical infantry behavior

### DIFF
--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -31,7 +31,11 @@ public class ServerHelper {
         if (isPlatoon && !te.isDestroyed() && !te.isDoomed() && !ignoreInfantryDoubleDamage
                 && (((Infantry) te).getDugIn() != Infantry.DUG_IN_COMPLETE)
                 && !te.hasAbility(OptionsConstants.MD_DERMAL_ARMOR)) {
-            te_hex = game.getBoard().getHex(te.getPosition());
+        	
+        	if(te_hex == null) {
+        		te_hex = game.getBoard().getHex(te.getPosition());
+        	}
+        	
             if ((te_hex != null) && !te_hex.containsTerrain(Terrains.WOODS) && !te_hex.containsTerrain(Terrains.JUNGLE)
                     && !te_hex.containsTerrain(Terrains.ROUGH) && !te_hex.containsTerrain(Terrains.RUBBLE)
                     && !te_hex.containsTerrain(Terrains.SWAMP) && !te_hex.containsTerrain(Terrains.BUILDING)


### PR DESCRIPTION
Now that the bot regularly gets field gunners, I noticed that they love running out into the open to meet my Firestarters in glorious battle, instead of camping out in the woods and firing at long range.

Once I made this change, a platoon of AC/5 field gunners changed their behavior from running out into the open and opening fire with their auto-rifles to camping out in the woods and getting in two engine crits. This will probably also benefit their non-field-gunner counterparts.

Technical notes:
- Max damage evaluation wasn't taking into account the fact that field guns cannot be fired if a unit has moved.
- "Unit in open" check was returning results based on the unit's current hex rather than unit's destination hex.
- "aggression" modifier was causing infantry to want to close in anyway, even though it's not to their benefit. Changed it to only apply aggression modifier if the path being considered will result in no damage being inflicted by the unit.