### PR TITLE
Don't count multiple slots for armored cockpit

### DIFF
--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -848,7 +848,7 @@ public class TestMech extends TestEntity {
                     // Armored cockpit (including command console) adds 1 ton, regardless of number of slots
                     if ((cs.getType() == CriticalSlot.TYPE_SYSTEM)
                             && (cs.getIndex() == Mech.SYSTEM_COCKPIT)) {
-                        cockpitWeight = 1.0;;
+                        cockpitWeight = 1.0;
                     } else {
                         weight += 0.5;
                     }

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -840,21 +840,22 @@ public class TestMech extends TestEntity {
     @Override
     public double getArmoredComponentWeight() {
         double weight = 0.0;
-
+        double cockpitWeight = 0.0;
         for (int location = Mech.LOC_HEAD; location < mech.locations(); location++) {
             for (int slot = 0; slot < mech.getNumberOfCriticals(location); slot++) {
                 CriticalSlot cs = mech.getCritical(location, slot);
                 if ((cs != null) && cs.isArmored()) {
-                    weight += 0.5;
-
+                    // Armored cockpit (including command console) adds 1 ton, regardless of number of slots
                     if ((cs.getType() == CriticalSlot.TYPE_SYSTEM)
                             && (cs.getIndex() == Mech.SYSTEM_COCKPIT)) {
+                        cockpitWeight = 1.0;;
+                    } else {
                         weight += 0.5;
                     }
                 }
             }
         }
-        return weight;
+        return weight + cockpitWeight;
     }
 
     /**


### PR DESCRIPTION
Per rules for armored components (Tac Ops, p. 282), adding armor to any cockpit system (including command console) simply adds one ton to the cockpit weight. Currently we are adding one ton per slot, which results in an extra ton for multi-slot cockpits (command console, quadvee, unofficial dual cockpit).

Fixes #422