### PR TITLE
Summarycache cleanup

### DIFF
--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -734,7 +734,7 @@ public class MechSummaryCache {
         File lookupNames = new MegaMekFile(getUnitCacheDir(),
                 FILENAME_LOOKUP).getFile();
         boolean needsUpdate = false;
-        if (lookupNames.exists() && lookupNames.lastModified() > lLastCheck) {
+        if (lookupNames.exists()) {
             try {
                 InputStream is = new FileInputStream(lookupNames);
                 BufferedReader reader = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));


### PR DESCRIPTION
While testing the last few changes on the RATGenerator editor I discovered why the name_changes.txt file doesn't always work as intended and in the process of cleaning up the file I found and fixed a few more problems.

The name_changes.txt file is currently only processed if the timestamp is later than the timestamp on the units.cache file. The problem is that when the units.cache is built the first time or deleted and rebuilt, it gets a later timestamp and the name changes will never be applied unless that file is changed. The solution is to read it each time.

Other problems discovered are that the loading thread is synchronized using a non-final object and the code that records whether a unit is illegal in the summary has not been updated in some time and validation has been added for a number of unit types since then.