### PR TITLE
Add theme selection and dark themes

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.freemarker:freemarker:2.3.28'
     implementation 'log4j:log4j:1.2.17'
     implementation 'org.apache.commons:commons-text:1.8'
+    implementation 'com.formdev:flatlaf:0.26'
 
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.0'

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -809,6 +809,7 @@ CommonSettingsDialog.showMapHexPopup=Show map hex popup.
 CommonSettingsDialog.showMapsheets=Show mapsheet borders.
 CommonSettingsDialog.showUnitId=Show each unit's unique Id next to its name.
 CommonSettingsDialog.showWrecks=Show wrecks.
+CommonSettingsDialog.uiTheme=UI Theme:
 CommonSettingsDialog.skinFile=Skin File: 
 CommonSettingsDialog.skinFileFail.title=Failed to load skin!
 CommonSettingsDialog.skinFileFail.msg=Error parsing skin specification file, reverting to previous skin!

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -355,6 +355,7 @@ public class BoardEditor extends JComponent
             //$NON-NLS-2$
             frame.dispose();
         }
+
         // Add a mouse listener for mouse button release 
         // to handle Undo
         bv.addMouseListener(new MouseAdapter() {
@@ -506,7 +507,7 @@ public class BoardEditor extends JComponent
             }
         });
     }
-    
+
     /**
      * Sets up JButtons
      */

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -62,6 +62,8 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -250,6 +252,8 @@ public class CommonSettingsDialog extends ClientDialog implements
     private JLabel gameLogFilenameLabel;
     
     private JComboBox<String> skinFiles;
+
+    private JComboBox<UITheme> uiThemes;
 
     // Avanced Settings
     private JList<AdvancedOptionData> keys;
@@ -842,6 +846,12 @@ public class CommonSettingsDialog extends ClientDialog implements
         skinFiles.setSelectedItem(SkinXMLHandler.defaultSkinXML);
         // If this select fials, the default skin will be selected
         skinFiles.setSelectedItem(GUIPreferences.getInstance().getSkinFile());
+
+        uiThemes.removeAllItems();
+        for (LookAndFeelInfo lafInfo : UIManager.getInstalledLookAndFeels()) {
+            uiThemes.addItem(new UITheme(lafInfo.getClassName(), lafInfo.getName()));
+        }
+        uiThemes.setSelectedItem(new UITheme(GUIPreferences.getInstance().getUITheme()));
         
         fovInsideEnabled.setSelected(gs.getFovHighlight());
         fovHighlightAlpha.setValue((int) ((100./255.) * gs.getFovHighlightAlpha()));
@@ -948,6 +958,12 @@ public class CommonSettingsDialog extends ClientDialog implements
         }
 
         gs.setAntiAliasing(chkAntiAliasing.isSelected());
+
+        UITheme newUITheme = (UITheme)uiThemes.getSelectedItem();
+        String oldUITheme = gs.getUITheme();
+        if (!oldUITheme.equals(newUITheme.getClassName())) {
+            gs.setUITheme(newUITheme.getClassName());
+        }
 
         String newSkinFile = (String)skinFiles.getSelectedItem();
         String oldSkinFile = gs.getSkinFile();
@@ -1308,6 +1324,20 @@ public class CommonSettingsDialog extends ClientDialog implements
         row.add(mmSymbol);
         comps.add(row);
 
+        // UI Theme
+        uiThemes = new JComboBox<UITheme>();
+        uiThemes.setMaximumSize(new Dimension(400,uiThemes.getMaximumSize().height));
+        //JLabel uiThemesLabel = new JLabel(Messages.getString("CommonSettingsDialog.skinFile")); //$NON-NLS-1$
+        JLabel uiThemesLabel = new JLabel("UI Theme"); //$NON-NLS-1$
+        row = new ArrayList<>();
+        row.add(uiThemesLabel);
+        row.add(uiThemes);
+        comps.add(row);   
+        
+        // Spacer
+        row = new ArrayList<>();
+        row.add(Box.createRigidArea(new Dimension(0, 5)));
+        comps.add(row);
 
         // Skin
         skinFiles = new JComboBox<String>();

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -1327,8 +1327,7 @@ public class CommonSettingsDialog extends ClientDialog implements
         // UI Theme
         uiThemes = new JComboBox<UITheme>();
         uiThemes.setMaximumSize(new Dimension(400,uiThemes.getMaximumSize().height));
-        //JLabel uiThemesLabel = new JLabel(Messages.getString("CommonSettingsDialog.skinFile")); //$NON-NLS-1$
-        JLabel uiThemesLabel = new JLabel("UI Theme"); //$NON-NLS-1$
+        JLabel uiThemesLabel = new JLabel(Messages.getString("CommonSettingsDialog.uiTheme")); //$NON-NLS-1$
         row = new ArrayList<>();
         row.add(uiThemesLabel);
         row.add(uiThemes);

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -201,6 +201,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String SHOW_DAMAGE_LEVEL = "ShowDamageLevel";
     public static final String SKIN_FILE = "SkinFile";
     public static final String DEFAULT_WEAP_SORT_ORDER = "DefaultWeaponSortOrder";
+    public static final String UI_THEME = "UITheme";
     
     // RAT dialog preferences
     public static String RAT_TECH_LEVEL = "RATTechLevel";
@@ -370,6 +371,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(SHOW_DAMAGE_LEVEL, false);
         store.setDefault(SKIN_FILE, "BW - Default.xml");
         store.setDefault(SOFTCENTER, false);
+        store.setDefault(UI_THEME, javax.swing.UIManager.getSystemLookAndFeelClassName());
 
         store.setDefault(RAT_TECH_LEVEL, 0);
         store.setDefault(RAT_BV_MIN, "5800");
@@ -794,6 +796,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
         return store.getString(SKIN_FILE);
     }
 
+    public String getUITheme() {
+        return store.getString(UI_THEME);
+    }
+
     public int getDefaultWeaponSortOrder() {
         return store.getInt(DEFAULT_WEAP_SORT_ORDER);
     }
@@ -1181,6 +1187,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
     
     public void setSkinFile(String s) {
         store.setValue(SKIN_FILE, s);
+    }
+
+    public void setUITheme(String s) {
+        store.setValue(UI_THEME, s);
     }
     
     public void setDefaultWeaponSortOrder(int i) {

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -23,6 +23,7 @@ import java.awt.DisplayMode;
 import java.awt.Font;
 import java.awt.FontFormatException;
 import java.awt.FontMetrics;
+import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.GraphicsEnvironment;
 import java.awt.GridBagConstraints;
@@ -37,6 +38,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
+import java.awt.Window;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -53,6 +55,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
@@ -144,9 +147,15 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
         System.setProperty("com.apple.mrj.application.apple.menu.about.name",
                 "MegaMek");
 
+        // Add additional themes
+        UIManager.installLookAndFeel("Flat Light", "com.formdev.flatlaf.FlatLightLaf");
+        UIManager.installLookAndFeel("Flat IntelliJ", "com.formdev.flatlaf.FlatIntelliJLaf");
+        UIManager.installLookAndFeel("Flat Dark", "com.formdev.flatlaf.FlatDarkLaf");
+        UIManager.installLookAndFeel("Flat Darcula", "com.formdev.flatlaf.FlatDarculaLaf");
+
         // this should also help to make MegaMek look more system-specific
         try {
-            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+            UIManager.setLookAndFeel(GUIPreferences.getInstance().getUITheme());
         } catch (Exception e) {
             System.err.println("Error setting look and feel!");
             e.printStackTrace();
@@ -1168,6 +1177,23 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
         if (e.getName().equals(GUIPreferences.SKIN_FILE)) {
             showMainMenu();
             frame.repaint();
+        } else if (e.getName().equals(GUIPreferences.UI_THEME)) {
+            try {
+                UIManager.setLookAndFeel((String)e.getNewValue());
+                // We went all Oprah and gave everybody frames...
+                // so now we have to let everybody who got a frame
+                // under their chair know that we updated our look
+                // and feel.
+                for (Frame f : Frame.getFrames()) {
+                    SwingUtilities.updateComponentTreeUI(f);
+                }
+                // ...and also all of our windows and dialogs, etc.
+                for (Window w : Window.getWindows()) {
+                    SwingUtilities.updateComponentTreeUI(w);
+                }
+            } catch (Exception ex) {
+                DefaultMmLogger.getInstance().error(getClass(), "preferenceChange(GUIPreferences.UI_THEME)", ex);
+            }
         }
     }
     

--- a/megamek/src/megamek/client/ui/swing/UITheme.java
+++ b/megamek/src/megamek/client/ui/swing/UITheme.java
@@ -1,0 +1,67 @@
+package megamek.client.ui.swing;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Represents a UI Theme for Swing.
+ */
+public class UITheme {
+    private final String name;
+    private final String className;
+
+    /**
+     * Creates a new {@code UITheme} class.
+     * @param className The class name to load the UI Theme.
+     */
+    public UITheme(String className) {
+        this(className, className);
+    }
+
+    /**
+     * Creates a new {@code UITheme} class.
+     * @param name The optional name of the UI Theme.
+     * @param className The class name to load the UI Theme.
+     */
+    public UITheme(String className, String name) {
+        this.className = Objects.requireNonNull(className);
+        this.name = Optional.ofNullable(name).orElse(className);
+    }
+
+    /**
+     * Gets the name of the theme.
+     * @return The name of the theme.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the class name to load the theme with.
+     * @return The class name of the theme.
+     */
+    public String getClassName() {
+        return className;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        return className.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        } else if (other == null || other.getClass() != getClass()) {
+            return false;
+        } else {
+            return getClassName().equals(((UITheme)other).getClassName());
+        }
+    }
+}


### PR DESCRIPTION
This adds theme selection to MM and adds dark themes. Still TODO:

- Making the themes selectable by name rather than class name.
- Making tables use the correct row backgrounds
- Make all the various sub-UI's support theming

![image](https://user-images.githubusercontent.com/8238690/73614854-fd18da80-45d0-11ea-8f9b-a3efc1b1a05e.png)

![image](https://user-images.githubusercontent.com/8238690/73614856-07d36f80-45d1-11ea-8467-47c224930812.png)

![image](https://user-images.githubusercontent.com/8238690/73614871-25083e00-45d1-11ea-95c1-a522d26db97a.png)

![image](https://user-images.githubusercontent.com/8238690/73614866-1f125d00-45d1-11ea-97a4-5b996d9c3fe2.png)
