### PR TITLE
1597: Adding AlphaSled's RAT Fixes

### DIFF
--- a/megamek/data/forcegenerator/3082.xml
+++ b/megamek/data/forcegenerator/3082.xml
@@ -10751,7 +10751,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Nuberu Anti Aircraft Tank 2' unitType='Tank'>
+	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
 		<availability>RA.OA:2,RA:3-</availability>
 		<model name='2 &apos;Numantia&apos;'>
 			<roles>fire_support</roles>

--- a/megamek/data/forcegenerator/3085.xml
+++ b/megamek/data/forcegenerator/3085.xml
@@ -11212,7 +11212,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Nuberu Anti Aircraft Tank 2' unitType='Tank'>
+	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='2 &apos;Numantia&apos;'>
 			<roles>fire_support</roles>

--- a/megamek/data/forcegenerator/3100.xml
+++ b/megamek/data/forcegenerator/3100.xml
@@ -11505,7 +11505,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Nuberu Anti Aircraft Tank 2' unitType='Tank'>
+	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='2 &apos;Numantia&apos;'>
 			<roles>fire_support</roles>

--- a/megamek/data/forcegenerator/3135.xml
+++ b/megamek/data/forcegenerator/3135.xml
@@ -12115,7 +12115,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Nuberu Anti Aircraft Tank 2' unitType='Tank'>
+	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='2 &apos;Numantia&apos;'>
 			<roles>fire_support</roles>

--- a/megamek/data/forcegenerator/3145.xml
+++ b/megamek/data/forcegenerator/3145.xml
@@ -11892,7 +11892,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Nuberu Anti Aircraft Tank 2' unitType='Tank'>
+	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='2 &apos;Numantia&apos;'>
 			<roles>fire_support</roles>

--- a/megamek/data/rat/(3072) - Wars of Reaving/Blood Spirit/ProtoMech/Blood Spirit Frontline ProtoMechs.txt
+++ b/megamek/data/rat/(3072) - Wars of Reaving/Blood Spirit/ProtoMech/Blood Spirit Frontline ProtoMechs.txt
@@ -9,4 +9,4 @@ Delphyne (Standard), 5
 Delphyne 2, 4
 Chrysaor 2, 3
 Roc (Standard), 2
-Sprite (Standard), 1
+Sprite Ultraheavy ProtoMech (Standard), 1

--- a/megamek/data/rat/(3072) - Wars of Reaving/Blood Spirit/ProtoMech/Blood Spirit Keshik ProtoMechs.txt
+++ b/megamek/data/rat/(3072) - Wars of Reaving/Blood Spirit/ProtoMech/Blood Spirit Keshik ProtoMechs.txt
@@ -7,6 +7,6 @@ Delphyne (Standard), 5
 Delphyne 2, 6
 Chrysaor 2, 5
 Roc (Standard), 4
-Sprite (Standard), 3
+Sprite Ultraheavy ProtoMech (Standard), 3
 Minotaur (Standard), 2
 Procyon (Standard), 1

--- a/megamek/data/rat/(3072) - Wars of Reaving/Coyote/ProtoMech/Coyote Secondline ProtoMechs.txt
+++ b/megamek/data/rat/(3072) - Wars of Reaving/Coyote/ProtoMech/Coyote Secondline ProtoMechs.txt
@@ -1,6 +1,6 @@
 Clan Coyote Secondline ProtoMechs (WoRS)
 Boggart Ultraheavy ProtoMech (Standard), 1
-Sprite 2, 2
+Sprite Ultraheavy ProtoMech 2, 2
 Procyon 4, 3
 Procyon 2, 4
 Satyr 2, 5

--- a/megamek/data/rat/(3072) - Wars of Reaving/Society/ProtoMech/Society Command ProtoMechs.txt
+++ b/megamek/data/rat/(3072) - Wars of Reaving/Society/ProtoMech/Society Command ProtoMechs.txt
@@ -4,9 +4,9 @@ Hobgoblin Ultraheavy ProtoMech (Standard), 2
 Boggart Ultraheavy ProtoMech 2, 3
 Basilisk ProtoMech (Quad) B, 4
 Minotaur Z, 5
-Sprite (Standard), 6
+Sprite Ultraheavy ProtoMech (Standard), 6
 Hobgoblin Ultraheavy ProtoMech 2, 5
 Basilisk (Standard), 4
 Roc (Standard), 3
 Roc Z, 2
-Sprite 2, 1
+Sprite Ultraheavy ProtoMech 2, 1

--- a/megamek/data/rat/(3076 - 3100) - FM 3085/Clan/Clan Hells Horses/Protomech/3085 Clan Hells Horses Protomech Front Line.txt
+++ b/megamek/data/rat/(3076 - 3100) - FM 3085/Clan/Clan Hells Horses/Protomech/3085 Clan Hells Horses Protomech Front Line.txt
@@ -8,6 +8,6 @@ Hydra (Standard),6
 Minotaur (Standard),5
 Hydra 2,4
 Minotaur P2,3
-Procyon (Quad),2
+Procyon ProtoMech (Quad),2
 Svartalfa Ultra ProtoMech (Standard),1
 Svartalfa Ultra ProtoMech (LRM Variant),1

--- a/megamek/data/rat/(3076 - 3100) - FM 3085/Clan/Clan Hells Horses/Protomech/3085 Clan Hells Horses Protomech Keshik.txt
+++ b/megamek/data/rat/(3076 - 3100) - FM 3085/Clan/Clan Hells Horses/Protomech/3085 Clan Hells Horses Protomech Keshik.txt
@@ -6,7 +6,7 @@ Hydra (Standard),4
 Minotaur (Standard),5
 Hydra 2,6
 Minotaur P2,5
-Procyon (Quad),4
+Procyon ProtoMech (Quad),4
 Svartalfa Ultra ProtoMech (Standard),3
 #Hobgoblin,2
 Svartalfa Ultra ProtoMech (LRM Variant),1

--- a/megamek/data/rat/(3130 on) - FM 3145/Clan/Clan Hells Horses/Protomech/Protomech Front Line.txt
+++ b/megamek/data/rat/(3130 on) - FM 3145/Clan/Clan Hells Horses/Protomech/Protomech Front Line.txt
@@ -1,6 +1,6 @@
 3145 Clan Hell's Horses Protomechs - Front Line
 Hydra (Standard),1
-Procyon (Quad),2
+Procyon ProtoMech (Quad),2
 Orc 2,3
 Orc (Standard),4
 Minotaur P2,5

--- a/megamek/data/rat/(3130 on) - FM 3145/Clan/Clan Hells Horses/Protomech/Protomech Keshik.txt
+++ b/megamek/data/rat/(3130 on) - FM 3145/Clan/Clan Hells Horses/Protomech/Protomech Keshik.txt
@@ -8,5 +8,5 @@ Minotaur (Standard),6
 Hydra 2,5
 Svartalfa Ultra ProtoMech (Standard),4
 Svartalfa Ultra ProtoMech (LRM Variant),3
-Procyon (Quad),2
-Procyon (Quad),1
+Procyon ProtoMech (Quad),2
+Procyon ProtoMech (Quad),1

--- a/megamek/data/rat/(3130 on) - FM 3145/Clan/Clan Hells Horses/Protomech/Protomech Second Line.txt
+++ b/megamek/data/rat/(3130 on) - FM 3145/Clan/Clan Hells Horses/Protomech/Protomech Second Line.txt
@@ -8,5 +8,5 @@ Orc (Standard),6
 Orc 3,5
 Minotaur 2,4
 Hydra (Standard),3
-Procyon (Quad),2
+Procyon ProtoMech (Quad),2
 Orc 2,1


### PR DESCRIPTION
This implements #1597, and replaces #1601. It now uses the proper names for the units as saved in the Mechfiles folder.

It also fixes a bug with the name of the Nuberu tank, where model and name both had the model number 2 in it.