### PR TITLE
Fix exception thrown when there are > 35 SPAs.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/widget/PilotMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/PilotMapSet.java
@@ -257,17 +257,17 @@ public class PilotMapSet implements DisplayMapSet {
         int i = 0;
         for (Enumeration<IOptionGroup> advGroups = en.getCrew().getOptions().getGroups(); advGroups
                 .hasMoreElements();) {
-            if (i >= (N_ADV - 1)) {
-                advantagesR[i++].setString(Messages.getString("PilotMapSet.more"));
+            if (i >= advantagesR.length - 1) {
+                advantagesR[advantagesR.length - 1].setString(Messages.getString("PilotMapSet.more"));
                 break;
             }
             IOptionGroup advGroup = advGroups.nextElement();
             if (en.getCrew().countOptions(advGroup.getKey()) > 0) {
                 advantagesR[i++].setString(advGroup.getDisplayableName());
                 for (Enumeration<IOption> advs = advGroup.getOptions(); advs.hasMoreElements();) {
-                    if (i >= (N_ADV - 1)) {
-                        advantagesR[i++].setString("  " + Messages.getString("PilotMapSet.more"));
-                        break;
+                    if (i >= advantagesR.length - 1) {
+                        advantagesR[advantagesR.length - 1].setString("  " + Messages.getString("PilotMapSet.more"));
+                        return;
                     }
                     IOption adv = advs.nextElement();
                     if ((adv != null) && adv.booleanValue()) {


### PR DESCRIPTION
The unit display has the capacity to show 35 SPAs. When the number exceeds this, the last line is supposed to show a String indicating that there are more. But if the limit is hit during an SPA group, the index is incremented then the same check is performed in an outer loop. But by then the index exceeds the size of the array.
Since this is the last thing done in that method I replaced the break with a return. I also did a bit of bomb-proofing by changing the index size checks to use the size of the array directly instead of the constant used to initialize it, so the check will always be correct. I also changed it to use the final index of the array rather than the index counter.

Fixes #1549 