### PR TITLE
Preserve capital bay lookup names

### DIFF
--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -1154,6 +1154,9 @@ public class WeaponType extends EquipmentType {
 
     /**
      * Add all the types of weapons we can create to the list
+     *
+     * When a weapon class extends another, the subclass must be listed first to avoid
+     * clobbering the name lookup when calling the contructor of the superclass.
      */
     public static void initializeTypes() {
         // Laser types
@@ -2178,6 +2181,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new CapitalACBayWeapon());
         EquipmentType.addType(new CapitalGaussBayWeapon());
         EquipmentType.addType(new CapitalPPCBayWeapon());
+        EquipmentType.addType(new TeleOperatedMissileBayWeapon());
         EquipmentType.addType(new CapitalMissileBayWeapon());
         EquipmentType.addType(new CapitalMDBayWeapon());
         EquipmentType.addType(new AR10BayWeapon());
@@ -2188,7 +2192,6 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new SubCapitalMissileBayWeapon());
         EquipmentType.addType(new MiscBayWeapon());
         EquipmentType.addType(new AMSBayWeapon());
-        EquipmentType.addType(new TeleOperatedMissileBayWeapon());
 
         // Improved OS Weapons
         EquipmentType.addType(new ISLRM5IOS());


### PR DESCRIPTION
When a weapon class extends another, the child class must be initialized first. When its constructor calls super() it will add the parent's internal name and additional lookup names to the EquipmentType lookup hash pointing to the child class. If the child initialized second, all the names for both classes point to the child. If the child is initialized first, the parent class with come behind and fix the values that should be pointing to the parent.

This fixes the relationship between CapitalMissileBayWeapon and TeleOperatedMissileBayWeapon, but removing the gotcha would require an extensive rework and I haven't figured out the best way to go about it yet. I did add a warning to the javadoc comment for the method, but as the method is 1000+ lines it's not likely to be seen.

Fixes MegaMek/megameklab#371