### PR TITLE
Tech advancement for superheavy industrial mechs.

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -3110,6 +3110,15 @@ public abstract class Mech extends Entity {
                     .setProductionFactions(F_TH).setTechRating(RATING_C)
                     .setAvailability(RATING_C, RATING_X, RATING_F, RATING_F)
                     .setStaticTechLevel(SimpleTechLevel.ADVANCED);
+        } else if (industrial && (EntityWeightClass.WEIGHT_SUPER_HEAVY == weightClass)) {
+            // Superheavy industrialmechs don't have a separate entry on the tech advancement
+            // table in IO, but the dates for the superheavy tripod are based on the
+            // three-man digging machine, which is an industrialmech.
+            return new TechAdvancement(TECH_BASE_IS)
+                    .setAdvancement(2930, 2940).setPrototypeFactions(F_FW)
+                    .setProductionFactions(F_FW).setTechRating(RATING_D)
+                    .setAvailability(RATING_X, RATING_F, RATING_X, RATING_F)
+                    .setStaticTechLevel(SimpleTechLevel.ADVANCED);
         } else if (industrial) {
             return new TechAdvancement(TECH_BASE_ALL)
                     .setAdvancement(2460, 2470, 2500).setPrototypeFactions(F_TH)


### PR DESCRIPTION
Adds separate tech advancement data for superheavy IndustrialMechs, which are currently just using base IndustrialMech dates. This was probably overlooked because SH IMs don't have their own listing in IO, but the listing for Superheavy tripods are based on the Three-Man Digging Machine, which is an IndustrialMech, and these are the dates that are given in the construction rules for superheavy IMs.

This is related to Megamek/megameklab#351, but does not involve any API changes so they can be handled independently.