### PR TITLE
Shrink save game sizes by using XStream's ID_REFERENCES

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1395,6 +1395,12 @@ public class Server implements Runnable {
             sFile = sFile.replace(".gz", "");
         }
         XStream xstream = new XStream();
+
+        // This will make save games much smaller
+        // by using a more efficient means of referencing
+        // objects in the XML graph
+        xstream.setMode(XStream.ID_REFERENCES);
+
         String sFinalFile = sFile;
         if (!sFinalFile.endsWith(".sav")) {
             sFinalFile = sFile + ".sav";
@@ -1479,6 +1485,10 @@ public class Server implements Runnable {
         IGame newGame;
         try(InputStream is = new GZIPInputStream(new FileInputStream(f))) {
             XStream xstream = new XStream();
+
+            // This mirrors the settings is saveGame
+            xstream.setMode(XStream.ID_REFERENCES);
+
             xstream.registerConverter(new Converter() {
                 @SuppressWarnings("rawtypes")
                 @Override


### PR DESCRIPTION
Currently MegaMek uses XStream's default means of serializing object graphs, which uses relative XPath references. During testing of larger aerospace games this resulted in a fair amount of save game bloat, and many object references were duplicated rather than being coalesced. This switches to using `ID_REFERENCES` which results in a cleaner, smaller XML file for save games. It also makes diffing save games much cleaner.