### PR TITLE
Check equipment compatibility with motive type when validating vehicles

### DIFF
--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -1007,6 +1007,15 @@ public class TestSupportVehicle extends TestEntity {
             buff.append("Omni configuration exceeds weapon capacity of base chassis fire control system.\n");
             correct = false;
         }
+        if (supportVee instanceof Tank) {
+            for (Mounted m : supportVee.getEquipment()) {
+                if (!TestTank.legalForMotiveType(m.getType(), supportVee.getMovementMode())) {
+                    buff.append(m.getType().getName()).append(" is incompatible with ")
+                            .append(supportVee.getMovementModeAsString());
+                    correct = false;
+                }
+            }
+        }
         for (int loc = 0; loc < supportVee.locations(); loc++) {
             int count = 0;
             for (Mounted misc : supportVee.getMisc()) {

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -406,6 +406,10 @@ public class TestTank extends TestEntity {
                     correct = false;
                 }
             }
+            if (!legalForMotiveType(m.getType(), tank.getMovementMode())) {
+                buff.append(m.getType().getName()).append(" is incompatible with ").append(tank.getMovementModeAsString());
+                correct = false;
+            }
         }
         for (int loc = 0; loc < tank.locations(); loc++) {
             int count = 0;
@@ -449,6 +453,55 @@ public class TestTank extends TestEntity {
             correct = false;
         }
         return correct;
+    }
+
+    /**
+     * Checks whether the equipment is compatible with the vehicle's motive type
+     *
+     * @param eq   The equipment to check
+     * @param mode The vehicle's motive type
+     * @return     Whether the equipment and motive type are compatible
+     */
+    public static boolean legalForMotiveType(EquipmentType eq, EntityMovementMode mode) {
+        if (eq.hasFlag(MiscType.F_FLOTATION_HULL)) {
+            // Per errata, WiGE vehicles automatically include flotation hull
+            return mode.equals(EntityMovementMode.HOVER) || mode.equals(EntityMovementMode.VTOL);
+        }
+        if (eq.hasFlag(MiscType.F_FULLY_AMPHIBIOUS)
+                || eq.hasFlag(MiscType.F_LIMITED_AMPHIBIOUS)
+                || eq.hasFlag(MiscType.F_BULLDOZER)
+                || (eq.hasFlag(MiscType.F_CLUB) && eq.hasSubType(MiscType.S_COMBINE))) {
+            return mode.equals(EntityMovementMode.WHEELED) || mode.equals(EntityMovementMode.TRACKED);
+        }
+        if (eq.hasFlag(MiscType.F_DUNE_BUGGY)) {
+            return mode.equals(EntityMovementMode.WHEELED);
+        }
+        if (eq.hasFlag(MiscType.F_CLUB)
+                && eq.hasSubType(MiscType.S_CHAINSAW | MiscType.S_DUAL_SAW | MiscType.S_MINING_DRILL)) {
+            return mode.equals(EntityMovementMode.WHEELED) || mode.equals(EntityMovementMode.TRACKED)
+                    || mode.equals(EntityMovementMode.HOVER) || mode.equals(EntityMovementMode.WIGE);
+        }
+        if (eq.hasFlag(MiscType.F_LIFEBOAT)) {
+            // Need to filter out atmospheric lifeboat
+            return eq.hasFlag(MiscType.F_TANK_EQUIPMENT)
+                    && (mode.equals(EntityMovementMode.NAVAL)
+                    || mode.equals(EntityMovementMode.HYDROFOIL)
+                    || mode.equals(EntityMovementMode.SUBMARINE));
+        }
+        if (eq.hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER)
+                || eq.hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER)
+                || eq.hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER)
+                || (eq.hasFlag(MiscType.F_CLUB)
+                && eq.hasSubType(MiscType.S_BACKHOE | MiscType.S_ROCK_CUTTER
+                | MiscType.S_SPOT_WELDER | MiscType.S_WRECKING_BALL))) {
+            return !mode.equals(EntityMovementMode.VTOL);
+        }
+        if (eq.hasFlag(MiscType.F_CLUB) && eq.hasSubType(MiscType.S_PILE_DRIVER)) {
+            return !mode.equals(EntityMovementMode.VTOL)
+                    && !mode.equals(EntityMovementMode.HOVER)
+                    && !mode.equals(EntityMovementMode.WIGE);
+        }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
This is part of the fix for MegaMek/megameklab#440. The bug report only mentions combat vehicle flotation hull, but I have included the amphibious and dune buggy CV mods, as well as industrial equipment and a few other equipment types I noticed. The logic is in a public static method in TestTank where it can be used by TestSupportVehicle, as well as MML in equipment filtering.