### PR TITLE
Rac heat

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -17,7 +17,6 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -2254,7 +2253,7 @@ public class FireControl {
     	}
     	
         for(Mounted weapon : shooter.getWeaponList()) {
-        	if(weapon.getType().hasModeType(Weapon.Mode_Missile_Indirect)) {
+        	if(weapon.getType().hasModeType(Weapon.MODE_MISSILE_INDIRECT)) {
         		fireControlState.getEntityIDFStates().put(shooter.getId(), true);
         		return true;
         	}

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -646,8 +646,8 @@ public class WeaponFireInfo {
         }
         
         // if we are able to switch the weapon to indirect fire mode, do so and try again
-        if(!getWeapon().curMode().equals(Weapon.Mode_Missile_Indirect)) {
-            return getWeapon().setMode(Weapon.Mode_Missile_Indirect);
+        if(!getWeapon().curMode().equals(Weapon.MODE_MISSILE_INDIRECT)) {
+            return getWeapon().setMode(Weapon.MODE_MISSILE_INDIRECT);
         } else {
             return getWeapon().setMode("");
         }

--- a/megamek/src/megamek/client/commands/FireCommand.java
+++ b/megamek/src/megamek/client/commands/FireCommand.java
@@ -292,7 +292,7 @@ public class FireCommand extends ClientCommand {
             if (m.isUsedThisRound()) {
                 str += " Can't shoot: "
                        + Messages.getString("FiringDisplay.alreadyFired");
-            } else if ((m.getType().hasFlag(WeaponType.F_AUTO_TARGET) && !m.curMode().equals(Weapon.Mode_AMS_Manual))
+            } else if ((m.getType().hasFlag(WeaponType.F_AUTO_TARGET) && !m.curMode().equals(Weapon.MODE_AMS_MANUAL))
             			|| (m.getType().hasModes() && m.curMode().equals("Point Defense"))) {
                 str += " Can't shoot: "
                        + Messages.getString("FiringDisplay.autoFiringWeapon");

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -1941,7 +1941,7 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements
                 clientgui.mechD.wPan.wToHitR.setText(Messages
                         .getString("FiringDisplay.alreadyFired")); //$NON-NLS-1$
                 setFireEnabled(false);
-            } else if ((m.getType().hasFlag(WeaponType.F_AUTO_TARGET) && !m.curMode().equals(Weapon.Mode_AMS_Manual))
+            } else if ((m.getType().hasFlag(WeaponType.F_AUTO_TARGET) && !m.curMode().equals(Weapon.MODE_AMS_MANUAL))
             			|| (m.getType().hasModes() && m.curMode().equals("Point Defense"))) {
                 clientgui.mechD.wPan.wToHitR.setText(Messages
                         .getString("FiringDisplay.autoFiringWeapon"));

--- a/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
@@ -870,7 +870,7 @@ public class PointblankShotDisplay extends FiringDisplay implements
                 clientgui.mechD.wPan.wToHitR.setText(Messages
                         .getString("FiringDisplay.alreadyFired")); //$NON-NLS-1$
                 setFireEnabled(false);
-            } else if ((m.getType().hasFlag(WeaponType.F_AUTO_TARGET) && !m.curMode().equals(Weapon.Mode_AMS_Manual))) {
+            } else if ((m.getType().hasFlag(WeaponType.F_AUTO_TARGET) && !m.curMode().equals(Weapon.MODE_AMS_MANUAL))) {
                 clientgui.mechD.wPan.wToHitR.setText(Messages
                         .getString("FiringDisplay.autoFiringWeapon"));
                 //$NON-NLS-1$

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -1093,7 +1093,7 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
             } else if (m.isInBearingsOnlyMode() && distance < RangeType.RANGE_BEARINGS_ONLY_MINIMUM) {
                 clientgui.mechD.wPan.wToHitR.setText(Messages.getString("TargetingPhaseDisplay.bearingsOnlyMinRange"));
                 setFireEnabled(false);
-            } else if ((m.getType().hasFlag(WeaponType.F_AUTO_TARGET) && !m.curMode().equals(Weapon.Mode_AMS_Manual))) {
+            } else if ((m.getType().hasFlag(WeaponType.F_AUTO_TARGET) && !m.curMode().equals(Weapon.MODE_AMS_MANUAL))) {
                 clientgui.mechD.wPan.wToHitR.setText(Messages
                         .getString("TargetingPhaseDisplay.autoFiringWeapon"));
                 //$NON-NLS-1$

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -3652,7 +3652,7 @@ public class Compute {
         threshold = atk.toHit(cgame).getValue();
 
         // Set the weapon to single shot mode
-        weapon.setMode(rapidAC ? "" : Weapon.Mode_AC_Single);
+        weapon.setMode(rapidAC ? "" : Weapon.MODE_AC_SINGLE);
         final_spin = 0;
 
         // If weapon can't hit target, exit the function with the weapon on
@@ -3667,11 +3667,11 @@ public class Compute {
             final_spin = 1;
             if ((wtype.getAmmoType() == AmmoType.T_AC_ULTRA)
                 || (wtype.getAmmoType() == AmmoType.T_AC_ULTRA_THB)) {
-                weapon.setMode(Weapon.Mode_UAC_Ultra);
+                weapon.setMode(Weapon.MODE_UAC_ULTRA);
             } else if (wtype.getAmmoType() == AmmoType.T_AC_ROTARY) {
-                weapon.setMode(Weapon.Mode_RAC_TwoShot);
+                weapon.setMode(Weapon.MODE_RAC_TWO_SHOT);
             } else if (rapidAC) {
-            	weapon.setMode(Weapon.Mode_AC_Rapid);
+            	weapon.setMode(Weapon.MODE_AC_RAPID);
             }
         }
 
@@ -3681,13 +3681,13 @@ public class Compute {
             // If random roll is >= to-hit + 2 then set to quad-spin
             if (spinupThreshold >= (threshold + 1)) {
                 final_spin = 2;
-                weapon.setMode(Weapon.Mode_RAC_FourShot);
+                weapon.setMode(Weapon.MODE_RAC_FOUR_SHOT);
             }
 
             // If random roll is >= to-hit + 3 then set to six-spin
             if (spinupThreshold >= (threshold + 2)) {
                 final_spin = 3;
-                weapon.setMode(Weapon.Mode_RAC_SixShot);
+                weapon.setMode(Weapon.MODE_RAC_SIX_SHOT);
             }
         }
         return final_spin;

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3723,7 +3723,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                 || (!mounted.getType().hasFlag(WeaponType.F_TAG) && (game
                                                                              .getPhase() == IGame.Phase.PHASE_OFFBOARD))
                 //No AMS, unless it's in 'weapon' mode
-                || (mounted.getType().hasFlag(WeaponType.F_AMS) && !mounted.curMode().equals(Weapon.Mode_AMS_Manual))) {
+                || (mounted.getType().hasFlag(WeaponType.F_AMS) && !mounted.curMode().equals(Weapon.MODE_AMS_MANUAL))) {
                 continue;
             }
 
@@ -3772,8 +3772,8 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         // Start reached, now we can attempt to pick a weapon.
         if ((mounted != null)
             && (mounted.isReady())
-            && (!(mounted.getType().hasFlag(WeaponType.F_AMS) && mounted.curMode().equals(Weapon.Mode_AMS_On)))
-            && (!(mounted.getType().hasFlag(WeaponType.F_AMS) && mounted.curMode().equals(Weapon.Mode_AMS_Off)))
+            && (!(mounted.getType().hasFlag(WeaponType.F_AMS) && mounted.curMode().equals(Weapon.MODE_AMS_ON)))
+            && (!(mounted.getType().hasFlag(WeaponType.F_AMS) && mounted.curMode().equals(Weapon.MODE_AMS_OFF)))
             && (!mounted.getType().hasFlag(WeaponType.F_AMSBAY))
             && (!(mounted.getType().hasModes() && mounted.curMode().equals("Point Defense")))
             && ((mounted.getLinked() == null)
@@ -6382,7 +6382,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
 
             // Make sure the AMS is good to go
             if (!weapon.isReady() || weapon.isMissing()
-                || !weapon.curMode().equals(Weapon.Mode_AMS_On)) {
+                || !weapon.curMode().equals(Weapon.MODE_AMS_ON)) {
                 continue;
             }
 

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -754,7 +754,7 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         // figure out # of shots for variable-shot weapons
         if (((wtype.getAmmoType() == AmmoType.T_AC_ULTRA) || (wtype
                 .getAmmoType() == AmmoType.T_AC_ULTRA_THB))
-                && (ignoreMode || mode.equals("Ultra"))) {
+                && (ignoreMode || mode.equals(Weapon.Mode_UAC_Ultra))) {
             nShots = 2;
         }
         // sets number of shots for AC rapid mode
@@ -763,19 +763,19 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
                 || (wtype.getAmmoType() == AmmoType.T_AC_IMP)
                 || (wtype.getAmmoType() == AmmoType.T_PAC))
                 && wtype.hasModes()
-                && (ignoreMode || mode.equals("Rapid"))) {
+                && (ignoreMode || mode.equals(Weapon.Mode_AC_Rapid))) {
             nShots = 2;
         } else if ((wtype.getAmmoType() == AmmoType.T_AC_ROTARY)
                 || wtype.getInternalName().equals(BattleArmor.MINE_LAUNCHER)) {
-            if ((mode != null) && mode.equals("2-shot")) {
+            if ((mode != null) && mode.equals(Weapon.Mode_RAC_ThreeShot)) {
                 nShots = 2;
-            } else if ((mode != null) && mode.equals("3-shot")) {
+            } else if ((mode != null) && mode.equals(Weapon.Mode_RAC_ThreeShot)) {
                 nShots = 3;
-            } else if ((mode != null) && mode.equals("4-shot")) {
+            } else if ((mode != null) && mode.equals(Weapon.Mode_RAC_FourShot)) {
                 nShots = 4;
-            } else if ((mode != null) && mode.equals("5-shot")) {
+            } else if ((mode != null) && mode.equals(Weapon.Mode_RAC_FiveShot)) {
                 nShots = 5;
-            } else if ((ignoreMode || mode.equals("6-shot"))) {
+            } else if ((ignoreMode || mode.equals(Weapon.Mode_RAC_SixShot))) {
                 nShots = 6;
             }
         }

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -753,7 +753,7 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         // figure out # of shots for variable-shot weapons
         if (((wtype.getAmmoType() == AmmoType.T_AC_ULTRA) || (wtype
                 .getAmmoType() == AmmoType.T_AC_ULTRA_THB))
-                && (ignoreMode || mode.equals(Weapon.Mode_UAC_Ultra))) {
+                && (ignoreMode || mode.equals(Weapon.MODE_UAC_ULTRA))) {
             return 2;
         }
         // sets number of shots for AC rapid mode
@@ -762,19 +762,19 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
                 || (wtype.getAmmoType() == AmmoType.T_AC_IMP)
                 || (wtype.getAmmoType() == AmmoType.T_PAC))
                 && wtype.hasModes()
-                && (ignoreMode || mode.equals(Weapon.Mode_AC_Rapid))) {
+                && (ignoreMode || mode.equals(Weapon.MODE_AC_RAPID))) {
             return 2;
         } else if ((wtype.getAmmoType() == AmmoType.T_AC_ROTARY)
                 || wtype.getInternalName().equals(BattleArmor.MINE_LAUNCHER)) {
-            if (ignoreMode || (mode == null) || mode.equals(Weapon.Mode_RAC_SixShot)) {
+            if (ignoreMode || (mode == null) || mode.equals(Weapon.MODE_RAC_SIX_SHOT)) {
                 return 6;
-            } else if (mode.equals(Weapon.Mode_RAC_ThreeShot)) {
+            } else if (mode.equals(Weapon.MODE_RAC_TWO_SHOT)) {
                 return 2;
-            } else if (mode.equals(Weapon.Mode_RAC_ThreeShot)) {
+            } else if (mode.equals(Weapon.MODE_RAC_THREE_SHOT)) {
                 return 3;
-            } else if (mode.equals(Weapon.Mode_RAC_FourShot)) {
+            } else if (mode.equals(Weapon.MODE_RAC_FOUR_SHOT)) {
                 return 4;
-            } else if (mode.equals(Weapon.Mode_RAC_FiveShot)) {
+            } else if (mode.equals(Weapon.MODE_RAC_FIVE_SHOT)) {
                 return 5;
             }
         }
@@ -1711,14 +1711,14 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
      * @return
      */
     public boolean isInBearingsOnlyMode() {
-        if ((curMode().equals(Weapon.Mode_CapMissile_Bearing_Ext)
-                    || curMode().equals(Weapon.Mode_CapMissile_Bearing_Long)
-                    || curMode().equals(Weapon.Mode_CapMissile_Bearing_Med)
-                    || curMode().equals(Weapon.Mode_CapMissile_Bearing_Short)
-                    || curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Ext)
-                    || curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Long)
-                    || curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Med)
-                    || curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Short)) 
+        if ((curMode().equals(Weapon.MODE_CAP_MISSILE_BEARING_EXT)
+                    || curMode().equals(Weapon.MODE_CAP_MISSILE_BEARING_LONG)
+                    || curMode().equals(Weapon.MODE_CAP_MISSILE_BEARING_MED)
+                    || curMode().equals(Weapon.MODE_CAP_MISSILE_BEARING_SHORT)
+                    || curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_EXT)
+                    || curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_LONG)
+                    || curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_MED)
+                    || curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_SHORT))
                 && getEntity().isSpaceborne()) {
             return true;
         }
@@ -1731,11 +1731,11 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
      * @return
      */
     public boolean isInWaypointLaunchMode() {
-        if ((curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Ext)
-                || curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Long)
-                || curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Med)
-                || curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Short)
-                || curMode().equals(Weapon.Mode_CapMissile_Waypoint)) 
+        if ((curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_EXT)
+                || curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_LONG)
+                || curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_MED)
+                || curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_SHORT)
+                || curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT))
             && getEntity().isSpaceborne()) {
             return true;
         }
@@ -1750,16 +1750,16 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
     public void setModesForMapType() {
         //If the entity is not in space, remove these modes, which get set up based on game options in Weapon before game type is known
         if (!getEntity().isSpaceborne()) {
-            getType().removeMode(Weapon.Mode_CapMissile_Waypoint_Bearing_Ext);
-            getType().removeMode(Weapon.Mode_CapMissile_Waypoint_Bearing_Long);
-            getType().removeMode(Weapon.Mode_CapMissile_Waypoint_Bearing_Med);
-            getType().removeMode(Weapon.Mode_CapMissile_Waypoint_Bearing_Short);
-            getType().removeMode(Weapon.Mode_CapMissile_Waypoint);
-            getType().removeMode(Weapon.Mode_CapMissile_Tele_Operated);
-            getType().removeMode(Weapon.Mode_CapMissile_Bearing_Ext);
-            getType().removeMode(Weapon.Mode_CapMissile_Bearing_Long);
-            getType().removeMode(Weapon.Mode_CapMissile_Bearing_Med);
-            getType().removeMode(Weapon.Mode_CapMissile_Bearing_Short);
+            getType().removeMode(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_EXT);
+            getType().removeMode(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_LONG);
+            getType().removeMode(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_MED);
+            getType().removeMode(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_SHORT);
+            getType().removeMode(Weapon.MODE_CAP_MISSILE_WAYPOINT);
+            getType().removeMode(Weapon.MODE_CAP_MISSILE_TELE_OPERATED);
+            getType().removeMode(Weapon.MODE_CAP_MISSILE_BEARING_EXT);
+            getType().removeMode(Weapon.MODE_CAP_MISSILE_BEARING_LONG);
+            getType().removeMode(Weapon.MODE_CAP_MISSILE_BEARING_MED);
+            getType().removeMode(Weapon.MODE_CAP_MISSILE_BEARING_SHORT);
         }
         /*
         //Placeholder. This will be used to add the space modes back when we're able to switch maps.

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -750,12 +750,11 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
      */
     public static int getNumShots(WeaponType wtype, EquipmentMode mode,
             boolean ignoreMode) {
-        int nShots = 1;
         // figure out # of shots for variable-shot weapons
         if (((wtype.getAmmoType() == AmmoType.T_AC_ULTRA) || (wtype
                 .getAmmoType() == AmmoType.T_AC_ULTRA_THB))
                 && (ignoreMode || mode.equals(Weapon.Mode_UAC_Ultra))) {
-            nShots = 2;
+            return 2;
         }
         // sets number of shots for AC rapid mode
         else if (((wtype.getAmmoType() == AmmoType.T_AC) 
@@ -764,22 +763,22 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
                 || (wtype.getAmmoType() == AmmoType.T_PAC))
                 && wtype.hasModes()
                 && (ignoreMode || mode.equals(Weapon.Mode_AC_Rapid))) {
-            nShots = 2;
+            return 2;
         } else if ((wtype.getAmmoType() == AmmoType.T_AC_ROTARY)
                 || wtype.getInternalName().equals(BattleArmor.MINE_LAUNCHER)) {
-            if ((mode != null) && mode.equals(Weapon.Mode_RAC_ThreeShot)) {
-                nShots = 2;
-            } else if ((mode != null) && mode.equals(Weapon.Mode_RAC_ThreeShot)) {
-                nShots = 3;
-            } else if ((mode != null) && mode.equals(Weapon.Mode_RAC_FourShot)) {
-                nShots = 4;
-            } else if ((mode != null) && mode.equals(Weapon.Mode_RAC_FiveShot)) {
-                nShots = 5;
-            } else if ((ignoreMode || mode.equals(Weapon.Mode_RAC_SixShot))) {
-                nShots = 6;
+            if (ignoreMode || (mode == null) || mode.equals(Weapon.Mode_RAC_SixShot)) {
+                return 6;
+            } else if (mode.equals(Weapon.Mode_RAC_ThreeShot)) {
+                return 2;
+            } else if (mode.equals(Weapon.Mode_RAC_ThreeShot)) {
+                return 3;
+            } else if (mode.equals(Weapon.Mode_RAC_FourShot)) {
+                return 4;
+            } else if (mode.equals(Weapon.Mode_RAC_FiveShot)) {
+                return 5;
             }
         }
-        return nShots;
+        return 1;
     }
 
     public boolean isPendingDump() {

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -364,7 +364,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                         && (munition == AmmoType.M_CLUSTER))
                         || (munition == AmmoType.M_FLAK) || (atype.getAmmoType() == AmmoType.T_HAG));
         
-        boolean isIndirect = (wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_Missile_Indirect));
+        boolean isIndirect = (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_MISSILE_INDIRECT));
         
         boolean isInferno = ((atype != null)
                 && ((atype.getAmmoType() == AmmoType.T_SRM)
@@ -2166,7 +2166,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             
             // Gauss weapons using the TacOps powered down rule can't fire
             if ((wtype instanceof GaussWeapon) 
-                    && wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_Gauss_Powered_Down)) {
+                    && wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_GAUSS_POWERED_DOWN)) {
                 return Messages.getString("WeaponAttackAction.WeaponNotReady");
             }
             
@@ -2331,7 +2331,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                 return Messages.getString("WeaponAttackAction.NoWorkingMGs");
             }
             // Or if the array is off
-            if (wtype.hasFlag(WeaponType.F_MGA) && wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_AMS_Off)) {
+            if (wtype.hasFlag(WeaponType.F_MGA) && wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_AMS_OFF)) {
                 return Messages.getString("WeaponAttackAction.MGArrayOff");
             } else if (wtype.hasFlag(WeaponType.F_MG)) {
                 // and you can't fire an individual MG if it's in an array
@@ -2361,7 +2361,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             // PPCs linked to capacitors can't fire while charging
             if (weapon.getType().hasFlag(WeaponType.F_PPC) && (weapon.getLinkedBy() != null)
                     && weapon.getLinkedBy().getType().hasFlag(MiscType.F_PPC_CAPACITOR)
-                    && weapon.getLinkedBy().pendingMode().equals(Weapon.Mode_PPC_Charge)) {
+                    && weapon.getLinkedBy().pendingMode().equals(Weapon.MODE_PPC_CHARGE)) {
                 return Messages.getString("WeaponAttackAction.PPCCharging");
             }
             
@@ -2434,8 +2434,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             
             // Large Craft weapon bays cannot bracket small craft at short range
             if (wtype.hasModes()
-                    && (weapon.curMode().equals(Weapon.Mode_Capital_Bracket_80) || weapon.curMode().equals(Weapon.Mode_Capital_Bracket_60)
-                            || weapon.curMode().equals(Weapon.Mode_Capital_Bracket_40))
+                    && (weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_80) || weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_60)
+                            || weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_40))
                     && target.isAero() && te!= null && !te.isLargeCraft()
                     && (RangeType.rangeBracket(ae.getPosition().distance(target.getPosition()), wtype.getRanges(weapon),
                             true, false) == RangeType.RANGE_SHORT)) {
@@ -2443,20 +2443,20 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             }
             
             // you must have enough weapons in your bay to be able to use bracketing
-            if (wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_Capital_Bracket_80) && (weapon.getBayWeapons().size() < 2)) {
+            if (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_80) && (weapon.getBayWeapons().size() < 2)) {
                 return Messages.getString("WeaponAttackAction.BayTooSmallForBracket");
             }
-            if (wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_Capital_Bracket_60) && (weapon.getBayWeapons().size() < 3)) {
+            if (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_60) && (weapon.getBayWeapons().size() < 3)) {
                 return Messages.getString("WeaponAttackAction.BayTooSmallForBracket");
             }
-            if (wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_Capital_Bracket_40) && (weapon.getBayWeapons().size() < 4)) {
+            if (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_40) && (weapon.getBayWeapons().size() < 4)) {
                 return Messages.getString("WeaponAttackAction.BayTooSmallForBracket");
             }
             
             // If you're an aero, can't fire an AMS Bay at all or a Point Defense bay that's in PD Mode
             if (wtype.hasFlag(WeaponType.F_AMSBAY)) {
                 return Messages.getString("WeaponAttackAction.AutoWeapon");
-            } else if (wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_Point_Defense)) {
+            } else if (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_POINT_DEFENSE)) {
                 return Messages.getString("WeaponAttackAction.PDWeapon");
             }
             
@@ -2859,7 +2859,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
         
         // AAA mode makes targeting large craft more difficult
-        if (wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_CapLaser_AAA) && te != null && te.isLargeCraft()) {
+        if (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_CAP_LASER_AAA) && te != null && te.isLargeCraft()) {
             toHit.addModifier(+1, Messages.getString("WeaponAttackAction.AAALaserAtShip"));
         }
         
@@ -2874,13 +2874,13 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
 
         // Bracketing modes
-        if (wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_Capital_Bracket_80)) {
+        if (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_80)) {
             toHit.addModifier(-1, Messages.getString("WeaponAttackAction.Bracket80"));
         }
-        if (wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_Capital_Bracket_60)) {
+        if (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_60)) {
             toHit.addModifier(-2, Messages.getString("WeaponAttackAction.Bracket60"));
         }
-        if (wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_Capital_Bracket_40)) {
+        if (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_40)) {
             toHit.addModifier(-3, Messages.getString("WeaponAttackAction.Bracket40"));
         }
         
@@ -2899,7 +2899,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                 && (wtype.getAtClass() != WeaponType.CLASS_AR10) && te != null && !te.isLargeCraft()) {
             // Capital Lasers have an AAA mode for shooting at small targets
             int aaaMod = 0;
-            if (wtype.hasModes() && weapon.curMode().equals(Weapon.Mode_CapLaser_AAA)) {
+            if (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_CAP_LASER_AAA)) {
                 aaaMod = 2;
             }
             if (wtype.isSubCapital()) {
@@ -2973,7 +2973,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         // +1 to hit if the Kinder Rapid-Fire ACs optional rule is turned on, but only Jams on a 2.
         // See TacOps Autocannons for the rest of the rules
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC) 
-                && weapon.curMode().equals(Weapon.Mode_AC_Rapid)) {
+                && weapon.curMode().equals(Weapon.MODE_AC_RAPID)) {
             toHit.addModifier(1, Messages.getString("WeaponAttackAction.AcRapid"));
         }
         

--- a/megamek/src/megamek/common/weapons/CapitalMissileBearingsOnlyHandler.java
+++ b/megamek/src/megamek/common/weapons/CapitalMissileBearingsOnlyHandler.java
@@ -54,14 +54,14 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
      */
     private static final long serialVersionUID = -1277549123532227298L;
     boolean handledAmmoAndReport = false;
-    boolean detRangeShort = (weapon.curMode().equals(Weapon.Mode_CapMissile_Bearing_Short) 
-            || weapon.curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Short));
-    boolean detRangeMedium = (weapon.curMode().equals(Weapon.Mode_CapMissile_Bearing_Med) 
-            || weapon.curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Med));
-    boolean detRangeLong = (weapon.curMode().equals(Weapon.Mode_CapMissile_Bearing_Long) 
-            || weapon.curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Long));
-    boolean detRangeExtreme = (weapon.curMode().equals(Weapon.Mode_CapMissile_Bearing_Ext) 
-            || weapon.curMode().equals(Weapon.Mode_CapMissile_Waypoint_Bearing_Ext));
+    boolean detRangeShort = (weapon.curMode().equals(Weapon.MODE_CAP_MISSILE_BEARING_SHORT)
+            || weapon.curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_SHORT));
+    boolean detRangeMedium = (weapon.curMode().equals(Weapon.MODE_CAP_MISSILE_BEARING_MED)
+            || weapon.curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_MED));
+    boolean detRangeLong = (weapon.curMode().equals(Weapon.MODE_CAP_MISSILE_BEARING_LONG)
+            || weapon.curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_LONG));
+    boolean detRangeExtreme = (weapon.curMode().equals(Weapon.MODE_CAP_MISSILE_BEARING_EXT)
+            || weapon.curMode().equals(Weapon.MODE_CAP_MISSILE_WAYPOINT_BEARING_EXT));
 
     /**
      * This constructor may only be used for deserialization.

--- a/megamek/src/megamek/common/weapons/RACHandler.java
+++ b/megamek/src/megamek/common/weapons/RACHandler.java
@@ -99,17 +99,17 @@ public class RACHandler extends UltraWeaponHandler {
         int actualShots;
         setDone();
         checkAmmo();
-        if (weapon.curMode().equals(Weapon.Mode_RAC_SixShot)) {
+        if (weapon.curMode().equals(Weapon.MODE_RAC_SIX_SHOT)) {
             howManyShots = 6;
-        } else if (weapon.curMode().equals(Weapon.Mode_RAC_FiveShot)) {
+        } else if (weapon.curMode().equals(Weapon.MODE_RAC_FIVE_SHOT)) {
             howManyShots = 5;
-        } else if (weapon.curMode().equals(Weapon.Mode_RAC_FourShot)) {
+        } else if (weapon.curMode().equals(Weapon.MODE_RAC_FOUR_SHOT)) {
             howManyShots = 4;
-        } else if (weapon.curMode().equals(Weapon.Mode_RAC_ThreeShot)) {
+        } else if (weapon.curMode().equals(Weapon.MODE_RAC_THREE_SHOT)) {
             howManyShots = 3;
-        } else if (weapon.curMode().equals(Weapon.Mode_RAC_TwoShot)) {
+        } else if (weapon.curMode().equals(Weapon.MODE_RAC_TWO_SHOT)) {
             howManyShots = 2;
-        } else if (weapon.curMode().equals(Weapon.Mode_AC_Single)) {
+        } else if (weapon.curMode().equals(Weapon.MODE_AC_SINGLE)) {
             howManyShots = 1;
         }
         int total = ae.getTotalAmmoOfType(ammo.getType());

--- a/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
@@ -70,7 +70,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
         setDone();
         checkAmmo();
         int total = ae.getTotalAmmoOfType(ammo.getType());
-        if ((total > 1) && !weapon.curMode().equals(Weapon.Mode_AC_Single)) {
+        if ((total > 1) && !weapon.curMode().equals(Weapon.MODE_AC_SINGLE)) {
             howManyShots = 2;
         } else {
             howManyShots = 1;

--- a/megamek/src/megamek/common/weapons/Weapon.java
+++ b/megamek/src/megamek/common/weapons/Weapon.java
@@ -47,50 +47,50 @@ public abstract class Weapon extends WeaponType implements Serializable {
     }
     
     //Mode text tokens
-    public static final String Mode_Flamer_Damage = "Damage";
-    public static final String Mode_Flamer_Heat = "Heat";
+    public static final String MODE_FLAMER_DAMAGE = "Damage";
+    public static final String MODE_FLAMER_HEAT = "Heat";
     
-    public static final String Mode_AMS_On = "On";
-    public static final String Mode_AMS_Off = "Off";
-    public static final String Mode_AMS_Manual = "Use as Weapon";
+    public static final String MODE_AMS_ON = "On";
+    public static final String MODE_AMS_OFF = "Off";
+    public static final String MODE_AMS_MANUAL = "Use as Weapon";
     
-    public static final String Mode_CapLaser_AAA = "AAA";
+    public static final String MODE_CAP_LASER_AAA = "AAA";
     
-    public static final String Mode_Capital_Bracket_80 = "Bracket 80%";
-    public static final String Mode_Capital_Bracket_60 = "Bracket 60%";
-    public static final String Mode_Capital_Bracket_40 = "Bracket 40%";
+    public static final String MODE_CAPITAL_BRACKET_80 = "Bracket 80%";
+    public static final String MODE_CAPITAL_BRACKET_60 = "Bracket 60%";
+    public static final String MODE_CAPITAL_BRACKET_40 = "Bracket 40%";
     
-    public static final String Mode_CapMissile_Waypoint_Bearing_Ext = "Waypoint Launch Bearings-Only Extreme Detection Range";
-    public static final String Mode_CapMissile_Waypoint_Bearing_Long = "Waypoint Launch Bearings-Only Long Detection Range";
-    public static final String Mode_CapMissile_Waypoint_Bearing_Med = "Waypoint Launch Bearings-Only Medium Detection Range";
-    public static final String Mode_CapMissile_Waypoint_Bearing_Short = "Waypoint Launch Bearings-Only Short Detection Range";
-    public static final String Mode_CapMissile_Waypoint = "Waypoint Launch";
+    public static final String MODE_CAP_MISSILE_WAYPOINT_BEARING_EXT = "Waypoint Launch Bearings-Only Extreme Detection Range";
+    public static final String MODE_CAP_MISSILE_WAYPOINT_BEARING_LONG = "Waypoint Launch Bearings-Only Long Detection Range";
+    public static final String MODE_CAP_MISSILE_WAYPOINT_BEARING_MED = "Waypoint Launch Bearings-Only Medium Detection Range";
+    public static final String MODE_CAP_MISSILE_WAYPOINT_BEARING_SHORT = "Waypoint Launch Bearings-Only Short Detection Range";
+    public static final String MODE_CAP_MISSILE_WAYPOINT = "Waypoint Launch";
     
-    public static final String Mode_CapMissile_Bearing_Ext = "Bearings-Only Extreme Detection Range";
-    public static final String Mode_CapMissile_Bearing_Long = "Bearings-Only Long Detection Range";
-    public static final String Mode_CapMissile_Bearing_Med = "Bearings-Only Medium Detection Range";
-    public static final String Mode_CapMissile_Bearing_Short = "Bearings-Only Short Detection Range";
+    public static final String MODE_CAP_MISSILE_BEARING_EXT = "Bearings-Only Extreme Detection Range";
+    public static final String MODE_CAP_MISSILE_BEARING_LONG = "Bearings-Only Long Detection Range";
+    public static final String MODE_CAP_MISSILE_BEARING_MED = "Bearings-Only Medium Detection Range";
+    public static final String MODE_CAP_MISSILE_BEARING_SHORT = "Bearings-Only Short Detection Range";
     
-    public static final String Mode_CapMissile_Tele_Operated = "Tele-Operated";
+    public static final String MODE_CAP_MISSILE_TELE_OPERATED = "Tele-Operated";
     
-    public static final String Mode_AC_Rapid = "Rapid";
-    public static final String Mode_AC_Single = "Single";
-    public static final String Mode_UAC_Ultra = "Ultra";
-    public static final String Mode_RAC_TwoShot = "2-shot";
-    public static final String Mode_RAC_ThreeShot = "3-shot";
-    public static final String Mode_RAC_FourShot = "4-shot";
-    public static final String Mode_RAC_FiveShot = "5-shot";
-    public static final String Mode_RAC_SixShot = "6-shot";
+    public static final String MODE_AC_RAPID = "Rapid";
+    public static final String MODE_AC_SINGLE = "Single";
+    public static final String MODE_UAC_ULTRA = "Ultra";
+    public static final String MODE_RAC_TWO_SHOT = "2-shot";
+    public static final String MODE_RAC_THREE_SHOT = "3-shot";
+    public static final String MODE_RAC_FOUR_SHOT = "4-shot";
+    public static final String MODE_RAC_FIVE_SHOT = "5-shot";
+    public static final String MODE_RAC_SIX_SHOT = "6-shot";
     
-    public static final String Mode_Gauss_Powered_Down = "Powered Down";
+    public static final String MODE_GAUSS_POWERED_DOWN = "Powered Down";
     
-    public static final String Mode_Missile_Indirect = "Indirect";
+    public static final String MODE_MISSILE_INDIRECT = "Indirect";
     
-    public static final String Mode_PPC_Charge = "Charge";
+    public static final String MODE_PPC_CHARGE = "Charge";
     
-    public static final String Mode_Point_Defense = "Point Defense";
+    public static final String MODE_POINT_DEFENSE = "Point Defense";
     
-    public static final String Mode_Normal = "Normal";
+    public static final String MODE_NORMAL = "Normal";
     
 
     public AttackHandler fire(WeaponAttackAction waa, IGame game, Server server) {
@@ -167,48 +167,48 @@ public abstract class Weapon extends WeaponType implements Serializable {
             } else {
                 if (getAtClass() == WeaponType.CLASS_TELE_MISSILE) {
                     setInstantModeSwitch(false);
-                    addMode(Mode_Normal);
-                    addMode(Mode_CapMissile_Tele_Operated);
+                    addMode(MODE_NORMAL);
+                    addMode(MODE_CAP_MISSILE_TELE_OPERATED);
                 }
                 
                 if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_WAYPOINT_LAUNCH)) {
                     setInstantModeSwitch(false);
-                    addMode(Mode_Normal);
-                    addMode(Mode_CapMissile_Waypoint);
+                    addMode(MODE_NORMAL);
+                    addMode(MODE_CAP_MISSILE_WAYPOINT);
                     if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BEARINGS_ONLY_LAUNCH)) {
-                        addMode(Mode_CapMissile_Waypoint_Bearing_Ext);
-                        addMode(Mode_CapMissile_Waypoint_Bearing_Long);
-                        addMode(Mode_CapMissile_Waypoint_Bearing_Med);
-                        addMode(Mode_CapMissile_Waypoint_Bearing_Short);
+                        addMode(MODE_CAP_MISSILE_WAYPOINT_BEARING_EXT);
+                        addMode(MODE_CAP_MISSILE_WAYPOINT_BEARING_LONG);
+                        addMode(MODE_CAP_MISSILE_WAYPOINT_BEARING_MED);
+                        addMode(MODE_CAP_MISSILE_WAYPOINT_BEARING_SHORT);
                     } else {
-                        removeMode(Mode_CapMissile_Waypoint_Bearing_Ext);
-                        removeMode(Mode_CapMissile_Waypoint_Bearing_Long);
-                        removeMode(Mode_CapMissile_Waypoint_Bearing_Med);
-                        removeMode(Mode_CapMissile_Waypoint_Bearing_Short);
+                        removeMode(MODE_CAP_MISSILE_WAYPOINT_BEARING_EXT);
+                        removeMode(MODE_CAP_MISSILE_WAYPOINT_BEARING_LONG);
+                        removeMode(MODE_CAP_MISSILE_WAYPOINT_BEARING_MED);
+                        removeMode(MODE_CAP_MISSILE_WAYPOINT_BEARING_SHORT);
                     }
                 } else {
-                    removeMode(Mode_CapMissile_Waypoint);
+                    removeMode(MODE_CAP_MISSILE_WAYPOINT);
                 }
 
                 if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BEARINGS_ONLY_LAUNCH)) {
                     setInstantModeSwitch(false);
-                    addMode(Mode_Normal);
-                    addMode(Mode_CapMissile_Bearing_Ext);
-                    addMode(Mode_CapMissile_Bearing_Long);
-                    addMode(Mode_CapMissile_Bearing_Med);
-                    addMode(Mode_CapMissile_Bearing_Short);
+                    addMode(MODE_NORMAL);
+                    addMode(MODE_CAP_MISSILE_BEARING_EXT);
+                    addMode(MODE_CAP_MISSILE_BEARING_LONG);
+                    addMode(MODE_CAP_MISSILE_BEARING_MED);
+                    addMode(MODE_CAP_MISSILE_BEARING_SHORT);
                 } else {
-                    removeMode(Mode_CapMissile_Bearing_Ext);
-                    removeMode(Mode_CapMissile_Bearing_Long);
-                    removeMode(Mode_CapMissile_Bearing_Med);
-                    removeMode(Mode_CapMissile_Bearing_Short);
+                    removeMode(MODE_CAP_MISSILE_BEARING_EXT);
+                    removeMode(MODE_CAP_MISSILE_BEARING_LONG);
+                    removeMode(MODE_CAP_MISSILE_BEARING_MED);
+                    removeMode(MODE_CAP_MISSILE_BEARING_SHORT);
                 }
             }
         }
 
         if (hasFlag(WeaponType.F_AMS)) {
             if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS)) {
-                addMode(Weapon.Mode_AMS_Manual);
+                addMode(Weapon.MODE_AMS_MANUAL);
             }
             if (gOp.booleanOption(OptionsConstants.BASE_AUTO_AMS)) {
                 removeMode("Automatic");

--- a/megamek/src/megamek/common/weapons/Weapon.java
+++ b/megamek/src/megamek/common/weapons/Weapon.java
@@ -76,11 +76,11 @@ public abstract class Weapon extends WeaponType implements Serializable {
     public static final String Mode_AC_Rapid = "Rapid";
     public static final String Mode_AC_Single = "Single";
     public static final String Mode_UAC_Ultra = "Ultra";
-    public static final String Mode_RAC_TwoShot = "2-Shot";
-    public static final String Mode_RAC_ThreeShot = "3-Shot";
-    public static final String Mode_RAC_FourShot = "4-Shot";
-    public static final String Mode_RAC_FiveShot = "5-Shot";
-    public static final String Mode_RAC_SixShot = "6-Shot";
+    public static final String Mode_RAC_TwoShot = "2-shot";
+    public static final String Mode_RAC_ThreeShot = "3-shot";
+    public static final String Mode_RAC_FourShot = "4-shot";
+    public static final String Mode_RAC_FiveShot = "5-shot";
+    public static final String Mode_RAC_SixShot = "6-shot";
     
     public static final String Mode_Gauss_Powered_Down = "Powered Down";
     

--- a/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
@@ -148,10 +148,10 @@ public abstract class ACWeapon extends AmmoWeapon {
         // Modes for allowing standard and light AC rapid fire
         if (gOp.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RAPID_AC)) {
             addMode("");
-            addMode(Weapon.Mode_AC_Rapid);
+            addMode(Weapon.MODE_AC_RAPID);
         } else {
             removeMode("");
-            removeMode(Weapon.Mode_AC_Rapid);
+            removeMode(Weapon.MODE_AC_RAPID);
         }
     }
     

--- a/megamek/src/megamek/common/weapons/autocannons/RACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/RACWeapon.java
@@ -26,7 +26,6 @@ import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.RACHandler;
 import megamek.common.weapons.UltraWeaponHandler;
-import megamek.common.weapons.Weapon;
 import megamek.server.Server;
 
 /**
@@ -42,8 +41,8 @@ public abstract class RACWeapon extends UACWeapon {
     public RACWeapon() {
         super();
         ammoType = AmmoType.T_AC_ROTARY;
-        String[] modeStrings = { Mode_AC_Single, Mode_RAC_TwoShot, Mode_RAC_ThreeShot, 
-        		Mode_RAC_FourShot, Mode_RAC_FiveShot, Mode_RAC_SixShot };
+        String[] modeStrings = {MODE_AC_SINGLE, MODE_RAC_TWO_SHOT, MODE_RAC_THREE_SHOT,
+                MODE_RAC_FOUR_SHOT, MODE_RAC_FIVE_SHOT, MODE_RAC_SIX_SHOT};
         setModes(modeStrings);
         // explosive when jammed
         explosive = true;
@@ -64,10 +63,10 @@ public abstract class RACWeapon extends UACWeapon {
             WeaponAttackAction waa, IGame game, Server server) {
         Mounted weapon = game.getEntity(waa.getEntityId()).getEquipment(
                 waa.getWeaponId());
-        if (weapon.curMode().equals(Mode_RAC_SixShot)
-                || weapon.curMode().equals(Mode_RAC_FiveShot)
-                || weapon.curMode().equals(Mode_RAC_FourShot)
-                || weapon.curMode().equals(Mode_RAC_ThreeShot)) {
+        if (weapon.curMode().equals(MODE_RAC_SIX_SHOT)
+                || weapon.curMode().equals(MODE_RAC_FIVE_SHOT)
+                || weapon.curMode().equals(MODE_RAC_FOUR_SHOT)
+                || weapon.curMode().equals(MODE_RAC_THREE_SHOT)) {
             return new RACHandler(toHit, waa, game, server);
         } else {
             return new UltraWeaponHandler(toHit, waa, game, server);

--- a/megamek/src/megamek/common/weapons/autocannons/UACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/UACWeapon.java
@@ -44,7 +44,7 @@ public abstract class UACWeapon extends AmmoWeapon {
         flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON).or(F_PROTO_WEAPON)
                 .or(F_BALLISTIC).or(F_DIRECT_FIRE);
         ammoType = AmmoType.T_AC_ULTRA;
-        String[] modeStrings = { Mode_AC_Single, Mode_UAC_Ultra };
+        String[] modeStrings = {MODE_AC_SINGLE, MODE_UAC_ULTRA};
         setModes(modeStrings);
         atClass = CLASS_AC;
     }

--- a/megamek/src/megamek/common/weapons/bayweapons/AR10BayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/AR10BayWeapon.java
@@ -88,7 +88,7 @@ public class AR10BayWeapon extends AmmoBayWeapon {
         int rangeToTarget = attacker.getPosition().distance(waa.getTarget(game).getPosition());
         if (weapon.isInBearingsOnlyMode() && rangeToTarget >= RangeType.RANGE_BEARINGS_ONLY_MINIMUM) {
             return new CapitalMissileBearingsOnlyHandler(toHit, waa, game, server);
-        } else if (weapon.curMode().equals(Weapon.Mode_CapMissile_Tele_Operated)) {
+        } else if (weapon.curMode().equals(Weapon.MODE_CAP_MISSILE_TELE_OPERATED)) {
             return new TeleMissileHandler(toHit, waa, game, server);
         } else {  
             return new CapitalMissileBayHandler(toHit, waa, game, server);

--- a/megamek/src/megamek/common/weapons/bayweapons/TeleOperatedMissileBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/TeleOperatedMissileBayWeapon.java
@@ -76,7 +76,7 @@ public class TeleOperatedMissileBayWeapon extends CapitalMissileBayWeapon {
         if (weapon.isInBearingsOnlyMode()
                 && rangeToTarget >= RangeType.RANGE_BEARINGS_ONLY_MINIMUM) {
             return new CapitalMissileBearingsOnlyHandler(toHit, waa, game, server);
-        } else if (weapon.curMode().equals(Weapon.Mode_CapMissile_Tele_Operated)) {
+        } else if (weapon.curMode().equals(Weapon.MODE_CAP_MISSILE_TELE_OPERATED)) {
             return new TeleMissileHandler(toHit, waa, game, server);
         } else {    
             return new CapitalMissileBayHandler(toHit, waa, game, server);


### PR DESCRIPTION
In commit 249faf4 the string literals for RAC and UAC modes were replaced by constants, but the capitalization in the values assigned to the RAC constants did not match the previous values, so in Mounted#getNumShots, where the string literals are still used, the match fails.

I replaced the string literals in getNumShots with constants and also changed the values of the constants to the former capitalization in case there are other uses that I missed seeing in my search. I also fixed the logic in Mounted#getNumShots and simplified it a bit. The only changes that affect function are in Weapon and Mounted. The other files are all a result of changing the mode constant identifiers to all caps per Java standards for constants.

Fixes #1516