### PR TITLE
fix npe when multi-target unit has no viable targets

### DIFF
--- a/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
@@ -283,8 +283,11 @@ public class MultiTargetFireControl extends FireControl {
         }
         
         // now, we look at the bottom right cell, which contains our optimal firing solution
-        for(int arc : arcBackpack.get(arcBackpack.size() - 1).get(shooter.getHeatCapacity() - 1)) {
-            retVal.addAll(arcShots.get(arc));
+        // unless there is no firing solution at all, in which case we skip this part
+        if(arcBackpack.size() > 0) {
+            for(int arc : arcBackpack.get(arcBackpack.size() - 1).get(shooter.getHeatCapacity() - 1)) {
+                retVal.addAll(arcShots.get(arc));
+            }
         }
         
         return retVal;


### PR DESCRIPTION
Fixes a bug introduced for units that use the multi-target fire control logic which would cause the bot to NPE when attempting to do a firing phase for a unit with no viable targets.