### PR TITLE
don't use home-brewed comparator

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -2152,13 +2152,20 @@ public class Aero extends Entity implements IAero, IBomber {
 
             // sort the heat-using weapons by modified BV
             Collections.sort(heatBVs, (obj1, obj2) -> {
+                Double obj1BV = (Double) obj1.get(0); // BV
+                Double obj2BV = (Double) obj2.get(0); // BV
+                
                 // first element in the the ArrayList is BV, second is heat
                 // if same BV, lower heat first
-                if (obj1.get(0).equals(obj2.get(0))) {
-                    return (int) Math.ceil((Double) obj1.get(1) - (Double) obj2.get(1));
+                if(obj1BV == obj2BV) {
+                    Double obj1Heat = (Double) obj1.get(1);
+                    Double obj2Heat = (Double) obj2.get(1);
+                    
+                    return Double.compare(obj1Heat, obj2Heat);
                 }
+                
                 // higher BV first
-                return (int) Math.ceil((Double) obj2.get(0) - (Double) obj1.get(0));
+                return Double.compare(obj2BV, obj1BV);
             });
 
             // count heat-generating weapons at full modified BV until

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -2157,7 +2157,7 @@ public class Aero extends Entity implements IAero, IBomber {
                 
                 // first element in the the ArrayList is BV, second is heat
                 // if same BV, lower heat first
-                if(obj1BV == obj2BV) {
+                if(obj1BV.equals(obj2BV)) {
                     Double obj1Heat = (Double) obj1.get(1);
                     Double obj2Heat = (Double) obj2.get(1);
                     

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4760,15 +4760,20 @@ public abstract class Mech extends Entity {
                 @Override
                 public int compare(ArrayList<Object> obj1,
                         ArrayList<Object> obj2) {
+                    Double obj1BV = (Double) obj1.get(0); // BV
+                    Double obj2BV = (Double) obj2.get(0); // BV
+                    
                     // first element in the the ArrayList is BV, second is heat
                     // if same BV, lower heat first
-                    if (obj1.get(0).equals(obj2.get(0))) {
-                        return (int) Math.ceil((Double) obj1.get(1)
-                                - (Double) obj2.get(1));
+                    if(obj1BV == obj2BV) {
+                        Double obj1Heat = (Double) obj1.get(1);
+                        Double obj2Heat = (Double) obj2.get(1);
+                        
+                        return Double.compare(obj1Heat, obj2Heat);
                     }
+                    
                     // higher BV first
-                    return (int) Math.ceil((Double) obj2.get(0)
-                            - (Double) obj1.get(0));
+                    return Double.compare(obj2BV, obj1BV);
                 }
             });
             // count heat-generating weapons at full modified BV until

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4765,7 +4765,7 @@ public abstract class Mech extends Entity {
                     
                     // first element in the the ArrayList is BV, second is heat
                     // if same BV, lower heat first
-                    if(obj1BV == obj2BV) {
+                    if(obj1BV.equals(obj2BV)) {
                         Double obj1Heat = (Double) obj1.get(1);
                         Double obj2Heat = (Double) obj2.get(1);
                         


### PR DESCRIPTION
We use the built-in comparator for Double to compare doubles when calculating weapon-heat BVs, rather than the home-brewed approach. This results in the BV being calculated correctly for units that a) have different weapons with nearly identical BVs and b) do not have enough heat capacity to fire all those weapons