### PR TITLE
Fix tank heavy damage check.

### DIFF
--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -4037,7 +4037,7 @@ public class Tank extends Entity {
 
     @Override
     public boolean isDmgHeavy() {
-        if (((double) getWalkMP() / getOriginalJumpMP()) <= 0.5) {
+        if (((double) getWalkMP() / getOriginalWalkMP()) <= 0.5) {
             return true;
         }
 


### PR DESCRIPTION
The check for whether a Tank has heavy damage calculates the ratio of current cruise MP to original jump instead of original cruise.