### PR TITLE
Further refine theme support #1479

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
@@ -156,7 +156,6 @@ public class BotConfigDialog extends JDialog implements ActionListener, KeyListe
                                                TitledBorder.LEFT,
                                                TitledBorder.DEFAULT_POSITION);
         panel.setBorder(border);
-        panel.setBackground(Color.white);
         String longestEntry = title;
 
         Vector<String> playerList = new Vector<>(ghostPlayers.size());

--- a/megamek/src/megamek/client/ui/swing/CamoChoiceDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CamoChoiceDialog.java
@@ -45,6 +45,7 @@ import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.JTree;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.UIManager;
 import javax.swing.event.MouseInputAdapter;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
@@ -555,14 +556,15 @@ public class CamoChoiceDialog extends JDialog implements TreeSelectionListener {
                     Object value, boolean isSelected, boolean hasFocus,
                     int row, int column) {
                 Component c = this;
-                setOpaque(true);
                 String name = getValueAt(row, column).toString();
                 setText(getValueAt(row, column).toString());
                 setImage(category, name);
                 if (isSelected) {
-                    setBackground(new Color(220, 220, 220));
+                    setBackground(UIManager.getColor("Table.selectionBackground"));
+                    setForeground(UIManager.getColor("Table.selectionForeground"));
                 } else {
-                    setBackground(Color.WHITE);
+                    setBackground(UIManager.getColor("Table.background"));
+                    setForeground(UIManager.getColor("Table.foreground"));
                 }
 
                 return c;

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -75,6 +75,7 @@ import javax.swing.ListModel;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.event.MouseInputAdapter;
@@ -3466,16 +3467,35 @@ public class ChatLounge extends AbstractPhaseDisplay
                                         .booleanOption(OptionsConstants.RPG_TOUGHNESS)));
                     }
                 }
+
                 if (isSelected) {
-                    c.setBackground(Color.DARK_GRAY);
+                    c.setForeground(table.getSelectionForeground());
+                    c.setBackground(table.getSelectionBackground());
                 } else {
-                    // tiger stripes
-                    if ((row % 2) == 0) {
-                        c.setBackground(new Color(220, 220, 220));
-                    } else {
-                        c.setBackground(Color.WHITE);
+                    Color background = table.getBackground();
+                    if (row % 2 != 0) {
+                        Color alternateColor = UIManager.getColor("Table.alternateRowColor");
+                        if (alternateColor != null) {
+                            background = alternateColor;
+                        }
+                    }
+                    c.setForeground(table.getForeground());
+                    c.setBackground(background);
+                }
+
+                if (hasFocus) {
+                    if (!isSelected ) {
+                        Color col = UIManager.getColor("Table.focusCellForeground");
+                        if (col != null) {
+                            c.setForeground(col);
+                        }
+                        col = UIManager.getColor("Table.focusCellBackground");
+                        if (col != null) {
+                            c.setBackground(col);
+                        }
                     }
                 }
+
                 return c;
             }
 
@@ -4399,7 +4419,7 @@ public class ChatLounge extends AbstractPhaseDisplay
         }
 
     }
-
+    
     public class MekInfo extends JPanel {
 
         /**
@@ -4447,11 +4467,7 @@ public class ChatLounge extends AbstractPhaseDisplay
         }
 
         public void setText(String s, boolean isSelected) {
-            String color = "black";
-            if (isSelected) {
-                color = "white";
-            }
-            lblImage.setText("<html><font size='2' color='" + color + "'>" + s + "</font></html>");
+            lblImage.setText(String.format("<html>%s</html>", s));
         }
 
         public void clearImage() {

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -3475,6 +3475,11 @@ public class ChatLounge extends AbstractPhaseDisplay
                     Color background = table.getBackground();
                     if (row % 2 != 0) {
                         Color alternateColor = UIManager.getColor("Table.alternateRowColor");
+                        if (alternateColor == null) {
+                            // If we don't have an alternate row color, use 'controlHighlight'
+                            // as it is pretty reasonable across the various themes.
+                            alternateColor = UIManager.getColor("controlHighlight");
+                        }
                         if (alternateColor != null) {
                             background = alternateColor;
                         }
@@ -4419,7 +4424,7 @@ public class ChatLounge extends AbstractPhaseDisplay
         }
 
     }
-    
+
     public class MekInfo extends JPanel {
 
         /**

--- a/megamek/src/megamek/client/ui/swing/ForceGeneratorOptionsView.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGeneratorOptionsView.java
@@ -35,6 +35,7 @@ import javax.swing.JTextField;
 import javax.swing.JTree;
 import javax.swing.ProgressMonitor;
 import javax.swing.SwingWorker;
+import javax.swing.UIManager;
 import javax.swing.event.TreeModelListener;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreeModel;
@@ -1174,12 +1175,11 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
                     tree, value, sel,
                     expanded, leaf, row,
                     hasFocus);
-            setOpaque(true);
-            setBackground(Color.WHITE);
-            setForeground(Color.BLACK);
+            setBackground(UIManager.getColor("Tree.textBackground"));
+            setForeground(UIManager.getColor("Tree.textForeground"));
             if(sel) {
-                setBackground(Color.DARK_GRAY);
-                setForeground(Color.WHITE);
+                setBackground(UIManager.getColor("Tree.selectionBackground"));
+                setForeground(UIManager.getColor("Tree.selectionForeground"));
             }
 
             ForceDescriptor fd = (ForceDescriptor)value;

--- a/megamek/src/megamek/client/ui/swing/ForceGeneratorViewUi.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGeneratorViewUi.java
@@ -42,6 +42,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTree;
 import javax.swing.ListSelectionModel;
+import javax.swing.UIManager;
 import javax.swing.event.TreeExpansionEvent;
 import javax.swing.event.TreeExpansionListener;
 import javax.swing.event.TreeModelListener;
@@ -508,12 +509,11 @@ public class ForceGeneratorViewUi {
                     tree, value, sel,
                     expanded, leaf, row,
                     hasFocus);
-            setOpaque(true);
-            setBackground(Color.WHITE);
-            setForeground(Color.BLACK);
+            setBackground(UIManager.getColor("Tree.textBackground"));
+            setForeground(UIManager.getColor("Tree.textForeground"));
             if(sel) {
-                setBackground(Color.DARK_GRAY);
-                setForeground(Color.WHITE);
+                setBackground(UIManager.getColor("Tree.selectionBackground"));
+                setForeground(UIManager.getColor("Tree.selectionForeground"));
             }
 
             ForceDescriptor fd = (ForceDescriptor)value;

--- a/megamek/src/megamek/client/ui/swing/MechViewPanel.java
+++ b/megamek/src/megamek/client/ui/swing/MechViewPanel.java
@@ -20,7 +20,6 @@
 
 package megamek.client.ui.swing;
 
-import java.awt.Color;
 import java.awt.ComponentOrientation;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
@@ -67,8 +66,6 @@ public class MechViewPanel extends JPanel {
     
     public MechViewPanel(int width, int height, boolean noBorder) {
  
-        setBackground(Color.WHITE);
-        
         icon = null;
         
         txtMek = new JTextPane();

--- a/megamek/src/megamek/client/ui/swing/PlayerListDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PlayerListDialog.java
@@ -15,7 +15,6 @@
 package megamek.client.ui.swing;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
@@ -56,8 +55,6 @@ public class PlayerListDialog extends JDialog implements ActionListener {
         getContentPane().setLayout(new BorderLayout());
 
         JPanel listPan = new JPanel();
-        listPan.setBackground(Color.white);
-        playerList.setBackground(Color.white);
         listPan.add(playerList, BorderLayout.NORTH);
         listPan.add(Box.createVerticalStrut(40), BorderLayout.SOUTH);
 

--- a/megamek/src/megamek/client/ui/swing/PortraitChoiceDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PortraitChoiceDialog.java
@@ -15,7 +15,6 @@
 
 package megamek.client.ui.swing;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -38,6 +37,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
+import javax.swing.UIManager;
 import javax.swing.event.MouseInputAdapter;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
@@ -374,9 +374,11 @@ public class PortraitChoiceDialog extends JDialog {
                    setText(getValueAt(row, column).toString());
                    setImage(category, name);
                    if(isSelected) {
-                       setBackground(new Color(220,220,220));
+                       setBackground(UIManager.getColor("Table.selectionBackground"));
+                       setForeground(UIManager.getColor("Table.selectionForeground"));
                    } else {
-                       setBackground(Color.WHITE);
+                    setBackground(UIManager.getColor("Table.background"));
+                    setForeground(UIManager.getColor("Table.foreground"));
                    }
     
                    return c;

--- a/megamek/src/megamek/client/ui/swing/util/MenuScroller.java
+++ b/megamek/src/megamek/client/ui/swing/util/MenuScroller.java
@@ -4,7 +4,6 @@
 
 package megamek.client.ui.swing.util;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -19,6 +18,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.MenuSelectionManager;
 import javax.swing.Timer;
+import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.PopupMenuEvent;
@@ -578,10 +578,10 @@ public class MenuScroller {
     public void paintIcon(Component c, Graphics g, int x, int y) {
       Dimension size = c.getSize();
       Graphics g2 = g.create(size.width / 2 - 5, size.height / 2 - 5, 10, 10);
-      g2.setColor(Color.GRAY);
+      g2.setColor(UIManager.getColor("MenuItem.disabledForeground"));
       g2.drawPolygon(xPoints, yPoints, 3);
       if (c.isEnabled()) {
-        g2.setColor(Color.BLACK);
+        g2.setColor(UIManager.getColor("MenuItem.foreground"));
         g2.fillPolygon(xPoints, yPoints, 3);
       }
       g2.dispose();


### PR DESCRIPTION
This builds upon the addition of theme support for MegaMek in #1644 by making as many of the components as lookless as possible. Because we override some areas with HTML, there may still be places this missed. That being said, this is enough of a start to send it out into the wild, and should more than address #1479.
![image](https://user-images.githubusercontent.com/8238690/74108023-b3397280-4b43-11ea-96c3-701c76210df7.png)
![image](https://user-images.githubusercontent.com/8238690/74108029-bf253480-4b43-11ea-9e1b-443447c99eb1.png)
![image](https://user-images.githubusercontent.com/8238690/74108039-eda30f80-4b43-11ea-8245-a8be725cb55c.png)
![image](https://user-images.githubusercontent.com/8238690/74108042-f72c7780-4b43-11ea-94ea-8c1fcfb44af2.png)
![image](https://user-images.githubusercontent.com/8238690/74108047-03183980-4b44-11ea-866f-7b03f56d341d.png)

