### PR TITLE
Improve bot infantry behavior again

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2104,7 +2104,7 @@ public class FireControl {
      *            The game currently being played.
      * @return the 'best' firing plan under a certain heat.
      */
-    private FiringPlan guessBestFiringPlanUnderHeat(final Entity shooter,
+    protected FiringPlan guessBestFiringPlanUnderHeat(final Entity shooter,
                                                     @Nullable final EntityState shooterState,
                                                     final Targetable target,
                                                     @Nullable final EntityState targetState,
@@ -3117,8 +3117,8 @@ public class FireControl {
                 validFacingChanges.add(2);
                 validFacingChanges.add(-2);
             }
-        } else if (shooter instanceof Tank
-                   && !((Tank) shooter).hasNoTurret()) {
+        } else if ((shooter instanceof Tank
+                   && !((Tank) shooter).hasNoTurret()) || (shooter instanceof Infantry)) {
             validFacingChanges.add(1);
             validFacingChanges.add(-1);
             validFacingChanges.add(2);

--- a/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
@@ -170,6 +170,19 @@ public class InfantryFireControl extends FireControl {
     @Override
     protected FiringPlan guessBestFiringPlanUnderHeat(final Entity shooter, @Nullable EntityState shooterState,
             final Targetable target, @Nullable EntityState targetState, int maxHeat, final IGame game) {
+        FiringPlan bestPlan = new FiringPlan(target);
+        
+        // Shooting isn't possible if one of us isn't on the board.
+        if ((null == shooter.getPosition()) || shooter.isOffBoard()
+                || !game.getBoard().contains(shooter.getPosition())) {
+            owner.log(getClass(), "InfantryFireControl.guessFiringPlan", LogLevel.ERROR, "Shooter's position is NULL/Off Board!");
+            return bestPlan;
+        }
+        if ((null == target.getPosition()) || target.isOffBoard() || !game.getBoard().contains(target.getPosition())) {
+            owner.log(getClass(), "InfantryFireControl.guessFiringPlan", LogLevel.ERROR, "Target's position is NULL/Off Board!");
+            return bestPlan;
+        }
+        
         // if it's not infantry, then we shouldn't be here, let's redirect to the base method.
         if(!(shooter instanceof Infantry)) {
             return super.guessBestFiringPlanUnderHeat(shooter, shooterState, target, targetState, maxHeat, game);
@@ -209,8 +222,6 @@ public class InfantryFireControl extends FireControl {
         firingPlans.add(swarmPlan);
 
         // now we'll pick the best of the plans
-        FiringPlan bestPlan = new FiringPlan(target);
-
         for (final FiringPlan firingPlan : firingPlans) {
             if ((bestPlan.getUtility() < firingPlan.getUtility())) {
                 bestPlan = firingPlan;
@@ -240,17 +251,6 @@ public class InfantryFireControl extends FireControl {
             final Targetable target, @Nullable EntityState targetState, final IGame game, InfantryFiringPlanType firingPlanType) {
         
         final FiringPlan myPlan = new FiringPlan(target);
-
-        // Shooting isn't possible if one of us isn't on the board.
-        if ((null == shooter.getPosition()) || shooter.isOffBoard()
-                || !game.getBoard().contains(shooter.getPosition())) {
-            owner.log(getClass(), "InfantryFireControl.guessFiringPlan", LogLevel.ERROR, "Shooter's position is NULL/Off Board!");
-            return myPlan;
-        }
-        if ((null == target.getPosition()) || target.isOffBoard() || !game.getBoard().contains(target.getPosition())) {
-            owner.log(getClass(), "InfantryFireControl.guessFiringPlan", LogLevel.ERROR, "Target's position is NULL/Off Board!");
-            return myPlan;
-        }
 
         // cycle through my field guns
         for (final Mounted weapon : shooter.getWeaponList()) {

--- a/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
@@ -1,13 +1,34 @@
+/*  
+* MegaMek - Copyright (C) 2019 - The MegaMek Team  
+*  
+* This program is free software; you can redistribute it and/or modify it under  
+* the terms of the GNU General Public License as published by the Free Software  
+* Foundation; either version 2 of the License, or (at your option) any later  
+* version.  
+*  
+* This program is distributed in the hope that it will be useful, but WITHOUT  
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more  
+* details.  
+*/  
+
 package megamek.client.bot.princess;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import megamek.common.Compute;
 import megamek.common.Entity;
+import megamek.common.IGame;
 import megamek.common.IHex;
 import megamek.common.Infantry;
 import megamek.common.Mounted;
 import megamek.common.MovePath;
 import megamek.common.RangeType;
+import megamek.common.Targetable;
 import megamek.common.WeaponType;
+import megamek.common.annotations.Nullable;
+import megamek.common.logging.LogLevel;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.server.ServerHelper;
 
@@ -20,6 +41,13 @@ import megamek.server.ServerHelper;
  */
 public class InfantryFireControl extends FireControl {
 
+    private enum InfantryFiringPlanType {
+        Standard,
+        FieldGuns,
+        Swarm,
+        Leg
+    }
+    
     public InfantryFireControl(Princess owner) {
         super(owner);
     }
@@ -43,8 +71,8 @@ public class InfantryFireControl extends FireControl {
         Entity shooter = shooterPath.getEntity();
         Entity target = targetPath.getEntity();
         IHex targetHex = target.getGame().getBoard().getHex(targetPath.getFinalCoords());
-        
-        // some preliminary computations 
+
+        // some preliminary computations
         // whether the target is an infantry platoon
         boolean targetIsPlatoon = target.hasETypeFlag(Entity.ETYPE_INFANTRY) && !((Infantry) target).isSquad();
         // whether the target is infantry (and not battle armor)
@@ -53,13 +81,15 @@ public class InfantryFireControl extends FireControl {
         boolean shooterIsActualInfantry = shooter.hasETypeFlag(Entity.ETYPE_INFANTRY)
                 && !shooter.hasETypeFlag(Entity.ETYPE_BATTLEARMOR);
         // field guns can't fire if the unit in question moved
-        boolean fieldGunsDoDamage = (shooterIsActualInfantry && shooterPath.getMpUsed() == 0) || !shooterIsActualInfantry;
-        boolean inBuilding = Compute.isInBuilding(target.getGame(), targetPath.getFinalElevation(), targetPath.getFinalCoords());
-        boolean inOpen = ServerHelper.infantryInOpen(target, targetHex, target.getGame(), targetIsPlatoon, false, false);
-        boolean nonInfantryVsMechanized = !shooter.hasETypeFlag(Entity.ETYPE_INFANTRY) && 
-                target.hasETypeFlag(Entity.ETYPE_INFANTRY) && ((Infantry) target).isMechanized();     
-        
-        
+        boolean fieldGunsDoDamage = (shooterIsActualInfantry && shooterPath.getMpUsed() == 0)
+                || !shooterIsActualInfantry;
+        boolean inBuilding = Compute.isInBuilding(target.getGame(), targetPath.getFinalElevation(),
+                targetPath.getFinalCoords());
+        boolean inOpen = ServerHelper.infantryInOpen(target, targetHex, target.getGame(), targetIsPlatoon, false,
+                false);
+        boolean nonInfantryVsMechanized = !shooter.hasETypeFlag(Entity.ETYPE_INFANTRY)
+                && target.hasETypeFlag(Entity.ETYPE_INFANTRY) && ((Infantry) target).isMechanized();
+
         // cycle through my weapons
         for (final Mounted weapon : shooter.getWeaponList()) {
             final WeaponType weaponType = (WeaponType) weapon.getType();
@@ -69,29 +99,36 @@ public class InfantryFireControl extends FireControl {
 
             if (RangeType.RANGE_OUT == bracket) {
                 continue;
-            }       
-            
+            }
+
             // there are three ways this can go:
-            // 1. Shooter is infantry using infantry weapon, target is infantry. Use infantry damage. Track damage separately.
-            // 2. Shooter is non-infantry, target is infantry in open. Use "directBlowInfantryDamage", multiply by 2.
-            // 3. Shooter is non-infantry, target is infantry in building. Use weapon damage, multiply by building dmg reduction.
-            // 4. Shooter is non-infantry, target is infantry in "cover". Use "directBlowInfantryDamage".
-            // 5. Shooter is non-infantry, target is non-infantry. Use base class.
-            
+            // 1. Shooter is infantry using infantry weapon, target is infantry.
+            // Use infantry damage. Track damage separately.
+            // 2. Shooter is non-infantry, target is infantry in open. Use
+            // "directBlowInfantryDamage", multiply by 2.
+            // 3. Shooter is non-infantry, target is infantry in building. Use
+            // weapon damage, multiply by building dmg reduction.
+            // 4. Shooter is non-infantry, target is infantry in "cover". Use
+            // "directBlowInfantryDamage".
+            // 5. Shooter is non-infantry, target is non-infantry. Use base
+            // class.
+
             // case 1
             if (weaponType.hasFlag(WeaponType.F_INFANTRY)) {
                 maxInfantryWeaponDamage += ((InfantryWeapon) weaponType).getInfantryDamage()
                         * ((Infantry) shooter).getInternal(Infantry.LOC_INFANTRY);
-            // field guns can't fire if the infantry unit has done anything other than turning
+                // field guns can't fire if the infantry unit has done anything
+                // other than turning
             } else if (targetIsActualInfantry && fieldGunsDoDamage) {
                 double damage = 0;
-                
-                // if we're outside, use the direct blow infantry damage calculation
+
+                // if we're outside, use the direct blow infantry damage
+                // calculation
                 // cases 2, 4
                 if (!inBuilding) {
                     damage = Compute.directBlowInfantryDamage(weaponType.getDamage(), 0,
                             weaponType.getInfantryDamageClass(), nonInfantryVsMechanized, false);
-                    
+
                     // if we're in the open, multiply damage by 2
                     damage *= inOpen ? 2 : 1;
                 } else {
@@ -101,14 +138,158 @@ public class InfantryFireControl extends FireControl {
                     damage = weaponType.getDamage() * shooter.getGame().getBoard()
                             .getBuildingAt(targetPath.getFinalCoords()).getDamageReductionFromOutside();
                 }
-                
+
                 maxFGDamage += damage;
-            // field guns can't fire if the infantry unit has done anything other than turning
+                // field guns can't fire if the infantry unit has done anything
+                // other than turning
             } else if (fieldGunsDoDamage) {
-            	maxFGDamage += weaponType.getDamage();
+                maxFGDamage += weaponType.getDamage();
             }
         }
 
         return Math.max(maxFGDamage, maxInfantryWeaponDamage);
+    }
+
+    /**
+     * Guesses the 'best' firing plan under a certain heat, except this is infantry so we ignore heat
+     *
+     * @param shooter
+     *            The unit doing the shooting.
+     * @param shooterState
+     *            The current state of the shooting unit.
+     * @param target
+     *            The unit being shot at.
+     * @param targetState
+     *            The current state of the target unit.
+     * @param maxHeat
+     *            How much heat we're willing to tolerate. Ignored, since infantry doesn't track heat.
+     * @param game
+     *            The game currently being played.
+     * @return the 'best' firing plan under a certain heat.
+     */
+    @Override
+    protected FiringPlan guessBestFiringPlanUnderHeat(final Entity shooter, @Nullable EntityState shooterState,
+            final Targetable target, @Nullable EntityState targetState, int maxHeat, final IGame game) {
+        // if it's not infantry, then we shouldn't be here, let's redirect to the base method.
+        if(!(shooter instanceof Infantry)) {
+            return super.guessBestFiringPlanUnderHeat(shooter, shooterState, target, targetState, maxHeat, game);
+        }
+        
+        if (null == shooterState) {
+            shooterState = new EntityState(shooter);
+        }
+        if (null == targetState) {
+            targetState = new EntityState(target);
+        }
+        
+        // Infantry can do the following things, which are mutually exclusive:
+        // 1. Fire standard infantry weapons, including "need to stay still" support weapons
+        // 2. Fire field guns - the unit needs to remain still to fire these
+        // 3. Swarm
+        // 4. Leg Attack
+        // Start with an alpha strike. If it falls under our heat limit, use it.
+        List<FiringPlan> firingPlans = new ArrayList<>();
+
+        // case 1: infantry weapons
+        FiringPlan standardPlan = guessFiringPlan(shooter, shooterState, target, targetState, game, InfantryFiringPlanType.Standard);
+        firingPlans.add(standardPlan);
+
+        // case 2: field guns if we didn't move
+        if (shooterState.getHexesMoved() == 0) {
+            FiringPlan fieldGunPlan = guessFiringPlan(shooter, shooterState, target, targetState, game, InfantryFiringPlanType.FieldGuns);
+            firingPlans.add(fieldGunPlan);
+        }
+        
+        // case 3: leg attack
+        FiringPlan legPlan = guessFiringPlan(shooter, shooterState, target, targetState, game, InfantryFiringPlanType.Leg);
+        firingPlans.add(legPlan);
+        
+        // case 4: swarm attack
+        FiringPlan swarmPlan = guessFiringPlan(shooter, shooterState, target, targetState, game, InfantryFiringPlanType.Swarm);
+        firingPlans.add(swarmPlan);
+
+        // now we'll pick the best of the plans
+        FiringPlan bestPlan = new FiringPlan(target);
+
+        for (final FiringPlan firingPlan : firingPlans) {
+            if ((bestPlan.getUtility() < firingPlan.getUtility())) {
+                bestPlan = firingPlan;
+            }
+        }
+        return bestPlan;
+    }
+
+    /**
+     * Creates a firing plan that fires all weapons with nonzero to hit value at
+     * a target ignoring heat, and using best guess from different states. Does
+     * not change facing.
+     *
+     * @param shooter
+     *            The unit doing the shooting.
+     * @param shooterState
+     *            The current state of the shooter.
+     * @param target
+     *            The unit being fired on.
+     * @param targetState
+     *            The current state of the target.
+     * @param game
+     *            The game being played.
+     * @return The {@link FiringPlan} containing all weapons to be fired.
+     */
+    private FiringPlan guessFiringPlan(final Entity shooter, @Nullable EntityState shooterState,
+            final Targetable target, @Nullable EntityState targetState, final IGame game, InfantryFiringPlanType firingPlanType) {
+        
+        final FiringPlan myPlan = new FiringPlan(target);
+
+        // Shooting isn't possible if one of us isn't on the board.
+        if ((null == shooter.getPosition()) || shooter.isOffBoard()
+                || !game.getBoard().contains(shooter.getPosition())) {
+            owner.log(getClass(), "InfantryFireControl.guessFiringPlan", LogLevel.ERROR, "Shooter's position is NULL/Off Board!");
+            return myPlan;
+        }
+        if ((null == target.getPosition()) || target.isOffBoard() || !game.getBoard().contains(target.getPosition())) {
+            owner.log(getClass(), "InfantryFireControl.guessFiringPlan", LogLevel.ERROR, "Target's position is NULL/Off Board!");
+            return myPlan;
+        }
+
+        // cycle through my field guns
+        for (final Mounted weapon : shooter.getWeaponList()) {
+            if(weaponIsAppropriate(weapon, firingPlanType)) {
+                final WeaponFireInfo shoot = buildWeaponFireInfo(shooter, shooterState, target, targetState, weapon,
+                        game, true);
+
+                if (0 < shoot.getProbabilityToHit()) {
+                    myPlan.add(shoot);
+                }
+            }
+        }
+
+        // Rank how useful this plan is.
+        calculateUtility(myPlan, calcHeatTolerance(shooter, null), shooterState.isAero());
+
+        return myPlan;
+    }
+    
+    /**
+     * Helper method that determines whether a weapon type is appropriate for a given firing plan type, 
+     * e.g. field guns cannot be fired when we're going to do a swarm attack, etc.
+     */
+    private boolean weaponIsAppropriate(Mounted weapon, InfantryFiringPlanType firingPlanType) {
+        boolean weaponIsSwarm = (weapon.getType()).getInternalName().equals(Infantry.SWARM_MEK);
+        boolean weaponIsLegAttack = (weapon.getType()).getInternalName().equals(Infantry.LEG_ATTACK);
+        boolean weaponIsFieldGuns = weapon.getLocation() == Infantry.LOC_FIELD_GUNS;
+        
+        switch(firingPlanType) {
+        case FieldGuns:
+            return weaponIsFieldGuns;
+        case Swarm:
+            return weaponIsSwarm;
+        case Leg:
+            return weaponIsLegAttack;
+        case Standard:
+            return !weaponIsFieldGuns && !weaponIsSwarm && !weaponIsLegAttack;
+        default:
+            return false;
+        }
     }
 }


### PR DESCRIPTION
I noticed during some games that field gun infantry were running around a little too much, so this change addresses that behavior. When "guessing" an optimal firing plan, an infantry unit will now generate four distinct firing plans - standard weapons, field guns, leg, swarm. Previously, guesses against already-moved units didn't take into account the fact that field guns can't be firing after movement.

Also allows the bot to have it's field gun infantry to "torso twist" during the firing phase if they happen to be facing the wrong way.