### PR TITLE
Add Superheavy/Small Command Console for battlemech

### DIFF
--- a/megamek/i18n/megamek/common/equipmentmessages.properties
+++ b/megamek/i18n/megamek/common/equipmentmessages.properties
@@ -618,6 +618,7 @@ SystemType.Cockpit.COCKPIT_QUADVEE=Quadvee\ Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_INDUSTRIAL=Superheavy\ Industrial\ Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE=Superheavy\ Command\ Console
 SystemType.Cockpit.COCKPIT_SMALL_COMMAND_CONSOLE=Small\ Command\ Console
+SystemType.Cockpit.COCKPIT_INDUSTRIAL_COMMAND_CONSOLE=Industrial\ Command\ Console
 
 BayType.STANDARD_CARGO=Cargo
 BayType.LIQUID_CARGO=Liquid Cargo

--- a/megamek/i18n/megamek/common/equipmentmessages.properties
+++ b/megamek/i18n/megamek/common/equipmentmessages.properties
@@ -616,6 +616,8 @@ SystemType.Cockpit.COCKPIT_INTERFACE=Interface\ Cockpit
 SystemType.Cockpit.COCKPIT_VRRP=Virtual\ Reality\ Piloting\ Pod
 SystemType.Cockpit.COCKPIT_QUADVEE=Quadvee\ Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_INDUSTRIAL=Superheavy\ Industrial\ Cockpit
+SystemType.Cockpit.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE=Superheavy\ Command\ Console
+SystemType.Cockpit.COCKPIT_SMALL_COMMAND_CONSOLE=Small\ Command\ Console
 
 BayType.STANDARD_CARGO=Cargo
 BayType.LIQUID_CARGO=Liquid Cargo

--- a/megamek/i18n/megamek/common/equipmentmessages.properties
+++ b/megamek/i18n/megamek/common/equipmentmessages.properties
@@ -619,6 +619,7 @@ SystemType.Cockpit.COCKPIT_SUPERHEAVY_INDUSTRIAL=Superheavy\ Industrial\ Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE=Superheavy\ Command\ Console
 SystemType.Cockpit.COCKPIT_SMALL_COMMAND_CONSOLE=Small\ Command\ Console
 SystemType.Cockpit.COCKPIT_INDUSTRIAL_COMMAND_CONSOLE=Industrial\ Command\ Console
+SystemType.Cockpit.COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE=Superheavy\ Industrial\ Command\ Console
 
 BayType.STANDARD_CARGO=Cargo
 BayType.LIQUID_CARGO=Liquid Cargo

--- a/megamek/i18n/megamek/common/equipmentmessages.properties
+++ b/megamek/i18n/megamek/common/equipmentmessages.properties
@@ -618,8 +618,6 @@ SystemType.Cockpit.COCKPIT_QUADVEE=Quadvee\ Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_INDUSTRIAL=Superheavy\ Industrial\ Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE=Superheavy\ Command\ Console
 SystemType.Cockpit.COCKPIT_SMALL_COMMAND_CONSOLE=Small\ Command\ Console
-SystemType.Cockpit.COCKPIT_INDUSTRIAL_COMMAND_CONSOLE=Industrial\ Command\ Console
-SystemType.Cockpit.COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE=Superheavy\ Industrial\ Command\ Console
 
 BayType.STANDARD_CARGO=Cargo
 BayType.LIQUID_CARGO=Liquid Cargo

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -182,13 +182,13 @@ public abstract class Mech extends Entity {
             "Primitive Industrial Cockpit", "Superheavy Cockpit",
             "Superheavy Tripod Cockpit", "Tripod Cockpit", "Interface Cockpit",
             "Virtual Reality Piloting Pod", "QuadVee Cockpit",
-            "Superheavy Industrial Cockpit", "Superheavy Command Console", "Small Command Console" };
+            "Superheavy Industrial Cockpit", "Superheavy Command Console", "Small Command Console", "Industrial Command Console" };
 
     public static final String[] COCKPIT_SHORT_STRING = { "Standard", "Small",
             "Command Console", "Torso Mounted", "Dual", "Industrial",
             "Primitive", "Primitive Industrial", "Superheavy",
             "Superheavy Tripod", "Tripod", "Interface", "VRRP", "Quadvee",
-            "Superheavy Industrial", "Superheavy Command", "Small Command" };
+            "Superheavy Industrial", "Superheavy Command", "Small Command", "Industrial Command" };
 
     public static final String FULL_HEAD_EJECT_STRING = "Full Head Ejection System";
 
@@ -358,6 +358,9 @@ public abstract class Mech extends Entity {
             setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;
         case COCKPIT_SMALL_COMMAND_CONSOLE:
+            setCrew(new Crew(CrewType.COMMAND_CONSOLE));
+            break;
+	case COCKPIT_INDUSTRIALL_COMMAND_CONSOLE:
             setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;
         }
@@ -3269,6 +3272,14 @@ public abstract class Mech extends Entity {
                 .setPrototypeFactions(F_FS).setProductionFactions(F_FS, F_CJF)
                 .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Small Command Console
+	    //FIXME: The data is for Industrial.
+	    new TechAdvancement(TECH_BASE_ALL).setISAdvancement(2625, 2631, DATE_NONE, 2850, 3030)
+                .setISApproximate(true, false, false, true, true)
+                .setClanAdvancement(2625, 2631).setClanApproximate(true, false)
+                .setPrototypeFactions(F_TH).setProductionFactions(F_TH)
+                .setReintroductionFactions(F_FS).setTechRating(RATING_D)
+                .setAvailability(RATING_C, RATING_F, RATING_E, RATING_D)
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Industrial command console
 
     };
 
@@ -5349,7 +5360,10 @@ public abstract class Mech extends Entity {
         } else if (getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) {
             // The cost is the sum of both small and command console
             cockpitCost = 675000;            
-        } else {
+        } else if (getCockpitType() == Mech.COCKPIT_INDUSTRIAL_COMMAND_CONSOLE) {
+            // The cost is the sum of both industrial and command console
+            cockpitCost = 600000;            
+        }else {
             cockpitCost = 200000;
         }
         if (hasEiCockpit()
@@ -5655,7 +5669,7 @@ public abstract class Mech extends Entity {
         }
 
         // Small/torso-mounted cockpit penalty?
-        if ( ( (getCockpitType() == Mech.COCKPIT_SMALL) || (getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) )
+        if (((getCockpitType() == Mech.COCKPIT_SMALL) || (getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE))
                 && (!hasAbility(OptionsConstants.MD_BVDNI)
                 && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
             roll.addModifier(1, "Small Cockpit");
@@ -6471,6 +6485,9 @@ public abstract class Mech extends Entity {
             case COCKPIT_SMALL_COMMAND_CONSOLE:
                 inName = "COCKPIT_SMALL_COMMAND_CONSOLE";
                 break;
+	    case COCKPIT_INDUSTRIAL_COMMAND_CONSOLE:
+                inName = "COCKPIT_INDUSTRIAL_COMMAND_CONSOLE";
+                break;
             default:
                 inName = "COCKPIT_UNKNOWN";
         }
@@ -7156,6 +7173,26 @@ public abstract class Mech extends Entity {
         return true;
     }
 
+    public boolean addIndustrialCommandConsole() {
+        if (getEmptyCriticals(LOC_HEAD) < 5) {
+            return false;
+        }
+        addCritical(LOC_HEAD, 0, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_LIFE_SUPPORT));
+        addCritical(LOC_HEAD, 1, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_SENSORS));
+        addCritical(LOC_HEAD, 2, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_COCKPIT));
+	addCritical(LOC_HEAD, 3, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_COCKPIT));
+        addCritical(LOC_HEAD, 4, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_SENSORS));
+        addCritical(LOC_HEAD, 5, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_LIFE_SUPPORT));
+        setCockpitType(COCKPIT_INDUSTRIAL_COMMAND_CONSOLE);
+        return true;
+    }
+	
     /**
      * Add the critical slots necessary for a torso-mounted cockpit. Note: This
      * is part of the mek creation public API, and might not be referenced by
@@ -7220,7 +7257,8 @@ public abstract class Mech extends Entity {
         //one.
         if (getCockpitType() == COCKPIT_COMMAND_CONSOLE
                 || getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE
-	            || getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE
+	        || getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE
+	        || getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE
                 || getCockpitType() == COCKPIT_DUAL
                 || getCockpitType() == COCKPIT_QUADVEE) {
             int crewSlot = 0;
@@ -7237,7 +7275,10 @@ public abstract class Mech extends Entity {
 
     @Override
     public boolean hasCommandConsoleBonus() {
-        return ((getCockpitType() == COCKPIT_COMMAND_CONSOLE) || (getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) || (getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE))
+        return ((getCockpitType() == COCKPIT_COMMAND_CONSOLE) 
+		|| (getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) 
+		|| (getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE)
+	        || (getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE))
                 && getCrew().hasActiveCommandConsole()
                 && getWeightClass() >= EntityWeightClass.WEIGHT_HEAVY
                 && (!isIndustrial() || hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL));
@@ -8284,9 +8325,11 @@ public abstract class Mech extends Entity {
         }
         if (getCockpitType() == COCKPIT_COMMAND_CONSOLE) {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
-        } else if (getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) {
+        }else if (getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
         }else if (getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE) {
+            specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
+        }else if (getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE) {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
         }else if (getCockpitType() == COCKPIT_VRRP) {
             specialAbilities.merge(BattleForceSPA.VR, 1, Integer::sum);

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -175,6 +175,8 @@ public abstract class Mech extends Entity {
     public static final int COCKPIT_SUPERHEAVY_COMMAND_CONSOLE = 15;
     
     public static final int COCKPIT_SMALL_COMMAND_CONSOLE = 16;
+	
+    public static final int COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE = 17;
 
     public static final String[] COCKPIT_STRING = { "Standard Cockpit",
             "Small Cockpit", "Command Console", "Torso-Mounted Cockpit",
@@ -182,13 +184,17 @@ public abstract class Mech extends Entity {
             "Primitive Industrial Cockpit", "Superheavy Cockpit",
             "Superheavy Tripod Cockpit", "Tripod Cockpit", "Interface Cockpit",
             "Virtual Reality Piloting Pod", "QuadVee Cockpit",
-            "Superheavy Industrial Cockpit", "Superheavy Command Console", "Small Command Console", "Industrial Command Console" };
+            "Superheavy Industrial Cockpit", "Superheavy Command Console", 
+	    "Small Command Console", "Industrial Command Console", 
+	    "Superheavy Industrial Command Console"};
 
     public static final String[] COCKPIT_SHORT_STRING = { "Standard", "Small",
             "Command Console", "Torso Mounted", "Dual", "Industrial",
             "Primitive", "Primitive Industrial", "Superheavy",
             "Superheavy Tripod", "Tripod", "Interface", "VRRP", "Quadvee",
-            "Superheavy Industrial", "Superheavy Command", "Small Command", "Industrial Command" };
+            "Superheavy Industrial", "Superheavy Command", 
+            "Small Command", "Industrial Command" 
+	    "Superheavy Industrial Command"};
 
     public static final String FULL_HEAD_EJECT_STRING = "Full Head Ejection System";
 
@@ -361,6 +367,10 @@ public abstract class Mech extends Entity {
             setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;
 	case COCKPIT_INDUSTRIALL_COMMAND_CONSOLE:
+            setCrew(new Crew(CrewType.COMMAND_CONSOLE));
+            break;
+        }
+	case COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE:
             setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;
         }
@@ -3280,6 +3290,12 @@ public abstract class Mech extends Entity {
                 .setReintroductionFactions(F_FS).setTechRating(RATING_D)
                 .setAvailability(RATING_C, RATING_F, RATING_E, RATING_D)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Industrial command console
+	    //FIXME: The data is for Superheavy Industrial.
+	    new TechAdvancement(TECH_BASE_IS).setISAdvancement(2905, 2940)
+                .setISApproximate(true, false).setTechRating(RATING_D)
+                .setPrototypeFactions(F_FW).setProductionFactions(F_FW)
+                .setAvailability(RATING_X, RATING_F, RATING_F, RATING_F)
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Superheavy industrial command console
 
     };
 
@@ -5363,6 +5379,9 @@ public abstract class Mech extends Entity {
         } else if (getCockpitType() == Mech.COCKPIT_INDUSTRIAL_COMMAND_CONSOLE) {
             // The cost is the sum of both industrial and command console
             cockpitCost = 600000;            
+        } else if (getCockpitType() == Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE) {
+            // The cost is the sum of both industrial and command console; for now, there is no actual cost for Superheavy Industrial cockpit.
+            cockpitCost = 600000;            
         }else {
             cockpitCost = 200000;
         }
@@ -6488,6 +6507,9 @@ public abstract class Mech extends Entity {
 	    case COCKPIT_INDUSTRIAL_COMMAND_CONSOLE:
                 inName = "COCKPIT_INDUSTRIAL_COMMAND_CONSOLE";
                 break;
+	    case COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE:
+                inName = "COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE";
+                break;
             default:
                 inName = "COCKPIT_UNKNOWN";
         }
@@ -7192,7 +7214,27 @@ public abstract class Mech extends Entity {
         setCockpitType(COCKPIT_INDUSTRIAL_COMMAND_CONSOLE);
         return true;
     }
-	
+
+    public boolean addSuperheavyIndustrialCommandConsole() {
+        if (getEmptyCriticals(LOC_HEAD) < 5) {
+            return false;
+        }
+        addCritical(LOC_HEAD, 0, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_LIFE_SUPPORT));
+        addCritical(LOC_HEAD, 1, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_SENSORS));
+        addCritical(LOC_HEAD, 2, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_COCKPIT));
+	addCritical(LOC_HEAD, 3, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_COCKPIT));
+        addCritical(LOC_HEAD, 4, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_SENSORS));
+        addCritical(LOC_HEAD, 5, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_LIFE_SUPPORT));
+        setCockpitType(COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE);
+        return true;
+    }
+
     /**
      * Add the critical slots necessary for a torso-mounted cockpit. Note: This
      * is part of the mek creation public API, and might not be referenced by
@@ -7259,6 +7301,7 @@ public abstract class Mech extends Entity {
                 || getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE
 	        || getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE
 	        || getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE
+	        || getCockpitType() == COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE
                 || getCockpitType() == COCKPIT_DUAL
                 || getCockpitType() == COCKPIT_QUADVEE) {
             int crewSlot = 0;
@@ -7278,7 +7321,8 @@ public abstract class Mech extends Entity {
         return ((getCockpitType() == COCKPIT_COMMAND_CONSOLE) 
 		|| (getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) 
 		|| (getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE)
-	        || (getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE))
+	        || (getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE)
+	        || (getCockpitType() == COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE))
                 && getCrew().hasActiveCommandConsole()
                 && getWeightClass() >= EntityWeightClass.WEIGHT_HEAVY
                 && (!isIndustrial() || hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL));
@@ -8330,6 +8374,8 @@ public abstract class Mech extends Entity {
         }else if (getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE) {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
         }else if (getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE) {
+            specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
+        }else if (getCockpitType() == CCOCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE) {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
         }else if (getCockpitType() == COCKPIT_VRRP) {
             specialAbilities.merge(BattleForceSPA.VR, 1, Integer::sum);

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -5237,7 +5237,7 @@ public abstract class Mech extends Entity {
 
         double cockpitMod = 1;
         if ((getCockpitType() == Mech.COCKPIT_SMALL)
-                || (getCockpitType() == Mech.COCKPIT_TORSO_MOUNTED
+                || (getCockpitType() == Mech.COCKPIT_TORSO_MOUNTED)
                     || (getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE)) {
             cockpitMod = 0.95;
             finalBV *= cockpitMod;
@@ -5655,7 +5655,7 @@ public abstract class Mech extends Entity {
         }
 
         // Small/torso-mounted cockpit penalty?
-        if ((getCockpitType() == Mech.COCKPIT_SMALL)
+        if ( ( (getCockpitType() == Mech.COCKPIT_SMALL) || (getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) )
                 && (!hasAbility(OptionsConstants.MD_BVDNI)
                 && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
             roll.addModifier(1, "Small Cockpit");

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -6468,7 +6468,7 @@ public abstract class Mech extends Entity {
             case COCKPIT_SUPERHEAVY_COMMAND_CONSOLE:
                 inName = "COCKPIT_SUPERHEAVY_COMMAND_CONSOLE";
                 break;
-            case COCKPIT_COCKPIT_SMALL_COMMAND_CONSOLE:
+            case COCKPIT_SMALL_COMMAND_CONSOLE:
                 inName = "COCKPIT_SMALL_COMMAND_CONSOLE";
                 break;
             default:
@@ -7237,7 +7237,7 @@ public abstract class Mech extends Entity {
 
     @Override
     public boolean hasCommandConsoleBonus() {
-        return (getCockpitType() == COCKPIT_COMMAND_CONSOLE || COCKPIT_SUPERHEAVY_COMMAND_CONSOLE || COCKPIT_SMALL_COMMAND_CONSOLE)
+        return ((getCockpitType() == COCKPIT_COMMAND_CONSOLE) || (getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) || (getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE))
                 && getCrew().hasActiveCommandConsole()
                 && getWeightClass() >= EntityWeightClass.WEIGHT_HEAVY
                 && (!isIndustrial() || hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL));

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -5345,13 +5345,7 @@ public abstract class Mech extends Entity {
         } else if (getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) {
             // The cost is the sum of both small and command console
             cockpitCost = 675000;            
-        } else if (getCockpitType() == Mech.COCKPIT_INDUSTRIAL_COMMAND_CONSOLE) {
-            // The cost is the sum of both industrial and command console
-            cockpitCost = 600000;            
-        } else if (getCockpitType() == Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE) {
-            // The cost is the sum of both industrial and command console; for now, there is no actual cost for Superheavy Industrial cockpit.
-            cockpitCost = 600000;            
-        }else {
+        } else {
             cockpitCost = 200000;
         }
         if (hasEiCockpit()

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -5655,7 +5655,7 @@ public abstract class Mech extends Entity {
         }
 
         // Small/torso-mounted cockpit penalty?
-        if ((getCockpitType() == Mech.COCKPIT_SMALL))
+        if ((getCockpitType() == Mech.COCKPIT_SMALL)
                 && (!hasAbility(OptionsConstants.MD_BVDNI)
                 && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
             roll.addModifier(1, "Small Cockpit");

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -176,7 +176,9 @@ public abstract class Mech extends Entity {
     
     public static final int COCKPIT_SMALL_COMMAND_CONSOLE = 16;
 	
-    public static final int COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE = 17;
+    public static final int COCKPIT_INDUSTRIAL_COMMAND_CONSOLE = 17;	
+	
+    public static final int COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE = 18;
 
     public static final String[] COCKPIT_STRING = { "Standard Cockpit",
             "Small Cockpit", "Command Console", "Torso-Mounted Cockpit",
@@ -369,7 +371,6 @@ public abstract class Mech extends Entity {
 	case COCKPIT_INDUSTRIALL_COMMAND_CONSOLE:
             setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;
-        }
 	case COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE:
             setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -171,6 +171,10 @@ public abstract class Mech extends Entity {
     public static final int COCKPIT_QUADVEE = 13;
 
     public static final int COCKPIT_SUPERHEAVY_INDUSTRIAL = 14;
+    
+    public static final int COCKPIT_SUPERHEAVY_COMMAND_CONSOLE = 15;
+    
+    public static final int COCKPIT_SMALL_COMMAND_CONSOLE = 16;
 
     public static final String[] COCKPIT_STRING = { "Standard Cockpit",
             "Small Cockpit", "Command Console", "Torso-Mounted Cockpit",
@@ -178,13 +182,13 @@ public abstract class Mech extends Entity {
             "Primitive Industrial Cockpit", "Superheavy Cockpit",
             "Superheavy Tripod Cockpit", "Tripod Cockpit", "Interface Cockpit",
             "Virtual Reality Piloting Pod", "QuadVee Cockpit",
-            "Superheavy Industrial Cockpit" };
+            "Superheavy Industrial Cockpit", "Superheavy Command Console", "Small Command Console" };
 
     public static final String[] COCKPIT_SHORT_STRING = { "Standard", "Small",
             "Command Console", "Torso Mounted", "Dual", "Industrial",
             "Primitive", "Primitive Industrial", "Superheavy",
             "Superheavy Tripod", "Tripod", "Interface", "VRRP", "Quadvee",
-            "Superheavy Industrial" };
+            "Superheavy Industrial", "Superheavy Command", "Small Command" };
 
     public static final String FULL_HEAD_EJECT_STRING = "Full Head Ejection System";
 
@@ -349,6 +353,12 @@ public abstract class Mech extends Entity {
             break;
         case COCKPIT_QUADVEE:
             setCrew(new Crew(CrewType.QUADVEE));
+            break;
+        case COCKPIT_SUPERHEAVY_COMMAND_CONSOLE:
+            setCrew(new Crew(CrewType.COMMAND_CONSOLE));
+            break;
+        case COCKPIT_SMALL_COMMAND_CONSOLE:
+            setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;
         }
     }
@@ -3246,6 +3256,20 @@ public abstract class Mech extends Entity {
                 .setPrototypeFactions(F_FW).setProductionFactions(F_FW)
                 .setAvailability(RATING_X, RATING_F, RATING_F, RATING_F)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Superheavy industrial
+            //FIXME: The data is for Superheavy.
+            new TechAdvancement(TECH_BASE_IS).setISAdvancement(3060, 3076)
+                .setISApproximate(true, false).setTechRating(RATING_E)
+                .setPrototypeFactions(F_WB).setProductionFactions(F_WB)
+                .setAvailability(RATING_X, RATING_X, RATING_F, RATING_E)
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Superheavy command console
+            //FIXME: The data is for Small, except for Tech Level which follows command console.
+            new TechAdvancement(TECH_BASE_ALL).setISAdvancement(3060, 3067, 3080)
+                .setISApproximate(true, false, false)
+                .setClanAdvancement(DATE_NONE, 3080, 3080).setTechRating(RATING_E)
+                .setPrototypeFactions(F_FS).setProductionFactions(F_FS, F_CJF)
+                .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
+                .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Small Command Console
+
     };
 
     // Advanced fire control for industrial mechs is implemented with a standard cockpit,
@@ -5213,7 +5237,8 @@ public abstract class Mech extends Entity {
 
         double cockpitMod = 1;
         if ((getCockpitType() == Mech.COCKPIT_SMALL)
-                || (getCockpitType() == Mech.COCKPIT_TORSO_MOUNTED)) {
+                || (getCockpitType() == Mech.COCKPIT_TORSO_MOUNTED
+                    || (getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE)) {
             cockpitMod = 0.95;
             finalBV *= cockpitMod;
         } else if ((getCockpitType() == Mech.COCKPIT_TRIPOD)
@@ -5318,6 +5343,12 @@ public abstract class Mech extends Entity {
             cockpitCost = 100000;
         } else if (getCockpitType() == Mech.COCKPIT_QUADVEE) {
             cockpitCost = 375000;
+        } else if (getCockpitType() == Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) {
+            // Same as standard cockpit command console
+            cockpitCost = 700000;
+        } else if (getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) {
+            // The cost is the sum of both small and command console
+            cockpitCost = 675000;            
         } else {
             cockpitCost = 200000;
         }
@@ -5624,7 +5655,7 @@ public abstract class Mech extends Entity {
         }
 
         // Small/torso-mounted cockpit penalty?
-        if ((getCockpitType() == Mech.COCKPIT_SMALL)
+        if (((getCockpitType() == Mech.COCKPIT_SMALL)|| (getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) )
                 && (!hasAbility(OptionsConstants.MD_BVDNI)
                 && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
             roll.addModifier(1, "Small Cockpit");
@@ -6434,6 +6465,12 @@ public abstract class Mech extends Entity {
             case COCKPIT_SUPERHEAVY_INDUSTRIAL:
                 inName = "COCKPIT_SUPERHEAVY_INDUSTRIAL";
                 break;
+            case COCKPIT_SUPERHEAVY_COMMAND_CONSOLE:
+                inName = "COCKPIT_SUPERHEAVY_COMMAND_CONSOLE";
+                break;
+            case COCKPIT_COCKPIT_SMALL_COMMAND_CONSOLE:
+                inName = "COCKPIT_SMALL_COMMAND_CONSOLE";
+                break;
             default:
                 inName = "COCKPIT_UNKNOWN";
         }
@@ -7082,6 +7119,42 @@ public abstract class Mech extends Entity {
         setCockpitType(COCKPIT_DUAL);
         return true;
     }
+            
+    public boolean addSuperheavyCommandConsole() {
+        addCritical(LOC_HEAD, 0, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_LIFE_SUPPORT));
+        addCritical(LOC_HEAD, 1, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_SENSORS));
+        addCritical(LOC_HEAD, 2, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_COCKPIT));
+        addCritical(LOC_HEAD, 3, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_COCKPIT));
+        addCritical(LOC_HEAD, 4, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_SENSORS));
+        addCritical(LOC_HEAD, 5, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_LIFE_SUPPORT));
+        setCockpitType(COCKPIT_SUPERHEAVY_COMMAND_CONSOLE);
+        return true;
+    }
+    
+    //The location of critical is based on small cockpit, but since command console requires two cockpit slots the second Sensor is return to the location 4.
+    public boolean addSmallCommandConsole() {
+        if (getEmptyCriticals(LOC_HEAD) < 5) {
+            return false;
+        }
+        addCritical(LOC_HEAD, 0, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_LIFE_SUPPORT));
+        addCritical(LOC_HEAD, 1, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_SENSORS));
+        addCritical(LOC_HEAD, 2, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_COCKPIT));
+        addCritical(LOC_HEAD, 3, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_COCKPIT));
+        addCritical(LOC_HEAD, 4, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_SENSORS));
+        setCockpitType(COCKPIT_SMALL_COMMAND_CONSOLE);
+        return true;
+    }
 
     /**
      * Add the critical slots necessary for a torso-mounted cockpit. Note: This
@@ -7146,6 +7219,8 @@ public abstract class Mech extends Entity {
         //For those with split cockpits, count the cockpit criticals in the location until we reach the correct
         //one.
         if (getCockpitType() == COCKPIT_COMMAND_CONSOLE
+                || getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE
+	            || getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE
                 || getCockpitType() == COCKPIT_DUAL
                 || getCockpitType() == COCKPIT_QUADVEE) {
             int crewSlot = 0;
@@ -7162,7 +7237,7 @@ public abstract class Mech extends Entity {
 
     @Override
     public boolean hasCommandConsoleBonus() {
-        return getCockpitType() == COCKPIT_COMMAND_CONSOLE
+        return (getCockpitType() == COCKPIT_COMMAND_CONSOLE || COCKPIT_SUPERHEAVY_COMMAND_CONSOLE || COCKPIT_SMALL_COMMAND_CONSOLE)
                 && getCrew().hasActiveCommandConsole()
                 && getWeightClass() >= EntityWeightClass.WEIGHT_HEAVY
                 && (!isIndustrial() || hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL));
@@ -8209,7 +8284,11 @@ public abstract class Mech extends Entity {
         }
         if (getCockpitType() == COCKPIT_COMMAND_CONSOLE) {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
-        } else if (getCockpitType() == COCKPIT_VRRP) {
+        } else if (getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) {
+            specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
+        }else if (getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE) {
+            specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
+        }else if (getCockpitType() == COCKPIT_VRRP) {
             specialAbilities.merge(BattleForceSPA.VR, 1, Integer::sum);
         }
         if (isIndustrial()) {

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -195,7 +195,7 @@ public abstract class Mech extends Entity {
             "Primitive", "Primitive Industrial", "Superheavy",
             "Superheavy Tripod", "Tripod", "Interface", "VRRP", "Quadvee",
             "Superheavy Industrial", "Superheavy Command", 
-            "Small Command", "Industrial Command" 
+            "Small Command", "Industrial Command",
 	    "Superheavy Industrial Command"};
 
     public static final String FULL_HEAD_EJECT_STRING = "Full Head Ejection System";
@@ -7159,7 +7159,25 @@ public abstract class Mech extends Entity {
         setCockpitType(COCKPIT_DUAL);
         return true;
     }
-            
+	
+    public boolean addSuperheavyIndustrialCockpit() {
+        if (getEmptyCriticals(LOC_HEAD) < 5) {
+            return false;
+        }
+        addCritical(LOC_HEAD, 0, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_LIFE_SUPPORT));
+        addCritical(LOC_HEAD, 1, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_SENSORS));
+        addCritical(LOC_HEAD, 2, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_COCKPIT));
+        addCritical(LOC_HEAD, 4, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_SENSORS));
+        addCritical(LOC_HEAD, 5, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
+                SYSTEM_LIFE_SUPPORT));
+        setCockpitType(COCKPIT_SUPERHEAVY_INDUSTRIAL);
+        return true;
+    }
+	
     public boolean addSuperheavyCommandConsole() {
         addCritical(LOC_HEAD, 0, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
                 SYSTEM_LIFE_SUPPORT));

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -175,10 +175,6 @@ public abstract class Mech extends Entity {
     public static final int COCKPIT_SUPERHEAVY_COMMAND_CONSOLE = 15;
     
     public static final int COCKPIT_SMALL_COMMAND_CONSOLE = 16;
-	
-    public static final int COCKPIT_INDUSTRIAL_COMMAND_CONSOLE = 17;	
-	
-    public static final int COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE = 18;
 
     public static final String[] COCKPIT_STRING = { "Standard Cockpit",
             "Small Cockpit", "Command Console", "Torso-Mounted Cockpit",
@@ -187,16 +183,14 @@ public abstract class Mech extends Entity {
             "Superheavy Tripod Cockpit", "Tripod Cockpit", "Interface Cockpit",
             "Virtual Reality Piloting Pod", "QuadVee Cockpit",
             "Superheavy Industrial Cockpit", "Superheavy Command Console", 
-	    "Small Command Console", "Industrial Command Console", 
-	    "Superheavy Industrial Command Console"};
+	    "Small Command Console"};
 
     public static final String[] COCKPIT_SHORT_STRING = { "Standard", "Small",
             "Command Console", "Torso Mounted", "Dual", "Industrial",
             "Primitive", "Primitive Industrial", "Superheavy",
             "Superheavy Tripod", "Tripod", "Interface", "VRRP", "Quadvee",
             "Superheavy Industrial", "Superheavy Command", 
-            "Small Command", "Industrial Command",
-	    "Superheavy Industrial Command"};
+            "Small Command"};
 
     public static final String FULL_HEAD_EJECT_STRING = "Full Head Ejection System";
 
@@ -357,22 +351,12 @@ public abstract class Mech extends Entity {
             setCrew(new Crew(CrewType.DUAL));
             break;
         case COCKPIT_COMMAND_CONSOLE:
+	case COCKPIT_SUPERHEAVY_COMMAND_CONSOLE:
+	case COCKPIT_SMALL_COMMAND_CONSOLE:
             setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;
         case COCKPIT_QUADVEE:
             setCrew(new Crew(CrewType.QUADVEE));
-            break;
-        case COCKPIT_SUPERHEAVY_COMMAND_CONSOLE:
-            setCrew(new Crew(CrewType.COMMAND_CONSOLE));
-            break;
-        case COCKPIT_SMALL_COMMAND_CONSOLE:
-            setCrew(new Crew(CrewType.COMMAND_CONSOLE));
-            break;
-	case COCKPIT_INDUSTRIAL_COMMAND_CONSOLE:
-            setCrew(new Crew(CrewType.COMMAND_CONSOLE));
-            break;
-	case COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE:
-            setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;
         }
     }
@@ -3276,28 +3260,12 @@ public abstract class Mech extends Entity {
                 .setPrototypeFactions(F_WB).setProductionFactions(F_WB)
                 .setAvailability(RATING_X, RATING_X, RATING_F, RATING_E)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Superheavy command console
-            //FIXME: The data is for Small, except for Tech Level which follows command console.
             new TechAdvancement(TECH_BASE_ALL).setISAdvancement(3060, 3067, 3080)
                 .setISApproximate(true, false, false)
                 .setClanAdvancement(DATE_NONE, 3080, 3080).setTechRating(RATING_E)
                 .setPrototypeFactions(F_FS).setProductionFactions(F_FS, F_CJF)
                 .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Small Command Console
-	    //FIXME: The data is for Industrial.
-	    new TechAdvancement(TECH_BASE_ALL).setISAdvancement(2625, 2631, DATE_NONE, 2850, 3030)
-                .setISApproximate(true, false, false, true, true)
-                .setClanAdvancement(2625, 2631).setClanApproximate(true, false)
-                .setPrototypeFactions(F_TH).setProductionFactions(F_TH)
-                .setReintroductionFactions(F_FS).setTechRating(RATING_D)
-                .setAvailability(RATING_C, RATING_F, RATING_E, RATING_D)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Industrial command console
-	    //FIXME: The data is for Superheavy Industrial.
-	    new TechAdvancement(TECH_BASE_IS).setISAdvancement(2905, 2940)
-                .setISApproximate(true, false).setTechRating(RATING_D)
-                .setPrototypeFactions(F_FW).setProductionFactions(F_FW)
-                .setAvailability(RATING_X, RATING_F, RATING_F, RATING_F)
-                .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Superheavy industrial command console
-
     };
 
     // Advanced fire control for industrial mechs is implemented with a standard cockpit,
@@ -6505,12 +6473,6 @@ public abstract class Mech extends Entity {
             case COCKPIT_SMALL_COMMAND_CONSOLE:
                 inName = "COCKPIT_SMALL_COMMAND_CONSOLE";
                 break;
-	    case COCKPIT_INDUSTRIAL_COMMAND_CONSOLE:
-                inName = "COCKPIT_INDUSTRIAL_COMMAND_CONSOLE";
-                break;
-	    case COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE:
-                inName = "COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE";
-                break;
             default:
                 inName = "COCKPIT_UNKNOWN";
         }
@@ -7214,40 +7176,6 @@ public abstract class Mech extends Entity {
         return true;
     }
 
-    public boolean addIndustrialCommandConsole() {
-        addCritical(LOC_HEAD, 0, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_LIFE_SUPPORT));
-        addCritical(LOC_HEAD, 1, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_SENSORS));
-        addCritical(LOC_HEAD, 2, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_COCKPIT));
-	addCritical(LOC_HEAD, 3, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_COCKPIT));
-        addCritical(LOC_HEAD, 4, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_SENSORS));
-        addCritical(LOC_HEAD, 5, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_LIFE_SUPPORT));
-        setCockpitType(COCKPIT_INDUSTRIAL_COMMAND_CONSOLE);
-        return true;
-    }
-
-    public boolean addSuperheavyIndustrialCommandConsole() {
-        addCritical(LOC_HEAD, 0, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_LIFE_SUPPORT));
-        addCritical(LOC_HEAD, 1, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_SENSORS));
-        addCritical(LOC_HEAD, 2, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_COCKPIT));
-	addCritical(LOC_HEAD, 3, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_COCKPIT));
-        addCritical(LOC_HEAD, 4, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_SENSORS));
-        addCritical(LOC_HEAD, 5, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
-                SYSTEM_LIFE_SUPPORT));
-        setCockpitType(COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE);
-        return true;
-    }
-
     /**
      * Add the critical slots necessary for a torso-mounted cockpit. Note: This
      * is part of the mek creation public API, and might not be referenced by
@@ -7313,8 +7241,6 @@ public abstract class Mech extends Entity {
         if (getCockpitType() == COCKPIT_COMMAND_CONSOLE
                 || getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE
 	        || getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE
-	        || getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE
-	        || getCockpitType() == COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE
                 || getCockpitType() == COCKPIT_DUAL
                 || getCockpitType() == COCKPIT_QUADVEE) {
             int crewSlot = 0;
@@ -7333,9 +7259,7 @@ public abstract class Mech extends Entity {
     public boolean hasCommandConsoleBonus() {
         return ((getCockpitType() == COCKPIT_COMMAND_CONSOLE) 
 		|| (getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) 
-		|| (getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE)
-	        || (getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE)
-	        || (getCockpitType() == COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE))
+		|| (getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE))
                 && getCrew().hasActiveCommandConsole()
                 && getWeightClass() >= EntityWeightClass.WEIGHT_HEAVY
                 && (!isIndustrial() || hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL));
@@ -8385,10 +8309,6 @@ public abstract class Mech extends Entity {
         }else if (getCockpitType() == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
         }else if (getCockpitType() == COCKPIT_SMALL_COMMAND_CONSOLE) {
-            specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
-        }else if (getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE) {
-            specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
-        }else if (getCockpitType() == COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE) {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
         }else if (getCockpitType() == COCKPIT_VRRP) {
             specialAbilities.merge(BattleForceSPA.VR, 1, Integer::sum);

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -368,7 +368,7 @@ public abstract class Mech extends Entity {
         case COCKPIT_SMALL_COMMAND_CONSOLE:
             setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;
-	case COCKPIT_INDUSTRIALL_COMMAND_CONSOLE:
+	case COCKPIT_INDUSTRIAL_COMMAND_CONSOLE:
             setCrew(new Crew(CrewType.COMMAND_CONSOLE));
             break;
 	case COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE:

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -8394,7 +8394,7 @@ public abstract class Mech extends Entity {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
         }else if (getCockpitType() == COCKPIT_INDUSTRIAL_COMMAND_CONSOLE) {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
-        }else if (getCockpitType() == CCOCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE) {
+        }else if (getCockpitType() == COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE) {
             specialAbilities.merge(BattleForceSPA.MHQ, 1, Integer::sum);
         }else if (getCockpitType() == COCKPIT_VRRP) {
             specialAbilities.merge(BattleForceSPA.VR, 1, Integer::sum);

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -5655,7 +5655,7 @@ public abstract class Mech extends Entity {
         }
 
         // Small/torso-mounted cockpit penalty?
-        if (((getCockpitType() == Mech.COCKPIT_SMALL)|| (getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) )
+        if ((getCockpitType() == Mech.COCKPIT_SMALL))
                 && (!hasAbility(OptionsConstants.MD_BVDNI)
                 && !hasAbility(OptionsConstants.UNOFF_SMALL_PILOT))) {
             roll.addModifier(1, "Small Cockpit");

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -7215,9 +7215,6 @@ public abstract class Mech extends Entity {
     }
 
     public boolean addIndustrialCommandConsole() {
-        if (getEmptyCriticals(LOC_HEAD) < 5) {
-            return false;
-        }
         addCritical(LOC_HEAD, 0, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
                 SYSTEM_LIFE_SUPPORT));
         addCritical(LOC_HEAD, 1, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
@@ -7235,9 +7232,6 @@ public abstract class Mech extends Entity {
     }
 
     public boolean addSuperheavyIndustrialCommandConsole() {
-        if (getEmptyCriticals(LOC_HEAD) < 5) {
-            return false;
-        }
         addCritical(LOC_HEAD, 0, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,
                 SYSTEM_LIFE_SUPPORT));
         addCritical(LOC_HEAD, 1, new CriticalSlot(CriticalSlot.TYPE_SYSTEM,

--- a/megamek/src/megamek/common/TechConstants.java
+++ b/megamek/src/megamek/common/TechConstants.java
@@ -760,6 +760,38 @@ public class TechConstants {
                     } else {
                         return T_IS_TW_NON_BOX;
                     }
+                //Same as Command Console
+                case Mech.COCKPIT_INDUSTRIAL_COMMAND_CONSOLE:
+                    if (isClan) {
+                        if (year <= 2807) {
+                            return T_CLAN_UNOFFICIAL;
+                        }
+                        return T_CLAN_ADVANCED;
+                    }
+                    if (year <= 2620) {
+                        return T_IS_UNOFFICIAL;
+                    } else if (year <= 2631) {
+                        return T_IS_EXPERIMENTAL;
+                    } else if (year <= 2845) {
+                        return T_IS_ADVANCED;
+                    } else if (year <= 3025) {
+                        return T_IS_UNOFFICIAL;
+                    } else {
+                        return T_IS_ADVANCED;
+                    }
+                //Same as Superheavy industrial
+                case Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE:
+                    if (isClan) {
+                        return T_CLAN_UNOFFICIAL;
+                    }
+
+                    if (year <= 2900) {
+                        return T_IS_UNOFFICIAL;
+                    } else if (year <= 2940) {
+                        return T_IS_EXPERIMENTAL;
+                    } else {
+                        return T_IS_ADVANCED;
+                    }
 
             }
         } else if ((entityType & Entity.ETYPE_AERO) != 0) {

--- a/megamek/src/megamek/common/TechConstants.java
+++ b/megamek/src/megamek/common/TechConstants.java
@@ -760,38 +760,6 @@ public class TechConstants {
                     } else {
                         return T_IS_TW_NON_BOX;
                     }
-                //Same as Command Console
-                case Mech.COCKPIT_INDUSTRIAL_COMMAND_CONSOLE:
-                    if (isClan) {
-                        if (year <= 2807) {
-                            return T_CLAN_UNOFFICIAL;
-                        }
-                        return T_CLAN_ADVANCED;
-                    }
-                    if (year <= 2620) {
-                        return T_IS_UNOFFICIAL;
-                    } else if (year <= 2631) {
-                        return T_IS_EXPERIMENTAL;
-                    } else if (year <= 2845) {
-                        return T_IS_ADVANCED;
-                    } else if (year <= 3025) {
-                        return T_IS_UNOFFICIAL;
-                    } else {
-                        return T_IS_ADVANCED;
-                    }
-                //Same as Superheavy industrial
-                case Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE:
-                    if (isClan) {
-                        return T_CLAN_UNOFFICIAL;
-                    }
-
-                    if (year <= 2900) {
-                        return T_IS_UNOFFICIAL;
-                    } else if (year <= 2940) {
-                        return T_IS_EXPERIMENTAL;
-                    } else {
-                        return T_IS_ADVANCED;
-                    }
 
             }
         } else if ((entityType & Entity.ETYPE_AERO) != 0) {

--- a/megamek/src/megamek/common/TechConstants.java
+++ b/megamek/src/megamek/common/TechConstants.java
@@ -730,6 +730,36 @@ public class TechConstants {
                     } else {
                         return T_IS_ADVANCED;
                     }
+                //Same as Superheavy cockpit
+                case Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE:
+                    if (isClan) {
+                        return T_CLAN_UNOFFICIAL;
+                    }
+
+                    if (year <= 3055) {
+                        return T_IS_UNOFFICIAL;
+                    } else if (year <= 3076) {
+                        return T_IS_EXPERIMENTAL;
+                    } else {
+                        return T_IS_ADVANCED;
+                    }
+                //Same as Small cockpit
+                case Mech.COCKPIT_SMALL_COMMAND_CONSOLE:
+                    if (isClan) {
+                        if (year <= 3080) {
+                            return T_CLAN_UNOFFICIAL;
+                        }
+                        return T_CLAN_ADVANCED;
+                    }
+                    if (year <= 3060) {
+                        return T_IS_UNOFFICIAL;
+                    } else if (year <= 3067) {
+                        return T_IS_EXPERIMENTAL;
+                    } else if (year <= 3080) {
+                        return T_IS_ADVANCED;
+                    } else {
+                        return T_IS_TW_NON_BOX;
+                    }
 
             }
         } else if ((entityType & Entity.ETYPE_AERO) != 0) {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -286,6 +286,12 @@ public class TestMech extends TestEntity {
         }else if (mech.getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) {
             // Like as normal command console, it is technically two seperate 2-ton and 3-ton pieces of equipment. 
             weight = 5.0;
+        }else if (mech.getCockpitType() == Mech.COCKPIT_INDUSTRIAL_COMMAND_CONSOLE) {
+            // Like as normal command console, it is technically two seperate 3-ton pieces of equipment.
+            weight = 6.0;
+        }else if (mech.getCockpitType() == Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE) {
+            // Like as normal command console, it is technically two seperate 4-ton and 3-ton pieces of equipment.
+            weight = 7.0;
         }
 
         return weight;

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -280,6 +280,12 @@ public class TestMech extends TestEntity {
             weight = 4.0;
         } else if (mech.getCockpitType() == Mech.COCKPIT_QUADVEE) {
             weight = 4.0;
+        }else if (mech.getCockpitType() == Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) {
+            // Like as normal command console, it is technically two seperate 4-ton and 3-ton pieces of equipment.
+            weight = 7.0;
+        }else if (mech.getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) {
+            // Like as normal command console, it is technically two seperate 2-ton and 3-ton pieces of equipment. 
+            weight = 5.0;
         }
 
         return weight;

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -286,12 +286,6 @@ public class TestMech extends TestEntity {
         }else if (mech.getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) {
             // Like as normal command console, it is technically two seperate 2-ton and 3-ton pieces of equipment. 
             weight = 5.0;
-        }else if (mech.getCockpitType() == Mech.COCKPIT_INDUSTRIAL_COMMAND_CONSOLE) {
-            // Like as normal command console, it is technically two seperate 3-ton pieces of equipment.
-            weight = 6.0;
-        }else if (mech.getCockpitType() == Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL_COMMAND_CONSOLE) {
-            // Like as normal command console, it is technically two seperate 4-ton and 3-ton pieces of equipment.
-            weight = 7.0;
         }
 
         return weight;


### PR DESCRIPTION
As #1448, I add the code for Superheavy/Small Command Console. 

I did find everything on the search that related to both of them, but still I am not sure that I did all the requirements. So, please help me if you find any missing points.

Basically, both new Command Consoles are defined as a Command Console, so I didn't touched crew requisition or advantage of Command Console in combat. 

Also, there would be an another pull request on MegaMekLab that is related with this - I want to merge both of them but I can't find the way to do, so I post the seperated pull request on MegaMekLab as well.