### PR TITLE
Bot aero anti dropship behavior fix

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -262,7 +262,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                                     IGame game) {
 
         // If they don't have the range, they can't do damage.
-        int maxRange = enemy.getMaxWeaponRange();
+        int maxRange = getOwner().getMaxWeaponRange(enemy, path.getEntity().isAirborne());
         if (distance > maxRange) {
             return 0;
         }
@@ -283,7 +283,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             targetState = new EntityState(actualTarget);            
         }
 
-        int maxHeat = (enemy.getHeatCapacity() - enemy.heat) + 5;
+        int maxHeat = (enemy.getHeatCapacity() - enemy.heat) + (enemy.isAero() ? 0 : 5);
         FiringPlanCalculationParameters guess =
                 new FiringPlanCalculationParameters.Builder()
                         .buildGuess(enemy,
@@ -321,7 +321,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         // exception: I might, if I'm an aero on a ground map attacking a ground unit because aero unit ranges are a "special case"
         boolean aeroAttackingGroundUnitOnGroundMap = me.isAirborne() && !enemy.isAero() && game.getBoard().onGround();
         
-        int maxRange = me.getMaxWeaponRange();
+        int maxRange = getOwner().getMaxWeaponRange(me, enemy.isAirborne());
         if (distance > maxRange && !aeroAttackingGroundUnitOnGroundMap) {
             return 0;
         }
@@ -381,7 +381,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         EntityEvaluationResponse returnResponse = new EntityEvaluationResponse();
 
         int distance = enemy.getPosition().distance(path.getFinalCoords());                
-        
+        int alpha = 1;
         // How much damage can they do to me?
         double theirDamagePotential = calculateDamagePotential(enemy,
                                                                new EntityState(enemy),
@@ -577,6 +577,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                 EntityEvaluationResponse eval;
 
                 if (evaluateAsMoved(enemy)) { //For units that have already moved
+                    int alpha = 1;
                     eval = evaluateMovedEnemy(enemy, pathCopy, game);
                 } else { //for units that have not moved this round
                     eval = evaluateUnmovedEnemy(enemy, path, extremeRange,

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -380,8 +380,8 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
 
         EntityEvaluationResponse returnResponse = new EntityEvaluationResponse();
 
-        int distance = enemy.getPosition().distance(path.getFinalCoords());                
-        int alpha = 1;
+        int distance = enemy.getPosition().distance(path.getFinalCoords());
+        
         // How much damage can they do to me?
         double theirDamagePotential = calculateDamagePotential(enemy,
                                                                new EntityState(enemy),
@@ -577,7 +577,6 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                 EntityEvaluationResponse eval;
 
                 if (evaluateAsMoved(enemy)) { //For units that have already moved
-                    int alpha = 1;
                     eval = evaluateMovedEnemy(enemy, pathCopy, game);
                 } else { //for units that have not moved this round
                     eval = evaluateUnmovedEnemy(enemy, path, extremeRange,

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2189,7 +2189,6 @@ public class FireControl {
                 noTwistPlan = getBestFiringPlan(shooter, target, owner.getGame(), ammoConservation);
                 break;
             case GUESS:
-                int alpha = 1;
                 noTwistPlan = guessBestFiringPlanUnderHeat(shooter,
                                                            shooterState,
                                                            target,

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -343,7 +343,7 @@ public class FireControl {
         }
 
         // Is the target in range at all?
-        final int maxRange = shooter.getMaxWeaponRange();
+        final int maxRange = owner.getMaxWeaponRange(shooter, target.isAirborne());
         if (distance > maxRange) {
             return new ToHitData(TH_RNG_TOO_FAR);
         }
@@ -2189,6 +2189,7 @@ public class FireControl {
                 noTwistPlan = getBestFiringPlan(shooter, target, owner.getGame(), ammoConservation);
                 break;
             case GUESS:
+                int alpha = 1;
                 noTwistPlan = guessBestFiringPlanUnderHeat(shooter,
                                                            shooterState,
                                                            target,

--- a/megamek/src/megamek/client/bot/princess/FireControlState.java
+++ b/megamek/src/megamek/client/bot/princess/FireControlState.java
@@ -69,6 +69,9 @@ public class FireControlState {
         return airborneTarget ? airborneTargetWeaponRanges : weaponRanges;
     }
     
+    /**
+     * Clears data that shouldn't persist phase-to-phase
+     */
     public void clearTransientData() {
     	clearEntityIDFStates();
     	clearOrderedFiringEntities();

--- a/megamek/src/megamek/client/bot/princess/FireControlState.java
+++ b/megamek/src/megamek/client/bot/princess/FireControlState.java
@@ -17,11 +17,15 @@ public class FireControlState {
     private List<Targetable> additionalTargets;
     private Map<Integer, Boolean> entityIDFStates;
     private LinkedList<Entity> orderedFiringEntities;
+    private Map<Integer, Integer> weaponRanges;
+    private Map<Integer, Integer> airborneTargetWeaponRanges;
     
     public FireControlState() {
         additionalTargets = new ArrayList<>();
         entityIDFStates = new HashMap<>();
         orderedFiringEntities = new LinkedList<>();
+        weaponRanges = new HashMap<>();
+        airborneTargetWeaponRanges = new HashMap<>();
     }
     
     /**
@@ -61,8 +65,14 @@ public class FireControlState {
     	this.orderedFiringEntities.clear();
     }
     
+    public Map<Integer, Integer> getWeaponRanges(boolean airborneTarget) {
+        return airborneTarget ? airborneTargetWeaponRanges : weaponRanges;
+    }
+    
     public void clearTransientData() {
     	clearEntityIDFStates();
     	clearOrderedFiringEntities();
+    	weaponRanges.clear();
+    	airborneTargetWeaponRanges.clear();
     }
 }

--- a/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
@@ -81,7 +81,7 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker implements IPa
             int distance, IGame game) {
         Entity me = path.getEntity();
 
-        int maxRange = me.getMaxWeaponRange();
+        int maxRange = getOwner().getMaxWeaponRange(me, enemy.isAirborne());
         if (distance > maxRange) {
             return 0;
         }

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -107,6 +107,7 @@ public abstract class PathRanker implements IPathRanker {
             BigDecimal interval = new BigDecimal(5);
             for (MovePath path : validPaths) {
                 count = count.add(BigDecimal.ONE);
+                
                 returnPaths.add(rankPath(path, game, maxRange, fallTolerance, startingHomeDistance, enemies,
                                          allyCenter));
                 BigDecimal percent = count.divide(numberPaths, 2, RoundingMode.DOWN).multiply(new BigDecimal(100))

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -297,12 +297,8 @@ public class Princess extends BotClient {
      * @return
      */
     public int getMaxWeaponRange(Entity entity, boolean airborneTarget) {
-        if(!getFireControlState().getWeaponRanges(airborneTarget).containsKey(entity.getId())) {
-            getFireControlState().getWeaponRanges(airborneTarget).put(entity.getId(), 
-                    entity.getMaxWeaponRange(airborneTarget));
-        }
-        
-        return getFireControlState().getWeaponRanges(airborneTarget).get(entity.getId());
+        return getFireControlState().getWeaponRanges(airborneTarget).
+            computeIfAbsent(entity.getId(), ent -> entity.getMaxWeaponRange(airborneTarget));
     }
 
     public void setFallBack(final boolean fallBack,

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -283,6 +283,27 @@ public class Princess extends BotClient {
     Precognition getPrecognition() {
         return precognition;
     }
+    
+    public int getMaxWeaponRange(Entity entity) {
+        return getMaxWeaponRange(entity, false);
+    }
+    
+    /**
+     * Retrieves maximum weapon range for the given entity.
+     * Cached version of entity.getMaxWeaponRange() 
+     * @param entity Entity we're checking
+     * @param airborneTarget Whether the potential target is in the air, only relevant for
+     *          aircraft shooting at other aircraft on ground maps.
+     * @return
+     */
+    public int getMaxWeaponRange(Entity entity, boolean airborneTarget) {
+        if(!getFireControlState().getWeaponRanges(airborneTarget).containsKey(entity.getId())) {
+            getFireControlState().getWeaponRanges(airborneTarget).put(entity.getId(), 
+                    entity.getMaxWeaponRange(airborneTarget));
+        }
+        
+        return getFireControlState().getWeaponRanges(airborneTarget).get(entity.getId());
+    }
 
     public void setFallBack(final boolean fallBack,
                             final String reason) {
@@ -1418,7 +1439,7 @@ public class Princess extends BotClient {
                        
             final List<RankedPath> rankedpaths = getPathRanker(entity).rankPaths(paths,
                                                     getGame(),
-                                                    entity.getMaxWeaponRange(),
+                                                    getMaxWeaponRange(entity),
                                                     fallTolerance,
                                                     startingHomeDistance,
                                                     getEnemyEntities(),
@@ -2096,7 +2117,7 @@ public class Princess extends BotClient {
                 
                 // this is a primitive condition that checks whether we're within "engagement range" of an enemy
                 // where "engagement range" is defined as the maximum range of our weapons plus our walking movement
-                boolean inEngagementRange = loadedEntity.getWalkMP() + loadedEntity.getMaxWeaponRange() >= distanceToClosestEnemy;
+                boolean inEngagementRange = loadedEntity.getWalkMP() + getMaxWeaponRange(loadedEntity) >= distanceToClosestEnemy;
                 
                 if(!unloadFatal && !unloadIllegal && inEngagementRange) {
                     path.addStep(MoveStepType.UNLOAD, loadedEntity, pathEndpoint);

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1854,7 +1854,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                 m_chBayWeapon.addItem(formatBayWeapon(curWeapon));
             }
 
-            if (chosen == -1) {
+            if (chosen == -1 || chosen >= m_chBayWeapon.getItemCount()) {
                 m_chBayWeapon.setSelectedIndex(0);
             } else {
                 m_chBayWeapon.setSelectedIndex(chosen);
@@ -2053,15 +2053,13 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
         }
 
         // Aero
-        if (entity.isAirborne()){
-                //|| entity.usesWeaponBays()) {
+        if (entity.isAirborne()) {
 
             // prepare fresh ranges, no underwater
             ranges[0] = new int[] { 0, 0, 0, 0, 0 };  
             ranges[1] = new int[] { 0, 0, 0, 0, 0 };
             int maxr = WeaponType.RANGE_SHORT;
-
-            maxr = WeaponType.RANGE_SHORT;
+            
             // In the WeaponPanel, when the weapon is out of ammo
             // or otherwise nonfunctional, SHORT range will be listed;
             // the field of fire is instead disabled

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2053,8 +2053,8 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
         }
 
         // Aero
-        if (entity.isAirborne() 
-                || entity.usesWeaponBays()) {
+        if (entity.isAirborne()){
+                //|| entity.usesWeaponBays()) {
 
             // prepare fresh ranges, no underwater
             ranges[0] = new int[] { 0, 0, 0, 0, 0 };  
@@ -2088,22 +2088,17 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                 }
 
                 // set the standard ranges, depending on capital or no
-                boolean isCap = wtype.isCapital();
-                ranges[0][0] = 0;
-                ranges[0][1] = isCap ? 12 : 6;
-                if (maxr > WeaponType.RANGE_SHORT) 
-                    ranges[0][2] = isCap ? 24 : 12;
-                if (maxr > WeaponType.RANGE_MED)
-                    ranges[0][3] = isCap ? 40 : 20;
-                if (maxr > WeaponType.RANGE_LONG) 
-                    ranges[0][4] = isCap ? 50 : 25;
-                
+                //boolean isCap = wtype.isCapital();
+                int rangeMultiplier = wtype.isCapital() ? 2 : 1;
                 final IGame game = unitDisplay.getClientGUI().getClient().getGame();
                 if (game.getBoard().onGround()) {
-                    ranges[0][1] *= 8;
-                    ranges[0][2] *= 8;
-                    ranges[0][3] *= 8;
-                    ranges[0][4] *= 8;
+                    rangeMultiplier *= 8;
+                }
+                
+                for(int rangeIndex = RangeType.RANGE_MINIMUM; rangeIndex <= RangeType.RANGE_EXTREME; rangeIndex++) {
+                    if(maxr >= rangeIndex) {
+                        ranges[0][rangeIndex] = WeaponType.AIRBORNE_WEAPON_RANGES[rangeIndex] * rangeMultiplier;
+                    }
                 }
             }
         }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -14707,11 +14707,27 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         return 1;
     }
 
+    /**
+     * The max weapons range of this entity, taking into account whether or not
+     * we're on an air/space map, using extreme range. Assumes target is not airborne
+     * if we are on a ground map.
+     * @return
+     */
     public int getMaxWeaponRange() {
+        return getMaxWeaponRange(false);
+    }
+    
+    /**
+     * The max weapons range of this entity, taking into account whether or not
+     * we're on an air/space map, using extreme range, and whether or not the target is
+     * air borne.
+     * @param targetIsAirborne
+     * @return
+     */
+    public int getMaxWeaponRange(boolean targetIsAirborne) {
         // Aeros on the ground map must shoot along their flight path, giving
         // them effectively 0 range
-        if (isAero() && isAirborne()
-                && game.getBoard().onGround()) {
+        if (isAirborneAeroOnGroundMap() && !targetIsAirborne) {
             return 0;
         }
 
@@ -14729,9 +14745,19 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             }
 
             WeaponType type = (WeaponType) weapon.getType();
-            int range = (game.getOptions().booleanOption(
+            int range;
+            
+            if(isAirborne()) {
+                int rangeMultiplier = type.isCapital() ? 2 : 1;
+                rangeMultiplier *= isAirborneAeroOnGroundMap() ? 8 : 1;
+                
+                range = WeaponType.AIRBORNE_WEAPON_RANGES[type.getMaxRange(weapon)] * rangeMultiplier;
+            } else {
+                range = (game.getOptions().booleanOption(
                     OptionsConstants.ADVCOMBAT_TACOPS_RANGE) ? type.getExtremeRange()
                     : type.getLongRange());
+            }
+            
             if (range > maxRange) {
                 maxRange = range;
             }

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -613,6 +613,10 @@ public class WeaponType extends EquipmentType {
     public static final int RANGE_MED = RangeType.RANGE_MEDIUM;
     public static final int RANGE_LONG = RangeType.RANGE_LONG;
     public static final int RANGE_EXT = RangeType.RANGE_EXTREME;
+    
+    // weapons for airborne units all have fixed weapon ranges:
+    // no minimum, 6 short, 12 medium, 20 long, 25 extreme
+    public static final int[] AIRBORNE_WEAPON_RANGES = { 0, 6, 12, 20, 25 };
 
     // add weapon classes for AT2
     public static final int CLASS_NONE = 0;

--- a/megamek/src/megamek/common/weapons/AltitudeBombAttack.java
+++ b/megamek/src/megamek/common/weapons/AltitudeBombAttack.java
@@ -41,6 +41,7 @@ public class AltitudeBombAttack extends Weapon {
         mediumRange = 0;
         longRange = 0;
         extremeRange = 0;
+        maxRange = 0;
         tonnage = 0.0;
         criticals = 0;
         bv = 0;

--- a/megamek/src/megamek/common/weapons/DiveBombAttack.java
+++ b/megamek/src/megamek/common/weapons/DiveBombAttack.java
@@ -43,6 +43,7 @@ public class DiveBombAttack extends Weapon {
         mediumRange = 0;
         longRange = 0;
         extremeRange = 0;
+        maxRange = 0;
         tonnage = 0.0;
         criticals = 0;
         bv = 0;

--- a/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
@@ -6,6 +6,7 @@ import megamek.common.BipedMech;
 import megamek.common.Compute;
 import megamek.common.Coords;
 import megamek.common.Entity;
+import megamek.common.EquipmentMode;
 import megamek.common.IGame;
 import megamek.common.Mounted;
 import megamek.common.Targetable;
@@ -50,6 +51,7 @@ public class WeaponFireInfoTest {
     private Mounted mockWeapon;
     private WeaponType mockWeaponType;
     private WeaponAttackAction mockWeaponAttackAction;
+    private EquipmentMode mockEquipmentMode;
     private Princess mockPrincess;
     private FireControl mockFireControl;
 
@@ -78,6 +80,7 @@ public class WeaponFireInfoTest {
         mockPrincess = Mockito.mock(Princess.class);
         Mockito.when(mockPrincess.getFireControl(FireControlType.Basic)).thenReturn(mockFireControl);
         Mockito.when(mockPrincess.getLogger()).thenReturn(fakeLogger);
+        Mockito.when(mockPrincess.getMaxWeaponRange(Mockito.any(Entity.class))).thenReturn(21);
 
         mockShooter = Mockito.mock(BipedMech.class);
         Mockito.when(mockShooter.getPosition()).thenReturn(SHOOTER_COORDS);
@@ -102,7 +105,10 @@ public class WeaponFireInfoTest {
 
         mockWeaponType = Mockito.mock(WeaponType.class);
         mockWeapon = Mockito.mock(Mounted.class);
+        mockEquipmentMode = Mockito.mock(EquipmentMode.class);
         Mockito.when(mockWeapon.getType()).thenReturn(mockWeaponType);
+        Mockito.when(mockEquipmentMode.getName()).thenReturn("");
+        Mockito.when(mockWeapon.curMode()).thenReturn(mockEquipmentMode);
 
         mockWeaponAttackAction = Mockito.mock(WeaponAttackAction.class);
     }


### PR DESCRIPTION
Four sets of changes:

1) Fixes a bot behavior where aircraft would love to present their tail directly to the front battery of hostile dropships.
2) Minor bot optimization: there are a lot of calls to "entity.getMaxWeaponRange()", repeated multiple times for each entity during each phase (probably # paths x # enemies on board). Caches these calls, since enemy max weapon range isn't affected by the path the unit is considering.
3) Fix bot estimation for weapon ranges of hostile air/spaceborne units
4) Clean-up user-visible range calculation adjustment for air/spaceborne units