### PR TITLE
allow dropships to fire nose/aft weapons in space

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1484,7 +1484,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         // firing arcs are more complicated
         // TW errata 2.1
         if ((Compute.useSpheroidAtmosphere(game, ae) ||
-                (ae.isAero() && ((IAero) ae).isSpheroid() && ae.getAltitude() == 0))
+                (ae.isAero() && ((IAero) ae).isSpheroid() && (ae.getAltitude() == 0) && game.getBoard().onGround()))
                 && weapon != null) {
             int altDif = target.getAltitude() - ae.getAltitude();
             int range = Compute.effectiveDistance(game, ae, target, false);


### PR DESCRIPTION
Stupid little code omission, but completely borks spheroid dropship firing on space maps. Fixes #1630. 