### PR TITLE
Fix light suction system system weight.

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -7242,7 +7242,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 1;
         misc.tonnage = .5;
         misc.cost = 1000;
-        misc.flags = misc.flags.or(F_FLUID_SUCTION_SYSTEM).or(F_MECH_EQUIPMENT).andNot(F_SC_EQUIPMENT)
+        misc.flags = misc.flags.or(F_LIGHT_FLUID_SUCTION_SYSTEM).or(F_MECH_EQUIPMENT).andNot(F_SC_EQUIPMENT)
                 .andNot(F_DS_EQUIPMENT).andNot(F_JS_EQUIPMENT).andNot(F_WS_EQUIPMENT).andNot(F_SS_EQUIPMENT);
         misc.rulesRefs = "248,TM";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
@@ -7260,7 +7260,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(misc.name);
         misc.criticals = 1;
         misc.tankslots = 1;
-        misc.tonnage = .5;
+        misc.tonnage = 0.015;
         misc.cost = 1000;
         misc.flags = misc.flags.or(F_LIGHT_FLUID_SUCTION_SYSTEM).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT)
                 .andNot(F_SC_EQUIPMENT).andNot(F_DS_EQUIPMENT).andNot(F_JS_EQUIPMENT).andNot(F_WS_EQUIPMENT)


### PR DESCRIPTION
The vehicular light fluid suction system is 0.015 tons (TM, p. 344), not 0.5 tons. That's the weight for the industrial mech version. I also noticed that the mech system had the flag for the standard fluid suction system (which involves refueling) rather than the light fluid suction system (which involves spraying) and fixed that as well.

Fixes MegaMek/megameklab#453