### PR TITLE
technically enable indirect LRM fire

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -69,6 +69,7 @@ import megamek.common.logging.LogLevel;
 import megamek.common.options.OptionsConstants;
 import megamek.common.pathfinder.AeroGroundPathFinder;
 import megamek.common.weapons.StopSwarmAttack;
+import megamek.common.weapons.Weapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.common.weapons.missiles.ATMWeapon;
 import megamek.common.weapons.missiles.MMLWeapon;
@@ -2249,6 +2250,15 @@ public class FireControl {
                                                         final FireControlState fireControlState) {
         final List<Targetable> targetableEnemyList = new ArrayList<>();
 
+        boolean shooterHasIDF = false;
+
+        for(Mounted weapon : shooter.getWeaponList()) {
+        	if(weapon.getType().hasModeType(Weapon.Mode_Missile_Indirect)) {
+        		shooterHasIDF = true;
+        		break;
+        	}
+        }
+        
         // Go through every unit in the game.
         for (final Entity entity : game.getEntitiesVector()) {
 
@@ -2261,7 +2271,9 @@ public class FireControl {
 
                 final LosEffects effects =
                         LosEffects.calculateLos(game, shooter.getId(), entity);
-                if (effects.canSee()) {
+                
+                // if we're in LOS or we have IDF capability
+                if (effects.canSee() || shooterHasIDF) {
                     targetableEnemyList.add(entity);
                 }
             }

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -35,6 +35,7 @@ import megamek.common.actions.WeaponAttackAction;
 import megamek.common.annotations.Nullable;
 import megamek.common.logging.LogLevel;
 import megamek.common.options.OptionsConstants;
+import megamek.common.weapons.Weapon;
 
 /**
  * WeaponFireInfo is a wrapper around a WeaponAttackAction that includes
@@ -523,7 +524,18 @@ public class WeaponFireInfo {
 
             // If we can't hit, set everything zero and return..
             if (12 < getToHit().getValue()) {
-            	// todo: if weapon capable of indirect fire, switch mode to indirect and try again
+            	// if we are able to switch the weapon to indirect fire mode, do so and try again
+            	if(!getWeapon().curMode().equals(Weapon.Mode_Missile_Indirect)) {
+	            	int indirectMode = getWeapon().setMode(Weapon.Mode_Missile_Indirect);
+            	
+	            	// this will be the case if the weapon is able to switch to indirect fire mode
+	            	if(indirectMode > -1) {
+	            		setUpdatedFiringMode(indirectMode);
+	            		initDamage(shooterPath, assumeUnderFlightPath, guess, bombPayload);
+	            		getWeapon().setMode(""); // make sure to reset the weapon firing mode
+	            		return;
+	            	}
+            	}
             	
                 owner.log(getClass(), METHOD_NAME, LogLevel.DEBUG, msg.append("\n\tImpossible toHit: ")
                                                                       .append(getToHit().getValue()).toString());

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -470,6 +470,25 @@ public class EquipmentType implements ITechnology {
     public boolean hasModes() {
         return (modes != null) && (!modes.isEmpty());
     }
+    
+    /**
+     * Simple way to check if a piece of equipment has a specific usage/firing mode
+     * @param modeType The name of the mode to check.
+     * @return True or false.
+     */
+    public boolean hasModeType(String modeType) {
+    	if(!hasModes()) {
+    		return false;
+    	}
+    	
+    	for(EquipmentMode mode : modes) {
+    		if(mode.getName().equals(modeType)) {
+    			return true;
+    		}
+    	}
+    	
+    	return false;
+    }
 
     /**
      * @return the number of modes that this type of equipment can be in or

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -267,7 +267,7 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
     public EquipmentType getType() {
         return (null != type) ? type : (type = EquipmentType.get(typeName));
     }
-
+    
     /**
      * @return the current mode of the equipment, or <code>null</code> if it's
      *         not available.

--- a/megamek/src/megamek/common/weapons/Weapon.java
+++ b/megamek/src/megamek/common/weapons/Weapon.java
@@ -80,6 +80,8 @@ public abstract class Weapon extends WeaponType implements Serializable {
     public static final String Mode_RAC_FiveShot = "5-Shot";
     public static final String Mode_RAC_SixShot = "6-Shot";
     
+    public static final String Mode_Missile_Indirect = "Indirect";
+    
     public static final String Mode_CapMissile_Tele_Operated = "Tele-Operated";
     
     public static final String Mode_Normal = "Normal";


### PR DESCRIPTION
Enabling the bot to use indirect fire was surprisingly easy, although the actual likelyhood of IDF occuring is pretty minimal - the only way the bot can currently spot is via the use of TAG, and the chances of something getting TAGged and having an IDF-capable unit facing the right way and being out of LOS and in range are pretty minimal, as there's no such coordination.

I'll investigate the possibility of spotting and spreading out TAG designations in another PR.