### PR TITLE
Improve bot physicals and "honorable" behavior.

### DIFF
--- a/megamek/src/megamek/client/bot/PhysicalCalculator.java
+++ b/megamek/src/megamek/client/bot/PhysicalCalculator.java
@@ -65,7 +65,7 @@ public final class PhysicalCalculator {
         return null;
     }
 
-    static PhysicalOption getBestPhysical(Entity entity, IGame game) {
+    public static PhysicalOption getBestPhysical(Entity entity, IGame game) {
         // Infantry can't conduct physical attacks.
         if (entity instanceof Infantry) {
             return null;

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -519,6 +519,15 @@ public class Tank extends Entity {
         return super.isImmobile() || m_bImmobile;
     }
     
+    /**
+     * Whether this unit is irreversibly immobilized for the rest of the game.
+     * Tanks have some additional criteria.
+     */
+    @Override
+    public boolean isPermanentlyImmobilized(boolean checkCrew) {
+        return super.isPermanentlyImmobilized(checkCrew) || isMovementHit();
+    }
+    
     @Override
     public boolean hasCommandConsoleBonus() {
         if (!hasWorkingMisc(MiscType.F_COMMAND_CONSOLE) || isCommanderHit() || isUsingConsoleCommander()) {


### PR DESCRIPTION
The old TestBot was able to brush off infantry and narc pods if it wasn't busy doing something else with its arms, so I replaced Princess' existing physical attack determination with the old one, and now she can punch herself in the face while trying to brush off infantry just like human players can.

Also, the bot will re-initialize the list of broken and dishonored enemy units on load so that, when loading a saved game, the bot doesn't suddenly start firing at crippled units where she wasn't doing so before.

Finally, we fix the behavior where a tank that crashes into prohibited terrain will report itself as non-crippled even though it can't move any more (which leads to unexpected behavior of the bot shooting with immobile units).