### PR TITLE
Added ignore for YML files and fixed a depreicated warning

### DIFF
--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -313,7 +313,7 @@ public class MechSummaryCache {
          * loadReport.append(" --")
          * .append(failedUnitsDesc.nextElement()).append("\n"); }
          */
-        
+
         System.out.print(loadReport.toString());
 
         done();
@@ -325,7 +325,7 @@ public class MechSummaryCache {
         }
 
         initialized = true;
-        
+
         for (int i = 0; i < listeners.size(); i++) {
             listeners.get(i).doneLoading();
         }
@@ -355,7 +355,7 @@ public class MechSummaryCache {
         ms.setName(e.getShortNameRaw());
         ms.setChassis(e.getChassis());
         ms.setModel(e.getModel());
-        ms.setUnitType(UnitType.determineUnitType(e));
+        ms.setUnitType(UnitType.getTypeName(e.getUnitType()));
         ms.setSourceFile(f);
         ms.setEntryName(entry);
         ms.setYear(e.getYear());
@@ -459,20 +459,20 @@ public class MechSummaryCache {
                             entityVerifier.tankOption, null);
                 }
             }else if (e.getEntityType() == Entity.ETYPE_AERO
-                    && e.getEntityType() != 
+                    && e.getEntityType() !=
                             Entity.ETYPE_DROPSHIP
-                    && e.getEntityType() != 
+                    && e.getEntityType() !=
                             Entity.ETYPE_SMALL_CRAFT
-                    && e.getEntityType() != 
+                    && e.getEntityType() !=
                             Entity.ETYPE_FIGHTER_SQUADRON
-                    && e.getEntityType() != 
+                    && e.getEntityType() !=
                             Entity.ETYPE_JUMPSHIP
-                    && e.getEntityType() != 
+                    && e.getEntityType() !=
                             Entity.ETYPE_SPACE_STATION) {
-                testEntity = new TestAero((Aero)e, 
+                testEntity = new TestAero((Aero)e,
                         entityVerifier.mechOption, null);
             } else if (e instanceof BattleArmor){
-                testEntity = new TestBattleArmor((BattleArmor) e, 
+                testEntity = new TestBattleArmor((BattleArmor) e,
                         entityVerifier.baOption, null);
             }
             if (testEntity != null &&
@@ -499,7 +499,7 @@ public class MechSummaryCache {
         } else {
             ms.setMyomerName("None");
         }
-        
+
         return ms;
     }
 
@@ -572,6 +572,9 @@ public class MechSummaryCache {
                     continue;
                 }
                 if (f.getName().toLowerCase().endsWith(".ds_store")) {
+                    continue;
+                }
+                if (f.getName().toLowerCase().endsWith(".yml")) {
                     continue;
                 }
                 if (f.getName().equals("UnitVerifierOptions.xml")) {
@@ -671,6 +674,9 @@ public class MechSummaryCache {
             if (zEntry.getName().toLowerCase().endsWith(".txt")) {
                 continue;
             }
+            if (zEntry.getName().toLowerCase().endsWith(".yml")) {
+                continue;
+            }
             if ((Math.max(fZipFile.lastModified(), zEntry.getTime()) < lLastCheck)
                     && sKnownFiles.contains(zEntry.getName())) {
                 continue;
@@ -722,7 +728,7 @@ public class MechSummaryCache {
 
         return bNeedsUpdate;
     }
-    
+
     private boolean addLookupNames(long lLastCheck) {
         final String METHOD_NAME = "addLookupNames(long)"; //$NON-NLS-1$
         File lookupNames = new MegaMekFile(getUnitCacheDir(),


### PR DESCRIPTION
This fixes 2 issues:

1) Removes a deprecation warning when setting UnitType.
2) Adds YML file ignoring during loading.

Some users are using GitLab CI/CD to generate release zips for custom units and those releases will include a YML file for the CI system to run. This change simply ensures these files don't create unneeded warnings for users.

And some white space removal as well.