### PR TITLE
Allow units with C3 and Nova CEWS to link with the units with C3 and without Nova on lobby

### DIFF
--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1739,10 +1739,6 @@ public class EquipChoicePanel extends JPanel implements Serializable {
                 if (entity.hasNavalC3() != e.hasNavalC3()) {
                     continue;
                 }
-                // likewise can't connect c3 to nova
-                if (entity.hasNovaCEWS() != e.hasNovaCEWS()) {
-                    continue;
-                }
                 // maximum depth of a c3 network is 2 levels.
                 Entity eCompanyMaster = e.getC3Master();
                 if ((eCompanyMaster != null)


### PR DESCRIPTION
I hope that it will fix #1664. 

Currently, you can't link Nova in the lobby unlike C3, and you can only do that by type /nova link numbers123 manually. And the check only see if both the unit and target have Nova or does not have Nova. So the phrase is unnecessary I think. Is there anything I have missed?