### PR TITLE
fix for tanks being considered mobile when they're not

### DIFF
--- a/megamek/src/megamek/common/SupportTank.java
+++ b/megamek/src/megamek/common/SupportTank.java
@@ -278,7 +278,7 @@ public class SupportTank extends Tank {
     public int getWalkMP(boolean gravity, boolean ignoreheat,
                          boolean ignoremodulararmor) {
         int mp = getOriginalWalkMP();
-        if (engineHit) {
+        if (engineHit || isImmobile()) {
             return 0;
         }
         if (hasWorkingMisc(MiscType.F_HYDROFOIL)) {

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -265,7 +265,7 @@ public class Tank extends Entity {
     public int getWalkMP(boolean gravity, boolean ignoreheat,
             boolean ignoremodulararmor) {
         int j = getOriginalWalkMP();
-        if (engineHit) {
+        if (engineHit || isImmobile()) {
             return 0;
         }
         j = Math.max(0, j - motiveDamage);


### PR DESCRIPTION
In high-pressure atmospheres with high gravity, the getWalkMP calculation would incorrectly return >0 for units that took a total immobility crit. In that case, we can skip the calculation altogether.

If necessary, I'll address the possible inconsistency in MP calculation for non-immobilizing mobility damage in another PR.