### PR TITLE
Small SV power amplifier cost

### DIFF
--- a/megamek/src/megamek/common/FixedWingSupport.java
+++ b/megamek/src/megamek/common/FixedWingSupport.java
@@ -378,7 +378,8 @@ public class FixedWingSupport extends ConvFighter {
             }
         }
         paWeight = Math.ceil(paWeight * 2) / 2;
-        if(hasEngine() && getEngine().isFusion()) {
+        if ((hasEngine() && (getEngine().isFusion() || getEngine().getEngineType() == Engine.FISSION))
+                || getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
             paWeight = 0;
         }
         costs[i++] = 20000 * paWeight;

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2702,7 +2702,8 @@ public class Tank extends Entity {
             }
         }
         paWeight = Math.ceil(paWeight * 2) / 2;
-        if(hasEngine() && getEngine().isFusion()) {
+        if ((hasEngine() && (getEngine().isFusion() || getEngine().getEngineType() == Engine.FISSION))
+                || getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
             paWeight = 0;
         }
         turretWeight = Math.ceil(turretWeight * 2) / 2;


### PR DESCRIPTION
Small support vehicles do not need power amplifiers for their infantry-scale weapons, so the cost should be zero. Also fission-powered vehicles do not need power amplifiers (TO, p. 306).

Fixes MegaMek/megameklab#460