### PR TITLE
Slot placement for superheavy large engines

### DIFF
--- a/megamek/src/megamek/common/Engine.java
+++ b/megamek/src/megamek/common/Engine.java
@@ -552,7 +552,7 @@ public class Engine implements Serializable, ITechnology {
             }
             int[] slots;
             if (hasFlag(SUPERHEAVY_ENGINE)) {
-                slots = new int[]{ 0, 1, 2, 7 };
+                slots = new int[]{ 0, 1, 2, 5 };
             } else {
                 slots = new int[]{ 0, 1, 2, 7, 8, 9, 10, 11 };
             }


### PR DESCRIPTION
Large engines (rating > 400) on superheavy mechs are skipping four slots for the superheavy gryo and should only be skipping two.