### PR TITLE
Check for water or ice when WiGE sideslips

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -5322,10 +5322,6 @@ public class Server implements Runnable {
             // but VTOL keep altitude
             if (entity.getMovementMode() == EntityMovementMode.VTOL) {
                 nextAltitude = Math.max(nextAltitude, curAltitude);
-            } else if (entity.getMovementMode() == EntityMovementMode.WIGE
-                    && elevation > 0 && nextAltitude < curAltitude) {
-                // Airborne WiGEs drop to one level above the surface
-                nextAltitude++;
             } else {
                 // Is there a building to "catch" the unit?
                 if (nextHex.containsTerrain(Terrains.BLDG_ELEV)) {
@@ -5363,16 +5359,25 @@ public class Server implements Runnable {
                 }
                 if ((nextAltitude <= nextHex.surface())
                     && (curAltitude >= curHex.surface())) {
-                    // Hovercraft can "skid" over water.
+                    // Hovercraft and WiGEs can "skid" over water.
                     // all units can skid over ice.
-                    if ((entity instanceof Tank)
-                            && (entity.getMovementMode() == EntityMovementMode.HOVER)
+                    if ((entity.getMovementMode().equals(EntityMovementMode.HOVER)
+                                || entity.getMovementMode().equals(EntityMovementMode.WIGE))
                             && nextHex.containsTerrain(Terrains.WATER)) {
                         nextAltitude = nextHex.surface();
                     } else {
                         if (nextHex.containsTerrain(Terrains.ICE)) {
                             nextAltitude = nextHex.surface();
                         }
+                    }
+                }
+                if (entity.getMovementMode() == EntityMovementMode.WIGE
+                        && elevation > 0 && nextAltitude < curAltitude) {
+                    // Airborne WiGEs drop to one level above the surface
+                    if (entity.climbMode()) {
+                        nextAltitude = curAltitude;
+                    } else {
+                        nextAltitude++;
                     }
                 }
             }


### PR DESCRIPTION
A WiGE sideslipping into a hex with water or ice is using the floor of the hex instead of the surface for its next elevation. Moving the block that deals with WiGE elevation also takes buildings into account. It also now checks the climb mode to see whether it should maintain elevation or drop to one level above the surface.

Fixes #1647