### PR TITLE
Minor bot improvements

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -380,6 +380,10 @@ public abstract class BotClient extends Client {
     @Override
     public void changePhase(IGame.Phase phase) {
         super.changePhase(phase);
+        
+        // clear out transient data
+        currentTurnEnemyEntities = null;
+        currentTurnFriendlyEntities = null;
 
         try {
             switch (phase) {
@@ -497,11 +501,7 @@ public abstract class BotClient extends Client {
         return unMoved.get(Compute.randomInt(unMoved.size()));
     }
 
-    private synchronized void calculateMyTurn() {
-        // clear out transient data
-        currentTurnEnemyEntities = null;
-        currentTurnFriendlyEntities = null;
-        
+    private synchronized void calculateMyTurn() {        
         try {
             if (game.getPhase() == IGame.Phase.PHASE_MOVEMENT) {
                 MovePath mp;

--- a/megamek/src/megamek/client/bot/PhysicalOption.java
+++ b/megamek/src/megamek/client/bot/PhysicalOption.java
@@ -28,6 +28,7 @@ import megamek.common.actions.EntityAction;
 import megamek.common.actions.KickAttackAction;
 import megamek.common.actions.PunchAttackAction;
 import megamek.common.actions.PushAttackAction;
+import megamek.common.actions.ThrashAttackAction;
 
 /**
  * TODO: add more options, pushing, kick both for quad mechs, etc.
@@ -135,10 +136,8 @@ public class PhysicalOption {
                 return new BrushOffAttackAction(attacker.getId(), target
                         .getTargetType(), target.getId(),
                         BrushOffAttackAction.BOTH);
-                /*
-                 * case THRASH_INF : return new
-                 * ThrashAttackAction(attacker.getId(), target.getId());
-                 */
+            case THRASH_INF : 
+                return new ThrashAttackAction(attacker.getId(), target.getId());
         }
         return null;
     }

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -42,6 +42,7 @@ import megamek.common.Infantry;
 import megamek.common.LosEffects;
 import megamek.common.Mech;
 import megamek.common.MechWarrior;
+import megamek.common.Minefield;
 import megamek.common.MiscType;
 import megamek.common.MovePath;
 import megamek.common.MoveStep;
@@ -540,7 +541,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
 
             // look at all of my enemies          
             FiringPhysicalDamage damageEstimate = new FiringPhysicalDamage();
-            
+                       
             double expectedDamageTaken = checkPathForHazards(pathCopy,
                                                              movingUnit,
                                                              game);
@@ -937,13 +938,13 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                 hazards.add(type);
             }
         }
-
+        
         // No hazards were found, so nothing to worry about.
-        if (hazards.isEmpty()) {
+        if (hazards.isEmpty() && (getOwner().getGame().getNbrMinefields(step.getPosition()) == 0)) {
             logMsg.append(" has no hazards.");
             return 0;
         }
-
+        
         // Calculate hazard value by terrain type.
         double hazardValue = 0;
         for (int hazard : hazards) {
@@ -973,6 +974,14 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                     break;
             }
         }
+        
+        double mineValue = 0;
+        for(Minefield mines : getOwner().getGame().getMinefields(step.getPosition())) {
+            mineValue += mines.getDensity() * (Compute.oddsAbove(mines.getDetonationTarget(movingUnit)) / 100);
+        }
+        
+        hazardValue += mineValue;
+        
         logMsg.append("\n\tTotal Hazard = ")
               .append(LOG_DECIMAL.format(hazardValue));
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2401,8 +2401,7 @@ public class FireControl {
         final List<Targetable> enemies = getTargetableEnemyEntities(shooter, game, owner.getFireControlState());
 
         // Loop through each enemy and find the best plan for attacking them.
-        for (final Targetable enemy : enemies) {
-
+        for (final Targetable enemy : enemies) {           
             final boolean priorityTarget = owner.getPriorityUnitTargets().contains(enemy.getTargetId());
 
             // Skip retreating enemies so long as they haven't fired on me while retreating.

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1778,15 +1778,21 @@ public class FireControl {
         final HexTarget hexToBomb = new HexTarget(target.getPosition(), game.getBoard(), 
                 shooter.isAero() ? Targetable.TYPE_HEX_AERO_BOMB : Targetable.TYPE_HEX_BOMB);
 
+        // things that cause us to avoid calculating a bomb plan:
+        // not having any bombs (in the first place)
         final Iterator<Mounted> weaponIter = shooter.getWeapons();
         if (null == weaponIter) {
+            return diveBombPlan;
+        }
+        
+        // not having any bombs (due to expenditure/damage)
+        if(shooter.getBombs(BombType.F_GROUND_BOMB).size() == 0) {
             return diveBombPlan;
         }
 
         while (weaponIter.hasNext()) {
             final Mounted weapon = weaponIter.next();
             if(weapon.getType().hasFlag(WeaponType.F_DIVE_BOMB)) {
-
                 final int[] bombPayload = new int[BombType.B_NUM];
                 // load up all droppable bombs, yeah baby! Mix thunder bombs and infernos 'cause why the hell not.
                 // seriously, though, TODO: more intelligent bomb drops
@@ -2250,6 +2256,12 @@ public class FireControl {
     	// cache the results of our computation
     	if(fireControlState.getEntityIDFStates().containsKey(shooter.getId())) {
     		return fireControlState.getEntityIDFStates().get(shooter.getId());
+    	}
+    	
+    	// airborne aerospace units cannot use indirect fire
+    	if(shooter.isAirborne()) {
+    	    fireControlState.getEntityIDFStates().put(shooter.getId(), false);
+    	    return false;
     	}
     	
         for(Mounted weapon : shooter.getWeaponList()) {

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -664,7 +664,7 @@ public class Princess extends BotClient {
             if(!skipFiring) {
                 // Set up ammo conservation.
                 final Map<Mounted, Double> ammoConservation = calcAmmoConservation(shooter);
-    
+                
                 // entity that can act this turn make sure weapons are loaded
                 final FiringPlan plan = getFireControl(shooter).getBestFiringPlan(shooter,
                                                                       getHonorUtil(),
@@ -1419,6 +1419,7 @@ public class Princess extends BotClient {
                         // inside them, since there's no other way to attack
                         // them.
                         if (isEnemyInfantry(entity, coords)
+                                && !entity.isCrippled()
                                 && Compute.isInBuilding(game, entity)
                                 && !entity.isHidden()) {
                             fireControlState.getAdditionalTargets().add(bt);
@@ -1613,14 +1614,16 @@ public class Princess extends BotClient {
         methodBegin(getClass(), METHOD_NAME);
 
         try {
-            if (initialized) {
-                return; // no need to initialize twice
-            }
-
+            // these need to be checked at the start of every phase, otherwise the bot will 
+            // not necessarily have the most up-to-date
             checkForDishonoredEnemies();
             checkForBrokenEnemies();
             refreshCrippledUnits();
             
+            if (initialized) {
+                return; // no need to initialize twice
+            }
+
             initializePathRankers();
             fireControlState = new FireControlState();
             pathRankerState = new PathRankerState();
@@ -1717,7 +1720,7 @@ public class Princess extends BotClient {
         return entity.hasETypeFlag(Entity.ETYPE_GUN_EMPLACEMENT)
                && entity.getOwner().isEnemyOf(getLocalPlayer())
                && !getStrategicBuildingTargets().contains(coords)
-               && (null != entity.getCrew()) && !entity.getCrew().isDead();
+               && !entity.isCrippled();
     }
 
     private boolean isEnemyInfantry(final Entity entity,

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1113,7 +1113,7 @@ public class Princess extends BotClient {
             }
 
             // the original bot's physical options seem superior
-            PhysicalOption bestPhysical = PhysicalCalculator.getBestPhysical(attacker, game);
+            PhysicalOption bestPhysical = PhysicalCalculator.getBestPhysical(attacker, game, getForcedWithdrawal() ? getHonorUtil() : null);
             return bestPhysical;
         } finally {
             methodEnd(getClass(), METHOD_NAME);
@@ -1384,6 +1384,21 @@ public class Princess extends BotClient {
     }
 
     @Override
+    public void changePhase(IGame.Phase phase) {
+        switch(phase) {
+        case PHASE_FIRING:
+        case PHASE_PHYSICAL:
+        case PHASE_TARGETING:
+            checkForDishonoredEnemies();
+            checkForBrokenEnemies();
+            refreshCrippledUnits();
+            break;
+        }
+        
+        super.changePhase(phase);
+    }
+    
+    @Override
     protected void initFiring() {
         final String METHOD_NAME = "initFiring()";
         methodBegin(getClass(), METHOD_NAME);
@@ -1613,7 +1628,6 @@ public class Princess extends BotClient {
         methodBegin(getClass(), METHOD_NAME);
 
         try {      
-            
             if (initialized) {
                 return; // no need to initialize twice
             }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1487,8 +1487,7 @@ public class Princess extends BotClient {
 
                     if (getHonorUtil().isEnemyBroken(entity.getTargetId(),
                                                      entity.getOwnerId(),
-                                                     getForcedWithdrawal()) ||
-                        !entity.isMilitary()) {
+                                                     getForcedWithdrawal())) {
                         // If he'd just continued running, I would have let him 
                         // go, but the bastard shot at me!
                         msg.append("\n\t")
@@ -1613,16 +1612,16 @@ public class Princess extends BotClient {
         final String METHOD_NAME = "initialize()";
         methodBegin(getClass(), METHOD_NAME);
 
-        try {
-            // these need to be checked at the start of every phase, otherwise the bot will 
-            // not necessarily have the most up-to-date
-            checkForDishonoredEnemies();
-            checkForBrokenEnemies();
-            refreshCrippledUnits();
+        try {      
             
             if (initialized) {
                 return; // no need to initialize twice
             }
+
+            // if we're just loading in, let's figure out who we shouldn't fire on
+            checkForDishonoredEnemies();
+            checkForBrokenEnemies();
+            refreshCrippledUnits();
 
             initializePathRankers();
             fireControlState = new FireControlState();

--- a/megamek/src/megamek/common/Minefield.java
+++ b/megamek/src/megamek/common/Minefield.java
@@ -18,6 +18,8 @@ package megamek.common;
 import java.io.Serializable;
 import java.util.Objects;
 
+import megamek.common.options.OptionsConstants;
+
 public class Minefield implements Serializable, Cloneable {
 
     /**
@@ -212,6 +214,31 @@ public class Minefield implements Serializable, Cloneable {
         if(isReduced) {
             setDensity(getDensity() - 5);
         }    
+    }
+    
+    /**
+     * Calculates the minefields detonation target roll based on the 
+     * minefield's characteristics and  
+     * @param victim
+     * @return
+     */
+    public int getDetonationTarget(Entity victim) {
+        int target = getTrigger();
+        if (getType() == Minefield.TYPE_ACTIVE) {
+            target = 9;
+        }
+        if (victim instanceof Infantry) {
+            target += 1;
+        }
+        if (victim.hasAbility(OptionsConstants.MISC_EAGLE_EYES)) {
+            target += 2;
+        }
+        if ((victim.getMovementMode() == EntityMovementMode.HOVER)
+                || (victim.getMovementMode() == EntityMovementMode.WIGE)) {
+            target = 12;
+        }
+        
+        return target;
     }
     
 }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -11659,20 +11659,7 @@ public class Server implements Runnable {
 
             // set the target number
             if (target == -1) {
-                target = mf.getTrigger();
-                if (mf.getType() == Minefield.TYPE_ACTIVE) {
-                    target = 9;
-                }
-                if (entity instanceof Infantry) {
-                    target += 1;
-                }
-                if (entity.hasAbility(OptionsConstants.MISC_EAGLE_EYES)) {
-                    target += 2;
-                }
-                if ((entity.getMovementMode() == EntityMovementMode.HOVER)
-                        || (entity.getMovementMode() == EntityMovementMode.WIGE)) {
-                    target = 12;
-                }
+                target = mf.getDetonationTarget(entity);
             }
 
             int roll = Compute.d6(2);


### PR DESCRIPTION
Two bot behavior updates:

1) The bot will no longer obsessively target crippled units belonging to other bots, preferring to move on to more dangerous targets. This was due to a stale cache that wasn't being updated during phases that didn't have a "calculateMyTurn" method call.

2) First crack at getting the bot to try to avoid minefields, classifying them as hazards. It's not enough, as, occasionally, the paths that don't move over minefields/hazards are pruned prior to being evaluated for hazards. The damage estimate of walking over the minefield is the damage it will inflict * odds of it going off.