### PR TITLE
SV cost calculation tweaks

### DIFF
--- a/megamek/src/megamek/common/Engine.java
+++ b/megamek/src/megamek/common/Engine.java
@@ -21,8 +21,6 @@ package megamek.common;
 
 import java.io.Serializable;
 
-import megamek.common.verifier.TestEntity;
-
 /**
  * This class represents an engine, such as those driving mechs.
  */
@@ -148,23 +146,6 @@ public class Engine implements Serializable, ITechnology {
         SV_ENGINE_RATINGS[EXTERNAL][EquipmentType.RATING_F] = 0.6;
     }
 
-    /**
-     * Lookup factor used in calculating support vehicle engine rating
-     *
-     * @param etype       The engine type constant
-     * @param techRating  The tech rating of the engine ({@link ITechnology#RATING_A} through {@link }ITechnology#RATING_F})
-     * @return            The engine factor
-     */
-    public static double getSVEngineFactor(int etype, int techRating) {
-        if ((etype >= 0) && (etype < NUM_ENGINE_TYPES)
-            && (techRating >= EquipmentType.RATING_A)
-            && (techRating <= EquipmentType.RATING_F)
-                && (SV_ENGINE_RATINGS[etype] != null)) {
-            return SV_ENGINE_RATINGS[etype][techRating];
-        }
-        return 0.0;
-    }
-       
     public boolean engineValid;
     private int engineRating;
     private int engineType;

--- a/megamek/src/megamek/common/Engine.java
+++ b/megamek/src/megamek/common/Engine.java
@@ -148,6 +148,22 @@ public class Engine implements Serializable, ITechnology {
         SV_ENGINE_RATINGS[EXTERNAL][EquipmentType.RATING_F] = 0.6;
     }
 
+    /**
+     * Lookup factor used in calculating support vehicle engine rating
+     *
+     * @param etype       The engine type constant
+     * @param techRating  The tech rating of the engine ({@link ITechnology#RATING_A} through {@link }ITechnology#RATING_F})
+     * @return            The engine factor
+     */
+    public static double getSVEngineFactor(int etype, int techRating) {
+        if ((etype >= 0) && (etype < NUM_ENGINE_TYPES)
+            && (techRating >= EquipmentType.RATING_A)
+            && (techRating <= EquipmentType.RATING_F)
+                && (SV_ENGINE_RATINGS[etype] != null)) {
+            return SV_ENGINE_RATINGS[etype][techRating];
+        }
+        return 0.0;
+    }
        
     public boolean engineValid;
     private int engineRating;
@@ -704,6 +720,36 @@ public class Engine implements Serializable, ITechnology {
             cost *= 2;
         }
         return cost;
+    }
+
+    /**
+     * Values used for calculating the cost of a support vehicle engine. The engine cost in C-bills is
+     * tonnage * 5,000 * type multiplier
+     *
+     * @param etype The engine type
+     * @return      The type multiplier for cost
+     */
+    public static double getSVCostMultiplier(int etype) {
+        switch (etype) {
+            case STEAM:
+                return 0.8;
+            case BATTERY:
+                return 1.2;
+            case FUEL_CELL:
+                return 1.4;
+            case SOLAR:
+                return 1.6;
+            case MAGLEV:
+                return 2.5;
+            case FISSION:
+                return 3.0;
+            case NORMAL_ENGINE:
+                return 2.0;
+            case COMBUSTION_ENGINE:
+            case EXTERNAL:
+            default:
+                return 1.0;
+        }
     }
 
     private static final TechAdvancement STANDARD_FUSION_TA = new TechAdvancement(TECH_BASE_ALL)

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -904,7 +904,7 @@ public class EquipmentType implements ITechnology {
         if (bar < 0) {
             return 0;
         }
-        return SV_ARMOR_COST[Math.min(bar, SV_ARMOR_COST.length)];
+        return SV_ARMOR_COST[Math.min(bar, SV_ARMOR_COST.length - 1)];
     }
     
     /* Armor and structure are stored as integers and standard uses a generic MiscType that

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -886,6 +886,26 @@ public class EquipmentType implements ITechnology {
         }
         return 0.0;
     }
+
+    /**
+     * Cost in C-bills of a single point of SV armor for various BAR values.
+     */
+    private static int[] SV_ARMOR_COST = {
+            0, 0, 50, 100, 150, 200, 250, 300, 400, 500, 625
+    };
+
+    /**
+     * Cost lookup for standard SV armor.
+     *
+     * @param bar The barrier armor rating of the support vehicle armor
+     * @return    The cost per point, in C-bills.
+     */
+    public static double getSupportVehicleArmorCostPerPoint(int bar) {
+        if (bar < 0) {
+            return 0;
+        }
+        return SV_ARMOR_COST[Math.min(bar, SV_ARMOR_COST.length)];
+    }
     
     /* Armor and structure are stored as integers and standard uses a generic MiscType that
      * does not have its own TechAdvancement.
@@ -903,6 +923,45 @@ public class EquipmentType implements ITechnology {
             .setAdvancement(DATE_NONE).setTechRating(RATING_A)
             .setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
             .setStaticTechLevel(SimpleTechLevel.INTRO);
+    private static final TechAdvancement[] TA_SV_ARMOR = {
+            TA_NONE, // Placeholder for index 0
+            TA_NONE, // Placeholder for index 1
+            new TechAdvancement(TECH_BASE_ALL).setAdvancement(DATE_PS, DATE_PS, DATE_PS)
+                    .setTechRating(RATING_A).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
+                    .setStaticTechLevel(SimpleTechLevel.STANDARD), // BAR 2
+            new TechAdvancement(TECH_BASE_ALL).setAdvancement(DATE_PS, DATE_PS, DATE_PS)
+                    .setTechRating(RATING_A).setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
+                    .setStaticTechLevel(SimpleTechLevel.STANDARD), // BAR 3
+            new TechAdvancement(TECH_BASE_ALL).setAdvancement(DATE_PS, DATE_PS, DATE_PS)
+                    .setTechRating(RATING_B).setAvailability(RATING_B, RATING_B, RATING_A, RATING_A)
+                    .setStaticTechLevel(SimpleTechLevel.STANDARD), // BAR 4
+            new TechAdvancement(TECH_BASE_ALL).setAdvancement(DATE_ES, DATE_ES, DATE_ES)
+                    .setTechRating(RATING_B).setAvailability(RATING_B, RATING_B, RATING_B, RATING_A)
+                    .setStaticTechLevel(SimpleTechLevel.STANDARD), // BAR 5
+            new TechAdvancement(TECH_BASE_ALL).setAdvancement(DATE_ES, DATE_ES, DATE_ES)
+                    .setTechRating(RATING_C).setAvailability(RATING_C, RATING_B, RATING_B, RATING_A)
+                    .setStaticTechLevel(SimpleTechLevel.STANDARD), // BAR 6
+            new TechAdvancement(TECH_BASE_ALL).setAdvancement(2250, 2300, 2305)
+                    .setApproximate(true, true, false).setPrototypeFactions(F_TA)
+                    .setProductionFactions(F_TA).setTechRating(RATING_C)
+                    .setAvailability(RATING_C, RATING_B, RATING_B, RATING_B)
+                    .setStaticTechLevel(SimpleTechLevel.STANDARD), // BAR 7
+            new TechAdvancement(TECH_BASE_ALL).setAdvancement(2425, 2435, 22445)
+                    .setPrototypeFactions(F_TH).setProductionFactions(F_TH)
+                    .setTechRating(RATING_D)
+                    .setAvailability(RATING_C, RATING_C, RATING_B, RATING_B)
+                    .setStaticTechLevel(SimpleTechLevel.STANDARD), // BAR 8
+            new TechAdvancement(TECH_BASE_ALL).setAdvancement(2440, 2450, 2470)
+                    .setPrototypeFactions(F_TH).setProductionFactions(F_TH)
+                    .setTechRating(RATING_D)
+                    .setAvailability(RATING_C, RATING_C, RATING_C, RATING_B)
+                    .setStaticTechLevel(SimpleTechLevel.STANDARD), // BAR 9
+            new TechAdvancement(TECH_BASE_ALL).setAdvancement(2460, 2470, 2505)
+                    .setPrototypeFactions(F_TH).setProductionFactions(F_TH)
+                    .setApproximate(true, false, false).setTechRating(RATING_D)
+                    .setAvailability(RATING_D, RATING_D, RATING_D, RATING_C)
+                    .setStaticTechLevel(SimpleTechLevel.STANDARD) // BAR 10
+    };
 
     /**
      * Tech advancement for armor based on the armor type index and tech base
@@ -919,6 +978,19 @@ public class EquipmentType implements ITechnology {
         EquipmentType armor = EquipmentType.get(armorName);
         if (armor != null) {
             return armor.getTechAdvancement();
+        }
+        return TA_NONE;
+    }
+
+    /**
+     * Tech advancement for support vehicle armor
+     *
+     * @param bar The armor's barrier armor rating
+     * @return    The armor tech advancement
+     */
+    public static TechAdvancement getSVArmorTechAdvancement(int bar) {
+        if ((bar >= 0) && (bar < TA_SV_ARMOR.length)) {
+            return TA_SV_ARMOR[bar];
         }
         return TA_NONE;
     }

--- a/megamek/src/megamek/common/FixedWingSupport.java
+++ b/megamek/src/megamek/common/FixedWingSupport.java
@@ -14,6 +14,11 @@
  */
 package megamek.common;
 
+import megamek.common.verifier.SupportVeeStructure;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -292,6 +297,202 @@ public class FixedWingSupport extends ConvFighter {
         if (getMaxBombPoints() > 0) {
             specialAbilities.put(BattleForceSPA.BOMB, getMaxBombPoints() / 5);
         }
+    }
+
+    @Override
+    public double getCost(boolean ignoreAmmo) {
+        double[] costs = new double[13 + locations()];
+        int i = 0;
+        // Chassis cost for Support Vehicles
+
+        double chassisCost = 2500 * SupportVeeStructure.getWeightStructure(this);
+        if (hasMisc(MiscType.F_AMPHIBIOUS)) {
+            chassisCost *= 1.25;
+        }
+        if (hasMisc(MiscType.F_ARMORED_CHASSIS)) {
+            chassisCost *= 2.0;
+        }
+        if (hasMisc(MiscType.F_ENVIRONMENTAL_SEALING)) {
+            chassisCost *= 1.75;
+        }
+        if (hasMisc(MiscType.F_PROP)) {
+            chassisCost *= 0.75;
+        }
+        if (hasMisc(MiscType.F_STOL_CHASSIS)) {
+            chassisCost *= 1.5;
+        }
+        if (hasMisc(MiscType.F_ULTRA_LIGHT)) {
+            chassisCost *= 1.5;
+        }
+        if (hasMisc(MiscType.F_VSTOL_CHASSIS)) {
+            chassisCost *= 2;
+        }
+        costs[i++] = chassisCost;
+
+        // Engine Costs
+        double engineCost = 0.0;
+        if (hasEngine()) {
+            engineCost = 5000 * getEngine().getWeightEngine(this)
+                    * Engine.getSVCostMultiplier(getEngine().getEngineType());
+        }
+        costs[i++] = engineCost;
+
+        // armor
+        if (getArmorType(firstArmorIndex()) == EquipmentType.T_ARMOR_STANDARD) {
+            int totalArmorPoints = 0;
+            for (int loc = 0; loc < locations(); loc++) {
+                totalArmorPoints += getOArmor(loc);
+            }
+            costs[i++] = totalArmorPoints *
+                    EquipmentType.getSupportVehicleArmorCostPerPoint(getBARRating(firstArmorIndex()));
+        } else {
+            if (hasPatchworkArmor()) {
+                for (int loc = 0; loc < locations(); loc++) {
+                    costs[i++] = getArmorWeight(loc)
+                            * EquipmentType.getArmorCost(armorType[loc]);
+                }
+
+            } else {
+                costs[i++] = getArmorWeight()
+                        * EquipmentType.getArmorCost(armorType[0]);
+            }
+        }
+
+        // Compute final structural cost
+        int structCostIdx = i++;
+        costs[i++] = 0;
+        for (int c = 0; c < structCostIdx; c++) {
+            costs[structCostIdx] += costs[c];
+        }
+        double techRatingMultiplier = 0.5 + (getStructuralTechRating() * 0.25);
+        costs[structCostIdx] *= techRatingMultiplier;
+
+        double freeHeatSinks = (hasEngine() ? getEngine().getWeightFreeEngineHeatSinks() : 0);
+        int sinks = 0;
+        double paWeight = 0;
+        for (Mounted m : getWeaponList()) {
+            WeaponType wt = (WeaponType) m.getType();
+            if (wt.hasFlag(WeaponType.F_LASER) || wt.hasFlag(WeaponType.F_PPC)) {
+                sinks += wt.getHeat();
+                paWeight += wt.getTonnage(this) / 10.0;
+            }
+        }
+        paWeight = Math.ceil(paWeight * 2) / 2;
+        if(hasEngine() && getEngine().isFusion()) {
+            paWeight = 0;
+        }
+        costs[i++] = 20000 * paWeight;
+        costs[i++] = 2000 * Math.max(0, sinks - freeHeatSinks);
+
+        costs[i++] = getWeaponsAndEquipmentCost(ignoreAmmo);
+
+        double cost = 0; // calculate the total
+        for (int x = structCostIdx; x < i; x++) {
+            cost += costs[x];
+        }
+        if (isOmni()) { // Omni conversion cost goes here.
+            cost *= 1.25;
+            costs[i++] = -1.25;
+        } else {
+            costs[i++] = 0;
+        }
+
+        double multiplier = 1.0;
+        switch (movementMode) {
+            case AERODYNE:
+                multiplier += weight / 50.0;
+                break;
+            case AIRSHIP:
+                multiplier += weight / 10000;
+                break;
+            case STATION_KEEPING:
+                multiplier += weight / 75.0;
+                break;
+        }
+        cost *= multiplier;
+        costs[i++] = -multiplier;
+
+        addCostDetails(cost, costs);
+        return Math.round(cost);
+    }
+
+    private void addCostDetails(double cost, double[] costs) {
+        bvText = new StringBuffer();
+        List<String> left = new ArrayList<>();
+
+        left.add("Chassis");
+        left.add("Engine");
+        left.add("Armor");
+        left.add("Final Structural Cost");
+        left.add("Power Amplifiers");
+        left.add("Heat Sinks");
+        left.add("Equipment");
+        left.add("Omni Multiplier");
+        left.add("Tonnage Multiplier");
+
+        NumberFormat commafy = NumberFormat.getInstance();
+
+        bvText.append("<HTML><BODY><CENTER><b>Cost Calculations For ");
+        bvText.append(getChassis());
+        bvText.append(" ");
+        bvText.append(getModel());
+        bvText.append("</b></CENTER>");
+        bvText.append(nl);
+
+        bvText.append(startTable);
+        // find the maximum length of the columns.
+        for (int l = 0; l < left.size(); l++) {
+
+            if (l == 8) {
+                getWeaponsAndEquipmentCost(true);
+            }else {
+                if (left.get(l).equals("Final Structural Cost")) {
+                    bvText.append(startRow);
+                    bvText.append(startColumn);
+                    bvText.append(endColumn);
+                    bvText.append(startColumn);
+                    bvText.append("-------------");
+                    bvText.append(endColumn);
+                    bvText.append(endRow);
+                }
+                bvText.append(startRow);
+                bvText.append(startColumn);
+                bvText.append(left.get(l));
+                bvText.append(endColumn);
+                bvText.append(startColumn);
+
+                if (costs[l] == 0) {
+                    bvText.append("N/A");
+                } else if (costs[l] < 0) {
+                    bvText.append("x ");
+                    bvText.append(commafy.format(-costs[l]));
+                } else {
+                    bvText.append(commafy.format(costs[l]));
+
+                }
+                bvText.append(endColumn);
+                bvText.append(endRow);
+            }
+        }
+        bvText.append(startRow);
+        bvText.append(startColumn);
+        bvText.append(endColumn);
+        bvText.append(startColumn);
+        bvText.append("-------------");
+        bvText.append(endColumn);
+        bvText.append(endRow);
+
+        bvText.append(startRow);
+        bvText.append(startColumn);
+        bvText.append("Total Cost:");
+        bvText.append(endColumn);
+        bvText.append(startColumn);
+        bvText.append(commafy.format(cost));
+        bvText.append(endColumn);
+        bvText.append(endRow);
+
+        bvText.append(endTable);
+        bvText.append("</BODY></HTML>");
     }
 
     public long getEntityType(){

--- a/megamek/src/megamek/common/FuelType.java
+++ b/megamek/src/megamek/common/FuelType.java
@@ -27,7 +27,7 @@ public enum FuelType {
     NONE (0, ITechnology.RATING_A),
     /** Fuel cell */
     HYRDOGEN (15000, ITechnology.RATING_C),
-    /** Standard ICE fuel (non-aerospace) */
+    /** Standard non-aerospace ICE fuel */
     PETROCHEMICALS (1000, ITechnology.RATING_A),
     /** Alternate ICE fuel */
     ALCOHOL (1500, ITechnology.RATING_A),

--- a/megamek/src/megamek/common/FuelType.java
+++ b/megamek/src/megamek/common/FuelType.java
@@ -23,10 +23,15 @@ package megamek.common;
  * range. See StratOps, p. 179.
  */
 public enum FuelType {
+    /** Currently a place holder for "none of the others"; a better option than null */
     NONE (0, ITechnology.RATING_A),
+    /** Fuel cell */
     HYRDOGEN (15000, ITechnology.RATING_C),
+    /** Standard ICE fuel (non-aerospace) */
     PETROCHEMICALS (1000, ITechnology.RATING_A),
+    /** Alternate ICE fuel */
     ALCOHOL (1500, ITechnology.RATING_A),
+    /** Alternal ICE fuel */
     NATURAL_GAS (1200, ITechnology.RATING_A);
 
     /**

--- a/megamek/src/megamek/common/FuelType.java
+++ b/megamek/src/megamek/common/FuelType.java
@@ -23,6 +23,7 @@ package megamek.common;
  * range. See StratOps, p. 179.
  */
 public enum FuelType {
+    NONE (0, ITechnology.RATING_A),
     HYRDOGEN (15000, ITechnology.RATING_C),
     PETROCHEMICALS (1000, ITechnology.RATING_A),
     ALCOHOL (1500, ITechnology.RATING_A),

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2587,6 +2587,9 @@ public class Tank extends Entity {
             if (hasMisc(MiscType.F_ENVIRONMENTAL_SEALING)) {
                 chassisCost *= 1.75;
             }
+            if (hasMisc(MiscType.F_EXTERNAL_POWER_PICKUP)) {
+                chassisCost *= 1.1;
+            }
             if (hasMisc(MiscType.F_HYDROFOIL)) {
                 chassisCost *= 1.1;
             }
@@ -2627,30 +2630,8 @@ public class Tank extends Entity {
         double engineCost = 0.0;
         if(hasEngine()) {
             if (isSupportVehicle()) {
-                engineCost = 5000 * getEngine().getWeightEngine(this);
-                switch (getEngine().getEngineType()) {
-                    case Engine.STEAM:
-                        engineCost *= 0.8;
-                        break;
-                    case Engine.COMBUSTION_ENGINE:
-                        engineCost *= 1.0;
-                        break;
-                    case Engine.BATTERY:
-                        engineCost *= 1.2;
-                        break;
-                    case Engine.FUEL_CELL:
-                        engineCost *= 1.4;
-                        break;
-                    case Engine.SOLAR:
-                        engineCost *= 1.6;
-                        break;
-                    case Engine.FISSION:
-                        engineCost *= 3;
-                        break;
-                    case Engine.NORMAL_ENGINE:
-                        engineCost *= 2;
-                        break;
-                }
+                engineCost = 5000 * getEngine().getWeightEngine(this)
+                        * Engine.getSVCostMultiplier(getEngine().getEngineType());
             } else {
                 engineCost = (getEngine().getBaseCost() *
                         getEngine().getRating() * weight) / 75.0;

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -102,9 +102,6 @@ public class Tank extends Entity {
     private static String[] LOCATION_NAMES_DUAL_TURRET = { "Body", "Front",
             "Right", "Left", "Rear", "Rear Turret", "Front Turret" };
 
-    public static float[] BAR_ARMOR_COST_MULT = { 0, 0, 50, 100, 150, 200, 250,
-            300, 400, 500, 625 };
-
     @Override
     public int getUnitType() {
         EntityMovementMode mm = getMovementMode();
@@ -2645,8 +2642,8 @@ public class Tank extends Entity {
             for (int loc = 0; loc < locations(); loc++) {
                 totalArmorPoints += getOArmor(loc);
             }
-            costs[i++] = totalArmorPoints *
-                    BAR_ARMOR_COST_MULT[getBARRating(LOC_BODY)];
+            costs[i++] = totalArmorPoints
+                    * EquipmentType.getSupportVehicleArmorCostPerPoint(getBARRating(firstArmorIndex()));
         } else {
             if (hasPatchworkArmor()) {
                 for (int loc = 0; loc < locations(); loc++) {
@@ -2740,28 +2737,38 @@ public class Tank extends Entity {
 
 
         double multiplier = 1.0;
-        switch (movementMode) {
-            case HOVER:
-            case SUBMARINE:
-                multiplier += weight / 50.0;
-                break;
-            case HYDROFOIL:
-                multiplier += weight / 75.0;
-                break;
-            case NAVAL:
-            case WHEELED:
-                multiplier += weight / 200.0;
-                break;
-            case TRACKED:
-                multiplier += weight / 100.0;
-                break;
-            case VTOL:
-                multiplier += weight / 30.0;
-                break;
-            case WIGE:
-                multiplier += weight / 25.0;
-                break;
-            default:
+        if (isSupportVehicle()
+            && (movementMode.equals(EntityMovementMode.NAVAL)
+                || movementMode.equals(EntityMovementMode.HYDROFOIL)
+                || movementMode.equals(EntityMovementMode.SUBMARINE))) {
+            multiplier += weight / 100000.0;
+        } else {
+            switch (movementMode) {
+                case HOVER:
+                case SUBMARINE:
+                    multiplier += weight / 50.0;
+                    break;
+                case HYDROFOIL:
+                    multiplier += weight / 75.0;
+                    break;
+                case NAVAL:
+                case WHEELED:
+                    multiplier += weight / 200.0;
+                    break;
+                case TRACKED:
+                    multiplier += weight / 100.0;
+                    break;
+                case VTOL:
+                    multiplier += weight / 30.0;
+                    break;
+                case WIGE:
+                    multiplier += weight / 25.0;
+                    break;
+                case RAIL:
+                case MAGLEV:
+                    multiplier += weight / 250.0;
+                    break;
+            }
         }
         cost *= multiplier;
         costs[i++] = -multiplier;

--- a/megamek/src/megamek/common/verifier/SupportVeeStructure.java
+++ b/megamek/src/megamek/common/verifier/SupportVeeStructure.java
@@ -16,7 +16,6 @@ package megamek.common.verifier;
 
 import megamek.common.Entity;
 import megamek.common.MiscType;
-import megamek.common.Tank;
 
 public class SupportVeeStructure extends Structure {
 

--- a/megamek/src/megamek/common/verifier/SupportVeeStructure.java
+++ b/megamek/src/megamek/common/verifier/SupportVeeStructure.java
@@ -14,6 +14,7 @@
  */
 package megamek.common.verifier;
 
+import megamek.common.Entity;
 import megamek.common.MiscType;
 import megamek.common.Tank;
 
@@ -22,13 +23,13 @@ public class SupportVeeStructure extends Structure {
     static final double[] SV_TECH_RATING_STRUCTURE_MULTIPLIER = 
         { 1.60, 1.30, 1.15, 1.00, 0.85, 0.66 };
     
-    Tank sv;
+    Entity sv;
     
-    public SupportVeeStructure(Tank supportVee) {
+    public SupportVeeStructure(Entity supportVee) {
         this.sv = supportVee;
     }
     
-    public static double getWeightStructure(Tank sv) {
+    public static double getWeightStructure(Entity sv) {
         double baseChassisVal = sv.getBaseChassisValue();
         double trMult = SV_TECH_RATING_STRUCTURE_MULTIPLIER[sv
                 .getStructuralTechRating()];
@@ -50,6 +51,9 @@ public class SupportVeeStructure extends Structure {
         }
         if (sv.hasMisc(MiscType.F_ENVIRONMENTAL_SEALING)) {
             chassisModMult *= 2;
+        }
+        if (sv.hasMisc(MiscType.F_EXTERNAL_POWER_PICKUP)) {
+            chassisModMult *= 1.1;
         }
         if (sv.hasMisc(MiscType.F_HYDROFOIL)) {
             chassisModMult *= 1.7;

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -105,6 +105,7 @@ public class BasicPathRankerTest {
         mockPrincess = Mockito.mock(Princess.class);
         Mockito.when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
         Mockito.when(mockPrincess.getFireControl(FireControlType.Basic)).thenReturn(mockFireControl);
+        Mockito.when(mockPrincess.getFireControl(Mockito.any(Entity.class))).thenReturn(mockFireControl);
         Mockito.when(mockPrincess.getHomeEdge(Mockito.any(Entity.class))).thenReturn(CardinalEdge.NORTH);
         Mockito.when(mockPrincess.getHonorUtil()).thenReturn(mockHonorUtil);
         Mockito.when(mockPrincess.getLogger()).thenReturn(fakeLogger);


### PR DESCRIPTION
Fixed some errors in the support vehicle cost calculation, including having fixed wing support calculate cost as a support vehicle instead of as a conventional fighter.

Extracted some of the cost calculations into a separate method and moved them out of Tank for use by FixedWingSupport and by MekHQ parts.