### PR TITLE
Freezers

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -6832,7 +6832,7 @@ public class MiscType extends EquipmentType {
         misc.rulesRefs = "71, IO";
         misc.techAdvancement.setTechBase(TECH_BASE_IS).setISAdvancement(2559, DATE_NONE, DATE_NONE, 2567, DATE_NONE)
                 .setISApproximate(true, false, false, true, false).setPrototypeFactions(F_TH).setTechRating(RATING_E)
-                .setAvailability(RATING_F, RATING_X, RATING_X, RATING_X);
+                .setAvailability(RATING_F, RATING_X, RATING_X, RATING_X).setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
         return misc;
     }
 
@@ -6850,7 +6850,7 @@ public class MiscType extends EquipmentType {
         misc.rulesRefs = "71, IO";
         misc.techAdvancement.setTechBase(TECH_BASE_IS).setISAdvancement(3022, DATE_NONE, DATE_NONE, 3040, DATE_NONE)
                 .setISApproximate(true, false, false, true, false).setPrototypeFactions(F_FS).setTechRating(RATING_E)
-                .setAvailability(RATING_X, RATING_F, RATING_X, RATING_X);
+                .setAvailability(RATING_X, RATING_F, RATING_X, RATING_X).setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
         return misc;
     }
 

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -553,7 +553,7 @@ public class TestMech extends TestEntity {
                         && (m.getUsableShotsLeft() <= 1)) {
                     continue;
                 }
-                if ((mech instanceof Mech) && (m.getType().getCriticals(mech) == 0)) {
+                if (m.getType().getCriticals(mech) == 0) {
                     continue;
                 }
                 if (!(m.getType() instanceof MiscType)) {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -541,19 +541,19 @@ public class TestMech extends TestEntity {
         return false;
     }
 
-    public boolean checkCriticalSlotsForEquipment(Entity entity,
+    public boolean checkCriticalSlotsForEquipment(Mech mech,
             Vector<Mounted> unallocated, Vector<Serializable> allocation,
             Vector<Integer> heatSinks, StringBuffer buff) {
         boolean legal = true;
         int countInternalHeatSinks = 0;
-        for (Mounted m : entity.getEquipment()) {
+        for (Mounted m : mech.getEquipment()) {
             int loc = m.getLocation();
             if (loc == Entity.LOC_NONE) {
                 if ((m.getType() instanceof AmmoType)
                         && (m.getUsableShotsLeft() <= 1)) {
                     continue;
                 }
-                if ((entity instanceof Mech) && (m.getType().getCriticals(entity) == 0)) {
+                if ((mech instanceof Mech) && (m.getType().getCriticals(mech) == 0)) {
                     continue;
                 }
                 if (!(m.getType() instanceof MiscType)) {
@@ -571,8 +571,8 @@ public class TestMech extends TestEntity {
                 }
             }
             // Check for illegal allocations
-            if (entity.isOmni()
-                    && (entity instanceof BipedMech)
+            if (mech.isOmni()
+                    && (mech instanceof BipedMech)
                     && ((loc == Mech.LOC_LARM) || (loc == Mech.LOC_RARM))
                     && ((m.getType() instanceof GaussWeapon)
                             || (m.getType() instanceof ACWeapon)
@@ -589,21 +589,19 @@ public class TestMech extends TestEntity {
                 } else if (m.getType() instanceof PPCWeapon) {
                     weapon = "PPCs";
                 }
-                if (entity.hasSystem(Mech.ACTUATOR_LOWER_ARM, loc)
-                        || entity.hasSystem(Mech.ACTUATOR_HAND, loc)) {
-                    buff.append("Omni mechs with arm mounted " + weapon
-                            + " cannot have lower armor or hand actuators!\n");
+                if (mech.hasSystem(Mech.ACTUATOR_LOWER_ARM, loc)
+                        || mech.hasSystem(Mech.ACTUATOR_HAND, loc)) {
+                    buff.append("Omni mechs with arm mounted ").append(weapon)
+                            .append(" cannot have lower armor or hand actuators!\n");
                     legal = false;
                 }
             }
         }
-        if ((countInternalHeatSinks > engine.integralHeatSinkCapacity(mech
-                .hasCompactHeatSinks()))
-                || ((countInternalHeatSinks < engine
-                        .integralHeatSinkCapacity(mech.hasCompactHeatSinks()))
-                        && (countInternalHeatSinks != ((Mech) entity)
-                                .heatSinks()) && !entity.isOmni())) {
-            heatSinks.addElement(Integer.valueOf(countInternalHeatSinks));
+        if ((countInternalHeatSinks > engine.integralHeatSinkCapacity(this.mech.hasCompactHeatSinks()))
+                || ((countInternalHeatSinks < engine.integralHeatSinkCapacity(this.mech.hasCompactHeatSinks()))
+                        && (countInternalHeatSinks != mech.heatSinks(false))
+                && !mech.isOmni())) {
+            heatSinks.addElement(countInternalHeatSinks);
         }
         return legal;
     }


### PR DESCRIPTION
This fixes a couple things related to prototype double heat sinks which I ran into while working on MegaMek/megameklab#438. The rules are found in IO, p. 71. The brief summary is that the unit may replace any number of single heat sinks with a prototype double heat sink, but the double heat sinks must always be assigned critical slots (on Mechs), even if this leaves some of the engine capacity unmet. The two types of prototype double heat sinks are identical in function, but not considered the same part, as the one developed in the 3020s (often called "freezers") were developed independently rather than being recovered Star League lostech.

1. During validation, ignore the prototype double heat sinks when checking whether all the engine internal heat sinks are accounted for.
2. Set the tech level to experimental, which is the same for all prototype equipment.