### PR TITLE
Show vehicle lift equipment on cost breakdown

### DIFF
--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2516,7 +2516,7 @@ public class Tank extends Entity {
         // find the maximum length of the columns.
         for (int l = 0; l < left.size(); l++) {
 
-            if (l == 8) {
+            if (l == 7) {
                 getWeaponsAndEquipmentCost(true);
             }else {
                 if (left.get(l).equals("Final Structural Cost")) {


### PR DESCRIPTION
The whole BV and cost calculations are great candidates for refactoring, but for now this fixes an incorrect index that results in the equipment cost breakdown replacing the lift equipment entry instead of the total equipment cost.

Fixes MegaMek/megameklab#451