### PR TITLE
Fix AR10 ammo nuclear comparison

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -415,6 +415,10 @@ public class AmmoType extends EquipmentType {
                     .hasFlag(F_AR10_KILLER_WHALE)) {
                 return false;
             }
+            if (hasFlag(F_NUCLEAR) != ((AmmoType) other)
+                    .hasFlag(F_NUCLEAR)) {
+                return false;
+            }
         }
         return ((getAmmoType() == ((AmmoType) other).getAmmoType()) && (getRackSize() == ((AmmoType) other)
                 .getRackSize()));


### PR DESCRIPTION
+Bugfix  Fixes AR10 ammoType comparison to account for Santa Anna and Peacemaker nuclear warheads