### PR TITLE
Fixe NPE during firing phase

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8112,7 +8112,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
      *
      * @return A <code>List</code> of loaded <code>Entity</code> units. This
      * list will never be <code>null</code>, but it may be empty. The
-     * returned <code>List</code> is independant from the under- lying
+     * returned <code>List</code> is independent from the under- lying
      * data structure; modifying one does not affect the other.
      */
     @Override
@@ -8127,7 +8127,9 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                 continue;
             }
             for (Entity e : next.getLoadedUnits()) {
-                result.add(e);
+                if(e != null) {
+                    result.add(e);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes issue #1517 as well as multiple other problems trying to get all the way through the turn in the provided saved game. For some reason, some of the entities involved appear to be haunted (aka transporting null entities) which causes NPEs when looping through lists of transported units.