### PR TITLE
enable bot to respond to input requests to pick targets for homing artillery

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -206,6 +206,9 @@ public abstract class BotClient extends Client {
                         }
 
                         break;
+                    case Packet.COMMAND_CFR_TAG_TARGET:
+                        sendTAGTargetCFRResponse(pickTagTarget(evt));
+                        break;
                 }
             }
 
@@ -253,6 +256,10 @@ public abstract class BotClient extends Client {
     
     protected Vector<EntityAction> calculatePointBlankShot(int firingEntityID, int targetID) { 
         return null;
+    }
+    
+    protected int pickTagTarget(GameCFREvent evt) {
+        return 0;
     }
 
     /**
@@ -316,6 +323,16 @@ public abstract class BotClient extends Client {
             }
         }
         return result;
+    }
+    
+    protected Entity getArbitraryEntity() {
+        for (Entity entity : game.getEntitiesVector()) {
+            if (entity.getOwner().equals(getLocalPlayer())) {
+                return entity;
+            }
+        }
+        
+        return null;
     }
 
     public List<Entity> getEnemyEntities() {

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -61,7 +61,7 @@ public class ArtilleryTargetingControl {
     // this is a data structure that maps artillery damage value (which directly correlates with blast radius)
     // to a dictionary containing sets of coordinates and the damage value if one of those coordinates were hit by a shell
     // does not take into account hit odds or anything like that
-    private Map<Integer, HashMap<Coords, Double>> damageValues;
+    private Map<Integer, HashMap<Coords, Double>> damageValues = new HashMap<>();
     
     private Set<Targetable> targetSet;
     
@@ -75,7 +75,7 @@ public class ArtilleryTargetingControl {
      * @param shooter
      * @param game
      */
-    private double calculateDamageValue(int damage, Coords coords, Entity shooter, IGame game, Princess owner) {
+    public double calculateDamageValue(int damage, Coords coords, Entity shooter, IGame game, Princess owner) {
         if(getDamageValue(damage, coords) != null) {
             return getDamageValue(damage, coords);
         }
@@ -113,9 +113,9 @@ public class ArtilleryTargetingControl {
     private double calculateDamageValueForHex(int damage, Coords coords, Entity shooter, IGame game, Princess owner) {
         double value = 0;
         
-        for(Entity entity : game.getEntitiesVector(coords, false)) {
-            // ignore aircraft for now
-            if(entity.isAirborne() || entity.isAirborneVTOLorWIGE()) {
+        for(Entity entity : game.getEntitiesVector(coords, true)) {
+            // ignore aircraft for now, and also transported entities
+            if(entity.isAirborne() || entity.isAirborneVTOLorWIGE() || entity.getTransportId() != Entity.NONE) {
                 continue;
             }
             

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -235,7 +235,7 @@ public class Princess extends BotClient {
             return 0;
         }
         
-        double maxDamage = -999;
+        double maxDamage = -Double.MAX_VALUE;
         Coords maxDamageHex = null;
         
         // invoke ArtilleryTargetingControl.calculateDamageValue

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -63,6 +62,7 @@ import megamek.common.Transporter;
 import megamek.common.WeaponType;
 import megamek.common.annotations.Nullable;
 import megamek.common.containers.PlayerIDandList;
+import megamek.common.event.GameCFREvent;
 import megamek.common.event.GamePlayerChatEvent;
 import megamek.common.logging.LogLevel;
 import megamek.common.logging.DefaultMmLogger;
@@ -205,6 +205,58 @@ public class Princess extends BotClient {
 
     boolean getFleeBoard() {
         return fleeBoard;
+    }
+    
+    /**
+     * Picks a tag target based on the data contained within the given GameCFREvent
+     * Expects the event to have some tag targets and tag target types.
+     */
+    protected int pickTagTarget(GameCFREvent evt) {
+        List<Integer> TAGTargets = evt.getTAGTargets();
+        List<Integer> TAGTargetTypes = evt.getTAGTargetTypes();
+        Map<Coords, Integer> tagTargetHexes = new HashMap<>(); // maps coordinates to target index
+        
+        // Algorithm:
+        // get a list of the hexes being tagged
+        // figure out how much damage a hit to each of the tagged hexes will do (relatively)
+        // pick the one which will result in the best damage
+        
+        // get list of targetable hexes
+        for (int tagIndex = 0; tagIndex < TAGTargets.size(); tagIndex++) {
+            int nType = TAGTargetTypes.get(tagIndex);
+            Targetable tgt = getGame().getTarget(nType, TAGTargets.get(tagIndex));
+            if (tgt != null && !tagTargetHexes.containsKey(tgt.getPosition())) {
+                tagTargetHexes.put(tgt.getPosition(), tagIndex);
+            }
+        }
+        
+        Entity arbitraryEntity = getArbitraryEntity();
+        if(arbitraryEntity == null) {
+            return 0;
+        }
+        
+        double maxDamage = -999;
+        Coords maxDamageHex = null;
+        
+        // invoke ArtilleryTargetingControl.calculateDamageValue
+        for(Coords targetHex : tagTargetHexes.keySet()) {
+            // a note on parameters:
+            // we don't care about exact damage value since we're just comparing them relative to one another
+            //  note: technically we should, 
+            // we don't care about specific firing entity, we just want one on our side
+            //      since we only use it to determine friendlyness 
+            double currentDamage = getArtilleryTargetingControl().calculateDamageValue(10, targetHex, arbitraryEntity, game, this);
+            if(currentDamage > maxDamage) {
+                maxDamage = currentDamage;
+                maxDamageHex = targetHex;
+            }
+        }
+        
+        if(maxDamageHex != null) {
+            return tagTargetHexes.get(maxDamageHex);
+        } else {
+            return 0;
+        }
     }
 
     boolean getForcedWithdrawal() {


### PR DESCRIPTION
MKerensky introduced a query which asks the user to pick a target for homing munitions when said homing munition lands on the map. This PR enables the bot to handle said request (it's relevant because the bot can use artillery, which includes Arrow IV homing rounds).