### PR TITLE
Fixing Missing TROView String

### DIFF
--- a/megamek/i18n/megamek/common/messages.properties
+++ b/megamek/i18n/megamek/common/messages.properties
@@ -340,6 +340,7 @@ WeaponType.Missile=Missile
 WeaponType.Burst=Burst-fire
 
 TROView.None=None
+TROView.NA=N/A
 TROView.InnerSphere=Inner Sphere
 TROView.Clan=Clan
 TROView.Mixed=Mixed

--- a/megamek/src/megamek/common/templates/CapitalShipTROView.java
+++ b/megamek/src/megamek/common/templates/CapitalShipTROView.java
@@ -73,7 +73,7 @@ public class CapitalShipTROView extends AeroTROView {
         setModelData("escapePods", aero.getEscapePods());
         setModelData("lifeBoats", aero.getLifeBoats());
         setModelData("gravDecks", aero.getGravDecks().stream().map(size -> size + " m").collect(Collectors.toList()));
-        setModelData("sailIntegrity", aero.hasSail() ? aero.getSailIntegrity() : null);
+        setModelData("sailIntegrity", aero.hasSail() ? aero.getSailIntegrity() : Messages.getString("TROView.NA"));
         if (aero.getDriveCoreType() != Jumpship.DRIVE_CORE_NONE) {
             setModelData("kfIntegrity", aero.getKFIntegrity());
         }

--- a/megamek/src/megamek/common/templates/CapitalShipTROView.java
+++ b/megamek/src/megamek/common/templates/CapitalShipTROView.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import megamek.common.Aero;
+import megamek.common.Entity;
 import megamek.common.Jumpship;
 import megamek.common.Messages;
 import megamek.common.Mounted;
@@ -72,7 +73,7 @@ public class CapitalShipTROView extends AeroTROView {
         setModelData("escapePods", aero.getEscapePods());
         setModelData("lifeBoats", aero.getLifeBoats());
         setModelData("gravDecks", aero.getGravDecks().stream().map(size -> size + " m").collect(Collectors.toList()));
-        setModelData("sailIntegrity", aero.hasSail() ? aero.getSailIntegrity() : Messages.getString("TROView.NA"));
+        setModelData("sailIntegrity", aero.hasSail() ? aero.getSailIntegrity() : null);
         if (aero.getDriveCoreType() != Jumpship.DRIVE_CORE_NONE) {
             setModelData("kfIntegrity", aero.getKFIntegrity());
         }
@@ -145,7 +146,7 @@ public class CapitalShipTROView extends AeroTROView {
             { Jumpship.LOC_ARS, Jumpship.LOC_ALS }, { Jumpship.LOC_AFT } };
 
     private void addArmor() {
-        setModelData("armorValues", addArmorStructureEntries(aero, (en, loc) -> en.getOArmor(loc), ARMOR_LOCS));
+        setModelData("armorValues", addArmorStructureEntries(aero, Entity::getOArmor, ARMOR_LOCS));
     }
 
     protected void addCrew() {


### PR DESCRIPTION
This fixes a bug where Sail Integrity is specified as !TROView.NA!, by adding in the string "N/A"