### PR TITLE
Add trailer flag to CV trailer blk files

### DIFF
--- a/megamek/data/mechfiles/vehicles/3039u/J-27 Ordnance Transport (Trailer).blk
+++ b/megamek/data/mechfiles/vehicles/3039u/J-27 Ordnance Transport (Trailer).blk
@@ -79,3 +79,7 @@ TRO 3039 - Star League
 1
 </hasNoControlSystems>
 
+<trailer>
+1
+</trailer>
+

--- a/megamek/data/mechfiles/vehicles/3085u/Supplemental/Bokkusu Support Trailer (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Supplemental/Bokkusu Support Trailer (Standard).blk
@@ -98,3 +98,6 @@ TRO3086S - Early Repubic Era
 75.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3085u/Supplemental/Tenmaku Command Trailer (Standard.blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Supplemental/Tenmaku Command Trailer (Standard.blk
@@ -105,3 +105,6 @@ TRO 3085S - Early Republic
 75.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3145/Davion/Ballista Artillery Trailer (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Davion/Ballista Artillery Trailer (Standard).blk
@@ -120,7 +120,7 @@ TRO 3145 Federated Suns - Early Republic
 100.0
 </tonnage>
 
-<history>
-Trailers are not coded in MM. Unit included for completeness
-</history>
+<trailer>
+1
+</trailer>
 

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Ambush).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Ambush).blk
@@ -77,3 +77,6 @@ TRO 3145 Mercenaries - Early Republic
 10.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Artillery AAA).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Artillery AAA).blk
@@ -90,3 +90,6 @@ TRO 3145 Mercenaries - Early Republic
 35.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (LRM).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (LRM).blk
@@ -92,3 +92,6 @@ TRO 3145 Mercenaries - Early Republic
 35.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Mjolnir).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Mjolnir).blk
@@ -84,3 +84,6 @@ TRO 3145 Mercenaries - Late Republic
 35.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Siege).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Siege).blk
@@ -85,3 +85,6 @@ TRO 3145 Mercenaries - Early Republic
 35.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Sniper Cannon).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Sniper Cannon).blk
@@ -91,3 +91,6 @@ TRO 3145 Mercenaries - Late Republic
 35.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Stronghold).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Stronghold).blk
@@ -86,3 +86,6 @@ TRO 3145 Mercenaries - Early Republic
 35.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Thumper).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Thumper).blk
@@ -90,3 +90,6 @@ TRO 3145 Mercenaries - Early Republic
 35.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Thunderbolt).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Thunderbolt).blk
@@ -90,3 +90,6 @@ TRO 3145 Mercenaries - Early Republic
 35.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Ultra).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Merc/Trailers/Gun Trailer (Ultra).blk
@@ -90,3 +90,6 @@ TRO 3145 Mercenaries - Early Republic
 35.0
 </tonnage>
 
+<trailer>
+1
+</trailer>

--- a/megamek/src/megamek/common/loaders/BLKTankFile.java
+++ b/megamek/src/megamek/common/loaders/BLKTankFile.java
@@ -290,7 +290,7 @@ public class BLKTankFile extends BLKFile implements IMechLoader {
         }
 
         if (dataFile.exists("trailer")) {
-            t.setHasNoControlSystems(true);
+            t.setTrailer(true);
         }
 
         return t;


### PR DESCRIPTION
In the process of getting combat vehicles and support vehicles to behave properly as trailers in their own particular ways I failed to add the new trailer flag to the CV blk files. Also, if I had it wouldn't have been set correctly because of a copy/paste error. Because I suck.

Also, the blk file diffs are useless when showing whitespace changes, because line endings.

Fixes #1568