### PR TITLE
Fix Clans Improved AC/2

### DIFF
--- a/megamek/src/megamek/common/weapons/autocannons/CLImprovedAC2.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLImprovedAC2.java
@@ -40,9 +40,10 @@ public class CLImprovedAC2 extends ACWeapon {
         heat = 1;
         damage = 2;
         rackSize = 2;
-        shortRange = 4;
-        mediumRange = 8;
-        longRange = 16;
+        minimumRange = 4;
+        shortRange = 8;
+        mediumRange = 16;
+        longRange = 24;
         extremeRange = 32;
         tonnage = 5.0;
         criticals = 1;


### PR DESCRIPTION
Fix its range as equal to AC/2, for its range is need to be same as IS AC/2. For now it doesn't have minimum range, and its 'short range' to 'long range' are actually minimum range to medium range.