### PR TITLE
Fix for issue #1444: don't count hidden hostile units as valid targets

### DIFF
--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -609,6 +609,7 @@ public class Game implements Serializable, IGame {
             if ((otherEntity.getPosition() != null)
                     && !otherEntity.isOffBoard()
                     && otherEntity.isTargetable()
+                    && !otherEntity.isHidden()
                     && !otherEntity.isSensorReturn(entity.getOwner())
                     && otherEntity.hasSeenEntity(entity.getOwner())
                     && (entity.isEnemyOf(otherEntity) || (friendlyFire && (entity


### PR DESCRIPTION
Self-explanatory. Also fixes occasional flashes of bot prescience regarding hidden units.