### PR TITLE
Bot post bomb targeting fix

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1778,15 +1778,21 @@ public class FireControl {
         final HexTarget hexToBomb = new HexTarget(target.getPosition(), game.getBoard(), 
                 shooter.isAero() ? Targetable.TYPE_HEX_AERO_BOMB : Targetable.TYPE_HEX_BOMB);
 
+        // things that cause us to avoid calculating a bomb plan:
+        // not having any bombs (in the first place)
         final Iterator<Mounted> weaponIter = shooter.getWeapons();
         if (null == weaponIter) {
+            return diveBombPlan;
+        }
+        
+        // not having any bombs (due to expenditure/damage)
+        if(shooter.getBombs(BombType.F_GROUND_BOMB).size() == 0) {
             return diveBombPlan;
         }
 
         while (weaponIter.hasNext()) {
             final Mounted weapon = weaponIter.next();
             if(weapon.getType().hasFlag(WeaponType.F_DIVE_BOMB)) {
-
                 final int[] bombPayload = new int[BombType.B_NUM];
                 // load up all droppable bombs, yeah baby! Mix thunder bombs and infernos 'cause why the hell not.
                 // seriously, though, TODO: more intelligent bomb drops
@@ -2250,6 +2256,12 @@ public class FireControl {
     	// cache the results of our computation
     	if(fireControlState.getEntityIDFStates().containsKey(shooter.getId())) {
     		return fireControlState.getEntityIDFStates().get(shooter.getId());
+    	}
+    	
+    	// airborne aerospace units cannot use indirect fire
+    	if(shooter.isAirborne()) {
+    	    fireControlState.getEntityIDFStates().put(shooter.getId(), false);
+    	    return false;
     	}
     	
         for(Mounted weapon : shooter.getWeaponList()) {


### PR DESCRIPTION
Split a different PR into multiple smaller ones. This one fixes two issues with bot-controlled aerospace units:

- On ground maps, after dropping bombs, an ASF would refuse to attack anything - a "dive bomb plan" with no bombs dropped still counts as being non-zero length, so it was being evaluated further down the line, counted as being better than the "alpha strike" plan, and so no further firing plans would be considered.

- Airborne units mounting LRMs would attempt to check for the possibility of indirect fire, resulting in unnecessary calculations and firing mode switches.