### PR TITLE
Check for valid engine when assembling engine name.

### DIFF
--- a/megamek/src/megamek/common/Engine.java
+++ b/megamek/src/megamek/common/Engine.java
@@ -464,6 +464,9 @@ public class Engine implements Serializable, ITechnology {
     // Don't localize the marked strings below since they are used in mech
     // file parsing.
     public String getEngineName() {
+        if (!isValidEngine()) {
+            return Messages.getString("Engine.invalid");
+        }
         StringBuilder sb = new StringBuilder();
         sb.append(engineRating);
         if (hasFlag(LARGE_ENGINE)) {


### PR DESCRIPTION
An invalid engine will throw an IndexOutOfBoundsException.

This is pretty severe, since MekHQ instantiates EnginePart with an invalid engine when loading a campaign before the correct values are read and set.