### PR TITLE
Fixing AIDocs references

### DIFF
--- a/megamek/docs/help/en/PrincessBotDocumentation.html
+++ b/megamek/docs/help/en/PrincessBotDocumentation.html
@@ -48,7 +48,8 @@
     commanding more than a half-dozen units, it slows down exponentially
     when attempting to determine which unit to move next.&nbsp; You can
     get more details about the TestBot in the ai-readme.txt
-    document.<BR><BR>The Princess Bot was written many years after in an
+    document located in the docs folder, then in the Bot Stuff folder.
+    <BR><BR>The Princess Bot was written many years after in an
     attempt to create an AI that would process quicker even if it were
     slightly dimmer. Princess offers a few advantages over TestBot.&nbsp;
     First, Princess is still being maintained, though not by the original

--- a/megamek/i18n/megamek/client/bot/messages.properties
+++ b/megamek/i18n/megamek/client/bot/messages.properties
@@ -1,5 +1,5 @@
 BotClient.Hi=Hi, I'm a bot client\!
 BotClient.HowAbout=How about a nice game of chess?
 BotClient.Bye=Dave, this conversation can serve no purpose anymore. Goodbye.
-BotGUI.notifyOfBot.title=Please read the ai-readme.txt
-BotGUI.notifyOfBot.message=The bot does not work with all units or game options.\nPlease read the ai-readme.txt file before using the bot.\n \nWould you like to read the AI documentation now?\n
+BotGUI.notifyOfBot.title=Please read the ai-readme.txt located in the docs/Bot Stuff folder
+BotGUI.notifyOfBot.message=The bot does not work with all units or game options.\nPlease read the ai-readme.txt file in the docs/Bot Stuff folder before using the bot.\n \nWould you like to read the AI documentation now?\n

--- a/megamek/src/megamek/client/bot/ui/swing/BotGUI.java
+++ b/megamek/src/megamek/client/bot/ui/swing/BotGUI.java
@@ -82,7 +82,7 @@ public class BotGUI implements GameListener {
             }
 
             if (confirm.getAnswer()) {
-                File helpfile = new File("docs/ai-readme.txt"); //$NON-NLS-1$
+                File helpfile = new File("docs/Bot Stuff/ai-readme.txt"); //$NON-NLS-1$
                 new CommonHelpDialog(frame, helpfile).setVisible(true);
             }
         }


### PR DESCRIPTION
This fixes an issue where the AI Documentation was in a different location than the code expected, so it failed to load.