### PR TITLE
Primitive js max armor

### DIFF
--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -1967,6 +1967,7 @@ public class Jumpship extends Aero {
             armorPoints -= Math.round(get0SI() / 10.0) * locCount;
         } else {
             armorPoints -= Math.floor(Math.round(get0SI() / 10.0) * locCount * 0.66);
+            armorPoints = Math.ceil(armorPoints / 0.66);
         }
 
         // now I need to determine base armor points by type and weight
@@ -1993,8 +1994,6 @@ public class Jumpship extends Aero {
             baseArmor += 0.4;
         } else if (armorType[0] == EquipmentType.T_ARMOR_LC_LAMELLOR_FERRO_CARBIDE) {
             baseArmor += 0.6;
-        } else if (armorType[0] == EquipmentType.T_ARMOR_PRIMITIVE_AERO) {
-            baseArmor *= 0.66;
         }
 
         return RoundWeight.standard(armorPoints / baseArmor, this);

--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -166,10 +166,12 @@ public class TestAdvancedAerospace extends TestAero {
         }
         // The ship gets a number of armor points equal to 10% of the SI, rounded normally, per facing.
         double freeSI = Math.round(vessel.get0SI() / 10.0) * 6;
-        // Primitive jumpships have the free SI armor reduced, but the fractional amount is
-        // added to the value calculated from the max armor tonnage before truncating.
+        // Primitive jumpships multiply the armor by a factor of 0.66. Per errata, the armor is calculated
+        // based on standard armor then rounded down, and the free SI armor is rounded down separately.
         if (vessel.isPrimitive()) {
-            freeSI *= 0.66;
+            return (int) (Math.floor(CapitalArmor.STANDARD.pointsPerTon(vessel)
+                    * maxArmorWeight(vessel) * 0.66)
+                + Math.floor(freeSI * 0.66));
         }
         return (int) Math.floor(a.pointsPerTon(vessel) * maxArmorWeight(vessel) + freeSI);
     }


### PR DESCRIPTION
A couple more fixes for primitive jumpship armor rounding. TestAdvancedAerospace#maxArmorPoints can show the wrong value for max armor in MML or fail to flag excess armor in validation. Jumpship#getArmorWeight could calculate the armor weight incorrectly on load, which cause MML to set the armor tonnage incorrectly.

Fixes Megamek/megameklab#386 (For real this time. Probably.)