### PR TITLE
Supercharger and VTOL jet booster cost for support vehicles

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -867,7 +867,7 @@ public class MiscType extends EquipmentType {
                             * entity.getWeight() * 0.025f);
                 } else if (entity instanceof BattleArmor) {
                     costValue = entity.getOriginalWalkMP() * 75000;
-                } else if (hasSubType(MiscType.S_SUPERCHARGER)) {
+                } else if (hasSubType(MiscType.S_SUPERCHARGER) || hasSubType(MiscType.S_JETBOOSTER)) {
                     Engine e = entity.getEngine();
                     if (e == null) {
                         costValue = 0;

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -859,8 +859,6 @@ public class MiscType extends EquipmentType {
                 costValue = getTonnage(entity, loc) * 1000;
             } else if (hasFlag(F_ARMORED_MOTIVE_SYSTEM)) {
                 costValue = getTonnage(entity, loc) * 100000;
-            } else if (hasFlag(F_JET_BOOSTER)) {
-                costValue = (entity.hasEngine() ? entity.getEngine().getRating() * 10000 : 0);
             } else if (hasFlag(F_DRONE_OPERATING_SYSTEM)) {
                 costValue = (getTonnage(entity, loc) * 10000) + 5000;
             } else if (hasFlag(MiscType.F_MASC)) {
@@ -873,6 +871,8 @@ public class MiscType extends EquipmentType {
                     Engine e = entity.getEngine();
                     if (e == null) {
                         costValue = 0;
+                    } else if (entity.isSupportVehicle()) {
+                        costValue = e.getWeightEngine(entity) * 10000;
                     } else {
                         costValue = e.getRating() * 10000;
                     }


### PR DESCRIPTION
The supercharger and VTOL jet booster both have a cost formula of 10,000 x engine rating. Per errata (TacOps v3.03, p. 90), support vehicles use engine tonnage, since they don't have an engine rating. I looked over the cost tables in TM, TO, and IO and didn't see any other equipment affected. I also consolidated the code for the two items.

See MegaMek/megameklab#450