### PR TITLE
introduce boundary conditions for current bay doors; only destroy one…

### DIFF
--- a/megamek/src/megamek/common/Bay.java
+++ b/megamek/src/megamek/common/Bay.java
@@ -133,7 +133,8 @@ public class Bay implements Transporter, ITechnology {
     }
 
     public int getCurrentDoors() {
-        return currentdoors;
+        // defense against invalid values
+        return Math.min(doors, Math.max(currentdoors, 0));
     }
 
     public void setCurrentDoors(int d) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8055,7 +8055,6 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                                                                           .size()));
             chosenBay.destroyDoor();
             chosenBay.resetDoors();
-            chosenBay.setCurrentDoors(chosenBay.getCurrentDoors() - 1);
             bayType = chosenBay.getType();
         }
 


### PR DESCRIPTION
Uncovered this issue when attempting to edit a dropship with a blown-out bay door after a battle. The edit button mysteriously generated an NPE.

Two-pronged approach: 
- eliminate double bay door destruction when damaging a bay door
- check for boundary conditions when retrieving "current number of doors" for a bay.