### PR TITLE
Protomech armor validation

### DIFF
--- a/megamek/src/megamek/common/verifier/TestProtomech.java
+++ b/megamek/src/megamek/common/verifier/TestProtomech.java
@@ -95,16 +95,14 @@ public class TestProtomech extends TestEntity {
      *
      */
     public static enum ProtomechArmor {
-        STANDARD (EquipmentType.T_ARMOR_STANDARD, true, 0),
-        EDP (EquipmentType.T_ARMOR_EDP, true, 1);
+        STANDARD (EquipmentType.T_ARMOR_STANDARD, 0),
+        EDP (EquipmentType.T_ARMOR_EDP, 1);
 
         private final int type;
-        private final boolean isClan;
         private final int torsoSlots;
 
-        ProtomechArmor(int t, boolean c, int slots) {
+        ProtomechArmor(int t, int slots) {
             type = t;
-            isClan = c;
             torsoSlots = slots;
         }
 
@@ -122,8 +120,7 @@ public class TestProtomech extends TestEntity {
          *            or null if no match was found.
          */
         public static @Nullable ProtomechArmor getArmor(Protomech proto) {
-            return getArmor(proto.getArmorType(Protomech.LOC_TORSO),
-                    TechConstants.isClan(proto.getArmorTechLevel(Protomech.LOC_TORSO)));
+            return getArmor(proto.getArmorType(Protomech.LOC_TORSO));
         }
 
         /**
@@ -131,24 +128,38 @@ public class TestProtomech extends TestEntity {
          * represents that type.
          *
          * @param t   The armor type.
-         * @param c   Whether this armor type is Clan or not.
          * @return    The {@link ProtomechArmor} that corresponds to the given type
          *            or null if no match was found.
          */
-        public static @Nullable ProtomechArmor getArmor(int t, boolean c) {
+        public static @Nullable ProtomechArmor getArmor(int t) {
             for (ProtomechArmor a : values()) {
-                if ((a.type == t) && (a.isClan == c)) {
+                if (a.type == t) {
                     return a;
                 }
             }
             return null;
+        }
+
+        /**
+         * Given an armor type, return the {@link ProtomechArmor} instance that
+         * represents that type.
+         * @deprecated Use {@link #getArmor(int)} instead
+
+         * @param t   The armor type.
+         * @param c   Whether the armor has a Clan tech base
+         * @return    The {@link ProtomechArmor} that corresponds to the given type
+         *            or null if no match was found.
+         */
+        @Deprecated
+        public static @Nullable ProtomechArmor getArmor(int t, boolean c) {
+            return getArmor(t);
         }
         
         /**
          * @return The {@link MiscType} for this armor.
          */
         public EquipmentType getArmorEqType() {
-            String name = EquipmentType.getArmorTypeName(type, isClan);
+            String name = EquipmentType.getArmorTypeName(type, true);
             return EquipmentType.get(name);
         }
         
@@ -158,11 +169,7 @@ public class TestProtomech extends TestEntity {
         
         public int getArmorTech() {
             EquipmentType eq = getArmorEqType();
-            return eq.getStaticTechLevel().getCompoundTechLevel(isClan);
-        }
-        
-        public boolean isClan() {
-            return isClan;
+            return eq.getStaticTechLevel().getCompoundTechLevel(true);
         }
         
         public int getTorsoSlots() {

--- a/megamek/src/megamek/common/verifier/TestProtomech.java
+++ b/megamek/src/megamek/common/verifier/TestProtomech.java
@@ -111,13 +111,12 @@ public class TestProtomech extends TestEntity {
         }
 
         /**
-         * Given an armor type, return the {@link ProtomechArmor} instance that
-         * represents that type.
+         * Given a protomech, return the {@link ProtomechArmor} instance that
+         * represents the type installed
          *
-         * @param t   The armor type.
-         * @param c   Whether this armor type is Clan or not.
-         * @return    The {@link ProtomechArmor} that corresponds to the given type
-         *            or null if no match was found.
+         * @param proto The protomech
+         * @return      The {@link ProtomechArmor} that corresponds to the given type
+         *              or null if no match was found.
          */
         public static @Nullable ProtomechArmor getArmor(Protomech proto) {
             return getArmor(proto.getArmorType(Protomech.LOC_TORSO));


### PR DESCRIPTION
Fixes Megamek/megameklab#344

Remove tech base check from protmech armor enum lookup.

All protomech armor has a Clan tech base. Since standard uses the MiscType
corresponding to T_STANDARD, and it has an tech level of Intro, it can't make
the Clan/IS distinction and when the armor is set to standard in MML it is
treated as IS and fails to match. The tech base match was kept when the code
was copied from other unit types and modified, but is not necessary for
protomechs.