### PR TITLE
Remove spot for LRM indirect fire penalty for the unit that was successfully designated TAG on the same turn... again.

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3270,8 +3270,9 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             toHit.append(Compute.getSecondaryTargetMod(game, ae, target));
         }
         
-        // Spotting for indirect fire, add +1 (no penalty with second pilot in command console)
-        if (ae.isSpotting() && !ae.getCrew().hasActiveCommandConsole()) {
+        // if we're spotting for indirect fire, add +1
+        if (ae.isSpotting() && !ae.getCrew().hasActiveCommandConsole()
+                && game.getTagInfo().stream().noneMatch(inf -> inf.attackerId == ae.getId())) {
             toHit.addModifier(+1, Messages.getString("WeaponAttackAction.AeSpotting"));
         }
         


### PR DESCRIPTION
It was already solved in #1398 but the issue #1580 says that the bug occurs again. I have checked and found that someone was forgot to apply it during the recent cleanup.