### PR TITLE
Per errata, maximum docking hardpoints is rounded up instead of down.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -333,7 +333,11 @@ public class TestAdvancedAerospace extends TestAero {
      * @return       The maximum number of docking hardpoints (collars) that can be mounted on the ship.
      */
     public static int getMaxDockingHardpoints(Jumpship vessel) {
-        int max = (int) Math.floor(vessel.getWeight() / 50000);
+        // minimum of 50ktons
+        if (vessel.getWeight() < 50000) {
+            return 0;
+        }
+        int max = (int) Math.ceil(vessel.getWeight() / 50000);
         for (Bay bay : vessel.getTransportBays()) {
             max -= bay.hardpointCost();
         }


### PR DESCRIPTION
Changes the maximum docking hardpoint calculation to round up instead of down per errata. (See errata text and link in issue linked below). Also adds a check for the minimum 50kton limit, since it will no longer come out to zero when rounding up.

Fixes MegaMek/megameklab#384