### PR TITLE
Misc changes for printing vee record sheets

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -9213,6 +9213,7 @@ public class MiscType extends EquipmentType {
 
         misc.name = "Searchlight (Handheld)";
         misc.setInternalName("HHSearchlight");
+        misc.shortName = "Searchlight";
         misc.tonnage = 0.005;
         misc.criticals = 0;
         misc.tankslots = 0;
@@ -9235,6 +9236,7 @@ public class MiscType extends EquipmentType {
 
         misc.name = "Searchlight (Mounted)";
         misc.setInternalName("Searchlight");
+        misc.shortName = "Searchlight";
         misc.tonnage = 0.5;
         misc.criticals = 1;
         misc.tankslots = 1;
@@ -11022,6 +11024,7 @@ public class MiscType extends EquipmentType {
 
         misc.name = "Searchlight [BA]";
         misc.setInternalName("BASearchlight");
+        misc.shortName = "Searchlight";
         misc.tonnage = 0.005;
         misc.criticals = 1;
         misc.tankslots = 0;

--- a/megamek/src/megamek/common/actions/ClubAttackAction.java
+++ b/megamek/src/megamek/common/actions/ClubAttackAction.java
@@ -166,7 +166,7 @@ public class ClubAttackAction extends PhysicalAttackAction {
         }
 
         // TSM doesn't apply to some weapons, including Saws.
-        if ((((entity.heat >= 9) && ((Mech) entity).hasTSM()) || ((Mech) entity).hasIndustrialTSM())
+        if (entity instanceof Mech && ((((entity.heat >= 9) && ((Mech) entity).hasTSM()) || ((Mech) entity).hasIndustrialTSM())
             && !(mType.hasSubType(MiscType.S_DUAL_SAW)
                  || mType.hasSubType(MiscType.S_CHAINSAW)
                  || mType.hasSubType(MiscType.S_PILE_DRIVER)
@@ -181,7 +181,7 @@ public class ClubAttackAction extends PhysicalAttackAction {
                  || mType.hasSubType(MiscType.S_SPOT_WELDER)
                  || mType.hasSubType(MiscType.S_CHAIN_WHIP) || mType
                 .hasSubType(MiscType.S_COMBINE))
-            ) {
+            )) {
             nDamage *= 2;
         }
         int clubLocation = club.getLocation();


### PR DESCRIPTION
A few small changes to fix problems I ran across while reworking the printing of vehicle record sheets. The biggest is moving the weight class limits for the various motive types out of MML into the validation package in the process of fixing a bug that prevented creating superheavy naval combat vehicles for testing. While I was working on it anyway I moved it out of the MML ui code into its proper location .