### PR TITLE
Bypass artillery hit calculation for non-artillery weapons.

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -684,8 +684,10 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
         
         // Is this an Artillery attack?
-        toHit = handleArtilleryAttacks(game, ae, target, ttype, losMods, toHit, wtype, weapon, atype, isArtilleryDirect,
-                isArtilleryFLAK, isArtilleryIndirect, isHoming, usesAmmo, srt);
+        if (isArtilleryDirect || isArtilleryIndirect) {
+            toHit = handleArtilleryAttacks(game, ae, target, ttype, losMods, toHit, wtype, weapon, atype, isArtilleryDirect,
+                    isArtilleryFLAK, isArtilleryIndirect, isHoming, usesAmmo, srt);
+        }
         if (srt.isSpecialResolution()) {
             return toHit;
         }


### PR DESCRIPTION
When calculating weapon to-hit numbers, all weapons are sent through the artillery attack calculation, which is supposed to return the starting value if none of the artillery attack categories apply. But the check for auto-hit of designated targets does not filter out non-artillery weapons. While I could have added a check there, I see no reason to call the method for non-artillery weapons in the first place.

Fixes #1576