### PR TITLE
Report automatic failure to avoid skid

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -199,6 +199,7 @@
 2415=<data> collapes due to nuclear explosion ground zero.
 2420=<data> (<data>) automatically avoids the skid.
 2425=<data> (<data>) needs <data> to avoid the skid (<data>), rolls <data>.
+2426=<data> (<data>) automatically fails to avoid the skid (<data>).
 2440=The swamp becomes quicksand!
 2445=<data> (<data>) sinks into the quicksand.
 2450=<data> (<data>) converts to mech mode.

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -5645,20 +5645,29 @@ public class Server implements Runnable {
                         } else {
                             PilotingRollData psr = target.getBasePilotingRoll();
                             psr.addModifier(0, "avoiding collision");
-                            int roll = Compute.d6(2);
-                            r = new Report(2425);
-                            r.subject = target.getId();
-                            r.addDesc(target);
-                            r.add(psr.getValue());
-                            r.add(psr.getDesc());
-                            r.add(roll);
-                            addReport(r);
-                            if (roll >= psr.getValue()) {
-                                game.removeTurnFor(target);
-                                avoidedChargeUnits.add(target);
-                                continue;
-                                // TODO: the charge should really be suspended
-                                // and resumed after the target moved.
+                            if (psr.getValue() == TargetRoll.AUTOMATIC_FAIL
+                                    || psr.getValue() == TargetRoll.IMPOSSIBLE) {
+                                r = new Report(2426);
+                                r.subject = target.getId();
+                                r.addDesc(target);
+                                r.add(psr.getDesc());
+                                addReport(r);
+                            } else {
+                                int roll = Compute.d6(2);
+                                r = new Report(2425);
+                                r.subject = target.getId();
+                                r.addDesc(target);
+                                r.add(psr.getValue());
+                                r.add(psr.getDesc());
+                                r.add(roll);
+                                addReport(r);
+                                if (roll >= psr.getValue()) {
+                                    game.removeTurnFor(target);
+                                    avoidedChargeUnits.add(target);
+                                    continue;
+                                    // TODO: the charge should really be suspended
+                                    // and resumed after the target moved.
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
When a unit is required to make a PSR to avoid a skid, MM doesn't check for automatic failure and gives the PSR target as Integer.MAX_INT - 1 (TargetRoll.AUTOMATIC_FAILURE).

Current:
Dragon DRG-1N (Draconis Combine) needs 2147483646 to avoid the skid (Both legs destroyed), rolls 10.
    Skids into Dragon DRG-1N in hex 2432...; needs 5, rolls 9 :     Attacker takes 6 damage.

Change:
Enforcer ENF-5D (test) automatically fails to avoid the skid (Both legs destroyed).
    Skids into Enforcer ENF-5D in hex 0513...; needs 8, rolls 5 : misses.

Fixes #1587