### PR TITLE
Fix rounding in tank structure cost

### DIFF
--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2677,8 +2677,13 @@ public class Tank extends Entity {
             double techRatingMultiplier = 0.5 + (getStructuralTechRating() * 0.25);
             costs[structCostIdx] *= techRatingMultiplier;
         } else {
-            // IS has no variations, no Endo etc.
-            costs[i++] = RoundWeight.nextHalfTon(weight / 10.0) * 10000;
+            // IS has no variations, no Endo etc., but non-naval superheavies have heavier structure
+            if (!isSuperHeavy() || getMovementMode().equals(EntityMovementMode.NAVAL)
+                    || getMovementMode().equals(EntityMovementMode.SUBMARINE)) { // There are no superheavy hydrofoils
+                costs[i++] = RoundWeight.nextHalfTon(weight / 10.0) * 10000;
+            } else {
+                costs[i++] = RoundWeight.nextHalfTon(weight / 5.0) * 10000;
+            }
             double controlWeight = hasNoControlSystems() ? 0.0 : RoundWeight.nextHalfTon(weight * 0.05); // ?
             // should be rounded up to nearest half-ton
             costs[i++] = 10000 * controlWeight;

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2678,8 +2678,8 @@ public class Tank extends Entity {
             costs[structCostIdx] *= techRatingMultiplier;
         } else {
             // IS has no variations, no Endo etc.
-            costs[i++] = (weight / 10.0) * 10000;
-            double controlWeight = Math.ceil(weight * 0.05 * 2.0) / 2.0; // ?
+            costs[i++] = RoundWeight.nextHalfTon(weight / 10.0) * 10000;
+            double controlWeight = hasNoControlSystems() ? 0.0 : RoundWeight.nextHalfTon(weight * 0.05); // ?
             // should be rounded up to nearest half-ton
             costs[i++] = 10000 * controlWeight;
         }


### PR DESCRIPTION
Tank internal structure is 10,000 per ton. The structure weight should be calculated as 10% of the total weight, rounded up to the next half ton, but the cost is currently being calculated based on 10% without rounding. In addition, non-naval superheavy vehicles use 20% of the total tonnage for structure weight, which is not being accounted for.

I also noticed that the control systems cost calculation on the next line doesn't check whether it actually has control systems, which are optional in trailers that are not intended to act independently.

Fixes MegaMek/megameklab#459