### PR TITLE
Enable Bot Fireworks

### DIFF
--- a/megamek/src/megamek/client/bot/ChatProcessor.java
+++ b/megamek/src/megamek/client/bot/ChatProcessor.java
@@ -385,6 +385,7 @@ public class ChatProcessor {
             msg = "Aggression changed from " + currentAggression + " to " +
                   princess.getBehaviorSettings().getHyperAggressionIndex();
             princess.sendChat(msg);
+            princess.resetSpinupThreshold();
         }
 
         // Adjust herd mentality.

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1621,6 +1621,12 @@ public class FireControl {
 
         // cycle through my weapons
         for (final Mounted weapon : shooter.getWeaponList()) {
+        	// respect restriction on manual AMS firing.
+        	if(!game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS) &&
+        			weapon.getType().hasFlag(WeaponType.F_AMS)) {
+        		continue;
+        	}
+        	
             final WeaponFireInfo shoot = buildWeaponFireInfo(shooter,
                                                              shooterState,
                                                              target,
@@ -1628,20 +1634,6 @@ public class FireControl {
                                                              weapon,
                                                              game,
                                                              true);
-
-            // If zero move infantry unit that moved, don't include any weapons
-            if ((shooter instanceof Infantry)
-                && (0 == shooter.getWalkMP())
-                && !(EntityMovementType.MOVE_NONE == shooterState.getMovementType())) {
-                continue;
-            }
-
-            //If infantry field gun unit that moved, don't include field guns
-            if ((shooter instanceof Infantry)
-                && !(EntityMovementType.MOVE_NONE == shooterState.getMovementType())
-                && (Infantry.LOC_FIELD_GUNS == shoot.getWeapon().getLocation())) {
-                continue;
-            }
 
             if (0 < shoot.getProbabilityToHit()) {
                 myPlan.add(shoot);
@@ -1843,6 +1835,13 @@ public class FireControl {
 
         // cycle through my weapons
         for (final Mounted weapon : shooter.getWeaponList()) {
+        	// respect restriction on manual AMS firing.
+        	if(!game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS) &&
+        			weapon.getType().hasFlag(WeaponType.F_AMS)) {
+        		continue;
+        	}
+        	
+        	
             final double toHitThreshold = ammoConservation.get(weapon);
             final WeaponFireInfo shoot = buildWeaponFireInfo(shooter, target, weapon, game, false);
             if ((shoot.getProbabilityToHit() > toHitThreshold)) {
@@ -1871,6 +1870,10 @@ public class FireControl {
         return myPlan;
     }
 
+    protected void goToRapidFire(WeaponFireInfo shoot) {
+    	
+    }
+    
     protected int calcHeatTolerance(final Entity entity,
                                   @Nullable Boolean isAero) {
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1869,10 +1869,6 @@ public class FireControl {
         
         return myPlan;
     }
-
-    protected void goToRapidFire(WeaponFireInfo shoot) {
-    	
-    }
     
     protected int calcHeatTolerance(final Entity entity,
                                   @Nullable Boolean isAero) {

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -608,11 +608,16 @@ public class Princess extends BotClient {
     
                     // Add expected damage from the chosen FiringPlan to the 
                     // damageMap for the target enemy.
+                    // while we're looping through all the shots anyway, send any firing mode changes
                     for(WeaponFireInfo shot : plan) {
                         Integer targetId = shot.getTarget().getTargetId();
                         double existingTargetDamage = damageMap.getOrDefault(targetId, 0.0);
                         double newDamage = existingTargetDamage + shot.getExpectedDamage();
                         damageMap.put(targetId, newDamage);
+                        
+                        if(shot.getUpdatedFiringMode() != null) {
+                        	super.sendModeChange(shooter.getId(), shooter.getEquipmentNum(shot.getWeapon()), shot.getUpdatedFiringMode());
+                        }
                     }
     
                     // tell the game I want to fire

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -91,6 +91,7 @@ public class Princess extends BotClient {
     private PathRankerState pathRankerState;
     private ArtilleryTargetingControl atc;
     
+    private Integer spinupThreshold = null;
     
     private BehaviorSettings behaviorSettings;
     private double moveEvaluationTimeEstimate = 0;
@@ -274,6 +275,8 @@ public class Princess extends BotClient {
                                        Integer.parseInt(y) - 1);
             getStrategicBuildingTargets().add(coords);
         }
+        
+        spinupThreshold = null;
     }
 
     /**
@@ -1795,6 +1798,24 @@ public class Princess extends BotClient {
 
     IHonorUtil getHonorUtil() {
         return honorUtil;
+    }
+    
+    /**
+     * Lazy-loaded calculation of the "to-hit target number" threshold for
+     * spinning up a rapid fire autocannon.
+     */
+    public int getSpinupThreshold() {
+        if(spinupThreshold == null) {
+    	// we start spinning up the cannon at 11+ TN at highest aggression levels
+        // dropping it down to 6+ TN at the lower aggression levels
+        	spinupThreshold = Math.min(11, Math.max(getBehaviorSettings().getHyperAggressionIndex() + 2, 6));
+        }
+        
+        return spinupThreshold;
+    }
+    
+    public void resetSpinupThreshold() {
+    	spinupThreshold = null;
     }
 
     @Override

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -545,7 +545,7 @@ public class WeaponFireInfo {
             // now that we've calculated hit odds, if we're shooting
             // a weapon capable of rapid fire, it's time to decide whether we're going to spin it up
             String currentFireMode = getWeapon().curMode().getName();
-            int spinMode = Compute.spinUpCannon(getGame(), getAction(), owner.getBehaviorSettings().getHyperAggressionIndex() + 2);
+            int spinMode = Compute.spinUpCannon(getGame(), getAction(), owner.getSpinupThreshold());
             if(!currentFireMode.equals(getWeapon().curMode().getName())) {
             	setUpdatedFiringMode(spinMode);
             }

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -63,6 +63,7 @@ public class WeaponFireInfo {
     private IGame game;
     private EntityState shooterState = null;
     private EntityState targetState = null;
+    private Integer updatedFiringMode = null;
     private final Princess owner;
 
     /**
@@ -489,7 +490,7 @@ public class WeaponFireInfo {
      * @param shooterPath The path the attacker has moved.
      * @param assumeUnderFlightPath If TRUE, aero units will not check to make sure the target is under their flight
      *                              path.
-     * @param guess Set TRUE to esitmate the chance to hit rather than doing the full calculation.
+     * @param guess Set TRUE to estimate the chance to hit rather than doing the full calculation.
      */
     void initDamage(@Nullable final MovePath shooterPath,
                     final boolean assumeUnderFlightPath,
@@ -522,6 +523,8 @@ public class WeaponFireInfo {
 
             // If we can't hit, set everything zero and return..
             if (12 < getToHit().getValue()) {
+            	// todo: if weapon capable of indirect fire, switch mode to indirect and try again
+            	
                 owner.log(getClass(), METHOD_NAME, LogLevel.DEBUG, msg.append("\n\tImpossible toHit: ")
                                                                       .append(getToHit().getValue()).toString());
                 setProbabilityToHit(0);
@@ -532,13 +535,21 @@ public class WeaponFireInfo {
                 setExpectedDamageOnHit(0);
                 return;
             }
-
+            
             if (getShooterState().hasNaturalAptGun()) {
                 msg.append("\n\tAttacker has Natural Aptitude Gunnery");
             }
             setProbabilityToHit(Compute.oddsAbove(getToHit().getValue(), getShooterState().hasNaturalAptGun()) / 100);
             msg.append("\n\tHit Chance: ").append(LOG_PER.format(getProbabilityToHit()));
 
+            // now that we've calculated hit odds, if we're shooting
+            // a weapon capable of rapid fire, it's time to decide whether we're going to spin it up
+            String currentFireMode = getWeapon().curMode().getName();
+            int spinMode = Compute.spinUpCannon(getGame(), getAction(), owner.getBehaviorSettings().getHyperAggressionIndex() + 2);
+            if(!currentFireMode.equals(getWeapon().curMode().getName())) {
+            	setUpdatedFiringMode(spinMode);
+            }
+            
             setHeat(computeHeat(weapon));
             msg.append("\n\tHeat: ").append(getHeat());
 
@@ -647,5 +658,17 @@ public class WeaponFireInfo {
                 + ", Num Crits: " + LOG_DEC.format(getExpectedCriticals())
                 + ", Kill Prob: " + LOG_PER.format(getKillProbability());
 
+    }
+
+    /**
+     * The updated firing mode, if any of the weapon involved in this attack.
+     * Null if no update required.
+     */
+    public Integer getUpdatedFiringMode() {
+    	return updatedFiringMode;
+    }
+    
+    public void setUpdatedFiringMode(int mode) {
+    	updatedFiringMode = mode;
     }
 }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -3614,7 +3614,7 @@ public class Compute {
      * @return the <code>int</code> ID of weapon mode
      */
     public static int spinUpCannon(IGame cgame, WeaponAttackAction atk) {
-    	return spinUpCannon(cgame, atk, Compute.d6(2));
+    	return spinUpCannon(cgame, atk, Compute.d6(2) - 1);
     }
     
     /**
@@ -3627,12 +3627,13 @@ public class Compute {
     public static int spinUpCannon(IGame cgame, WeaponAttackAction atk, int spinupThreshold) {
 
         int threshold = 12;
-        int test, final_spin;
+        int final_spin;
         Entity shooter;
         Mounted weapon;
         WeaponType wtype = new WeaponType();
 
         // Double check this is an Ultra or Rotary cannon
+        // or a standard AC with the TacOps rapid fire rule turned on
         shooter = atk.getEntity(cgame);
         weapon = shooter.getEquipment(atk.getWeaponId());
         wtype = (WeaponType) shooter.getEquipment(atk.getWeaponId()).getType();
@@ -3660,11 +3661,8 @@ public class Compute {
             return final_spin;
         }
 
-        // Set a random 2d6 roll
-        test = spinupThreshold;
-
         // If random roll is >= to-hit + 1, then set double-spin
-        if (test >= (threshold + 1)) {
+        if (spinupThreshold >= threshold) {
             final_spin = 1;
             if ((wtype.getAmmoType() == AmmoType.T_AC_ULTRA)
                 || (wtype.getAmmoType() == AmmoType.T_AC_ULTRA_THB)) {
@@ -3680,13 +3678,13 @@ public class Compute {
         if (wtype.getAmmoType() == AmmoType.T_AC_ROTARY) {
 
             // If random roll is >= to-hit + 2 then set to quad-spin
-            if (test >= (threshold + 2)) {
+            if (spinupThreshold >= (threshold + 1)) {
                 final_spin = 2;
                 weapon.setMode(Weapon.Mode_RAC_FourShot);
             }
 
             // If random roll is >= to-hit + 3 then set to six-spin
-            if (test >= (threshold + 3)) {
+            if (spinupThreshold >= (threshold + 2)) {
                 final_spin = 3;
                 weapon.setMode(Weapon.Mode_RAC_SixShot);
             }

--- a/megamek/src/megamek/common/weapons/RACHandler.java
+++ b/megamek/src/megamek/common/weapons/RACHandler.java
@@ -99,17 +99,17 @@ public class RACHandler extends UltraWeaponHandler {
         int actualShots;
         setDone();
         checkAmmo();
-        if (weapon.curMode().equals("6-shot")) {
+        if (weapon.curMode().equals(Weapon.Mode_RAC_SixShot)) {
             howManyShots = 6;
-        } else if (weapon.curMode().equals("5-shot")) {
+        } else if (weapon.curMode().equals(Weapon.Mode_RAC_FiveShot)) {
             howManyShots = 5;
-        } else if (weapon.curMode().equals("4-shot")) {
+        } else if (weapon.curMode().equals(Weapon.Mode_RAC_FourShot)) {
             howManyShots = 4;
-        } else if (weapon.curMode().equals("3-shot")) {
+        } else if (weapon.curMode().equals(Weapon.Mode_RAC_ThreeShot)) {
             howManyShots = 3;
-        } else if (weapon.curMode().equals("2-shot")) {
+        } else if (weapon.curMode().equals(Weapon.Mode_RAC_TwoShot)) {
             howManyShots = 2;
-        } else if (weapon.curMode().equals("Single")) {
+        } else if (weapon.curMode().equals(Weapon.Mode_AC_Single)) {
             howManyShots = 1;
         }
         int total = ae.getTotalAmmoOfType(ammo.getType());

--- a/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
@@ -70,7 +70,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
         setDone();
         checkAmmo();
         int total = ae.getTotalAmmoOfType(ammo.getType());
-        if ((total > 1) && !weapon.curMode().equals("Single")) {
+        if ((total > 1) && !weapon.curMode().equals(Weapon.Mode_AC_Single)) {
             howManyShots = 2;
         } else {
             howManyShots = 1;

--- a/megamek/src/megamek/common/weapons/Weapon.java
+++ b/megamek/src/megamek/common/weapons/Weapon.java
@@ -71,6 +71,15 @@ public abstract class Weapon extends WeaponType implements Serializable {
     public static final String Mode_CapMissile_Bearing_Med = "Bearings-Only Medium Detection Range";
     public static final String Mode_CapMissile_Bearing_Short = "Bearings-Only Short Detection Range";
     
+    public static final String Mode_AC_Rapid = "Rapid";
+    public static final String Mode_AC_Single = "Single";
+    public static final String Mode_UAC_Ultra = "Ultra";
+    public static final String Mode_RAC_TwoShot = "2-Shot";
+    public static final String Mode_RAC_ThreeShot = "3-Shot";
+    public static final String Mode_RAC_FourShot = "4-Shot";
+    public static final String Mode_RAC_FiveShot = "5-Shot";
+    public static final String Mode_RAC_SixShot = "6-Shot";
+    
     public static final String Mode_CapMissile_Tele_Operated = "Tele-Operated";
     
     public static final String Mode_Normal = "Normal";

--- a/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
@@ -35,6 +35,7 @@ import megamek.common.weapons.ACWeaponHandler;
 import megamek.common.weapons.AmmoWeapon;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.RapidfireACWeaponHandler;
+import megamek.common.weapons.Weapon;
 import megamek.server.Server;
 
 /**
@@ -147,10 +148,10 @@ public abstract class ACWeapon extends AmmoWeapon {
         // Modes for allowing standard and light AC rapid fire
         if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RAPID_AC)) {
             addMode("");
-            addMode("Rapid");
+            addMode(Weapon.Mode_AC_Rapid);
         } else {
             removeMode("");
-            removeMode("Rapid");
+            removeMode(Weapon.Mode_AC_Rapid);
         }
     }
     

--- a/megamek/src/megamek/common/weapons/autocannons/RACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/RACWeapon.java
@@ -26,6 +26,7 @@ import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.RACHandler;
 import megamek.common.weapons.UltraWeaponHandler;
+import megamek.common.weapons.Weapon;
 import megamek.server.Server;
 
 /**
@@ -41,8 +42,8 @@ public abstract class RACWeapon extends UACWeapon {
     public RACWeapon() {
         super();
         ammoType = AmmoType.T_AC_ROTARY;
-        String[] modeStrings = { "Single", "2-shot", "3-shot", "4-shot",
-                "5-shot", "6-shot" };
+        String[] modeStrings = { Mode_AC_Single, Mode_RAC_TwoShot, Mode_RAC_ThreeShot, 
+        		Mode_RAC_FourShot, Mode_RAC_FiveShot, Mode_RAC_SixShot };
         setModes(modeStrings);
         // explosive when jammed
         explosive = true;
@@ -63,10 +64,10 @@ public abstract class RACWeapon extends UACWeapon {
             WeaponAttackAction waa, IGame game, Server server) {
         Mounted weapon = game.getEntity(waa.getEntityId()).getEquipment(
                 waa.getWeaponId());
-        if (weapon.curMode().equals("6-shot")
-                || weapon.curMode().equals("5-shot")
-                || weapon.curMode().equals("4-shot")
-                || weapon.curMode().equals("3-shot")) {
+        if (weapon.curMode().equals(Mode_RAC_SixShot)
+                || weapon.curMode().equals(Mode_RAC_FiveShot)
+                || weapon.curMode().equals(Mode_RAC_FourShot)
+                || weapon.curMode().equals(Mode_RAC_ThreeShot)) {
             return new RACHandler(toHit, waa, game, server);
         } else {
             return new UltraWeaponHandler(toHit, waa, game, server);

--- a/megamek/src/megamek/common/weapons/autocannons/UACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/UACWeapon.java
@@ -44,7 +44,7 @@ public abstract class UACWeapon extends AmmoWeapon {
         flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON).or(F_PROTO_WEAPON)
                 .or(F_BALLISTIC).or(F_DIRECT_FIRE);
         ammoType = AmmoType.T_AC_ULTRA;
-        String[] modeStrings = { "Single", "Ultra" };
+        String[] modeStrings = { Mode_AC_Single, Mode_UAC_Ultra };
         setModes(modeStrings);
         atClass = CLASS_AC;
     }


### PR DESCRIPTION
This PR gives Princess the ability to spin up her rapid-fire autocannons, pegged to a threshold determined by the aggression setting. 10 will spin it up on an 11+, while 4 and below will spin up on a 6+.