### PR TITLE
Spot welder heat

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1374,7 +1374,8 @@ public class MiscType extends EquipmentType {
                 || hasFlag(F_VIRAL_JAMMER_HOMING)) {
             return 12;
         } else if (hasFlag(F_RISC_LASER_PULSE_MODULE)
-                || hasFlag(F_NOVA)) {
+                || hasFlag(F_NOVA)
+                || (hasFlag(F_CLUB) && hasSubType(S_SPOT_WELDER))) {
             return 2;
         }
         return 0;

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -603,12 +603,17 @@ public class TestAero extends TestEntity {
                 if ((linkedBy != null) && 
                         (linkedBy.getType() instanceof MiscType) && 
                         linkedBy.getType().hasFlag(MiscType.F_PPC_CAPACITOR)){
-                    weight += ((MiscType)linkedBy.getType()).getTonnage(aero);
+                    weight += linkedBy.getType().getTonnage(aero);
                 }
             }
-            // Power amp weighs: 
+            for (Mounted m : aero.getMisc()) {
+                if (m.getType().hasFlag(MiscType.F_CLUB) && m.getType().hasSubType(MiscType.S_SPOT_WELDER)) {
+                    weight += m.getType().getTonnage(aero);
+                }
+            }
+            // Power amp weighs:
             //   energy weapon tonnage * 0.1 rounded to nearest half ton
-            return Math.ceil(0.1 * weight*2) / 2.0;
+            return Math.ceil(0.1 * weight * 2) / 2.0;
         }
         return 0;
     }

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -606,11 +606,6 @@ public class TestAero extends TestEntity {
                     weight += linkedBy.getType().getTonnage(aero);
                 }
             }
-            for (Mounted m : aero.getMisc()) {
-                if (m.getType().hasFlag(MiscType.F_CLUB) && m.getType().hasSubType(MiscType.S_SPOT_WELDER)) {
-                    weight += m.getType().getTonnage(aero);
-                }
-            }
             // Power amp weighs:
             //   energy weapon tonnage * 0.1 rounded to nearest half ton
             return Math.ceil(0.1 * weight * 2) / 2.0;

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -851,6 +851,12 @@ public abstract class TestEntity implements TestEntityOption {
             }
         }
         for (Mounted m : getEntity().getMisc()) {
+            // Spot welders are treated as energy weapons on units that don't have a fusion or fission engine
+            if (m.getType().hasFlag(MiscType.F_CLUB) && m.getType().hasSubType(MiscType.S_SPOT_WELDER)
+                && getEntity().hasEngine() && (getEntity().getEngine().isFusion()
+                                                || getEntity().getEngine().getEngineType() == Engine.FISSION)) {
+                continue;
+            }
             heat += m.getType().getHeat();
         }
         if (getEntity().hasStealth()) {

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -807,6 +807,11 @@ public class TestSupportVehicle extends TestEntity {
                     weight += m.getLinkedBy().getType().getTonnage(supportVee);
                 }
             }
+            for (Mounted m : supportVee.getMisc()) {
+                if (m.getType().hasFlag(MiscType.F_CLUB) && m.getType().hasSubType(MiscType.S_SPOT_WELDER)) {
+                    weight += m.getType().getTonnage(supportVee);
+                }
+            }
             return ceilWeight(weight / 10);
         }
         return 0.0;

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -750,6 +750,11 @@ public class TestTank extends TestEntity {
                     weight += (m.getLinkedBy().getType()).getTonnage(tank);
                 }
             }
+            for (Mounted m : tank.getMisc()) {
+                if (m.getType().hasFlag(MiscType.F_CLUB) && m.getType().hasSubType(MiscType.S_SPOT_WELDER)) {
+                    weight += m.getType().getTonnage(tank);
+                }
+            }
             return TestEntity.ceil(weight / 10, getWeightCeilingPowerAmp());
         }
         return 0;


### PR DESCRIPTION
Spot welders generate 2 points of heat when used as a weapon (TW, p. 148, footnote in the table). But unlike any other equipment, they are treated as energy weapons only when the unit does not have a fission or fusion engine (TM, p. 248). The special exception does not affect power amplifiers, other than having to loop through the misc equipment, since fusion and fission engines never require power amplifiers. But for heat sink calculations I had to add an engine check to determine whether to include it in the heat sink requirement.

Fixes MegaMek/megameklab#455