### PR TITLE
Save engine tech base when it differs from unit tech base.

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKAeroFile.java
+++ b/megamek/src/megamek/common/loaders/BLKAeroFile.java
@@ -1,5 +1,6 @@
 /*
  * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (C) 2019 The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -12,17 +13,6 @@
  * details.
  */
 
-/*
- * BLkFile.java
- *
- * Created on April 6, 2002, 2:06 AM
- */
-
-/**
- *
- * @author taharqa
- * @version
- */
 package megamek.common.loaders;
 
 import megamek.common.Aero;
@@ -39,6 +29,13 @@ import megamek.common.WeaponType;
 import megamek.common.util.BuildingBlock;
 import megamek.common.verifier.TestEntity;
 
+/**
+ * BLkFile.java
+ *
+ * Created on April 6, 2002, 2:06 AM
+ *
+ * @author taharqa
+ */
 public class BLKAeroFile extends BLKFile implements IMechLoader {
 
     // armor locatioms
@@ -109,7 +106,12 @@ public class BLKAeroFile extends BLKFile implements IMechLoader {
             engineCode = dataFile.getDataAsInt("engine_type")[0];
         }
         int engineFlags = 0;
-        if (a.isClan()) {
+        // Support for mixed tech units with an engine with a different tech base
+        if (dataFile.exists("clan_engine")) {
+            if (Boolean.parseBoolean(dataFile.getDataAsString("clan_engine")[0])) {
+                engineFlags |= Engine.CLAN_ENGINE;
+            }
+        } else if (a.isClan()) {
             engineFlags |= Engine.CLAN_ENGINE;
         }
         if (!dataFile.exists("SafeThrust")) {

--- a/megamek/src/megamek/common/loaders/BLKConvFighterFile.java
+++ b/megamek/src/megamek/common/loaders/BLKConvFighterFile.java
@@ -1,5 +1,6 @@
 /*
  * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (C) 2019 The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -12,17 +13,6 @@
  * details.
  */
 
-/*
- * BLkFile.java
- *
- * Created on April 6, 2002, 2:06 AM
- */
-
-/**
- *
- * @author taharqa
- * @version
- */
 package megamek.common.loaders;
 
 import megamek.common.Aero;
@@ -38,6 +28,13 @@ import megamek.common.WeaponType;
 import megamek.common.util.BuildingBlock;
 import megamek.common.verifier.TestEntity;
 
+/**
+ * BLkFile.java
+ *
+ * Created on April 6, 2002, 2:06 AM
+ *
+ * @author taharqa
+ */
 public class BLKConvFighterFile extends BLKFile implements IMechLoader {
 
     // armor locatioms
@@ -106,7 +103,12 @@ public class BLKConvFighterFile extends BLKFile implements IMechLoader {
             engineCode = dataFile.getDataAsInt("engine_type")[0];
         }
         int engineFlags = 0;
-        if (a.isClan()) {
+        // Support for mixed tech units with an engine with a different tech base
+        if (dataFile.exists("clan_engine")) {
+            if (Boolean.parseBoolean(dataFile.getDataAsString("clan_engine")[0])) {
+                engineFlags |= Engine.CLAN_ENGINE;
+            }
+        } else if (a.isClan()) {
             engineFlags |= Engine.CLAN_ENGINE;
         }
         if (!dataFile.exists("SafeThrust")) {

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1,5 +1,6 @@
 /*
  * MegaMek - Copyright (C) 2000-2004 Ben Mazur (bmazur@sev.org)
+ * Copyright (C) 2019 The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -574,6 +575,9 @@ public class BLKFile {
                         break;
                 }
                 blk.writeBlockData("engine_type", engineCode);
+                if (t.getEngine().isClan() != t.isClan()) {
+                    blk.writeBlockData("clan_engine", Boolean.toString(t.getEngine().isClan()));
+                }
             }
             if (!t.hasPatchworkArmor() && (t.getArmorType(1) != 0)) {
                 blk.writeBlockData("armor_type", t.getArmorType(1));

--- a/megamek/src/megamek/common/loaders/BLKFixedWingSupportFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFixedWingSupportFile.java
@@ -1,5 +1,6 @@
 /*
  * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (C) 2019 The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -12,17 +13,6 @@
  * details.
  */
 
-/*
- * BLkFile.java
- *
- * Created on April 6, 2002, 2:06 AM
- */
-
-/**
- *
- * @author taharqa
- * @version
- */
 package megamek.common.loaders;
 
 import megamek.common.Aero;
@@ -37,6 +27,13 @@ import megamek.common.TechConstants;
 import megamek.common.WeaponType;
 import megamek.common.util.BuildingBlock;
 
+/**
+ * BLkFile.java
+ *
+ * Created on April 6, 2002, 2:06 AM
+ *
+ * @author taharqa
+ */
 public class BLKFixedWingSupportFile extends BLKFile implements IMechLoader {
 
     // armor locatioms
@@ -94,9 +91,6 @@ public class BLKFixedWingSupportFile extends BLKFile implements IMechLoader {
             engineCode = dataFile.getDataAsInt("engine_type")[0];
         }
         int engineFlags = Engine.SUPPORT_VEE_ENGINE;
-        if (a.isClan()) {
-            engineFlags |= Engine.CLAN_ENGINE;
-        }
         if (!dataFile.exists("SafeThrust")) {
             throw new EntityLoadingException("Could not find SafeThrust block.");
         }

--- a/megamek/src/megamek/common/loaders/BLKLargeSupportTankFile.java
+++ b/megamek/src/megamek/common/loaders/BLKLargeSupportTankFile.java
@@ -1,5 +1,6 @@
 /*
  * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (C) 2019 The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -12,17 +13,6 @@
  * details.
  */
 
-/*
- * BLkFile.java
- *
- * Created on April 6, 2002, 2:06 AM
- */
-
-/**
- *
- * @author njrkrynn
- * @version
- */
 package megamek.common.loaders;
 
 import megamek.common.Engine;
@@ -33,6 +23,13 @@ import megamek.common.LargeSupportTank;
 import megamek.common.Tank;
 import megamek.common.util.BuildingBlock;
 
+/**
+ * BLkFile.java
+ *
+ * Created on April 6, 2002, 2:06 AM
+ *
+ * @author njrkrynn
+ */
 public class BLKLargeSupportTankFile extends BLKFile implements IMechLoader {
     public BLKLargeSupportTankFile(BuildingBlock bb) {
         dataFile = bb;

--- a/megamek/src/megamek/common/loaders/BLKSupportTankFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSupportTankFile.java
@@ -1,5 +1,6 @@
 /*
  * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (C) 2019 The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -12,17 +13,6 @@
  * details.
  */
 
-/*
- * BLkFile.java
- *
- * Created on April 6, 2002, 2:06 AM
- */
-
-/**
- *
- * @author njrkrynn
- * @version
- */
 package megamek.common.loaders;
 
 import megamek.common.Engine;
@@ -33,6 +23,13 @@ import megamek.common.SupportTank;
 import megamek.common.Tank;
 import megamek.common.util.BuildingBlock;
 
+/**
+ * BLkFile.java
+ *
+ * Created on April 6, 2002, 2:06 AM
+ *
+ * @author njrkrynn
+ */
 public class BLKSupportTankFile extends BLKFile implements IMechLoader {
     public BLKSupportTankFile(BuildingBlock bb) {
         dataFile = bb;
@@ -103,9 +100,6 @@ public class BLKSupportTankFile extends BLKFile implements IMechLoader {
             t.setFuelTonnage(dataFile.getDataAsDouble("fuel")[0]);
         }
         int engineFlags = Engine.TANK_ENGINE | Engine.SUPPORT_VEE_ENGINE;
-        if (t.isClan()) {
-            engineFlags |= Engine.CLAN_ENGINE;
-        }
         if (!dataFile.exists("cruiseMP")) {
             throw new EntityLoadingException("Could not find cruiseMP block.");
         }

--- a/megamek/src/megamek/common/loaders/BLKSupportVTOLFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSupportVTOLFile.java
@@ -1,5 +1,6 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004 Ben Mazur (bmazur@sev.org)
+ * Copyright (C) 2019 The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -10,9 +11,6 @@
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
- */
-/*
- * Created on Jun 2, 2005
  */
 package megamek.common.loaders;
 
@@ -26,6 +24,8 @@ import megamek.common.VTOL;
 import megamek.common.util.BuildingBlock;
 
 /**
+ * Created on Jun 2, 2005
+ *
  * @author Andrew Hunter
  */
 public class BLKSupportVTOLFile extends BLKFile implements IMechLoader {
@@ -97,9 +97,6 @@ public class BLKSupportVTOLFile extends BLKFile implements IMechLoader {
             t.setFuelTonnage(dataFile.getDataAsDouble("fuel")[0]);
         }
         int engineFlags = Engine.TANK_ENGINE | Engine.SUPPORT_VEE_ENGINE;
-        if (t.isClan()) {
-            engineFlags |= Engine.CLAN_ENGINE;
-        }
         if (!dataFile.exists("cruiseMP")) {
             throw new EntityLoadingException("Could not find cruiseMP block.");
         }

--- a/megamek/src/megamek/common/loaders/BLKTankFile.java
+++ b/megamek/src/megamek/common/loaders/BLKTankFile.java
@@ -1,5 +1,6 @@
 /*
  * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (C) 2019 The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -12,17 +13,6 @@
  * details.
  */
 
-/*
- * BLkFile.java
- *
- * Created on April 6, 2002, 2:06 AM
- */
-
-/**
- *
- * @author njrkrynn
- * @version
- */
 package megamek.common.loaders;
 
 import megamek.common.Engine;
@@ -33,6 +23,13 @@ import megamek.common.SuperHeavyTank;
 import megamek.common.Tank;
 import megamek.common.util.BuildingBlock;
 
+/**
+ * BLkFile.java
+ *
+ * Created on April 6, 2002, 2:06 AM
+ *
+ * @author njrkrynn
+ */
 public class BLKTankFile extends BLKFile implements IMechLoader {
     
     private boolean superheavy = false;
@@ -48,11 +45,9 @@ public class BLKTankFile extends BLKFile implements IMechLoader {
                 case SuperHeavyTank.LOC_FRONTRIGHT:
                     return 1;
                 case SuperHeavyTank.LOC_REARRIGHT:
-                    return 2;
                 case SuperHeavyTank.LOC_REAR:
                     return 2;
                 case SuperHeavyTank.LOC_REARLEFT:
-                    return 4;
                 case SuperHeavyTank.LOC_FRONTLEFT:
                     return 4;
                 case SuperHeavyTank.LOC_FRONT:
@@ -152,7 +147,12 @@ public class BLKTankFile extends BLKFile implements IMechLoader {
             engineCode = dataFile.getDataAsInt("engine_type")[0];
         }
         int engineFlags = Engine.TANK_ENGINE;
-        if (t.isClan()) {
+        // Support for mixed tech units with an engine with a different tech base
+        if (dataFile.exists("clan_engine")) {
+            if (Boolean.parseBoolean(dataFile.getDataAsString("clan_engine")[0])) {
+                engineFlags |= Engine.CLAN_ENGINE;
+            }
+        } else if (t.isClan()) {
             engineFlags |= Engine.CLAN_ENGINE;
         }
         if (!dataFile.exists("cruiseMP")) {

--- a/megamek/src/megamek/common/loaders/BLKVTOLFile.java
+++ b/megamek/src/megamek/common/loaders/BLKVTOLFile.java
@@ -1,5 +1,6 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004 Ben Mazur (bmazur@sev.org)
+ * Copyright (C) 2019 The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -10,9 +11,6 @@
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
- */
-/*
- * Created on Jun 2, 2005
  */
 package megamek.common.loaders;
 
@@ -25,6 +23,8 @@ import megamek.common.VTOL;
 import megamek.common.util.BuildingBlock;
 
 /**
+ * Created on Jun 2, 2005
+ *
  * @author Andrew Hunter
  */
 public class BLKVTOLFile extends BLKFile implements IMechLoader {
@@ -91,7 +91,12 @@ public class BLKVTOLFile extends BLKFile implements IMechLoader {
             engineCode = dataFile.getDataAsInt("engine_type")[0];
         }
         int engineFlags = Engine.TANK_ENGINE;
-        if (t.isClan()) {
+        // Support for mixed tech units with an engine with a different tech base
+        if (dataFile.exists("clan_engine")) {
+            if (Boolean.parseBoolean(dataFile.getDataAsString("clan_engine")[0])) {
+                engineFlags |= Engine.CLAN_ENGINE;
+            }
+        } else if (t.isClan()) {
             engineFlags |= Engine.CLAN_ENGINE;
         }
         if (!dataFile.exists("cruiseMP")) {


### PR DESCRIPTION
Mixed tech units are incorrectly having the engine tech base set to the unit tech base.
Support vehicle engines do not distinguish between IS and Clan, so there is no need to set the flag.

Fixes #1459: Using XXL(Clan) fusion engine on combat vehicle by mixed IS tech is not loaded properly