### PR TITLE
Avoid NRE in BotClient::getStartingCoordsArray #1500

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -897,7 +897,10 @@ public abstract class BotClient extends Client {
         // So we adjust each coordinate's fitness based on the "longest available path"
         if(highestFitness < -10) {
             for(RankedCoords rc : validCoords) {
-                rc.fitness += deploymentPathFinders.get(deployed_ent.getMovementMode()).getLongestNonEdgePath(rc.getCoords()).getHexesMoved();
+                MovePath movePath = getBoardEdgePathFinder(deployed_ent).getLongestNonEdgePath(rc.getCoords());
+                if (movePath != null) {
+                    rc.fitness += movePath.getHexesMoved();
+                }
             }
         }
         
@@ -910,6 +913,17 @@ public abstract class BotClient extends Client {
         }
 
         return result;
+    }
+
+    /**
+     * Gets the {@link BoardEdgePathFinder} for an {@link Entity} for their
+     * current movement mode.
+     * @param entity The entity to retrieve the {@link BoardEdgePathFinder}.
+     * @return The appropriate {@link BoardEdgePathFinder} for the given entity.
+     */
+    private BoardEdgePathFinder getBoardEdgePathFinder(Entity entity) {
+        return deploymentPathFinders.computeIfAbsent(entity.getMovementMode(), 
+            e -> new BoardEdgePathFinder());
     }
 
     // ToDo: Change this to 'hasSafePathToCenter' to account for buildings, lava and similar hazards.
@@ -926,17 +940,7 @@ public abstract class BotClient extends Client {
             return true;
         }
         
-        BoardEdgePathFinder boardEdgePathFinder;
-
-        if(deploymentPathFinders.containsKey(entity.getMovementMode())) {
-            boardEdgePathFinder = deploymentPathFinders.get(entity.getMovementMode());
-        }
-        else {
-            boardEdgePathFinder = new BoardEdgePathFinder();
-            deploymentPathFinders.put(entity.getMovementMode(), boardEdgePathFinder);
-        }
-        
-        MovePath mp = boardEdgePathFinder.findPathToEdge(entity);
+        MovePath mp = getBoardEdgePathFinder(entity).findPathToEdge(entity);
         return mp != null;
     }
 

--- a/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
@@ -33,6 +33,7 @@ import megamek.common.IHex;
 import megamek.common.MovePath;
 import megamek.common.Terrains;
 import megamek.common.MovePath.MoveStepType;
+import megamek.common.annotations.Nullable;
 import megamek.common.MoveStep;
 
 /**
@@ -384,7 +385,7 @@ public class BoardEdgePathFinder {
      * @param coords The coordinates to check
      * @return A move path or null if these coordinates haven't been evaluated.
      */
-    public MovePath getLongestNonEdgePath(Coords coords) {
+    public @Nullable MovePath getLongestNonEdgePath(Coords coords) {
         return longestNonEdgePathCache.get(coords);
     }
 


### PR DESCRIPTION
Debugging the save, I was unable to see exactly why #1500 NRE's and was unable to replicate on 47-snapshot. However, there are two possible NRE points on the affected line:
1. If `hasPathToEdge` is not called before.
2. If `getLongestNonEdgePath` returns null for the coordinates.

For (1) I consolidated the logic to create a new `BoardEdgePathFinder`, and for (2) I added an explicit test for a `null` `MovePath`. In the second case this is explicitly noted in the JavaDoc, so I added an annotation to the method as well.