### PR TITLE
prevent load from showing up during tow situations

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -3240,7 +3240,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         //tractor in the center isn't going to work well...
         for (Entity e : thisTrain) {
             for (Transporter t : e.getTransports()) {
-                if (t.canLoad(choice) && (t instanceof TankTrailerHitch)) {
+                if (t.canTow(choice)) {
                     TankTrailerHitch h = (TankTrailerHitch) t;
                     HitchChoice hitch = new HitchChoice(e.getId(), e.getTransports().indexOf(t), h);
                     hitchChoices.add(hitch);

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15356,7 +15356,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                 break;
             }
             for (Transporter t : e.getTransports()) {
-                if (t.canLoad(trailer)) {
+                if (t.canTow(trailer)) {
                     result = true;
                     hitchFound = true;
                     //stop looking

--- a/megamek/src/megamek/common/TankTrailerHitch.java
+++ b/megamek/src/megamek/common/TankTrailerHitch.java
@@ -102,6 +102,11 @@ public class TankTrailerHitch implements Transporter {
      */
     @Override
     public boolean canLoad(Entity unit) {
+        return false;
+    }
+    
+    @Override
+    public boolean canTow(Entity unit) {
         // Only trailers can be towed.
         if (!unit.isTrailer()) {
             return false;
@@ -111,9 +116,10 @@ public class TankTrailerHitch implements Transporter {
         if (towed != Entity.NONE) {
             return false;
         }
+        
         return true;
     }
-
+    
     /**
      * Load the given unit.
      *
@@ -127,7 +133,7 @@ public class TankTrailerHitch implements Transporter {
     @Override
     public final void load(Entity unit) throws IllegalArgumentException {
         // If we can't load the unit, throw an exception.
-        if (!canLoad(unit)) {
+        if (!canTow(unit)) {
             throw new IllegalArgumentException("Can not load " + unit.getShortName() + " onto this hitch.");
         }
 

--- a/megamek/src/megamek/common/Transporter.java
+++ b/megamek/src/megamek/common/Transporter.java
@@ -36,6 +36,11 @@ public interface Transporter extends Serializable {
      *         otherwise.
      */
     public boolean canLoad(Entity unit);
+    
+    /**
+     * Determines if this transporter can tow the given unit. By default, no.
+     */
+    public default boolean canTow(Entity unit) { return false; }
 
     /**
      * Load the given unit.


### PR DESCRIPTION
Fixes #1466 

canLoad was erroneously returning true for trailer hitches for just about every kind of unit under the sun. Introduced a new canTow method for transporters, which has the same logic but doesn't run afoul of transport bay logic.