### PR TITLE
Largecraft armor weight calc

### DIFF
--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -1966,7 +1966,7 @@ public class Jumpship extends Aero {
         if (!isPrimitive()) {
             armorPoints -= Math.round(get0SI() / 10.0) * locCount;
         } else {
-            armorPoints -= Math.round(get0SI() / 10.0) * locCount * 0.66;
+            armorPoints -= Math.floor(Math.round(get0SI() / 10.0) * locCount * 0.66);
         }
 
         // now I need to determine base armor points by type and weight

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -1956,7 +1956,7 @@ public class Jumpship extends Aero {
     
     @Override
     public double getArmorWeight() {
-        return getArmorWeight(locations());
+        return getArmorWeight(locations() - 1); // no armor in hull location
     }
     
     @Override

--- a/megamek/src/megamek/common/SmallCraft.java
+++ b/megamek/src/megamek/common/SmallCraft.java
@@ -598,7 +598,11 @@ public class SmallCraft extends Aero {
     public double getArmorWeight() {
         // first I need to subtract SI bonus from total armor
         int armorPoints = getTotalOArmor();
-        armorPoints -= getSI() * (locations() - 1); // no armor in hull location
+        int freeSI = getSI() * (locations() - 1); // no armor in hull location
+        if (isPrimitive()) {
+            freeSI = (int) (freeSI * 0.66);
+        }
+        armorPoints -= freeSI;
         double armorPerTon = SmallCraft.armorPointsPerTon(getWeight(), isSpheroid(),
                 getArmorType(0), TechConstants.isClan(getArmorTechLevel(0)));
 

--- a/megamek/src/megamek/common/SmallCraft.java
+++ b/megamek/src/megamek/common/SmallCraft.java
@@ -598,7 +598,7 @@ public class SmallCraft extends Aero {
     public double getArmorWeight() {
         // first I need to subtract SI bonus from total armor
         int armorPoints = getTotalOArmor();
-        armorPoints -= getSI() * locations();
+        armorPoints -= getSI() * (locations() - 1); // no armor in hull location
         double armorPerTon = SmallCraft.armorPointsPerTon(getWeight(), isSpheroid(),
                 getArmorType(0), TechConstants.isClan(getArmorTechLevel(0)));
 

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -182,7 +182,7 @@ public class Warship extends Jumpship {
 
     @Override
     public double getArmorWeight() {
-        return getArmorWeight(locations() - 3);
+        return getArmorWeight(locations() - 3); // No armor for RBS/LBS/HULL
     }
     
     @Override


### PR DESCRIPTION
Fixes a bug introduced with the addition of hull/system-wide locations for aerospace units. When a unit is loaded the construction weight of the armor is calculated for use by MML. For small craft and larger aerospace units this requires subtracting the free armor from SI before calculating the weight of the remaining armor. Since the addition of an unarmored location it is subtracting too much for the free SI armor and coming up with a lower construction weight.

Also accounts for the lower SI armor for primitive small craft and dropships and rounds the SI armor down per errata for capital ships. See Megamek/megameklab#386

Fixes Megamek/megameklab#385