### PR TITLE
Don't skip 0 armor locations in UnitEditorDialog.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
@@ -236,9 +236,6 @@ public class UnitEditorDialog extends JDialog {
 
         for (int i = 0; i < entity.locations(); i++) {
             // some units have hidden locations, skip these
-            if (entity.getOArmor(i) <= 0) {
-                continue;
-            }
             if (entity.getOInternal(i) <= 0) {
                 continue;
             }


### PR DESCRIPTION
Here's another unrelated thing I noticed while working with the simca ambulance.
Some units have no armor, and the internal structure for that location should still be shown. Aerospace units, which have armor but no internal structure, use a different panel.

Before:
![Screenshot from 2019-11-11 16-04-46](https://user-images.githubusercontent.com/16927464/68624817-4e677100-049d-11ea-85db-1ed401eef066.png)

After:
![Screenshot from 2019-11-11 16-08-56](https://user-images.githubusercontent.com/16927464/68624945-971f2a00-049d-11ea-9854-959749d15259.png)
.

