### PR TITLE
Space Sensors Improvements

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4092,7 +4092,7 @@ public class Compute {
                 && target.getTargetType() == Targetable.TYPE_ENTITY
                 && game.getBoard().inSpace()) {
             Entity te = (Entity) target;
-            return hasAnyFiringSolution(game, te);
+            return hasAnyFiringSolution(game, te.getId());
         }
         boolean teIlluminated = false;
         if (target.getTargetType() == Targetable.TYPE_ENTITY) {
@@ -4172,12 +4172,12 @@ public class Compute {
      * Used for sensor return icons on board
      *
      * @param game - the current game
-     * @param target - the target we're looking for
+     * @param targetId - the ID# of the target entity we're looking for
      */
-    public static boolean isSensorContact(IGame game, Entity target) {
+    public static boolean isAnySensorContact(IGame game, int targetId) {
         for (Entity detector : game.getEntitiesVector()) {
-            if (detector.sensorContacts.contains(target)) {
-                target.addBeenDetectedBy(detector.getOwner());
+            if (detector.hasSensorContactFor(targetId)) {
+                game.getEntity(targetId).addBeenDetectedBy(detector.getOwner());
                 return true;
             }
         }
@@ -4187,15 +4187,11 @@ public class Compute {
     /**
      * Checks to see if target entity has already appeared on @detector's sensors
      * Used with Naval C3 to determine if @detector can fire weapons at @target
-     *
-     * @param game - the current game
      * @param detector - the entity making a sensor scan
+     * @param targetId - the entity id of the scan target
      */
-    public static boolean hasSensorContact(IGame game, Entity detector, Entity target) {
-        if (detector.sensorContacts.contains(target)) {
-            return true;
-        }
-        return false;
+    public static boolean hasSensorContact(Entity detector, int targetId) {
+        return detector.hasSensorContactFor(targetId);
     }
 
     /**
@@ -4203,28 +4199,14 @@ public class Compute {
      * Used for visibility
      *
      * @param game - the current game
-     * @param target - the target we're firing at
+     * @param targetId - the ID # of the target we're firing at
      */
-    public static boolean hasAnyFiringSolution(IGame game, Entity target) {
+    public static boolean hasAnyFiringSolution(IGame game, int targetId) {
         for (Entity detector : game.getEntitiesVector()) {
-            if (detector.firingSolutions.contains(target)) {
-                target.addBeenSeenBy(detector.getOwner());
+            if (detector.hasFiringSolutionFor(targetId)) {
+                game.getEntity(targetId).addBeenSeenBy(detector.getOwner());
                 return true;
             }
-        }
-        return false;
-    }
-
-    /**
-     * Checks to see if target entity has already had a firing solution established by @detector
-     * Used to determine if @detector can fire weapons at @target
-     *
-     * @param game - the current game
-     * @param detector - the entity making a sensor scan
-     */
-    public static boolean hasFiringSolution(IGame game, Entity detector, Entity target) {
-        if (detector.firingSolutions.contains(target)) {
-            return true;
         }
         return false;
     }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4272,18 +4272,24 @@ public class Compute {
     }
 
     /**
-     * Checks to see if an entity has passed out of range of a previously established firing solution
+     * Updates an entity's firingSolutions, removing any objects that no longer meet criteria for being
+     * tracked as targets. Also, if the detecting entity no longer meets criteria for having firing solutions,
+     * empty the list. We wouldn't want a dead ship to be providing NC3 data, now would we...
      */
-    public static void removeFiringSolution(Entity detector) {
-        Vector<Entity> toRemove = new Vector<Entity>();
-        //If the detector is dead, has no position, or has flown offboard, remove everything
+    public static void updateFiringSolutions(IGame game, Entity detector) {
+        List<Integer> toRemove = new ArrayList<Integer>();
+        //Flush the detecting unit's firing solutions if any of these conditions applies
         if (detector.isDestroyed()
+                || detector.isDoomed()
+                || detector.getTransportId() != Entity.NONE
+                || detector.isPartOfFighterSquadron()
                 || detector.isOffBoard()
                 || detector.getPosition() == null) {
-            detector.firingSolutions.removeAllElements();
+            detector.clearFiringSolutions();
             return;
         }
-        for (Entity target : detector.firingSolutions) {
+        for (int id : detector.getSensorContacts()) {
+            Entity target = game.getEntity(id);
             //If the target is dead, has no position or has flown offboard, remove it
             if (target.isDestroyed()
                     || target.isOffBoard()
@@ -4315,8 +4321,8 @@ public class Compute {
             }
         }
         if (toRemove.size() >= 1) {
-            for (Entity e : toRemove) {
-                detector.firingSolutions.remove(e);
+            for (int entId : toRemove) {
+                detector.removeFiringSolution(entId);
             }
         }
     }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4176,7 +4176,7 @@ public class Compute {
      */
     public static boolean isAnySensorContact(IGame game, int targetId) {
         for (Entity detector : game.getEntitiesVector()) {
-            if (detector.hasSensorContactFor(targetId)) {
+            if (detector.hasSensorContactFor(targetId) && game.getEntity(targetId) != null) {
                 game.getEntity(targetId).addBeenDetectedBy(detector.getOwner());
                 return true;
             }
@@ -4203,7 +4203,7 @@ public class Compute {
      */
     public static boolean hasAnyFiringSolution(IGame game, int targetId) {
         for (Entity detector : game.getEntitiesVector()) {
-            if (detector.hasFiringSolutionFor(targetId)) {
+            if (detector.hasFiringSolutionFor(targetId) && game.getEntity(targetId) != null) {
                 game.getEntity(targetId).addBeenSeenBy(detector.getOwner());
                 return true;
             }
@@ -4291,12 +4291,13 @@ public class Compute {
         for (int id : detector.getFiringSolutions()) {
             Entity target = game.getEntity(id);
             //The target should be removed if it's off the board for any of these reasons
-            if (target.isDestroyed()
+            if (target == null
+                    || target.getPosition() == null
+                    || target.isDestroyed()
                     || target.isDoomed()
                     || target.getTransportId() != Entity.NONE
                     || target.isPartOfFighterSquadron()
-                    || target.isOffBoard()
-                    || target.getPosition() == null) {
+                    || target.isOffBoard()) {
                 toRemove.add(id);
                 continue;
             }
@@ -4320,11 +4321,7 @@ public class Compute {
                 }
             }
         }
-        if (toRemove.size() >= 1) {
-            for (int entId : toRemove) {
-                detector.removeFiringSolution(entId);
-            }
-        }
+        detector.removeFiringSolution(toRemove);
     }
 
     /**
@@ -4335,24 +4332,25 @@ public class Compute {
     public static void updateSensorContacts(IGame game, Entity detector) {
         List<Integer> toRemove = new ArrayList<Integer>();
         //Flush the detecting unit's sensor contacts if any of these conditions applies
-        if (detector.isDestroyed()
+        if (detector.getPosition() == null
+                || detector.isDestroyed()
                 || detector.isDoomed()
                 || detector.getTransportId() != Entity.NONE
                 || detector.isPartOfFighterSquadron()
-                || detector.isOffBoard()
-                || detector.getPosition() == null) {
+                || detector.isOffBoard()) {
             detector.clearSensorContacts();
             return;
         }
         for (int id : detector.getSensorContacts()) {
             Entity target = game.getEntity(id);
             //The target should be removed if it's off the board for any of these reasons
-            if (target.isDestroyed()
+            if (target == null
+                    || target.getPosition() == null
+                    || target.isDestroyed()
                     || target.isDoomed()
                     || target.getTransportId() != Entity.NONE
                     || target.isPartOfFighterSquadron()
-                    || target.isOffBoard()
-                    || target.getPosition() == null) {
+                    || target.isOffBoard()) {
                 toRemove.add(id);
                 continue;
             }
@@ -4364,11 +4362,7 @@ public class Compute {
                 toRemove.add(id);
             }
         }
-        if (toRemove.size() >= 1) {
-            for (int entId : toRemove) {
-                detector.removeSensorContact(entId);
-            }
-        }
+        detector.removeSensorContact(toRemove);
     }
 
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4420,6 +4420,10 @@ public class Compute {
             outOfVisualRange = Sensor.ASF_RADAR_MAX_RANGE;
             rangeIncrement = Sensor.ASF_RADAR_AUTOSPOT_RANGE;
         }
+        
+        if (distance > outOfVisualRange) {
+            return false;
+        }
 
         if (ae instanceof Aero) {
             Aero aero = (Aero) ae;
@@ -4431,26 +4435,19 @@ public class Compute {
             }
         }
 
-        //If using active radar, targets at 1/10 max range are automatically detected
+        //Targets at 1/10 max range are automatically detected
         if (ae.getActiveSensor().getType() == Sensor.TYPE_AERO_SENSOR) {
             autoVisualRange = Sensor.ASF_RADAR_AUTOSPOT_RANGE;
         } else if (ae.getActiveSensor().getType() == Sensor.TYPE_SPACECRAFT_RADAR) {
             autoVisualRange = Sensor.LC_RADAR_AUTOSPOT_RANGE;
-        }
-
-        //If using thermal/optical sensors, we can only establish a firing solution at 1/10 max range
-        if (ae.getActiveSensor().getType() == Sensor.TYPE_AERO_THERMAL) {
-            outOfVisualRange = Sensor.ASF_OPTICAL_FIRING_SOLUTION_RANGE;
+        } else if (ae.getActiveSensor().getType() == Sensor.TYPE_AERO_THERMAL) {
+            autoVisualRange = Sensor.ASF_OPTICAL_FIRING_SOLUTION_RANGE;
         } else if (ae.getActiveSensor().getType() == Sensor.TYPE_SPACECRAFT_THERMAL) {
-            outOfVisualRange = Sensor.LC_OPTICAL_FIRING_SOLUTION_RANGE;
+            autoVisualRange = Sensor.LC_OPTICAL_FIRING_SOLUTION_RANGE;
         }
 
         if (distance <= autoVisualRange) {
             return true;
-        }
-
-        if (distance > outOfVisualRange) {
-            return false;
         }
 
         //Apply Sensor Geek SPA, if present

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4288,7 +4288,7 @@ public class Compute {
             detector.clearFiringSolutions();
             return;
         }
-        for (int id : detector.getSensorContacts()) {
+        for (int id : detector.getFiringSolutions()) {
             Entity target = game.getEntity(id);
             //The target should be removed if it's off the board for any of these reasons
             if (target.isDestroyed()
@@ -4332,7 +4332,7 @@ public class Compute {
      * tracked. Also, if the detecting entity no longer meets criteria for having sensor contacts,
      * empty the list. We wouldn't want a dead ship to be providing sensor data, now would we...
      */
-    public static void removeSensorContact(IGame game, Entity detector) {
+    public static void updateSensorContacts(IGame game, Entity detector) {
         List<Integer> toRemove = new ArrayList<Integer>();
         //Flush the detecting unit's sensor contacts if any of these conditions applies
         if (detector.isDestroyed()

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15567,5 +15567,90 @@ public abstract class Entity extends TurnOrdered implements Transporter,
 
         return 1;
     }
-
+    
+    
+    //Getters and setters for sensor contacts and firing solutions. Currently only used in space combat
+    /**
+     * Retrieves the IDs of all entities that this entity has detected with sensors
+     * @return the contents of this entity's sensorContacts set
+     */
+    public Set<Integer> getSensorContacts() {
+        return sensorContacts;
+    }
+    
+    /**
+     * Checks the sensorContacts set for a specific target's ID number
+     * @param targetId the ID number of the target entity to check for
+     * @return true if the entity's sensorContacts set contains the passed-in target ID
+     */
+    public boolean isSensorContact(int targetId) {
+        return sensorContacts.contains(targetId);
+    }
+    
+    /**
+     * Adds the specified target entity's ID to this entity's sensorContacts
+     * @param targetId the ID number of the target entity to add
+     */
+    public void addSensorContact(int targetId) {
+        sensorContacts.add(targetId);
+    }
+    
+    /**
+     * Removes the specified target entity's ID from this entity's sensorContacts
+     * @param targetId the ID number of the target entity to remove
+     */
+    public void removeSensorContact(int targetId) {
+        sensorContacts.remove(targetId);
+    }
+    
+    /**
+     * Empties this entity's sensorContacts
+     * Used when it dies or moves offboard
+     * @param targetId the ID number of the target entity to remove
+     */
+    public void clearSensorContacts() {
+        sensorContacts.clear();
+    }
+    
+    /**
+     * Retrieves the IDs of all entities that this entity has established firing solutions on
+     * @return the contents of this entity's firingSolutions set
+     */
+    public Set<Integer> getFiringSolutions() {
+        return firingSolutions;
+    }
+    
+    /**
+     * Checks the firingSolutions set for a specific target's ID number
+     * @param targetId the ID number of the target entity to check for
+     * @return true if the entity's firingSolutions set contains the passed-in target ID
+     */
+    public boolean isFiringSolution(int targetId) {
+        return firingSolutions.contains(targetId);
+    }
+    
+    /**
+     * Adds the specified target entity's ID to this entity's firingSolutions
+     * @param targetId the ID number of the target entity to add
+     */
+    public void addFiringSolution(int targetId) {
+        firingSolutions.add(targetId);
+    }
+    
+    /**
+     * Removes the specified target entity's ID from this entity's firingSolutions
+     * @param targetId the ID number of the target entity to remove
+     */
+    public void removeFiringSolution(int targetId) {
+        firingSolutions.remove(targetId);
+    }
+    
+    /**
+     * Empties this entity's firingSolutions
+     * Used when it dies or moves offboard
+     * @param targetId the ID number of the target entity to remove
+     */
+    public void clearFiringSolutions() {
+        firingSolutions.clear();
+    }
 }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15597,10 +15597,10 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     
     /**
      * Removes the specified target entity's ID from this entity's sensorContacts
-     * @param targetId the ID number of the target entity to remove
+     * @param targetIds the ID number of the target entity to remove
      */
-    public void removeSensorContact(int targetId) {
-        sensorContacts.remove(targetId);
+    public void removeSensorContact(Collection<Integer> targetIds) {
+        sensorContacts.removeAll(targetIds);
     }
     
     /**
@@ -15638,10 +15638,10 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     
     /**
      * Removes the specified target entity's ID from this entity's firingSolutions
-     * @param targetId the ID number of the target entity to remove
+     * @param targetIds the ID number of the target entity to remove
      */
-    public void removeFiringSolution(int targetId) {
-        firingSolutions.remove(targetId);
+    public void removeFiringSolution(Collection<Integer> targetIds) {
+        firingSolutions.removeAll(targetIds);
     }
     
     /**

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15583,7 +15583,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * @param targetId the ID number of the target entity to check for
      * @return true if the entity's sensorContacts set contains the passed-in target ID
      */
-    public boolean isSensorContact(int targetId) {
+    public boolean hasSensorContactFor(int targetId) {
         return sensorContacts.contains(targetId);
     }
     
@@ -15625,7 +15625,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      * @param targetId the ID number of the target entity to check for
      * @return true if the entity's firingSolutions set contains the passed-in target ID
      */
-    public boolean isFiringSolution(int targetId) {
+    public boolean hasFiringSolutionFor(int targetId) {
         return firingSolutions.contains(targetId);
     }
     

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -628,20 +628,22 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     private Vector<IPlayer> entityDetectedBy = new Vector<IPlayer>();
 
     /**
-     * Contains all entities that have been detected by this entity's sensors.
+     * Contains the ids of all entities that have been detected by this entity's sensors.
      * Used for double-blind on space maps - SO p117
      *
-     * Entities need only be cleared from this when they move out of range
+     * Entities need only be cleared from this when they move out of range,
+     * are destroyed, or move off the board
      */
-    public Vector<Entity> sensorContacts = new Vector<Entity>();
+    public Set<Integer> sensorContacts = new HashSet<Integer>();
 
     /**
-     * Contains all entities that this entity has established a firing solution on.
+     * Contains the ids of all entities that this entity has established a firing solution on.
      * Used for double-blind on space maps - SO p117
      *
-     * Entities need only be cleared from this when they move out of range
+     * Entities need only be cleared from this when they move out of range,
+     * are destroyed, or move off the board
      */
-    public Vector<Entity> firingSolutions = new Vector<Entity>();
+    public Set<Integer> firingSolutions = new HashSet<Integer>();
 
     /**
      * Whether this entity is captured or not.

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15606,7 +15606,6 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     /**
      * Empties this entity's sensorContacts
      * Used when it dies or moves offboard
-     * @param targetId the ID number of the target entity to remove
      */
     public void clearSensorContacts() {
         sensorContacts.clear();
@@ -15648,7 +15647,6 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     /**
      * Empties this entity's firingSolutions
      * Used when it dies or moves offboard
-     * @param targetId the ID number of the target entity to remove
      */
     public void clearFiringSolutions() {
         firingSolutions.clear();

--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -214,7 +214,7 @@ public class FighterSquadron extends Aero implements IAero {
         }
         int vel = getCurrentVelocity();
         int vmod = vel - (2 * getWalkMP());
-        if (vmod > 0) {
+        if (!getGame().getBoard().inSpace() && (vmod > 0)) {
             prd.addModifier(vmod, "Velocity greater than 2x safe thrust");
         }
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3851,7 +3851,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             //Check to see if the attacker has a firing solution. Naval C3 networks share targeting data
             if (ae.hasNavalC3()) {
                 for (Entity en : game.getEntitiesVector()) {
-                    if (en != ae && !en.isEnemyOf(ae) && en.onSameC3NetworkAs(ae) && Compute.hasFiringSolution(game, en, te)) {
+                    if (en != ae && !en.isEnemyOf(ae) && en.onSameC3NetworkAs(ae) && ae.hasFiringSolutionFor(te.getId())) {
                         networkFiringSolution = true;
                         break;
                     }
@@ -3859,7 +3859,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             }
             if (!networkFiringSolution) {
                 //If we don't check for target type here, we can't fire screens and missiles at hexes...
-                if (!Compute.hasFiringSolution(game, ae, te) && target.getTargetType() == Targetable.TYPE_ENTITY) {
+                if (!ae.hasFiringSolutionFor(te.getId()) && target.getTargetType() == Targetable.TYPE_ENTITY) {
                     return Messages.getString("WeaponAttackAction.NoFiringSolution");
                 }
             }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -14799,9 +14799,10 @@ public class Server implements Runnable {
                     || detector.getTransportId() != Entity.NONE) {
                 continue;
             }
-            for (int targetId : detectedUnits) {
+            for (int targetId : detector.getSensorContacts()) {
+                Entity target = game.getEntity(targetId);
                 //if we already have a firing solution, no need to process a new one
-                if (detector.hasFiringSolutionFor(game, targetId)) {
+                if (detector.hasFiringSolutionFor(targetId)) {
                     continue;
                 }
                 //Don't process for invalid units
@@ -14821,7 +14822,7 @@ public class Server implements Runnable {
                 }
                 //If we successfully lock up the enemy, add it to the appropriate detector's firing solutions list
                 if (Compute.calcFiringSolution(game, detector, target)) {
-                    detector.firingSolutions.add(target);
+                    detector.addFiringSolution(targetId);
                 }
             }
         }
@@ -14839,8 +14840,8 @@ public class Server implements Runnable {
         }
         //Run through our list of units and remove any entities from the plotting board that have moved out of range
         for (Entity detector : game.getEntitiesVector()) {
-            Compute.removeFiringSolution(detector);
-            Compute.removeSensorContact(detector);
+            Compute.updateFiringSolutions(game, detector);
+            Compute.updateSensorContacts(game, detector);
         }
     }
 

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -14741,13 +14741,31 @@ public class Server implements Runnable {
 
         //Now, run the detection rolls
         for (Entity detector : game.getEntitiesVector()) {
+            //Don't process for invalid units
+            //in the case of squadrons and transports, we want the 'host'
+            //unit, not the component entities
+            if (detector.getPosition() == null
+                    || detector.isDestroyed()
+                    || detector.isDoomed()
+                    || detector.isOffBoard()
+                    || detector.isPartOfFighterSquadron()
+                    || detector.getTransportId() != Entity.NONE) {
+                continue;
+            }
             for (Entity target : game.getEntitiesVector()) {
                 //Once a target is detected, we don't need to detect it again
-                if (Compute.hasSensorContact(game, detector, target)) {
+                if (detector.hasSensorContactFor(target.getId())) {
                     continue;
                 }
-                //Don't process for units with no position
-                if ((detector.getPosition() == null) || (target.getPosition() == null)) {
+                //Don't process for invalid units
+                //in the case of squadrons and transports, we want the 'host'
+                //unit, not the component entities
+                if (target.getPosition() == null
+                        || target.isDestroyed()
+                        || target.isDoomed()
+                        || target.isOffBoard()
+                        || target.isPartOfFighterSquadron()
+                        || target.getTransportId() != Entity.NONE) {
                     continue;
                 }
                 // Only process for enemy units
@@ -14756,41 +14774,45 @@ public class Server implements Runnable {
                 }
                 //If we successfully detect the enemy, add it to the appropriate detector's sensor contacts list
                 if (Compute.calcSensorContact(game, detector, target)) {
-                    detector.sensorContacts.add(target);
+                    detector.addSensorContact(target.getId());
                     //If detector is part of a C3 network, share the contact
                     if (detector.hasNavalC3()) {
                         for (Entity c3NetMate : game.getEntitiesVector()) {
                             if (c3NetMate != detector && c3NetMate.onSameC3NetworkAs(detector)) {
-                                c3NetMate.sensorContacts.add(target);
+                                c3NetMate.addSensorContact(target.getId());
                             }
                         }
                     }
                 }
             }
         }
-
-        //Now, try to establish firing solutions on detected units
-        ArrayList<Entity> detectedUnits = new ArrayList<>();
-        for (Entity target : game.getEntitiesVector()) {
-            if (Compute.isSensorContact(game, target)) {
-                detectedUnits.add(target);
-            }
-        }
-
-        // If no one is detected, there's nothing more to do
-        if (detectedUnits.size() < 1) {
-            return;
-        }
-
-        //Now, run the detection rolls
+        //Now, run the firing solution calculations
         for (Entity detector : game.getEntitiesVector()) {
-            for (Entity target : detectedUnits) {
+            //Don't process for invalid units
+            //in the case of squadrons and transports, we want the 'host'
+            //unit, not the component entities
+            if (detector.getPosition() == null
+                    || detector.isDestroyed()
+                    || detector.isDoomed()
+                    || detector.isOffBoard()
+                    || detector.isPartOfFighterSquadron()
+                    || detector.getTransportId() != Entity.NONE) {
+                continue;
+            }
+            for (int targetId : detectedUnits) {
                 //if we already have a firing solution, no need to process a new one
-                if (Compute.hasFiringSolution(game, detector, target)) {
+                if (detector.hasFiringSolutionFor(game, targetId)) {
                     continue;
                 }
-                //Don't process for units with no position
-                if ((detector.getPosition() == null) || (target.getPosition() == null)) {
+                //Don't process for invalid units
+                //in the case of squadrons and transports, we want the 'host'
+                //unit, not the component entities
+                if (target.getPosition() == null
+                        || target.isDestroyed()
+                        || target.isDoomed()
+                        || target.isOffBoard()
+                        || target.isPartOfFighterSquadron()
+                        || target.getTransportId() != Entity.NONE) {
                     continue;
                 }
                 // Only process for enemy units

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -14808,7 +14808,8 @@ public class Server implements Runnable {
                 //Don't process for invalid units
                 //in the case of squadrons and transports, we want the 'host'
                 //unit, not the component entities
-                if (target.getPosition() == null
+                if (target == null
+                        || target.getPosition() == null
                         || target.isDestroyed()
                         || target.isDoomed()
                         || target.isOffBoard()


### PR DESCRIPTION
+ Bugfix Corrects an issue where sensor detections in space battles create an infinite loop of entities, eventually consuming all available memory

+ Improvement Thermal/Optical sensors now properly establish firing solutions per SO rules

+ Bugfix Fighter squadrons no longer suffer a PSR penalty for "more than 2x safe thrust" in space battles