### PR TITLE
Industrial mech bv

### DIFF
--- a/megamek/data/mechfiles/mechs/3075/Patron-I LoaderMech.mtf
+++ b/megamek/data/mechfiles/mechs/3075/Patron-I LoaderMech.mtf
@@ -12,7 +12,7 @@ Mass:15
 Engine:40 Fuel Cell Engine(IS)
 Structure:IS Industrial
 Myomer:Standard
-Cockpit:Primitive Cockpit
+Cockpit:Primitive Industrial Cockpit
 Gyro:Standard Gyro
 
 Heat Sinks:1 Single

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -5151,14 +5151,14 @@ public abstract class Mech extends Entity {
             bvText.append("Weapon BV * Firing Control Modifier");
             bvText.append(endColumn);
             bvText.append(startColumn);
-            bvText.append(obv);
+            bvText.append(weaponBV);
             bvText.append(" * ");
             bvText.append("0.9");
             bvText.append(endColumn);
             weaponBV *= 0.9;
             bvText.append(startColumn);
             bvText.append(" = ");
-            bvText.append(obv);
+            bvText.append(weaponBV);
             bvText.append(endColumn);
             bvText.append(endRow);
         }


### PR DESCRIPTION
Closes Megamek/megameklab#356

Fixes two problems discovered while investigating this issue:
1. The line on the BV report that shows the 0.9 multiplier for industrialmechs without advanced fire control uses the value of `obv` (offensive battle value), which has not yet been assigned, instead of the weapon BV. This only affects the report. The calculation was being performed correctly.
2. The Patron I LoaderMech is supposed to have a primitive industrial cockpit. Verified this against RS3075, unabridged, p. 170.
![Screenshot from 2019-10-19 14-40-20](https://user-images.githubusercontent.com/16927464/67150564-a932f180-f27e-11e9-82ff-5d012b3e45fa.png)
