### PR TITLE
Bay costs

### DIFF
--- a/megamek/src/megamek/common/ASFBay.java
+++ b/megamek/src/megamek/common/ASFBay.java
@@ -266,4 +266,10 @@ public final class ASFBay extends Bay {
         return ASFBay.techAdvancement();
     }
 
+    @Override
+    public long getCost() {
+        // Based on the number of cubicles
+        return 20000L * (long) totalSpace;
+    }
+
 }

--- a/megamek/src/megamek/common/BattleArmorBay.java
+++ b/megamek/src/megamek/common/BattleArmorBay.java
@@ -147,4 +147,10 @@ public final class BattleArmorBay extends Bay {
         return isClan;
     }
 
+    @Override
+    public long getCost() {
+        // Based on the weight of the equipment (not capacity), rounded up to the whole ton
+        return 15000L * (long) Math.ceil(getWeight());
+    }
+
 }

--- a/megamek/src/megamek/common/Bay.java
+++ b/megamek/src/megamek/common/Bay.java
@@ -628,4 +628,11 @@ public class Bay implements Transporter, ITechnology {
         return false;
     }
 
-} // End package class TroopSpace implements Transporter
+    /**
+     * @return The cost of the bay in C-bills
+     */
+    public long getCost() {
+        return 0;
+    }
+
+ } // End package class TroopSpace implements Transporter

--- a/megamek/src/megamek/common/CrewQuartersCargoBay.java
+++ b/megamek/src/megamek/common/CrewQuartersCargoBay.java
@@ -98,4 +98,9 @@ public final class CrewQuartersCargoBay extends Bay {
         return "crewquarters:" + weight + ":" + doors;
     }
 
+    @Override
+    public long getCost() {
+        return 15000L * (long) totalSpace;
+    }
+
 }

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -378,7 +378,7 @@ public class Dropship extends SmallCraft {
     
     @Override
     public double getCost(boolean ignoreAmmo) {
-        double[] costs = new double[19];
+        double[] costs = new double[20];
         int costIdx = 0;
         double cost = 0;
 
@@ -438,12 +438,18 @@ public class Dropship extends SmallCraft {
         // Transport Bays
         int baydoors = 0;
         long bayCost = 0;
+        long quartersCost = 0;
         for (Bay next : getTransportBays()) {
             baydoors += next.getDoors();
-            bayCost += next.getCost();
+            if (next.isQuarters()) {
+                quartersCost += next.getCost();
+            } else {
+                bayCost += next.getCost();
+            }
         }
 
         costs[costIdx++] += bayCost + (baydoors * 1000);
+        costs[costIdx++] = quartersCost;
 
         // Life Boats and Escape Pods
         costs[costIdx++] += 5000 * (getLifeBoats() + getEscapePods());
@@ -468,8 +474,8 @@ public class Dropship extends SmallCraft {
         bvText = new StringBuffer();
         String[] left = { "Bridge", "Computer", "Life Support", "Sensors", "FCS", "Gunnery Control Systems",
                 "Structural Integrity", "Attitude Thruster", "Landing Gear", "Docking Collar",
-                "Engine", "Drive Unit", "Fuel Tanks", "Armor", "Heat Sinks", "Weapons/Equipment", "Bays/Quarters",
-                "Life Boats/Escape Pods", "Weight Multiplier" };
+                "Engine", "Drive Unit", "Fuel Tanks", "Armor", "Heat Sinks", "Weapons/Equipment", "Bays",
+                "Quarters", "Life Boats/Escape Pods", "Weight Multiplier" };
 
         NumberFormat commafy = NumberFormat.getInstance();
 

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -448,7 +448,7 @@ public class Dropship extends SmallCraft {
             }
         }
 
-        costs[costIdx++] += bayCost + (baydoors * 1000);
+        costs[costIdx++] += bayCost + (baydoors * 1000L);
         costs[costIdx++] = quartersCost;
 
         // Life Boats and Escape Pods

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -437,15 +437,10 @@ public class Dropship extends SmallCraft {
 
         // Transport Bays
         int baydoors = 0;
-        int bayCost = 0;
+        long bayCost = 0;
         for (Bay next : getTransportBays()) {
             baydoors += next.getDoors();
-            if ((next instanceof MechBay) || (next instanceof ASFBay) || (next instanceof SmallCraftBay)) {
-                bayCost += 20000 * next.totalSpace;
-            }
-            if ((next instanceof LightVehicleBay) || (next instanceof HeavyVehicleBay)) {
-                bayCost += 10000 * next.totalSpace;
-            }
+            bayCost += next.getCost();
         }
 
         costs[costIdx++] += bayCost + (baydoors * 1000);
@@ -473,7 +468,7 @@ public class Dropship extends SmallCraft {
         bvText = new StringBuffer();
         String[] left = { "Bridge", "Computer", "Life Support", "Sensors", "FCS", "Gunnery Control Systems",
                 "Structural Integrity", "Attitude Thruster", "Landing Gear", "Docking Collar",
-                "Engine", "Drive Unit", "Fuel Tanks", "Armor", "Heat Sinks", "Weapons/Equipment", "Bays",
+                "Engine", "Drive Unit", "Fuel Tanks", "Armor", "Heat Sinks", "Weapons/Equipment", "Bays/Quarters",
                 "Life Boats/Escape Pods", "Weight Multiplier" };
 
         NumberFormat commafy = NumberFormat.getInstance();

--- a/megamek/src/megamek/common/DropshuttleBay.java
+++ b/megamek/src/megamek/common/DropshuttleBay.java
@@ -108,4 +108,10 @@ public class DropshuttleBay extends Bay {
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED);
     }
 
+    @Override
+    public long getCost() {
+        // Set cost for 2-capacity bay
+        return 150000000;
+    }
+
 }

--- a/megamek/src/megamek/common/FirstClassQuartersCargoBay.java
+++ b/megamek/src/megamek/common/FirstClassQuartersCargoBay.java
@@ -98,4 +98,9 @@ public final class FirstClassQuartersCargoBay extends Bay {
         return "1stclassquarters:" + weight + ":" + doors;
     }
 
+    @Override
+    public long getCost() {
+        return 30000L * (long) totalSpace;
+    }
+
 }

--- a/megamek/src/megamek/common/HeavyVehicleBay.java
+++ b/megamek/src/megamek/common/HeavyVehicleBay.java
@@ -128,4 +128,10 @@ public final class HeavyVehicleBay extends Bay {
         return HeavyVehicleBay.techAdvancement();
     }
 
+    @Override
+    public long getCost() {
+        // Based on the number of cubicles
+        return 10000L * (long) totalSpace;
+    }
+
 } // End package class TroopSpace implements Transporter

--- a/megamek/src/megamek/common/InfantryBay.java
+++ b/megamek/src/megamek/common/InfantryBay.java
@@ -204,4 +204,9 @@ public final class InfantryBay extends Bay {
         return platoonType;
     }
 
+    @Override
+    public long getCost() {
+        // Based on the weight of the equipment (not capacity), rounded up to the whole ton
+        return 15000L * (long) Math.ceil(getWeight());
+    }
 } // End package class TroopSpace implements Transporter

--- a/megamek/src/megamek/common/InsulatedCargoBay.java
+++ b/megamek/src/megamek/common/InsulatedCargoBay.java
@@ -106,4 +106,9 @@ public final class InsulatedCargoBay extends Bay {
         return true;
     }
 
+    @Override
+    public long getCost() {
+        // Based on the weight of the equipment (not capacity), rounded up to the whole ton
+        return 250L * (long) Math.ceil(getWeight());
+    }
 }

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -2097,7 +2097,7 @@ public class Jumpship extends Aero {
             }
         }
 
-        costs[costIdx++] += bayCost + (baydoors * 1000);
+        costs[costIdx++] += bayCost + (baydoors * 1000L);
         costs[costIdx++] = quartersCost;
 
         // Weapons and Equipment

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -2086,15 +2086,10 @@ public class Jumpship extends Aero {
 
         // Transport Bays
         int baydoors = 0;
-        int bayCost = 0;
+        long bayCost = 0;
         for (Bay next : getTransportBays()) {
             baydoors += next.getDoors();
-            if ((next instanceof MechBay) || (next instanceof ASFBay) || (next instanceof SmallCraftBay)) {
-                bayCost += 20000 * next.totalSpace;
-            }
-            if ((next instanceof LightVehicleBay) || (next instanceof HeavyVehicleBay)) {
-                bayCost += 20000 * next.totalSpace;
-            }
+            bayCost += next.getCost();
         }
 
         costs[costIdx++] += bayCost + (baydoors * 1000);
@@ -2129,7 +2124,7 @@ public class Jumpship extends Aero {
                 "Structural Integrity", "Engine", "Engine Control Unit",
                 "KF Drive", "KF Drive Support System", "Attitude Thrusters", "Docking Collars",
                 "Fuel Tanks", "Armor", "Heat Sinks", "Life Boats/Escape Pods", "Grav Decks",
-                "Bays", "HPG", "Weapons/Equipment", "Weight Multiplier" };
+                "Bays/Quarters", "HPG", "Weapons/Equipment", "Weight Multiplier" };
 
         NumberFormat commafy = NumberFormat.getInstance();
 

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -2003,7 +2003,7 @@ public class Jumpship extends Aero {
 
     @Override
     public double getCost(boolean ignoreAmmo) {
-        double[] costs = new double[22];
+        double[] costs = new double[23];
         int costIdx = 0;
         double cost = 0;
 
@@ -2087,12 +2087,18 @@ public class Jumpship extends Aero {
         // Transport Bays
         int baydoors = 0;
         long bayCost = 0;
+        long quartersCost = 0;
         for (Bay next : getTransportBays()) {
             baydoors += next.getDoors();
-            bayCost += next.getCost();
+            if (next.isQuarters()) {
+                quartersCost += next.getCost();
+            } else {
+                bayCost += next.getCost();
+            }
         }
 
         costs[costIdx++] += bayCost + (baydoors * 1000);
+        costs[costIdx++] = quartersCost;
 
         // Weapons and Equipment
         // HPG
@@ -2124,7 +2130,7 @@ public class Jumpship extends Aero {
                 "Structural Integrity", "Engine", "Engine Control Unit",
                 "KF Drive", "KF Drive Support System", "Attitude Thrusters", "Docking Collars",
                 "Fuel Tanks", "Armor", "Heat Sinks", "Life Boats/Escape Pods", "Grav Decks",
-                "Bays/Quarters", "HPG", "Weapons/Equipment", "Weight Multiplier" };
+                "Bays", "Quarters", "HPG", "Weapons/Equipment", "Weight Multiplier" };
 
         NumberFormat commafy = NumberFormat.getInstance();
 

--- a/megamek/src/megamek/common/LightVehicleBay.java
+++ b/megamek/src/megamek/common/LightVehicleBay.java
@@ -128,4 +128,10 @@ public final class LightVehicleBay extends Bay {
         return LightVehicleBay.techAdvancement();
     }
 
+    @Override
+    public long getCost() {
+        // Based on the number of cubicles
+        return 10000L * (long) totalSpace;
+    }
+
 } // End package class TroopSpace implements Transporter

--- a/megamek/src/megamek/common/LiquidCargoBay.java
+++ b/megamek/src/megamek/common/LiquidCargoBay.java
@@ -107,4 +107,10 @@ public final class LiquidCargoBay extends Bay {
         return true;
     }
 
+    @Override
+    public long getCost() {
+        // Based on the weight of the equipment (not capacity), rounded up to the whole ton
+        return 100L * (long) Math.ceil(getWeight());
+    }
+
 }

--- a/megamek/src/megamek/common/LivestockCargoBay.java
+++ b/megamek/src/megamek/common/LivestockCargoBay.java
@@ -108,4 +108,9 @@ public final class LivestockCargoBay extends Bay {
         return true;
     }
 
+    @Override
+    public long getCost() {
+        // Based on the weight of the equipment (not capacity), rounded up to the whole ton
+        return 2500L * (long) Math.ceil(getWeight());
+    }
 }

--- a/megamek/src/megamek/common/MechBay.java
+++ b/megamek/src/megamek/common/MechBay.java
@@ -128,4 +128,10 @@ public final class MechBay extends Bay {
         return MechBay.techAdvancement();
     }
 
+    @Override
+    public long getCost() {
+        // Based on the number of cubicles
+        return 20000L * (long) totalSpace;
+    }
+
 } // End package class TroopSpace implements Transporter

--- a/megamek/src/megamek/common/NavalRepairFacility.java
+++ b/megamek/src/megamek/common/NavalRepairFacility.java
@@ -144,5 +144,9 @@ public class NavalRepairFacility extends Bay {
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED);
     }
 
+    @Override
+    public long getCost() {
+        return (isPressurized() ? 10000L : 5000L) * (long) totalSpace;
+    }
 
 }

--- a/megamek/src/megamek/common/PillionSeatCargoBay.java
+++ b/megamek/src/megamek/common/PillionSeatCargoBay.java
@@ -98,4 +98,9 @@ public final class PillionSeatCargoBay extends Bay {
         return "pillionseats:" + weight + ":" + doors;
     }
 
+    @Override
+    public long getCost() {
+        return 10L * (long) totalSpace;
+    }
+
 }

--- a/megamek/src/megamek/common/ProtomechBay.java
+++ b/megamek/src/megamek/common/ProtomechBay.java
@@ -127,4 +127,10 @@ public final class ProtomechBay extends Bay {
         return ProtomechBay.techAdvancement();
     }
 
+    @Override
+    public long getCost() {
+        // Cost is per five cubicles
+        return 10000L * (long) Math.ceil(totalSpace / 5);
+    }
+
 } // End package class TroopSpace implements Transporter

--- a/megamek/src/megamek/common/RefrigeratedCargoBay.java
+++ b/megamek/src/megamek/common/RefrigeratedCargoBay.java
@@ -108,4 +108,10 @@ public final class RefrigeratedCargoBay extends Bay {
         return true;
     }
 
+    @Override
+    public long getCost() {
+        // Based on the weight of the equipment (not capacity), rounded up to the whole ton
+        return 200L * (long) Math.ceil(getWeight());
+    }
+
 }

--- a/megamek/src/megamek/common/ReinforcedRepairFacility.java
+++ b/megamek/src/megamek/common/ReinforcedRepairFacility.java
@@ -88,5 +88,9 @@ public class ReinforcedRepairFacility extends NavalRepairFacility {
                 .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
     }
 
+    @Override
+    public long getCost() {
+        return 30000L * (long) totalSpace;
+    }
 
 }

--- a/megamek/src/megamek/common/SecondClassQuartersCargoBay.java
+++ b/megamek/src/megamek/common/SecondClassQuartersCargoBay.java
@@ -98,4 +98,9 @@ public final class SecondClassQuartersCargoBay extends Bay {
         return "2ndclassquarters:" + weight + ":" + doors;
     }
 
+    @Override
+    public long getCost() {
+        return 15000L * (long) totalSpace;
+    }
+
 }

--- a/megamek/src/megamek/common/SmallCraftBay.java
+++ b/megamek/src/megamek/common/SmallCraftBay.java
@@ -266,4 +266,10 @@ public final class SmallCraftBay extends Bay {
         return SmallCraftBay.techAdvancement();
     }
 
+    @Override
+    public long getCost() {
+        // Based on the number of cubicles
+        return 20000L * (long) totalSpace;
+    }
+
 } // End package class TroopSpace implements Transporter

--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -83,7 +83,7 @@ public class SpaceStation extends Jumpship {
 
     @Override
     public double getCost(boolean ignoreAmmo) {
-        double[] costs = new double[20];
+        double[] costs = new double[21];
         int costIdx = 0;
         double cost = 0;
 
@@ -137,12 +137,18 @@ public class SpaceStation extends Jumpship {
         // Transport Bays
         int baydoors = 0;
         long bayCost = 0;
+        long quartersCost = 0;
         for (Bay next : getTransportBays()) {
             baydoors += next.getDoors();
-            bayCost += next.getCost();
+            if (next.isQuarters()) {
+                quartersCost += next.getCost();
+            } else {
+                bayCost += next.getCost();
+            }
         }
 
         costs[costIdx++] += bayCost + (baydoors * 1000);
+        costs[costIdx++] = quartersCost;
 
         // Weapons and Equipment
         // HPG
@@ -177,7 +183,7 @@ public class SpaceStation extends Jumpship {
                 "Structural Integrity", "Engine", "Engine Control Unit",
                 "Attitude Thrusters", "Docking Collars",
                 "Fuel Tanks", "Armor", "Heat Sinks", "Life Boats/Escape Pods", "Grav Decks",
-                "Bays/Quarters", "HPG", "Weapons/Equipment", "Weight Multiplier" };
+                "Bays", "Quarters", "HPG", "Weapons/Equipment", "Weight Multiplier" };
 
         NumberFormat commafy = NumberFormat.getInstance();
 

--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -147,7 +147,7 @@ public class SpaceStation extends Jumpship {
             }
         }
 
-        costs[costIdx++] += bayCost + (baydoors * 1000);
+        costs[costIdx++] += bayCost + (baydoors * 1000L);
         costs[costIdx++] = quartersCost;
 
         // Weapons and Equipment

--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -136,15 +136,10 @@ public class SpaceStation extends Jumpship {
 
         // Transport Bays
         int baydoors = 0;
-        int bayCost = 0;
+        long bayCost = 0;
         for (Bay next : getTransportBays()) {
             baydoors += next.getDoors();
-            if ((next instanceof MechBay) || (next instanceof ASFBay) || (next instanceof SmallCraftBay)) {
-                bayCost += 20000 * next.totalSpace;
-            }
-            if ((next instanceof LightVehicleBay) || (next instanceof HeavyVehicleBay)) {
-                bayCost += 20000 * next.totalSpace;
-            }
+            bayCost += next.getCost();
         }
 
         costs[costIdx++] += bayCost + (baydoors * 1000);
@@ -182,7 +177,7 @@ public class SpaceStation extends Jumpship {
                 "Structural Integrity", "Engine", "Engine Control Unit",
                 "Attitude Thrusters", "Docking Collars",
                 "Fuel Tanks", "Armor", "Heat Sinks", "Life Boats/Escape Pods", "Grav Decks",
-                "Bays", "HPG", "Weapons/Equipment", "Weight Multiplier" };
+                "Bays/Quarters", "HPG", "Weapons/Equipment", "Weight Multiplier" };
 
         NumberFormat commafy = NumberFormat.getInstance();
 

--- a/megamek/src/megamek/common/StandardSeatCargoBay.java
+++ b/megamek/src/megamek/common/StandardSeatCargoBay.java
@@ -98,4 +98,9 @@ public final class StandardSeatCargoBay extends Bay {
         return "standardseats:" + weight + ":" + doors;
     }
 
+    @Override
+    public long getCost() {
+        return 100L * (long) totalSpace;
+    }
+
 }

--- a/megamek/src/megamek/common/SteerageQuartersCargoBay.java
+++ b/megamek/src/megamek/common/SteerageQuartersCargoBay.java
@@ -98,4 +98,9 @@ public final class SteerageQuartersCargoBay extends Bay {
         return "steeragequarters:" + weight + ":" + doors;
     }
 
+    @Override
+    public long getCost() {
+        return 5000L * (long) totalSpace;
+    }
+
 }

--- a/megamek/src/megamek/common/SuperHeavyVehicleBay.java
+++ b/megamek/src/megamek/common/SuperHeavyVehicleBay.java
@@ -128,4 +128,10 @@ public final class SuperHeavyVehicleBay extends Bay {
         return SuperHeavyVehicleBay.techAdvancement();
     }
 
+    @Override
+    public long getCost() {
+        // Based on the number of cubicles
+        return 20000L * (long) totalSpace;
+    }
+
 } // End package class TroopSpace implements Transporter

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -273,15 +273,10 @@ public class Warship extends Jumpship {
 
         // Transport Bays
         int baydoors = 0;
-        int bayCost = 0;
+        long bayCost = 0;
         for (Bay next : getTransportBays()) {
             baydoors += next.getDoors();
-            if ((next instanceof MechBay) || (next instanceof ASFBay) || (next instanceof SmallCraftBay)) {
-                bayCost += 20000 * next.totalSpace;
-            }
-            if ((next instanceof LightVehicleBay) || (next instanceof HeavyVehicleBay)) {
-                bayCost += 20000 * next.totalSpace;
-            }
+            bayCost += next.getCost();
         }
 
         costs[costIdx++] += bayCost + (baydoors * 1000);
@@ -315,7 +310,7 @@ public class Warship extends Jumpship {
                 "Structural Integrity", "Drive Unit", "Engine", "Engine Control Unit",
                 "KF Drive", "KF Drive Support System", "Attitude Thrusters", "Docking Collars",
                 "Fuel Tanks", "Armor", "Heat Sinks", "Life Boats/Escape Pods", "Grav Decks",
-                "Bays", "HPG", "Weapons/Equipment", "Weight Multiplier" };
+                "Bays/Quarters", "HPG", "Weapons/Equipment", "Weight Multiplier" };
 
         NumberFormat commafy = NumberFormat.getInstance();
 

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -284,7 +284,7 @@ public class Warship extends Jumpship {
             }
         }
 
-        costs[costIdx++] += bayCost + (baydoors * 1000);
+        costs[costIdx++] += bayCost + (baydoors * 1000L);
         costs[costIdx++] = quartersCost;
 
         // Weapons and Equipment

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -187,7 +187,7 @@ public class Warship extends Jumpship {
     
     @Override
     public double getCost(boolean ignoreAmmo) {
-        double[] costs = new double[23];
+        double[] costs = new double[24];
         int costIdx = 0;
         double cost = 0;
 
@@ -274,12 +274,18 @@ public class Warship extends Jumpship {
         // Transport Bays
         int baydoors = 0;
         long bayCost = 0;
+        long quartersCost = 0;
         for (Bay next : getTransportBays()) {
             baydoors += next.getDoors();
-            bayCost += next.getCost();
+            if (next.isQuarters()) {
+                quartersCost += next.getCost();
+            } else {
+                bayCost += next.getCost();
+            }
         }
 
         costs[costIdx++] += bayCost + (baydoors * 1000);
+        costs[costIdx++] = quartersCost;
 
         // Weapons and Equipment
         // HPG
@@ -310,7 +316,7 @@ public class Warship extends Jumpship {
                 "Structural Integrity", "Drive Unit", "Engine", "Engine Control Unit",
                 "KF Drive", "KF Drive Support System", "Attitude Thrusters", "Docking Collars",
                 "Fuel Tanks", "Armor", "Heat Sinks", "Life Boats/Escape Pods", "Grav Decks",
-                "Bays/Quarters", "HPG", "Weapons/Equipment", "Weight Multiplier" };
+                "Bays", "Quarters", "HPG", "Weapons/Equipment", "Weight Multiplier" };
 
         NumberFormat commafy = NumberFormat.getInstance();
 


### PR DESCRIPTION
In large craft cost calculations only mech, asf, small craft, and vehicle bays are being counted (as well as all doors). I added C-bill cost calculation to `Bay` to make sure all bays are included. Since quarters/crew seating are also implemented as bays, I included them in the cost calculations as well, but as a separate line.

Fixes MegaMek/megameklab#337.