### PR TITLE
grounded flyers should behave like standard ground units

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -922,7 +922,7 @@ public abstract class BotClient extends Client {
      */
     private boolean hasPathToEdge(Entity entity, IBoard board) {
         // Flying units can always get anywhere
-        if (entity.isAero() || entity instanceof VTOL) {
+        if (entity.isAirborne() || entity instanceof VTOL) {
             return true;
         }
         


### PR DESCRIPTION
Deployment code would fail to generate an appropriate pathfinder for grounded aircraft, resulting in a NPE. The other fix is still valid, as dropships shouldn't be able to deploy onto/into buildings regardless.