### PR TITLE
Ba mines

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -911,6 +911,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         updateDumpButton();
         updateEvadeButton();
         updateBootleggerButton();
+        updateLayMineButton();
 
         updateStartupButton();
         updateShutdownButton();
@@ -979,7 +980,6 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 (ce instanceof Tank)
                 && (ce.getSwarmAttackerId() != Entity.NONE));
 
-        setLayMineEnabled(ce.canLayMine());
         setFleeEnabled(ce.canFlee());
         if (gOpts.booleanOption(OptionsConstants.ADVGRNDMOV_VEHICLES_CAN_EJECT) && (ce instanceof Tank)) {
             // Vehicle don't have ejection systems so crews abandon, and must 
@@ -1220,6 +1220,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         updateHoverButton();
         updateManeuverButton();
         updateAeroButtons();
+        updateLayMineButton();
 
         loadedUnits = ce.getLoadedUnits();
         if (ce instanceof Aero) {
@@ -2065,6 +2066,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             updateRollButton();
             updateTurnButton();
             updateTakeCoverButton();
+            updateLayMineButton();
             checkFuel();
             checkOOC();
             checkAtmosphere();
@@ -2933,6 +2935,24 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             }
         } // End ce-hasn't-moved
     } // private void updateLoadButtons
+
+    private void updateLayMineButton() {
+        final Entity ce = ce();
+        if (null == ce) {
+            return;
+        }
+
+        if (!ce.canLayMine()) {
+            setLayMineEnabled(false);
+        }
+        if (ce instanceof BattleArmor) {
+            setLayMineEnabled(cmd.getLastStep() == null
+                || cmd.isJumping()
+                || cmd.getLastStepMovementType().equals(EntityMovementType.MOVE_VTOL_WALK));
+        } else {
+            setLayMineEnabled(true);
+        }
+    }
 
     private Entity getMountedUnit() {
         Entity ce = ce();
@@ -5247,6 +5267,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         updateThrustButton();
         updateRollButton();
         updateTakeCoverButton();
+        updateLayMineButton();
         checkFuel();
         checkOOC();
         checkAtmosphere();

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2944,8 +2944,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
 
         if (!ce.canLayMine()) {
             setLayMineEnabled(false);
-        }
-        if (ce instanceof BattleArmor) {
+        } else if (ce instanceof BattleArmor) {
             setLayMineEnabled(cmd.getLastStep() == null
                 || cmd.isJumping()
                 || cmd.getLastStepMovementType().equals(EntityMovementType.MOVE_VTOL_WALK));

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4891,12 +4891,22 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         } else if (actionCmd.equals(MoveCommand.MOVE_LAY_MINE.getCmd())) {
             int i = chooseMineToLay();
             if (i != -1) {
-                Mounted m = ce().getEquipment(i);
+                Mounted m = ce.getEquipment(i);
                 if (m.getMineType() == Mounted.MINE_VIBRABOMB) {
                     VibrabombSettingDialog vsd = new VibrabombSettingDialog(
                             clientgui.frame);
                     vsd.setVisible(true);
                     m.setVibraSetting(vsd.getSetting());
+                }
+                if (cmd.getLastStep() == null
+                        && ce instanceof BattleArmor
+                        && ce.getMovementMode().equals(EntityMovementMode.INF_JUMP)) {
+                    cmd.addStep(MoveStepType.START_JUMP);
+                    gear = GEAR_JUMP;
+                    Color jumpColor = GUIPreferences.getInstance().getColor(
+                            GUIPreferences.ADVANCED_MOVE_JUMP_COLOR);
+                    clientgui.getBoardView().setHighlightColor(jumpColor);
+                    computeMovementEnvelope(ce);
                 }
                 cmd.addStep(MoveStepType.LAY_MINE, i);
                 clientgui.bv.drawMovementData(ce, cmd);

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -2772,8 +2772,8 @@ public class MoveStep implements Serializable {
         }
         
         if ((type == MoveStepType.LAY_MINE) && entity.canLayMine()) {
-            //All vechs may only lay mines on its first or last step.
-            //BA additionaly have to use Jump or VTOL movement.
+            //All units may only lay mines on its first or last step.
+            //BA additionally have to use Jump or VTOL movement.
             movementType = prev.movementType;
 
             if (entity instanceof BattleArmor &&

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -2777,7 +2777,8 @@ public class MoveStep implements Serializable {
             movementType = prev.movementType;
 
             if (entity instanceof BattleArmor &&
-                    !((prev.movementType == EntityMovementType.MOVE_JUMP)
+                    !(isFirstStep()
+                            || (prev.movementType == EntityMovementType.MOVE_JUMP)
                             || (prev.movementType == EntityMovementType.MOVE_VTOL_RUN)
                             || (prev.movementType == EntityMovementType.MOVE_VTOL_WALK))) {
                 movementType = EntityMovementType.MOVE_ILLEGAL;


### PR DESCRIPTION
Usability fixes for using BA with mine dispensers. See rules on TO, p. 325. BA can lay a mine at the beginning or end of movement, but only when using jumping or VTOL movement. Currently you can plot a movement turn that combines walking and laying a mine with no indication that anything is wrong and the mine-laying command just does nothing. This PR changes the behavior to switch to jumping mode automatically when jump-capable BA lay a mine at the beginning of a turn, and disable the mine-laying button for BA that have moved using any mode other than jump or VTOL.

Fixes #1590