### PR TITLE
Equipment type key

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -3054,7 +3054,7 @@ public class Aero extends Entity implements IAero, IBomber {
      */
     public void addClanCase() {
         boolean explosiveFound = false;
-        EquipmentType clCase = EquipmentType.get("CLCASE");
+        EquipmentType clCase = EquipmentType.get(EquipmentTypeLookup.CLAN_CASE);
         for (int i = 0; i < locations(); i++) {
             // Ignore wings location: it's not a valid loc to put equipment in
             if (i == LOC_WINGS) {

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -14116,7 +14116,8 @@ public class AmmoType extends EquipmentType {
 
         ammo.name = "Coolant Pod";
         ammo.shortName = "Coolant Pod";
-        ammo.setInternalName("IS Coolant Pod");
+        ammo.setInternalName(EquipmentTypeLookup.COOLANT_POD);
+        ammo.addLookupName("IS Coolant Pod");
         ammo.addLookupName("Clan Coolant Pod");
         ammo.damagePerShot = 10;
         ammo.rackSize = 1;

--- a/megamek/src/megamek/common/EjectedCrew.java
+++ b/megamek/src/megamek/common/EjectedCrew.java
@@ -55,9 +55,9 @@ public class EjectedCrew extends Infantry {
             && (!(this instanceof MechWarrior) 
                     || tmpGame.getOptions().booleanOption(OptionsConstants.ADVANCED_ARMED_MECHWARRIORS))) {
             try {
-                addEquipment(EquipmentType.get("InfantryAssaultRifle"),
+                addEquipment(EquipmentType.get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE),
                         Infantry.LOC_INFANTRY);
-                setPrimaryWeapon((InfantryWeapon) InfantryWeapon.get("InfantryAssaultRifle"));
+                setPrimaryWeapon((InfantryWeapon) InfantryWeapon.get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE));
             } catch (Exception ex) {
                 ex.printStackTrace();
             }
@@ -105,9 +105,9 @@ public class EjectedCrew extends Infantry {
             && (!(this instanceof MechWarrior) 
                     || tmpGame.getOptions().booleanOption(OptionsConstants.ADVANCED_ARMED_MECHWARRIORS))) {
             try {
-                addEquipment(EquipmentType.get("InfantryAssaultRifle"),
+                addEquipment(EquipmentType.get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE),
                         Infantry.LOC_INFANTRY);
-                setPrimaryWeapon((InfantryWeapon) InfantryWeapon.get("InfantryAssaultRifle"));
+                setPrimaryWeapon((InfantryWeapon) InfantryWeapon.get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE));
             } catch (Exception ex) {
                 ex.printStackTrace();
             }

--- a/megamek/src/megamek/common/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/EquipmentTypeLookup.java
@@ -83,6 +83,7 @@ public class EquipmentTypeLookup {
 
     public static final String AC_BAY = "AC Bay";
     public static final String AMS_BAY = "AMS Bay";
+    public static final String ARTILLERY_BAY = "Artillery Bay";
     public static final String AR10_BAY = "AR10 Bay";
     public static final String ATM_BAY = "ATM Bay";
     public static final String CAPITAL_AC_BAY = "Capital AC Bay";

--- a/megamek/src/megamek/common/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/EquipmentTypeLookup.java
@@ -18,6 +18,11 @@
  */
 package megamek.common;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * Constants that can be used as lookup keys for {@link EquipmentType#get}. The constant should be used
  * as the internal name when creating the {@link EquipmentType}.
@@ -30,85 +35,169 @@ package megamek.common;
  */
 public class EquipmentTypeLookup {
 
+    /**
+     * Static fields in this class annotated with {code }@EquipmentName} will be checked by the unit tests
+     * to verify they are valid {@link EquipmentType} lookup keys.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface EquipmentName{}
+
+    @EquipmentName
     public static final String JUMP_JET = "Jump Jet";
+    @EquipmentName
     public static final String IMPROVED_JUMP_JET = "Improved Jump Jet";
+    @EquipmentName
     public static final String PROTOTYPE_JUMP_JET = "ISPrototypeJumpJet";
+    @EquipmentName
     public static final String PROTOTYPE_IMPROVED_JJ = "ISPrototypeImprovedJumpJet";
+    @EquipmentName
     public static final String MECH_UMU = "UMU";
+    @EquipmentName
     public static final String MECH_JUMP_BOOSTER = "MechanicalJumpBooster";
+    @EquipmentName
     public static final String VEHICLE_JUMP_JET = "VehicleJumpJet";
+    @EquipmentName
     public static final String PROTOMECH_JUMP_JET = "ProtomechJumpJet";
+    @EquipmentName
     public static final String EXTENDED_JUMP_JET_SYSTEM = "ExtendedJumpJetSystem";
+    @EquipmentName
     public static final String PROTOMECH_UMU = "ProtomechUMU";
+    @EquipmentName
     public static final String PROTOMECH_MYOMER_BOOSTER = "CLMyomerBooster";
+    @EquipmentName
     public static final String BA_JUMP_JET = "BAJumpJet";
+    @EquipmentName
     public static final String BA_VTOL = "BAVTOL";
+    @EquipmentName
     public static final String BA_UMU = "BAUMU";
+    @EquipmentName
     public static final String BA_MYOMER_BOOSTER = "CLBAMyomerBooster";
+    @EquipmentName
     public static final String BA_PARTIAL_WING = "BAPartialWing";
+    @EquipmentName
     public static final String BA_JUMP_BOOSTER = "BAJumpBooster";
+    @EquipmentName
     public static final String BA_MECHANICAL_JUMP_BOOSTER = "BAMechanicalJumpBooster";
 
+    @EquipmentName
     public static final String SINGLE_HS = "Heat Sink";
+    @EquipmentName
     public static final String IS_DOUBLE_HS = "ISDoubleHeatSink";
+    @EquipmentName
     public static final String CLAN_DOUBLE_HS = "CLDoubleHeatSink";
+    @EquipmentName
     public static final String LASER_HS = "Laser Heat Sink";
+    @EquipmentName
     public static final String COMPACT_HS_1 = "1 Compact Heat Sink";
+    @EquipmentName
     public static final String COMPACT_HS_2 = "2 Compact Heat Sinks";
+    @EquipmentName
     public static final String IS_DOUBLE_HS_PROTOTYPE = "ISDoubleHeatSinkPrototype";
+    @EquipmentName
     public static final String IS_DOUBLE_HS_FREEZER = "ISDoubleHeatSinkFreezer";
 
+    @EquipmentName
     public static final String HITCH = "Hitch";
+    @EquipmentName
     public static final String CLAN_CASE = "CLCASE";
+    @EquipmentName
     public static final String COOLANT_POD = "Coolant Pod";
+    @EquipmentName
     public static final String MECH_TRACKS = "Tracks";
+    @EquipmentName
     public static final String QUADVEE_WHEELS = "QuadVee Wheels";
+    @EquipmentName
     public static final String IM_EJECTION_SEAT = "Ejection Seat (Industrial Mech)";
+    @EquipmentName
     public static final String TSM = "Triple Strength Myomer";
+    @EquipmentName
     public static final String SCM = "ISSuperCooledMyomer";
+    @EquipmentName
     public static final String ITSM = "Industrial Triple Strength Myomer";
+    @EquipmentName
     public static final String IS_MASC = "ISMASC";
+    @EquipmentName
     public static final String CLAN_MASC = "CLMASC";
+    @EquipmentName
     public static final String SPONSON_TURRET = "SponsonTurret";
+    @EquipmentName
     public static final String PINTLE_TURRET = "PintleTurret";
 
+    @EquipmentName
     public static final String LIMB_CLUB = "Limb Club";
+    @EquipmentName
     public static final String GIRDER_CLUB = "Girder Club";
+    @EquipmentName
     public static final String TREE_CLUB = "Tree Club";
 
+    @EquipmentName
     public static final String INFANTRY_ASSAULT_RIFLE = "InfantryAssaultRifle";
+    @EquipmentName
     public static final String INFANTRY_TAG = "InfantryTAG";
+    @EquipmentName
     public static final String VIBRO_SHOVEL = "Vibro-Shovel";
+    @EquipmentName
     public static final String DEMOLITION_CHARGE = "Demolition Charge";
 
+    @EquipmentName
     public static final String AC_BAY = "AC Bay";
+    @EquipmentName
     public static final String AMS_BAY = "AMS Bay";
+    @EquipmentName
     public static final String ARTILLERY_BAY = "Artillery Bay";
+    @EquipmentName
     public static final String AR10_BAY = "AR10 Bay";
+    @EquipmentName
     public static final String ATM_BAY = "ATM Bay";
+    @EquipmentName
     public static final String CAPITAL_AC_BAY = "Capital AC Bay";
+    @EquipmentName
     public static final String CAPITAL_GAUSS_BAY = "Capital Gauss Bay";
+    @EquipmentName
     public static final String CAPITAL_LASER_BAY = "Capital Laser Bay";
+    @EquipmentName
     public static final String CAPITAL_MASS_DRIVER_BAY = "Capital Mass Driver Bay";
+    @EquipmentName
     public static final String CAPITAL_MISSILE_BAY = "Capital Missile Bay";
+    @EquipmentName
     public static final String CAPITAL_PPC_BAY = "Capital PPC Bay";
+    @EquipmentName
     public static final String GAUSS_BAY = "Gauss Bay";
+    @EquipmentName
     public static final String LASER_BAY = "Laser Bay";
+    @EquipmentName
     public static final String LBX_AC_BAY = "LBX AC Bay";
+    @EquipmentName
     public static final String LRM_BAY = "LRM Bay";
+    @EquipmentName
     public static final String MISC_BAY = "Misc Bay";
+    @EquipmentName
     public static final String MML_BAY = "MML Bay";
+    @EquipmentName
     public static final String MRM_BAY = "MRM Bay";
+    @EquipmentName
     public static final String PLASMA_BAY = "Plasma Bay";
+    @EquipmentName
     public static final String POINT_DEFENSE_BAY = "Point Defense Bay";
+    @EquipmentName
     public static final String PPC_BAY = "PPC Bay";
+    @EquipmentName
     public static final String PULSE_LASER_BAY = "Pulse Laser Bay";
+    @EquipmentName
     public static final String ROCKET_LAUNCHER_BAY = "Rocket Launcher Bay";
+    @EquipmentName
     public static final String SCC_BAY = "Sub-Capital Cannon Bay";
+    @EquipmentName
     public static final String SCL_BAY = "Sub-Capital Laser Bay";
+    @EquipmentName
     public static final String SC_MISSILE_BAY = "Sub-Capital Missile Bay";
+    @EquipmentName
     public static final String SCREEN_LAUNCHER_BAY = "Screen Launcher Bay";
+    @EquipmentName
     public static final String SRM_BAY = "SRM Bay";
+    @EquipmentName
     public static final String TELE_CAPITAL_MISSILE_BAY = "Tele-Operated Capital Missile Bay";
+    @EquipmentName
     public static final String THUNDERBOLT_BAY = "Thunderbolt Bay";
 }

--- a/megamek/src/megamek/common/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/EquipmentTypeLookup.java
@@ -1,0 +1,93 @@
+/*
+ * MegaMek
+ * Copyright (C) 2019 The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package megamek.common;
+
+/**
+ * Constants that can be used as lookup keys for {@link EquipmentType#get}. The constant should be used
+ * as the internal name when creating the {@link EquipmentType}.
+ *
+ * This is not a complete list, as most equipment does not need to be retrieved directly.
+ * It is primarily for use by the construction rules when a specific piece of equipment is required.
+ * Armor and structure have their own methods that take tech base into account.
+ * @see EquipmentType#getArmorTypeName
+ * @see EquipmentType#getStructureTypeName
+ */
+public class EquipmentTypeLookup {
+
+    public static final String VEHICLE_JUMP_JET = "VehicleJumpJet";
+    public static final String PROTOMECH_JUMP_JET = "ProtomechJumpJet";
+    public static final String EXTENDED_JUMP_JET_SYSTEM = "ExtendedJumpJetSystem";
+    public static final String PROTOMECH_UMU = "ProtomechUMU";
+    public static final String PROTOMECH_MYOMER_BOOSTER = "CLMyomerBooster";
+
+    public static final String BA_MYOMER_BOOSTER = "CLBAMyomerBooster";
+    public static final String BA_PARTIAL_WING = "BAPartialWing";
+    public static final String BA_JUMP_BOOSTER = "BAJumpBooster";
+    public static final String BA_MECHANICAL_JUMP_BOOSTER = "BAMechanicalJumpBooster";
+
+    public static final String HITCH = "Hitch";
+    public static final String CLAN_CASE = "CLCASE";
+    public static final String COOLANT_POD = "Coolant Pod";
+    public static final String MECH_TRACKS = "Tracks";
+    public static final String QUADVEE_WHEELS = "QuadVee Wheels";
+    public static final String IM_EJECTION_SEAT = "Ejection Seat (Industrial Mech)";
+    public static final String TSM = "Triple Strength Myomer";
+    public static final String ITSM = "Industrial Triple Strength Myomer";
+    public static final String SPONSON_TURRET = "SponsonTurret";
+    public static final String PINTLE_TURRET = "PintleTurret";
+
+    public static final String LIMB_CLUB = "Limb Club";
+    public static final String GIRDER_CLUB = "Girder Club";
+    public static final String TREE_CLUB = "Tree Club";
+
+    public static final String INFANTRY_ASSAULT_RIFLE = "InfantryAssaultRifle";
+    public static final String INFANTRY_TAG = "InfantryTAG";
+    public static final String VIBRO_SHOVEL = "Vibro-Shovel";
+    public static final String DEMOLITION_CHARGE = "Demolition Charge";
+
+    public static final String AC_BAY = "AC Bay";
+    public static final String AMS_BAY = "AMS Bay";
+    public static final String AR10_BAY = "AR10 Bay";
+    public static final String ATM_BAY = "ATM Bay";
+    public static final String CAPITAL_AC_BAY = "Capital AC Bay";
+    public static final String CAPITAL_GAUSS_BAY = "Capital Gauss Bay";
+    public static final String CAPITAL_LASER_BAY = "Capital Laser Bay";
+    public static final String CAPITAL_MASS_DRIVER_BAY = "Capital Mass Driver Bay";
+    public static final String CAPITAL_MISSILE_BAY = "Capital Missile Bay";
+    public static final String CAPITAL_PPC_BAY = "Capital PPC Bay";
+    public static final String GAUSS_BAY = "Gauss Bay";
+    public static final String LASER_BAY = "Laser Bay";
+    public static final String LBX_AC_BAY = "LBX AC Bay";
+    public static final String LRM_BAY = "LRM Bay";
+    public static final String MISC_BAY = "Misc Bay";
+    public static final String MML_BAY = "MML Bay";
+    public static final String MRM_BAY = "MRM Bay";
+    public static final String PLASMA_BAY = "Plasma Bay";
+    public static final String POINT_DEFENSE_BAY = "Point Defense Bay";
+    public static final String PPC_BAY = "PPC Bay";
+    public static final String PULSE_LASER_BAY = "Pulse Laser Bay";
+    public static final String ROCKET_LAUNCHER_BAY = "Rocket Launcher Bay";
+    public static final String SCC_BAY = "Sub-Capital Cannon Bay";
+    public static final String SCL_BAY = "Sub-Capital Laser Bay";
+    public static final String SC_MISSILE_BAY = "Sub-Capital Missile Bay";
+    public static final String SCREEN_LAUNCHER_BAY = "Screen Launcher Bay";
+    public static final String SRM_BAY = "SRM Bay";
+    public static final String TELE_CAPITAL_MISSILE_BAY = "Tele-Operated Capital Missile Bay";
+    public static final String THUNDERBOLT_BAY = "Thunderbolt Bay";
+}

--- a/megamek/src/megamek/common/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/EquipmentTypeLookup.java
@@ -30,16 +30,33 @@ package megamek.common;
  */
 public class EquipmentTypeLookup {
 
+    public static final String JUMP_JET = "Jump Jet";
+    public static final String IMPROVED_JUMP_JET = "Improved Jump Jet";
+    public static final String PROTOTYPE_JUMP_JET = "ISPrototypeJumpJet";
+    public static final String PROTOTYPE_IMPROVED_JJ = "ISPrototypeImprovedJumpJet";
+    public static final String MECH_UMU = "UMU";
+    public static final String MECH_JUMP_BOOSTER = "MechanicalJumpBooster";
     public static final String VEHICLE_JUMP_JET = "VehicleJumpJet";
     public static final String PROTOMECH_JUMP_JET = "ProtomechJumpJet";
     public static final String EXTENDED_JUMP_JET_SYSTEM = "ExtendedJumpJetSystem";
     public static final String PROTOMECH_UMU = "ProtomechUMU";
     public static final String PROTOMECH_MYOMER_BOOSTER = "CLMyomerBooster";
-
+    public static final String BA_JUMP_JET = "BAJumpJet";
+    public static final String BA_VTOL = "BAVTOL";
+    public static final String BA_UMU = "BAUMU";
     public static final String BA_MYOMER_BOOSTER = "CLBAMyomerBooster";
     public static final String BA_PARTIAL_WING = "BAPartialWing";
     public static final String BA_JUMP_BOOSTER = "BAJumpBooster";
     public static final String BA_MECHANICAL_JUMP_BOOSTER = "BAMechanicalJumpBooster";
+
+    public static final String SINGLE_HS = "Heat Sink";
+    public static final String IS_DOUBLE_HS = "ISDoubleHeatSink";
+    public static final String CLAN_DOUBLE_HS = "CLDoubleHeatSink";
+    public static final String LASER_HS = "Laser Heat Sink";
+    public static final String COMPACT_HS_1 = "1 Compact Heat Sink";
+    public static final String COMPACT_HS_2 = "2 Compact Heat Sinks";
+    public static final String IS_DOUBLE_HS_PROTOTYPE = "ISDoubleHeatSinkPrototype";
+    public static final String IS_DOUBLE_HS_FREEZER = "ISDoubleHeatSinkFreezer";
 
     public static final String HITCH = "Hitch";
     public static final String CLAN_CASE = "CLCASE";
@@ -48,7 +65,10 @@ public class EquipmentTypeLookup {
     public static final String QUADVEE_WHEELS = "QuadVee Wheels";
     public static final String IM_EJECTION_SEAT = "Ejection Seat (Industrial Mech)";
     public static final String TSM = "Triple Strength Myomer";
+    public static final String SCM = "ISSuperCooledMyomer";
     public static final String ITSM = "Industrial Triple Strength Myomer";
+    public static final String IS_MASC = "ISMASC";
+    public static final String CLAN_MASC = "CLMASC";
     public static final String SPONSON_TURRET = "SponsonTurret";
     public static final String PINTLE_TURRET = "PintleTurret";
 

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1993,7 +1993,7 @@ public class Infantry extends Entity {
         if ((spec & TRENCH_ENGINEERS) > 0 && (infSpecs & TRENCH_ENGINEERS) == 0) {
             // Need to add vibro shovels
             try {
-                EquipmentType shovels = EquipmentType.get("Vibro-Shovel");
+                EquipmentType shovels = EquipmentType.get(EquipmentTypeLookup.VIBRO_SHOVEL);
                 addEquipment(shovels, Infantry.LOC_INFANTRY);
             } catch (LocationFullException e) {
                 e.printStackTrace();
@@ -2015,7 +2015,7 @@ public class Infantry extends Entity {
         if ((spec & DEMO_ENGINEERS) > 0 && (infSpecs & DEMO_ENGINEERS) == 0) {
             // Need to add vibro shovels
             try {
-                EquipmentType shovels = EquipmentType.get("Demolition Charge");
+                EquipmentType shovels = EquipmentType.get(EquipmentTypeLookup.DEMOLITION_CHARGE);
                 addEquipment(shovels, Infantry.LOC_INFANTRY);
             } catch (LocationFullException e) {
                 e.printStackTrace();

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -1553,14 +1553,14 @@ public abstract class Mech extends Entity {
     public void addEngineSinks(int totalSinks, BigInteger heatSinkFlag,
             boolean clan) {
         if (heatSinkFlag == MiscType.F_DOUBLE_HEAT_SINK) {
-            addEngineSinks(totalSinks, clan ? "CLDoubleHeatSink"
-                    : "ISDoubleHeatSink");
+            addEngineSinks(totalSinks, clan ? EquipmentTypeLookup.CLAN_DOUBLE_HS
+                    : EquipmentTypeLookup.IS_DOUBLE_HS);
         } else if (heatSinkFlag == MiscType.F_COMPACT_HEAT_SINK) {
-            addEngineSinks(totalSinks, "IS1 Compact Heat Sink");
+            addEngineSinks(totalSinks, EquipmentTypeLookup.COMPACT_HS_1);
         } else if (heatSinkFlag == MiscType.F_LASER_HEAT_SINK) {
-            addEngineSinks(totalSinks, "CLLaser Heat Sink");
+            addEngineSinks(totalSinks, EquipmentTypeLookup.LASER_HS);
         } else {
-            addEngineSinks(totalSinks, "Heat Sink");
+            addEngineSinks(totalSinks, EquipmentTypeLookup.SINGLE_HS);
         }
     }
 
@@ -2939,7 +2939,7 @@ public abstract class Mech extends Entity {
      */
     public void addClanCase() {
         boolean explosiveFound = false;
-        EquipmentType clCase = EquipmentType.get("CLCASE");
+        EquipmentType clCase = EquipmentType.get(EquipmentTypeLookup.CLAN_CASE);
         for (int i = 0; i < locations(); i++) {
             explosiveFound = false;
             for (Mounted m : getEquipment()) {

--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -643,7 +643,7 @@ public class MechFileParser {
                     WeaponType wtype = (WeaponType) mWeapon.getType();
 
                     //Handle weapon bays
-                    if (wtype.getBayType().equals(EquipmentType.get("PPC Bay"))){
+                    if (wtype.getBayType().equals(EquipmentType.get(EquipmentTypeLookup.PPC_BAY))){
                         for (int wId : mWeapon.getBayWeapons())
                         {
                             Mounted bayMountedWeapon = ent.getEquipment(wId);

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -2017,7 +2017,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Jump Jet";
-        misc.setInternalName("VehicleJumpJet");
+        misc.setInternalName(EquipmentTypeLookup.VEHICLE_JUMP_JET);
         misc.addLookupName("VJJ");
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
@@ -2039,7 +2039,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createProtomechJumpJet() {
         MiscType misc = new MiscType();
         misc.name = "Jump Jet";
-        misc.setInternalName("ProtomechJumpJet");
+        misc.setInternalName(EquipmentTypeLookup.PROTOMECH_JUMP_JET);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 0;
         misc.cost = 0;
@@ -2059,7 +2059,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
         // TODO Game Rules.
         misc.name = "Extended Jump Jet System";
-        misc.setInternalName("ExtendedJumpJetSystem");
+        misc.setInternalName(EquipmentTypeLookup.EXTENDED_JUMP_JET_SYSTEM);
         misc.addLookupName("XJJ");
         misc.shortName = "Extended Jump Jet";
         misc.tonnage = TONNAGE_VARIABLE;
@@ -2081,7 +2081,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
         // TODO Game Rules.
         misc.name = "UMU";
-        misc.setInternalName("ProtomechUMU");
+        misc.setInternalName(EquipmentTypeLookup.PROTOMECH_UMU);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
         misc.cost = 0;
@@ -2100,7 +2100,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Protomech Myomer Booster";
-        misc.setInternalName("CLMyomerBooster");
+        misc.setInternalName(EquipmentTypeLookup.PROTOMECH_MYOMER_BOOSTER);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 0;
         misc.cost = COST_VARIABLE;
@@ -2351,7 +2351,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Tracks";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.MECH_TRACKS);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = CRITICALS_VARIABLE;
         misc.spreadable = true;
@@ -2375,7 +2375,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "QuadVee Wheels";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.QUADVEE_WHEELS);
         misc.addLookupName("Wheels");
         misc.shortName = "Wheels";
         misc.tonnage = TONNAGE_VARIABLE;
@@ -5129,7 +5129,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Tree Club";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.TREE_CLUB);
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.flags = misc.flags.or(F_CLUB).or(F_MECH_EQUIPMENT);
@@ -5147,7 +5147,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Girder Club";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.GIRDER_CLUB);
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.flags = misc.flags.or(F_CLUB).or(F_MECH_EQUIPMENT);
@@ -5164,7 +5164,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Limb Club";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.LIMB_CLUB);
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.flags = misc.flags.or(F_CLUB);
@@ -5357,7 +5357,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "CASE";
-        misc.setInternalName("CLCASE");
+        misc.setInternalName(EquipmentTypeLookup.CLAN_CASE);
         misc.addLookupName("Clan CASE");
         misc.tonnage = 0.0f;
         misc.criticals = 0;
@@ -5918,7 +5918,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Ejection Seat (Industrial Mech)";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.IM_EJECTION_SEAT);
         misc.shortName = "Ejection Seat";
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
@@ -9886,7 +9886,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Triple Strength Myomer";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.TSM);
         misc.addLookupName("IS TSM");
         misc.addLookupName("TSM");
         misc.addLookupName("Triple Strength Myomer");
@@ -9914,7 +9914,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Industrial Triple Strength Myomer";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.ITSM);
         misc.addLookupName("IS Industrial TSM");
         misc.addLookupName("Industrial TSM");
         misc.tonnage = 0;
@@ -10369,7 +10369,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createHitch() {
         MiscType misc = new MiscType();
         misc.name = "Trailer Hitch";
-        misc.setInternalName("Hitch");
+        misc.setInternalName(EquipmentTypeLookup.HITCH);
         misc.tonnage = 0;
         misc.cost = 0;
         misc.criticals = 0; // being errata'd to no slots.
@@ -10522,7 +10522,8 @@ public class MiscType extends EquipmentType {
     public static MiscType createISSponsonTurret() {
         MiscType misc = new MiscType();
         misc.name = "Vehicular Sponson Turret";
-        misc.setInternalName("ISSponsonTurret");
+        misc.setInternalName(EquipmentTypeLookup.SPONSON_TURRET);
+        misc.addLookupName("ISSponsonTurret");
         misc.addLookupName("CLSponsonTurret");
         misc.shortName = "Sponson Turret";
         misc.tonnage = TONNAGE_VARIABLE;
@@ -10544,7 +10545,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createPintleTurret() {
         MiscType misc = new MiscType();
         misc.name = "Pintle Mount";
-        misc.setInternalName("PintleTurret");
+        misc.setInternalName(EquipmentTypeLookup.PINTLE_TURRET);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 0;
         misc.tankslots = 0;
@@ -11379,7 +11380,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Jump Booster [BA]";
-        misc.setInternalName("BAJumpBooster");
+        misc.setInternalName(EquipmentTypeLookup.BA_JUMP_BOOSTER);
         misc.addLookupName("ISBAJumpBooster");
         misc.addLookupName("CLBAJumpBooster");
         misc.tonnage = 0.125;
@@ -11427,7 +11428,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createISBAMechanicalJumpBooster() {
         MiscType misc = new MiscType();
         misc.name = "Mechanical Jump Booster";
-        misc.setInternalName("BAMechanicalJumpBooster");
+        misc.setInternalName(EquipmentTypeLookup.BA_MECHANICAL_JUMP_BOOSTER);
         misc.addLookupName("ISMechanicalJumpBooster");
         misc.addLookupName("CLMechanicalJumpBooster");
         misc.shortName = "Jump Booster";
@@ -11449,7 +11450,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "BA Myomer Booster";
-        misc.setInternalName("CLBAMyomerBooster");
+        misc.setInternalName(EquipmentTypeLookup.BA_MYOMER_BOOSTER);
         misc.addLookupName("CLBAMB");
         misc.addLookupName("BAMyomerBooster");
         // Need variable tonnage because we have to account for tonnage being
@@ -11474,7 +11475,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Partial Wing [BA]";
-        misc.setInternalName("BAPartialWing");
+        misc.setInternalName(EquipmentTypeLookup.BA_PARTIAL_WING);
         misc.tonnage = 0.2;
         misc.criticals = 1;
         misc.cost = 50000;
@@ -11682,7 +11683,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Demolition Charge";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.DEMOLITION_CHARGE);
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.hittable = false;
@@ -11704,7 +11705,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Vibro-Shovel";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.VIBRO_SHOVEL);
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.hittable = false;

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -925,9 +925,9 @@ public class MiscType extends EquipmentType {
                     }
                 } else {
                     int mascTonnage = 0;
-                    if (getInternalName().equals("ISMASC")) {
+                    if (getInternalName().equals(EquipmentTypeLookup.IS_MASC)) {
                         mascTonnage = (int) Math.round(entity.getWeight() / 20.0f);
-                    } else if (getInternalName().equals("CLMASC")) {
+                    } else if (getInternalName().equals(EquipmentTypeLookup.CLAN_MASC)) {
                         mascTonnage = (int) Math.round(entity.getWeight() / 25.0f);
                     }
                     costValue = (entity.hasEngine() ? entity.getEngine().getRating() : 0) * mascTonnage * 1000;
@@ -1927,7 +1927,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Jump Jet";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.JUMP_JET);
         misc.addLookupName("JumpJet");
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
@@ -1950,10 +1950,10 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Improved Jump Jet";
-        misc.setInternalName("IS Improved Jump Jet");
+        misc.setInternalName(EquipmentTypeLookup.IMPROVED_JUMP_JET);
+        misc.addLookupName("IS Improved Jump Jet");
         misc.addLookupName("ISImprovedJump Jet");
         misc.addLookupName("ImprovedJump Jet");
-        misc.addLookupName("Improved Jump Jet");
         misc.addLookupName("Clan Improved Jump Jet");
         misc.addLookupName("CLImprovedJump Jet");
         misc.tonnage = TONNAGE_VARIABLE;
@@ -1975,7 +1975,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Prototype Improved Jump Jet";
-        misc.setInternalName("ISPrototypeImprovedJumpJet");
+        misc.setInternalName(EquipmentTypeLookup.PROTOTYPE_IMPROVED_JJ);
         misc.shortName = "Prototype Imp. Jump Jet";
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
@@ -1996,7 +1996,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Primitive Prototype Jump Jet";
-        misc.setInternalName("ISPrototypeJumpJet");
+        misc.setInternalName(EquipmentTypeLookup.PROTOTYPE_JUMP_JET);
         misc.shortName = "Prototype Jump Jet";
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
@@ -2120,7 +2120,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "MASC";
-        misc.setInternalName("ISMASC");
+        misc.setInternalName(EquipmentTypeLookup.IS_MASC);
         misc.addLookupName("IS MASC");
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = CRITICALS_VARIABLE;
@@ -2142,7 +2142,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "MASC";
-        misc.setInternalName("CLMASC");
+        misc.setInternalName(EquipmentTypeLookup.CLAN_MASC);
         misc.addLookupName("Clan MASC");
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = CRITICALS_VARIABLE;
@@ -2165,8 +2165,9 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Mech Mechanical Jump Boosters";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.MECH_JUMP_BOOSTER);
         misc.addLookupName("Jump Booster");
+        misc.addLookupName(misc.name);
         misc.shortName = "Jump Booster";
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = CRITICALS_VARIABLE;
@@ -2250,7 +2251,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createISUMU() {
         MiscType misc = new MiscType();
         misc.name = "UMU";
-        misc.setInternalName("UMU");
+        misc.setInternalName(EquipmentTypeLookup.MECH_UMU);
         misc.addLookupName("ISUMU");
         misc.addLookupName("CLUMU");
         misc.addLookupName("IS Underwater Maneuvering Unit");
@@ -6792,7 +6793,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Heat Sink";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.SINGLE_HS);
         misc.tonnage = 1.0f;
         misc.criticals = 1;
         misc.tankslots = 0;
@@ -6817,7 +6818,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "1 Compact Heat Sink";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.COMPACT_HS_1);
         misc.addLookupName("IS1 Compact Heat Sink");
         misc.tonnage = 1.5f;
         misc.criticals = 1;
@@ -6836,7 +6837,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "2 Compact Heat Sinks";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.COMPACT_HS_2);
         misc.addLookupName("IS2 Compact Heat Sinks");
         misc.tonnage = 3.0f;
         misc.criticals = 1;
@@ -6855,7 +6856,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Double Heat Sink Prototype";
-        misc.setInternalName("ISDoubleHeatSinkPrototype");
+        misc.setInternalName(EquipmentTypeLookup.IS_DOUBLE_HS_PROTOTYPE);
         misc.addLookupName("IS Double Heat Sink Prototype");
         misc.addLookupName("ISDouble Heat Sink Prototype");
         misc.tonnage = 1.0f;
@@ -6874,7 +6875,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Double Heat Sink (Freezers)";
-        misc.setInternalName("ISDoubleHeatSinkFreezer");
+        misc.setInternalName(EquipmentTypeLookup.IS_DOUBLE_HS_FREEZER);
         misc.addLookupName("Freezers");
         misc.tonnage = 1.0f;
         misc.criticals = 3;
@@ -6892,7 +6893,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Double Heat Sink";
-        misc.setInternalName("ISDoubleHeatSink");
+        misc.setInternalName(EquipmentTypeLookup.IS_DOUBLE_HS);
         misc.addLookupName("IS Double Heat Sink");
         misc.addLookupName("ISDouble Heat Sink");
         misc.tonnage = 1.0f;
@@ -6910,7 +6911,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Double Heat Sink";
-        misc.setInternalName("CLDoubleHeatSink");
+        misc.setInternalName(EquipmentTypeLookup.CLAN_DOUBLE_HS);
         misc.addLookupName("Clan Double Heat Sink");
         misc.addLookupName("CLDouble Heat Sink");
         misc.tonnage = 1.0f;
@@ -6929,7 +6930,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Laser Heat Sink";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.LASER_HS);
         misc.addLookupName("CLLaser Heat Sink");
         misc.tonnage = 1.0f;
         misc.criticals = 2;
@@ -9564,7 +9565,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "RISC Super-Cooled Myomer";
-        misc.setInternalName("ISSuperCooledMyomer");
+        misc.setInternalName(EquipmentTypeLookup.SCM);
         misc.shortName = "Super-Cooled Myomer";
         misc.tonnage = 0;
         misc.criticals = 6;
@@ -11330,7 +11331,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Jump Jet [BA]";
-        misc.setInternalName("BAJumpJet");
+        misc.setInternalName(EquipmentTypeLookup.BA_JUMP_JET);
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.cost = 0;
@@ -11346,7 +11347,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "VTOL [BA]";
-        misc.setInternalName("BAVTOL");
+        misc.setInternalName(EquipmentTypeLookup.BA_VTOL);
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.cost = 0;
@@ -11363,7 +11364,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "UMU [BA]";
-        misc.setInternalName("BAUMU");
+        misc.setInternalName(EquipmentTypeLookup.BA_UMU);
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.cost = 0;

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -3247,13 +3247,13 @@ public class Tank extends Entity {
             //Add hitch to the rear by default
             if (isSuperHeavy()) {
                 try {
-                    addEquipment(EquipmentType.get("Hitch"), SuperHeavyTank.LOC_REAR);
+                    addEquipment(EquipmentType.get(EquipmentTypeLookup.HITCH), SuperHeavyTank.LOC_REAR);
                } catch (LocationFullException ex) {
                    //For vehicles, this shouldn't happen
                }
             } else {
                 try {
-                    addEquipment(EquipmentType.get("Hitch"), Tank.LOC_REAR);
+                    addEquipment(EquipmentType.get(EquipmentTypeLookup.HITCH), Tank.LOC_REAR);
                } catch (LocationFullException ex) {
                    //ditto
                }

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -1012,68 +1012,68 @@ public class WeaponType extends EquipmentType {
         // return the correct weapons bay for the given type of weapon
         switch (atClass) {
             case (CLASS_LASER):
-                return EquipmentType.get("Laser Bay");
+                return EquipmentType.get(EquipmentTypeLookup.LASER_BAY);
             case (CLASS_AMS):
-            	return EquipmentType.get("AMS Bay");
+                return EquipmentType.get(EquipmentTypeLookup.AMS_BAY);
             case (CLASS_POINT_DEFENSE):
-                return EquipmentType.get("Point Defense Bay");
+                return EquipmentType.get(EquipmentTypeLookup.POINT_DEFENSE_BAY);
             case (CLASS_PPC):
-                return EquipmentType.get("PPC Bay");
+                return EquipmentType.get(EquipmentTypeLookup.PPC_BAY);
             case (CLASS_PULSE_LASER):
-                return EquipmentType.get("Pulse Laser Bay");
+                return EquipmentType.get(EquipmentTypeLookup.PULSE_LASER_BAY);
             case (CLASS_ARTILLERY):
-                return EquipmentType.get("Artillery Bay");
+                return EquipmentType.get(EquipmentTypeLookup.ARTILLERY_BAY);
             case (CLASS_PLASMA):
-                return EquipmentType.get("Plasma Bay");
+                return EquipmentType.get(EquipmentTypeLookup.PLASMA_BAY);
             case (CLASS_AC):
-                return EquipmentType.get("AC Bay");
+                return EquipmentType.get(EquipmentTypeLookup.AC_BAY);
 /*            case (CLASS_GAUSS):
-                return EquipmentType.get("Gauss Bay");*/
+                return EquipmentType.get(EquipmentTypeLookup.GAUSS_BAY);*/
             case (CLASS_LBX_AC):
-                return EquipmentType.get("LBX AC Bay");
+                return EquipmentType.get(EquipmentTypeLookup.LBX_AC_BAY);
             case (CLASS_LRM):
-                return EquipmentType.get("LRM Bay");
+                return EquipmentType.get(EquipmentTypeLookup.LRM_BAY);
             case (CLASS_SRM):
-                return EquipmentType.get("SRM Bay");
+                return EquipmentType.get(EquipmentTypeLookup.SRM_BAY);
             case (CLASS_MRM):
-                return EquipmentType.get("MRM Bay");
+                return EquipmentType.get(EquipmentTypeLookup.MRM_BAY);
             case (CLASS_MML):
-                return EquipmentType.get("MML Bay");
+                return EquipmentType.get(EquipmentTypeLookup.MML_BAY);
             case (CLASS_THUNDERBOLT):
-                return EquipmentType.get("Thunderbolt Bay");
+                return EquipmentType.get(EquipmentTypeLookup.THUNDERBOLT_BAY);
             case (CLASS_ATM):
-                return EquipmentType.get("ATM Bay");
+                return EquipmentType.get(EquipmentTypeLookup.ATM_BAY);
             case (CLASS_ROCKET_LAUNCHER):
-                return EquipmentType.get("Rocket Launcher Bay");
+                return EquipmentType.get(EquipmentTypeLookup.ROCKET_LAUNCHER_BAY);
             case (CLASS_CAPITAL_LASER):
                 if (subCapital) {
-                    return EquipmentType.get("Sub-Capital Laser Bay");
+                    return EquipmentType.get(EquipmentTypeLookup.SCL_BAY);
                 }
-                return EquipmentType.get("Capital Laser Bay");
+                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_LASER_BAY);
             case (CLASS_CAPITAL_PPC):
-                return EquipmentType.get("Capital PPC Bay");
+                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_PPC_BAY);
             case (CLASS_CAPITAL_AC):
                 if (subCapital) {
-                    return EquipmentType.get("Sub-Capital Cannon Bay");
+                    return EquipmentType.get(EquipmentTypeLookup.SCC_BAY);
                 }
-                return EquipmentType.get("Capital AC Bay");
+                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_AC_BAY);
             case (CLASS_CAPITAL_GAUSS):
-                return EquipmentType.get("Capital Gauss Bay");
+                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_GAUSS_BAY);
             case (CLASS_CAPITAL_MD):
-                return EquipmentType.get("Capital Mass Driver Bay");
+                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_MASS_DRIVER_BAY);
             case (CLASS_CAPITAL_MISSILE):
                 if (subCapital) {
-                    return EquipmentType.get("Sub-Capital Missile Bay");
+                    return EquipmentType.get(EquipmentTypeLookup.SC_MISSILE_BAY);
                 }
-                return EquipmentType.get("Capital Missile Bay");
+                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_MISSILE_BAY);
             case (CLASS_TELE_MISSILE):
-                return EquipmentType.get("Tele-Operated Capital Missile Bay");
+                return EquipmentType.get(EquipmentTypeLookup.TELE_CAPITAL_MISSILE_BAY);
             case (CLASS_AR10):
-                return EquipmentType.get("AR10 Bay");
+                return EquipmentType.get(EquipmentTypeLookup.AR10_BAY);
             case (CLASS_SCREEN):
-                return EquipmentType.get("Screen Launcher Bay");
+                return EquipmentType.get(EquipmentTypeLookup.SCREEN_LAUNCHER_BAY);
             default:
-                return EquipmentType.get("Misc Bay");
+                return EquipmentType.get(EquipmentTypeLookup.MISC_BAY);
         }
     }
     

--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -23,17 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EntityWeightClass;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.TechConstants;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
@@ -247,9 +237,9 @@ public class TestBattleArmor extends TestEntity {
     }
 
     public enum BAMotiveSystems {
-        BA_JUMP ("BAJumpJet", EntityMovementMode.INF_JUMP, new int[] { 25, 25, 50, 125, 250 }),
-        BA_VTOL ("BAVTOL", EntityMovementMode.VTOL, new int[] { 30, 40, 60 }),
-        BA_UMU ("BAUMU", EntityMovementMode.INF_UMU, new int[] { 45, 45, 85, 160, 250});
+        BA_JUMP (EquipmentTypeLookup.BA_JUMP_JET, EntityMovementMode.INF_JUMP, new int[] { 25, 25, 50, 125, 250 }),
+        BA_VTOL (EquipmentTypeLookup.BA_VTOL, EntityMovementMode.VTOL, new int[] { 30, 40, 60 }),
+        BA_UMU (EquipmentTypeLookup.BA_UMU, EntityMovementMode.INF_UMU, new int[] { 45, 45, 85, 160, 250});
 
         private final String internalName;
         private final EntityMovementMode mode;
@@ -736,7 +726,7 @@ public class TestBattleArmor extends TestEntity {
                     + "mechanical jump booster!");
             return false;
         }
-        EquipmentType boosterType = EquipmentType.get("CLBAMyomerBooster");
+        EquipmentType boosterType = EquipmentType.get(EquipmentTypeLookup.BA_MYOMER_BOOSTER);
         if (ba.countWorkingMisc(MiscType.F_MASC) > boosterType.getCriticals(ba)) {
             buff.append("BattleArmor may only mount 1 " + "myomer booster!");
             return false;

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -26,29 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.Bay;
-import megamek.common.BombType;
-import megamek.common.CriticalSlot;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EntityWeightClass;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.ITechnology;
-import megamek.common.Jumpship;
-import megamek.common.Mech;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.Protomech;
-import megamek.common.SimpleTechLevel;
-import megamek.common.SmallCraft;
-import megamek.common.Tank;
-import megamek.common.TechConstants;
-import megamek.common.Transporter;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.util.StringUtil;
 
 /**
@@ -326,15 +304,15 @@ public abstract class TestEntity implements TestEntityOption {
         if ((entitytype & Entity.ETYPE_MECH) != 0) {
             return TestMech.MechJumpJets.allJJs(industrial);
         } else if ((entitytype & Entity.ETYPE_TANK) != 0) {
-            return Collections.singletonList(EquipmentType.get("VehicleJumpJet"));
+            return Collections.singletonList(EquipmentType.get(EquipmentTypeLookup.VEHICLE_JUMP_JET));
         } else if ((entitytype & Entity.ETYPE_BATTLEARMOR) != 0) {
             return TestBattleArmor.BAMotiveSystems.allSystems();
         } else if ((entitytype & Entity.ETYPE_PROTOMECH) != 0) {
             // Until we have a TestProtomech
             return Arrays.asList(new EquipmentType[] {
-                EquipmentType.get("ProtomechJumpJet"),
-                EquipmentType.get("ExtendedJumpJetSystem"),
-                EquipmentType.get("ProtomechUMU")});
+                EquipmentType.get(EquipmentTypeLookup.PROTOMECH_JUMP_JET),
+                EquipmentType.get(EquipmentTypeLookup.EXTENDED_JUMP_JET_SYSTEM),
+                EquipmentType.get(EquipmentTypeLookup.PROTOMECH_UMU)});
         } else {
             return Collections.emptyList();
         }

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -30,22 +30,7 @@ import java.util.Set;
 import java.util.Vector;
 import java.util.stream.Collectors;
 
-import megamek.common.AmmoType;
-import megamek.common.BipedMech;
-import megamek.common.CriticalSlot;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.LandAirMech;
-import megamek.common.Mech;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.QuadMech;
-import megamek.common.QuadVee;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TechConstants;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
 import megamek.common.weapons.autocannons.ACWeapon;
@@ -58,12 +43,12 @@ import megamek.common.weapons.ppc.PPCWeapon;
 public class TestMech extends TestEntity {
 
     public enum MechJumpJets {
-        JJ_STANDARD ("JumpJet", true, Mech.JUMP_STANDARD),
-        JJ_IMPROVED ("ImprovedJump Jet", false, Mech.JUMP_IMPROVED),
-        JJ_PROTOTYPE ("ISPrototypeJumpJet", true, Mech.JUMP_PROTOTYPE),
-        JJ_PROTOTYPE_IMPROVED ("ISPrototypeImprovedJumpJet", false, Mech.JUMP_PROTOTYPE_IMPROVED),
-        JJ_UMU ("UMU", false, Mech.JUMP_NONE),
-        JJ_BOOSTER ("Mech Mechanical Jump Boosters", true, Mech.JUMP_BOOSTER);
+        JJ_STANDARD (EquipmentTypeLookup.JUMP_JET, true, Mech.JUMP_STANDARD),
+        JJ_IMPROVED (EquipmentTypeLookup.IMPROVED_JUMP_JET, false, Mech.JUMP_IMPROVED),
+        JJ_PROTOTYPE (EquipmentTypeLookup.PROTOTYPE_JUMP_JET, true, Mech.JUMP_PROTOTYPE),
+        JJ_PROTOTYPE_IMPROVED (EquipmentTypeLookup.PROTOTYPE_IMPROVED_JJ, false, Mech.JUMP_PROTOTYPE_IMPROVED),
+        JJ_UMU (EquipmentTypeLookup.MECH_UMU, false, Mech.JUMP_NONE),
+        JJ_BOOSTER (EquipmentTypeLookup.MECH_JUMP_BOOSTER, true, Mech.JUMP_BOOSTER);
         
         private String internalName;
         private boolean industrial;

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeapon.java
@@ -16,12 +16,7 @@
  */
 package megamek.common.weapons;
 
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.IGame;
-import megamek.common.Mounted;
-import megamek.common.TechAdvancement;
-import megamek.common.ToHitData;
+import megamek.common.*;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.bayweapons.AmmoBayWeapon;
 import megamek.server.Server;
@@ -43,7 +38,7 @@ public class ArtilleryBayWeapon extends AmmoBayWeapon {
         // tech levels are a little tricky
         this.flags = flags.or(F_ARTILLERY);
         this.name = "Artillery Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.ARTILLERY_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/ACBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/ACBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class ACBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "AC Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.AC_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/AMSBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/AMSBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.TechAdvancement;
 import megamek.common.ToHitData;
@@ -40,7 +41,7 @@ public class AMSBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "AMS Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.AMS_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 1;

--- a/megamek/src/megamek/common/weapons/bayweapons/AR10BayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/AR10BayWeapon.java
@@ -16,11 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
-import megamek.common.Entity;
-import megamek.common.IGame;
-import megamek.common.Mounted;
-import megamek.common.RangeType;
-import megamek.common.ToHitData;
+import megamek.common.*;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.CapitalMissileBayHandler;
@@ -45,7 +41,7 @@ public class AR10BayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "AR10 Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.AR10_BAY);
         addLookupName("ISAR10Bay");
         addLookupName("CLAR10Bay");
         this.heat = 0;

--- a/megamek/src/megamek/common/weapons/bayweapons/ATMBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/ATMBayWeapon.java
@@ -16,13 +16,13 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.SimpleTechLevel;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.MissileBayWeaponHandler;
 import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.bayweapons.AmmoBayWeapon;
 import megamek.server.Server;
 
 /**
@@ -40,7 +40,7 @@ public class ATMBayWeapon extends AmmoBayWeapon {
     public ATMBayWeapon() {
         super();
         // tech levels are a little tricky
-        this.name = "ATM Bay";
+        this.name = EquipmentTypeLookup.ATM_BAY;
         this.setInternalName(this.name);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;

--- a/megamek/src/megamek/common/weapons/bayweapons/CapitalACBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/CapitalACBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class CapitalACBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Capital AC Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.CAPITAL_AC_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 12;

--- a/megamek/src/megamek/common/weapons/bayweapons/CapitalGaussBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/CapitalGaussBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class CapitalGaussBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Capital Gauss Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.CAPITAL_GAUSS_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 12;

--- a/megamek/src/megamek/common/weapons/bayweapons/CapitalLaserBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/CapitalLaserBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class CapitalLaserBayWeapon extends BayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Capital Laser Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.CAPITAL_LASER_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 12;

--- a/megamek/src/megamek/common/weapons/bayweapons/CapitalMDBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/CapitalMDBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class CapitalMDBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Capital Mass Driver Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.CAPITAL_MASS_DRIVER_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 12;

--- a/megamek/src/megamek/common/weapons/bayweapons/CapitalMissileBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/CapitalMissileBayWeapon.java
@@ -16,11 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
-import megamek.common.Entity;
-import megamek.common.IGame;
-import megamek.common.Mounted;
-import megamek.common.RangeType;
-import megamek.common.ToHitData;
+import megamek.common.*;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.CapitalMissileBayHandler;
@@ -50,7 +46,7 @@ public class CapitalMissileBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Capital Missile Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.CAPITAL_MISSILE_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 12;

--- a/megamek/src/megamek/common/weapons/bayweapons/CapitalPPCBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/CapitalPPCBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class CapitalPPCBayWeapon extends BayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Capital PPC Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.CAPITAL_PPC_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 12;

--- a/megamek/src/megamek/common/weapons/bayweapons/GaussBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/GaussBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class GaussBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Gauss Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.GAUSS_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/LBXBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/LBXBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class LBXBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "LBX AC Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.LBX_AC_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/LRMBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/LRMBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class LRMBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "LRM Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.LRM_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/LaserBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/LaserBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class LaserBayWeapon extends BayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Laser Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.LASER_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/MMLBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/MMLBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class MMLBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "MML Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.MML_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/MRMBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/MRMBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class MRMBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "MRM Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.MRM_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/MiscBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/MiscBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class MiscBayWeapon extends BayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Misc Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.MISC_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 0;

--- a/megamek/src/megamek/common/weapons/bayweapons/PPCBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/PPCBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class PPCBayWeapon extends BayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "PPC Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.PPC_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/PlasmaBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/PlasmaBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class PlasmaBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Plasma Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.PLASMA_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/PointDefenseBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/PointDefenseBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class PointDefenseBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Point Defense Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.POINT_DEFENSE_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/PulseLaserBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/PulseLaserBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class PulseLaserBayWeapon extends BayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Pulse Laser Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.PULSE_LASER_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/RLBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/RLBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class RLBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Rocket Launcher Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.ROCKET_LAUNCHER_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/SRMBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/SRMBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class SRMBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "SRM Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.SRM_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/ScreenLauncherBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/ScreenLauncherBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class ScreenLauncherBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Screen Launcher Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.SCREEN_LAUNCHER_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/bayweapons/SubCapCannonBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/SubCapCannonBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class SubCapCannonBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Sub-Capital Cannon Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.SCC_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 12;

--- a/megamek/src/megamek/common/weapons/bayweapons/SubCapLaserBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/SubCapLaserBayWeapon.java
@@ -16,6 +16,8 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
+
 /**
  * @author Jay Lawson
  */
@@ -32,7 +34,7 @@ public class SubCapLaserBayWeapon extends BayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Sub-Capital Laser Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.SCL_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 12;

--- a/megamek/src/megamek/common/weapons/bayweapons/SubCapitalMissileBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/SubCapitalMissileBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class SubCapitalMissileBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Sub-Capital Missile Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.SC_MISSILE_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 12;

--- a/megamek/src/megamek/common/weapons/bayweapons/TeleOperatedMissileBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/TeleOperatedMissileBayWeapon.java
@@ -16,11 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
-import megamek.common.Entity;
-import megamek.common.IGame;
-import megamek.common.Mounted;
-import megamek.common.RangeType;
-import megamek.common.ToHitData;
+import megamek.common.*;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.CapitalMissileBayHandler;
@@ -45,10 +41,10 @@ public class TeleOperatedMissileBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Tele-Operated Capital Missile Bay";
+        this.setInternalName(EquipmentTypeLookup.TELE_CAPITAL_MISSILE_BAY);
         String[] modeStrings = { "Normal", "Tele-Operated" };
         setModes(modeStrings);
         setInstantModeSwitch(false);
-        this.setInternalName(this.name);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 12;

--- a/megamek/src/megamek/common/weapons/bayweapons/ThunderboltBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/ThunderboltBayWeapon.java
@@ -16,6 +16,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -39,7 +40,7 @@ public class ThunderboltBayWeapon extends AmmoBayWeapon {
         super();
         // tech levels are a little tricky
         this.name = "Thunderbolt Bay";
-        this.setInternalName(this.name);
+        this.setInternalName(EquipmentTypeLookup.THUNDERBOLT_BAY);
         this.heat = 0;
         this.damage = DAMAGE_VARIABLE;
         this.shortRange = 6;

--- a/megamek/src/megamek/common/weapons/infantry/InfantryRifleAutoRifleWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryRifleAutoRifleWeapon.java
@@ -18,6 +18,7 @@
 package megamek.common.weapons.infantry;
 
 import megamek.common.AmmoType;
+import megamek.common.EquipmentTypeLookup;
 
 /**
  * @author Ben Grills
@@ -33,8 +34,8 @@ public class InfantryRifleAutoRifleWeapon extends InfantryWeapon {
 		super();
 
 		name = "Auto-Rifle (Modern, Generic)";
-		setInternalName(name);
-		addLookupName("InfantryAssaultRifle");
+		setInternalName(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+		addLookupName(name);
 		addLookupName("Auto Rifle");
 		addLookupName("Auto-Rifle");
 		addLookupName("Infantry Automatic Rifle");

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportTAGWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportTAGWeapon.java
@@ -13,6 +13,7 @@
  */
 package megamek.common.weapons.infantry;
 
+import megamek.common.EquipmentTypeLookup;
 import megamek.common.IGame;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
@@ -40,7 +41,7 @@ public class InfantrySupportTAGWeapon extends InfantryWeapon {
 		        .andNot(F_BA_WEAPON).andNot(F_PROTO_WEAPON).or(F_TAG).or(F_NO_FIRES).or(F_INF_ENCUMBER);
 
 		name = "TAG (Light, Man-Portable)";
-		setInternalName("InfantryTAG");
+		setInternalName(EquipmentTypeLookup.INFANTRY_TAG);
 		addLookupName("Infantry TAG");
 		damage = 0;
 		shortRange = 3;

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -74,108 +74,11 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 
 import megamek.MegaMek;
 import megamek.client.ui.swing.util.PlayerColors;
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.Bay;
-import megamek.common.BipedMech;
-import megamek.common.Board;
-import megamek.common.BoardDimensions;
-import megamek.common.BombType;
-import megamek.common.Building;
+import megamek.common.*;
 import megamek.common.Building.BasementType;
 import megamek.common.Building.DemolitionCharge;
-import megamek.common.BuildingTarget;
-import megamek.common.CalledShot;
-import megamek.common.CommonConstants;
-import megamek.common.Compute;
-import megamek.common.ComputeECM;
-import megamek.common.Configuration;
-import megamek.common.ConvFighter;
-import megamek.common.Coords;
-import megamek.common.Crew;
-import megamek.common.CriticalSlot;
-import megamek.common.Dropship;
-import megamek.common.ECMInfo;
-import megamek.common.EjectedCrew;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EntityMovementType;
-import megamek.common.EntitySelector;
-import megamek.common.EntityWeightClass;
-import megamek.common.EquipmentMode;
-import megamek.common.EquipmentType;
-import megamek.common.FighterSquadron;
-import megamek.common.Flare;
-import megamek.common.FuelTank;
-import megamek.common.Game;
-import megamek.common.GameTurn;
-import megamek.common.GunEmplacement;
-import megamek.common.HexTarget;
-import megamek.common.HitData;
-import megamek.common.IAero;
-import megamek.common.IArmorState;
-import megamek.common.IBoard;
-import megamek.common.IBomber;
-import megamek.common.IEntityRemovalConditions;
-import megamek.common.IGame;
 import megamek.common.IGame.Phase;
-import megamek.common.IHex;
-import megamek.common.ILocationExposureStatus;
-import megamek.common.INarcPod;
-import megamek.common.IPlayer;
-import megamek.common.ITerrain;
-import megamek.common.Infantry;
-import megamek.common.InfernoTracker;
-import megamek.common.Jumpship;
-import megamek.common.LandAirMech;
-import megamek.common.LargeSupportTank;
-import megamek.common.LocationFullException;
-import megamek.common.LosEffects;
-import megamek.common.MapSettings;
-import megamek.common.Mech;
-import megamek.common.MechWarrior;
-import megamek.common.Minefield;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.MovePath;
 import megamek.common.MovePath.MoveStepType;
-import megamek.common.MoveStep;
-import megamek.common.OffBoardDirection;
-import megamek.common.PhysicalResult;
-import megamek.common.PilotingRollData;
-import megamek.common.PlanetaryConditions;
-import megamek.common.Player;
-import megamek.common.Protomech;
-import megamek.common.QuadMech;
-import megamek.common.QuadVee;
-import megamek.common.Report;
-import megamek.common.Roll;
-import megamek.common.SmallCraft;
-import megamek.common.SpaceStation;
-import megamek.common.SpecialHexDisplay;
-import megamek.common.SuperHeavyTank;
-import megamek.common.SupportTank;
-import megamek.common.SupportVTOL;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
-import megamek.common.TargetRollModifier;
-import megamek.common.Targetable;
-import megamek.common.Team;
-import megamek.common.TechConstants;
-import megamek.common.TeleMissile;
-import megamek.common.Terrain;
-import megamek.common.Terrains;
-import megamek.common.ToHitData;
-import megamek.common.TripodMech;
-import megamek.common.TurnOrdered;
-import megamek.common.TurnVectors;
-import megamek.common.UnitLocation;
-import megamek.common.VTOL;
-import megamek.common.Warship;
-import megamek.common.WeaponComparatorBV;
-import megamek.common.WeaponType;
 import megamek.common.actions.AbstractAttackAction;
 import megamek.common.actions.AirmechRamAttackAction;
 import megamek.common.actions.ArtilleryAttackAction;
@@ -15490,7 +15393,7 @@ public class Server implements Runnable {
 
         // Is there a blown off arm in the hex?
         if (curHex.terrainLevel(Terrains.ARMS) > 0) {
-            clubType = EquipmentType.get("Limb Club");
+            clubType = EquipmentType.get(EquipmentTypeLookup.LIMB_CLUB);
             curHex.addTerrain(Terrains.getTerrainFactory().createTerrain(
                     Terrains.ARMS, curHex.terrainLevel(Terrains.ARMS) - 1));
             sendChangedHex(entity.getPosition());
@@ -15501,7 +15404,7 @@ public class Server implements Runnable {
         }
         // Is there a blown off leg in the hex?
         else if (curHex.terrainLevel(Terrains.LEGS) > 0) {
-            clubType = EquipmentType.get("Limb Club");
+            clubType = EquipmentType.get(EquipmentTypeLookup.LIMB_CLUB);
             curHex.addTerrain(Terrains.getTerrainFactory().createTerrain(
                     Terrains.LEGS, curHex.terrainLevel(Terrains.LEGS) - 1));
             sendChangedHex(entity.getPosition());
@@ -15550,7 +15453,7 @@ public class Server implements Runnable {
 
             // Let the player know if they found a club.
             if (found) {
-                clubType = EquipmentType.get("Girder Club");
+                clubType = EquipmentType.get(EquipmentTypeLookup.GIRDER_CLUB);
                 r = new Report(3045);
                 r.subject = entity.getId();
                 r.addDesc(entity);
@@ -15567,7 +15470,7 @@ public class Server implements Runnable {
         // Are there woods in the hex?
         else if (curHex.containsTerrain(Terrains.WOODS)
                  || curHex.containsTerrain(Terrains.JUNGLE)) {
-            clubType = EquipmentType.get("Tree Club");
+            clubType = EquipmentType.get(EquipmentTypeLookup.TREE_CLUB);
             r = new Report(3055);
             r.subject = entity.getId();
             r.addDesc(entity);
@@ -35502,14 +35405,13 @@ public class Server implements Runnable {
                 guerrilla.autoSetInternal();
                 guerrilla.getCrew().setGunnery(5, 0);
                 try {
-                    guerrilla.addEquipment(EquipmentType.get("InfantryAssaultRifle"),
+                    guerrilla.addEquipment(EquipmentType.get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE),
                             Infantry.LOC_INFANTRY);
-                    guerrilla.setPrimaryWeapon((InfantryWeapon) InfantryWeapon.get("InfantryAssaultRifle"));
+                    guerrilla.setPrimaryWeapon((InfantryWeapon) InfantryWeapon
+                            .get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE));
                 } catch (Exception ex) {
                     ex.printStackTrace();
                 }
-                //guerrilla.addEquipment(EquipmentType.get("InfantryAssaultRifle"), Infantry.LOC_INFANTRY);
-                //guerrilla.setPrimaryWeapon((InfantryWeapon) InfantryWeapon.get("InfantryAssaultRifle"));
                 guerrilla.setDeployed(true);
                 guerrilla.setDone(true);
                 guerrilla.setId(getFreeEntityId());

--- a/megamek/unittests/megamek/common/EquipmentTypeLookupTest.java
+++ b/megamek/unittests/megamek/common/EquipmentTypeLookupTest.java
@@ -1,0 +1,66 @@
+package megamek.common;
+
+import megamek.common.loaders.EntityLoadingException;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import static org.junit.Assert.*;
+
+public class EquipmentTypeLookupTest {
+
+    @Test
+    public void allLookupKeysValid() throws IllegalAccessException {
+        // Collect all failed fields so the test results will show which field(s) failed
+        final StringJoiner sj = new StringJoiner(", ");
+
+        for (Field field : EquipmentTypeLookup.class.getFields()) {
+            if (field.isAnnotationPresent(EquipmentTypeLookup.EquipmentName.class)
+                    && ((field.getModifiers() & Modifier.STATIC) == Modifier.STATIC)) {
+                String eqName = field.get(null).toString();
+                if (EquipmentType.get(eqName) == null) {
+                    sj.add(eqName);
+                }
+            }
+        }
+
+        assertEquals("", sj.toString());
+    }
+
+    /**
+     * This test is disabled because it fails to meet the expectation that unit tests should be quick,
+     * but is here because it is valuable as an integration test to check whether any units have equipment
+     * that cannot be loaded.
+     */
+    @Ignore
+    @Test
+    public void testFailedEquipment() {
+        final Set<String> failedEquipment = new HashSet<>();
+
+        final MechSummaryCache msc = MechSummaryCache.getInstance();
+        while (!msc.isInitialized()) {
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        for (MechSummary ms : msc.getAllMechs()) {
+            try {
+                Entity entity = new MechFileParser(ms.getSourceFile(),
+                        ms.getEntryName()).getEntity();
+                failedEquipment.addAll(entity.failedEquipmentList);
+            } catch (EntityLoadingException e) {
+                e.printStackTrace();
+            }
+        }
+
+        assertEquals("", String.join(",", failedEquipment));
+    }
+}


### PR DESCRIPTION
This was a bit tedious, but designed to make me feel better about some of the code I'm writing. There are some places in the code where a specific equipment instance must be retrieved using `EquipmentType#get`. This replaces the use of String literals as parameters with String constants. Only a small portion of the EquipmentType objects have named constants because most of them do not require direct specific lookup.

Besides guarding against null EquipmentTypes by typo, it provides assurance that the equipment will exist because the constant is used to initialize the internal name. A unit test provides an extra measure of security against changing the possibility of lookup failure due to the lookup name being changed.