### PR TITLE
Allow indirect LRMs to miss legs if target in water

### DIFF
--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1560,7 +1560,10 @@ public class WeaponHandler implements AttackHandler, Serializable {
 
         //For indirect fire, remove leg hits only if target is in water partial cover
         //Per TW errata for indirect fire
-        if ((!isIndirect || (isIndirect && targetHex.containsTerrain(Terrains.WATER)))
+        if ((!isIndirect 
+                || (isIndirect 
+                        && targetHex.containsTerrain(Terrains.WATER) 
+                        && entityTarget.relHeight() <= targetHex.surface()))
                 && entityTarget.removePartialCoverHits(hit.getLocation(), toHit
                         .getCover(), Compute.targetSideTable(ae, entityTarget,
                         weapon.getCalledShot().getCall()))) {

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -35,6 +35,7 @@ import megamek.common.HitData;
 import megamek.common.IAero;
 import megamek.common.IAimingModes;
 import megamek.common.IGame;
+import megamek.common.IHex;
 import megamek.common.ITerrain;
 import megamek.common.Infantry;
 import megamek.common.LosEffects;
@@ -1555,8 +1556,11 @@ public class WeaponHandler implements AttackHandler, Serializable {
         }
         boolean isIndirect = wtype.hasModes()
                 && weapon.curMode().equals("Indirect");
+        IHex targetHex = game.getBoard().getHex(target.getPosition());
 
-        if (!isIndirect
+        //For indirect fire, remove leg hits only if target is in water partial cover
+        //Per TW errata for indirect fire
+        if ((!isIndirect || (isIndirect && targetHex.containsTerrain(Terrains.WATER)))
                 && entityTarget.removePartialCoverHits(hit.getLocation(), toHit
                         .getCover(), Compute.targetSideTable(ae, entityTarget,
                         weapon.getCalledShot().getCall()))) {


### PR DESCRIPTION
This resolves RFE #1348, which references current errata for indirect fire on TW p111.