### PR TITLE
Fixed report ID numbers for ProtoMech near misses.

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -21375,11 +21375,11 @@ public class Server implements Runnable {
                                                      ToHitData.SIDE_FRONT);
                 if (hit.getLocation() == Protomech.LOC_NMISS) {
                     Protomech proto = (Protomech) entity;
-                    r = new Report(6305);
+                    r = new Report(6035);
                     r.subject = entity.getId();
                     r.indent(2);
                     if (proto.isGlider()) {
-                        r.messageId = 6306;
+                        r.messageId = 6036;
                         proto.setWingHits(proto.getWingHits() + 1);
                     }
                     addReport(r);
@@ -23243,11 +23243,11 @@ public class Server implements Runnable {
         if ((te instanceof Protomech)
                 && (hit.getLocation() == Protomech.LOC_NMISS)) {
             Protomech proto = (Protomech) te;
-            r = new Report(6305);
+            r = new Report(6035);
             r.subject = te.getId();
             r.indent(2);
             if (proto.isGlider()) {
-                r.messageId = 6306;
+                r.messageId = 6036;
                 proto.setWingHits(proto.getWingHits() + 1);
             }
             vDesc.add(r);


### PR DESCRIPTION
We have a case of metathesis. In a couple places (one copied from the other) the report numbers are
6305=&lt;font color='C00000'&gt;Critical hit on &lt;data&gt;.&lt;/font&gt;
6306=&lt;font color='C00000'&gt;Chance for motive system damage.&lt;/font&gt;

When they should be:
6035=Near miss! The Protomech is unaffected.
6036=The wing structure is damaged.

(N.B. glider protomechs take wing structure damage instead of near misses).

Fixes #1562