### PR TITLE
Armored bv calc

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -8047,7 +8047,7 @@ public abstract class Mech extends Entity {
             } else if (mountBv > 0) {
                 bv += mountBv * 0.05 * mount.getType().getCriticals(this);
             } else {
-                bv += 5;
+                bv += 5 * mount.getType().getCriticals(this);
             }
         }
 


### PR DESCRIPTION
Per TacOps, p. 380 an armored component adds 5% of its BV per slot to the defensive BV. An item without its own BV adds 5/slot. MM is correctly adding 5%/slot, but for the equipment with no BV of its own is only adding 5 total regardless of the number of slots.

Fixes Megamek/megameklab#357