### PR TITLE
Add check for maglev to external power pickup validity.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -278,7 +278,10 @@ public class TestSupportVehicle extends TestEntity {
                     && (!this.equals(HYDROFOIL) || sv.getWeight() <= 100.0)
                     // Can't put a turret on a convertible
                     && (!this.equals(CONVERTIBLE) || !(sv instanceof Tank)
-                        || ((Tank) sv).hasNoTurret());
+                        || ((Tank) sv).hasNoTurret())
+                    // External power pickup is only valid for RAIL movement mode (not MAGLEV)
+                    && (!this.equals(EXTERNAL_POWER_PICKUP)
+                        || sv.getMovementMode().equals(EntityMovementMode.RAIL));
         }
 
         /**


### PR DESCRIPTION
Discovered while working on MegaMek/megameklab#367. Added special case to check for rail vehicle movement mode when determining validity of external power pickup chassis mod.