### PR TITLE
Use correct cost for Protomech EDP armor

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -856,6 +856,19 @@ public class EquipmentType implements ITechnology {
     }
 
     /**
+     * Lookup method for protomech armor cost
+     * @param type The type of armor.
+     * @return     The cost per point in C-bills
+     */
+    public static int getProtomechArmorCostPerPoint(int type) {
+        // currently only one type of specialized armor for protomechs; anything else is treated as standard
+        if (type == T_ARMOR_EDP) {
+            return 1250;
+        }
+        return 625;
+    }
+
+    /**
      * Gives the weight of a single point of armor at a particular BAR for a
      * given tech level.
      */

--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -2031,7 +2031,7 @@ public class Protomech extends Entity {
         retVal += 2000 * sinks;
 
         // Armor is linear on the armor value of the Protomech
-        retVal += getTotalArmor() * 625;
+        retVal += getTotalArmor() * EquipmentType.getProtomechArmorCostPerPoint(getArmorType(firstArmorIndex()));
 
         // Add in equipment cost.
         retVal += getWeaponsAndEquipmentCost(ignoreAmmo);


### PR DESCRIPTION
Fairly simple - Protomech cost calculation assumes standard armor. I added a cost lookup method to EquipmentType, where it is also available to MekHQ for the ProtomechArmor part, to return the cost per point and changed the cost calculation to use that.