### PR TITLE
fix blank TRO display for gun emplacements

### DIFF
--- a/megamek/src/megamek/common/GunEmplacement.java
+++ b/megamek/src/megamek/common/GunEmplacement.java
@@ -543,4 +543,15 @@ public class GunEmplacement extends Tank {
         // TODO: Power generators and energy grid setup
         return false;
     }
+    
+    @Override
+    public int getArmorType(int loc) {
+        // this is a hack to get around the fact that gun emplacements don't even have armor
+        return 0;
+    }
+    
+    @Override
+    public boolean hasStealth() {
+        return false;
+    }
 }


### PR DESCRIPTION
Adds a few overrides to GunEmplacement to deal with problematic behavior when checking armor types.