### PR TITLE
Fix #1679 Vertical Lift Off PSR incorrectly applying crater modifier

### DIFF
--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -367,7 +367,9 @@ public interface IAero {
         // TW doesn't define what a crater is, assume it means that the hex
         // level of all surrounding hexes is greater than what we are sitting on
         boolean allAdjacentHigher = true;
-        Set<Coords> positions = new HashSet<Coords>(((Entity) this).getSecondaryPositions().values());
+        Set<Coords> positions = new HashSet<>();
+        positions.add(pos);
+        positions.addAll((((Entity) this).getSecondaryPositions().values()));
         IHex adjHex;
         for (Coords currPos : positions) {
             hex = ((Entity) this).getGame().getBoard().getHex(currPos);

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -367,9 +367,8 @@ public interface IAero {
         // TW doesn't define what a crater is, assume it means that the hex
         // level of all surrounding hexes is greater than what we are sitting on
         boolean allAdjacentHigher = true;
-        Set<Coords> positions = new HashSet<>();
+        Set<Coords> positions = new HashSet<Coords>(((Entity) this).getSecondaryPositions().values());
         positions.add(pos);
-        positions.addAll((((Entity) this).getSecondaryPositions().values()));
         IHex adjHex;
         for (Coords currPos : positions) {
             hex = ((Entity) this).getGame().getBoard().getHex(currPos);


### PR DESCRIPTION
Make crater check logic include the Entity's current hex, to support single hex Entities (e.g. ASFs)

#1679