### PR TITLE
Environmental sealing cleanup

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -640,16 +640,14 @@ public class MiscType extends EquipmentType {
             return defaultRounding.round(entity.getWeight() * 0.2, entity);
         } else if (hasFlag(F_ENDO_COMPOSITE)) {
             return defaultRounding.round(entity.getWeight() * 0.075, entity);
-        } else if (hasFlag(F_VACUUM_PROTECTION)) {
-            return RoundWeight.nextTon(entity.getWeight() * 0.1);
         } else if (hasFlag(F_DUNE_BUGGY)) {
             return entity.getWeight() / 10.0f;
         } else if (hasFlag(F_ENVIRONMENTAL_SEALING)) {
-            if ((entity instanceof SupportTank)
-                    || (entity instanceof FixedWingSupport) || (entity instanceof SupportVTOL)) {
+            if (entity.isSupportVehicle()) {
+                // SV Chassis mods are accounted for in the structure weight
                 return 0;
             } else {
-                return entity.getWeight() / 10.0;
+                return RoundWeight.standard(entity.getWeight() / 10.0, entity);
             }
 
             // Per TO Pg 413 BA Mechanical Jump Boosters weight is 2 times jump
@@ -10065,8 +10063,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 0;
         misc.cost = COST_VARIABLE; // Cost accounted as part of unit cost
         misc.tankslots = 0;
-        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_VACUUM_PROTECTION)
-                .or(F_TANK_EQUIPMENT).or(F_CHASSIS_MODIFICATION);
+        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_TANK_EQUIPMENT).or(F_CHASSIS_MODIFICATION);
         misc.omniFixedOnly = true;
         misc.bv = 0;
         misc.rulesRefs = "303,TO";
@@ -10208,7 +10205,7 @@ public class MiscType extends EquipmentType {
         misc.tankslots = 0;
         misc.cost = COST_VARIABLE;
         misc.spreadable = true;
-        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_VACUUM_PROTECTION).or(F_MECH_EQUIPMENT);
+        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_MECH_EQUIPMENT);
         misc.omniFixedOnly = true;
         misc.bv = 0;
         misc.rulesRefs = "216,TM";

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -23,7 +23,6 @@ package megamek.common;
 
 import java.math.BigInteger;
 
-import megamek.common.verifier.TestEntity;
 import megamek.common.weapons.ppc.CLERPPC;
 import megamek.common.weapons.ppc.ISERPPC;
 import megamek.common.weapons.ppc.ISHeavyPPC;
@@ -841,8 +840,9 @@ public class MiscType extends EquipmentType {
         if (costValue == EquipmentType.COST_VARIABLE) {
             if (hasFlag(F_DRONE_CARRIER_CONTROL)) {
                 costValue = getTonnage(entity, loc) * 10000;
-            } else if (hasFlag(F_FLOTATION_HULL) || hasFlag(F_VACUUM_PROTECTION) || hasFlag(F_ENVIRONMENTAL_SEALING)
-                    || hasFlag(F_OFF_ROAD)) {
+            } if (hasFlag(F_ENVIRONMENTAL_SEALING) && hasFlag(F_MECH_EQUIPMENT)) {
+                costValue = 10000 * entity.getWeight();
+            } else if (hasFlag(F_FLOTATION_HULL) || hasFlag(F_ENVIRONMENTAL_SEALING) || hasFlag(F_OFF_ROAD)) {
                 costValue = 0;
             } else if (hasFlag(F_LIMITED_AMPHIBIOUS) || hasFlag((F_FULLY_AMPHIBIOUS))) {
                 costValue = getTonnage(entity, loc) * 10000;
@@ -1391,7 +1391,6 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createGirderClub());
         EquipmentType.addType(MiscType.createLimbClub());
         EquipmentType.addType(MiscType.createHatchet());
-        EquipmentType.addType(MiscType.createVacuumProtection());
         EquipmentType.addType(MiscType.createStandard());
 
         // Start of Level2 stuff
@@ -1446,7 +1445,7 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createHeavyBridgeLayer());
 
         // For industrials and tanks
-        EquipmentType.addType(MiscType.createEnvironmentalSealing());
+        EquipmentType.addType(MiscType.createIndustrialMechEnvironmentalSealing());
         EquipmentType.addType(MiscType.createFieldKitchen());
 
         EquipmentType.addType(MiscType.createImprovedJumpJet());
@@ -10061,12 +10060,13 @@ public class MiscType extends EquipmentType {
         misc.shortName = "Environmental Sealing";
         misc.setInternalName("Environmental Sealed Chassis");
         misc.addLookupName("EnvironmentalSealingChassisMod");
+        misc.addLookupName("Vacuum Protection");
         misc.tonnage = 0;
         misc.criticals = 0;
-        misc.cost = 0; // Cost accounted as part of unit cost
+        misc.cost = COST_VARIABLE; // Cost accounted as part of unit cost
         misc.tankslots = 0;
-        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_TANK_EQUIPMENT).or(F_CHASSIS_MODIFICATION)
-                .or(F_SUPPORT_TANK_EQUIPMENT);
+        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_VACUUM_PROTECTION)
+                .or(F_TANK_EQUIPMENT).or(F_CHASSIS_MODIFICATION);
         misc.omniFixedOnly = true;
         misc.bv = 0;
         misc.rulesRefs = "303,TO";
@@ -10199,28 +10199,23 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createEnvironmentalSealing() {
+    public static MiscType createIndustrialMechEnvironmentalSealing() {
         MiscType misc = new MiscType();
-        // TODO - Review how this impacts the chassis stuff. See
-        // IO pg 48 and search in here for IndustrialMech Structure w/
-        // Environmental Sealing. Also likely needs to have a SV version split
-        // out from it.
         misc.name = "Environmental Sealing";
         misc.setInternalName(misc.name);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 8;
         misc.tankslots = 0;
-        misc.cost = 0; // Cost accounted as part of unit cost
+        misc.cost = COST_VARIABLE;
         misc.spreadable = true;
-        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT)
-                .or(F_CHASSIS_MODIFICATION);
+        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_VACUUM_PROTECTION).or(F_MECH_EQUIPMENT);
         misc.omniFixedOnly = true;
         misc.bv = 0;
-
+        misc.rulesRefs = "216,TM";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL);
         misc.techAdvancement.setAdvancement(DATE_NONE, DATE_NONE, DATE_PS);
         misc.techAdvancement.setTechRating(RATING_C);
-        misc.techAdvancement.setAvailability(new int[] { RATING_B, RATING_D, RATING_C, RATING_C });
+        misc.techAdvancement.setAvailability(RATING_B, RATING_D, RATING_C, RATING_C);
         return misc;
     }
 
@@ -10298,7 +10293,7 @@ public class MiscType extends EquipmentType {
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.tankslots = 0;
-        misc.cost = 0; // Cost accounted as part of unit cost
+        misc.cost = COST_VARIABLE; // Cost accounted as part of unit cost
         misc.flags = misc.flags.or(F_OFF_ROAD).or(F_CHASSIS_MODIFICATION)
                 .or(F_SUPPORT_TANK_EQUIPMENT);
         misc.omniFixedOnly = true;
@@ -11887,26 +11882,6 @@ public class MiscType extends EquipmentType {
      * misc.techAdvancement.setAvailability(new int[] { RATING_X, RATING_X,
      * RATING_E, RATING_X }); return misc; }
      */
-
-    public static MiscType createVacuumProtection() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Vacuum Protection";
-        misc.setInternalName(misc.name);
-        misc.tonnage = TONNAGE_VARIABLE;
-        misc.criticals = 0;
-        misc.cost = 0;
-        misc.flags = misc.flags.or(F_VACUUM_PROTECTION).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT);
-        ;
-        misc.bv = 0;
-        // TODO - Should be part of Environmental Sealing.
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL);
-        misc.techAdvancement.setUnofficial(true);
-        misc.techAdvancement.setAdvancement(DATE_NONE, DATE_NONE, DATE_PS);
-        misc.techAdvancement.setTechRating(RATING_C);
-        misc.techAdvancement.setAvailability(new int[] { RATING_A, RATING_A, RATING_A, RATING_X });
-        return misc;
-    }
 
     public static MiscType createLAMBombBay() {
         MiscType misc = new MiscType();

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1443,6 +1443,7 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createHeavyBridgeLayer());
 
         // For industrials and tanks
+        EquipmentType.addType(MiscType.createCVEnvironmentalSealedChassis());
         EquipmentType.addType(MiscType.createIndustrialMechEnvironmentalSealing());
         EquipmentType.addType(MiscType.createFieldKitchen());
 
@@ -1712,7 +1713,7 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createBicycleModification());
         EquipmentType.addType(MiscType.createConvertibleModification());
         EquipmentType.addType(MiscType.createISCVDuneBuggyChassis());
-        EquipmentType.addType(MiscType.createEnvironmentalSealedChassis());
+        EquipmentType.addType(MiscType.createEnvironmentalSealingChassisMod());
         EquipmentType.addType(MiscType.createExternalPowerPickup());
         EquipmentType.addType(MiscType.createHydroFoilChassisModification());
         EquipmentType.addType(MiscType.createMonocycleModification());
@@ -9944,6 +9945,27 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
+    public static MiscType createIndustrialMechEnvironmentalSealing() {
+        MiscType misc = new MiscType();
+        misc.name = "Environmental Sealing (Mech)";
+        misc.shortName = "Environmental Sealing";
+        misc.setInternalName(misc.name);
+        misc.tonnage = TONNAGE_VARIABLE;
+        misc.criticals = 8;
+        misc.tankslots = 0;
+        misc.cost = COST_VARIABLE;
+        misc.spreadable = true;
+        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_MECH_EQUIPMENT);
+        misc.omniFixedOnly = true;
+        misc.bv = 0;
+        misc.rulesRefs = "216,TM";
+        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setAdvancement(2300, 2350, 2495)
+                .setApproximate(true, false, false).setPrototypeFactions(F_TA)
+                .setProductionFactions(F_TH).setTechRating(RATING_C)
+                .setAvailability(RATING_C, RATING_C, RATING_C, RATING_C);
+        return misc;
+    }
+
     // Gyros - IO pg 48 - Located in Techconstants.java
 
     /*
@@ -10051,7 +10073,7 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createEnvironmentalSealedChassis() {
+    public static MiscType createCVEnvironmentalSealedChassis() {
         MiscType misc = new MiscType();
 
         misc.name = "Combat Vehicle Chassis Mod [Environmental Sealing]";
@@ -10196,7 +10218,7 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createIndustrialMechEnvironmentalSealing() {
+    public static MiscType createEnvironmentalSealingChassisMod() {
         MiscType misc = new MiscType();
         misc.name = "Environmental Sealing";
         misc.setInternalName(misc.name);
@@ -10205,10 +10227,10 @@ public class MiscType extends EquipmentType {
         misc.tankslots = 0;
         misc.cost = COST_VARIABLE;
         misc.spreadable = true;
-        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_MECH_EQUIPMENT);
+        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_SUPPORT_TANK_EQUIPMENT);
         misc.omniFixedOnly = true;
         misc.bv = 0;
-        misc.rulesRefs = "216,TM";
+        misc.rulesRefs = "122,TM";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL);
         misc.techAdvancement.setAdvancement(DATE_NONE, DATE_NONE, DATE_PS);
         misc.techAdvancement.setTechRating(RATING_C);

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2835,12 +2835,15 @@ public class Tank extends Entity {
     public boolean doomedInVacuum() {
         if (hasEngine() && (getEngine().isFusion() || getEngine().getEngineType() == Engine.FISSION
                 || getEngine().getEngineType() == Engine.FUEL_CELL)) {
-            return !hasWorkingMisc(MiscType.F_ENVIRONMENTAL_SEALING)
-                && !getMovementMode().equals(EntityMovementMode.SUBMARINE);
-            // That's right, automatic environmental sealing means submarines with the right
-            // engines can function in space. Your enemies never saw that coming.
+            return !hasEnvironmentalSealing();
         }
         return true;
+    }
+
+    @Override
+    public boolean hasEnvironmentalSealing() {
+        return getMovementMode().equals(EntityMovementMode.SUBMARINE)
+                || super.hasEnvironmentalSealing();
     }
 
     @Override

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -1473,15 +1473,15 @@ public class Tank extends Entity {
                 typeModifier = 0.6;
         }
 
-        if (!(this instanceof SupportTank)
+        if (!isSupportVehicle()
                 && (hasWorkingMisc(MiscType.F_LIMITED_AMPHIBIOUS)
                         || hasWorkingMisc(MiscType.F_DUNE_BUGGY)
                         || hasWorkingMisc(MiscType.F_FLOTATION_HULL)
-                        || hasWorkingMisc(MiscType.F_VACUUM_PROTECTION)
-                        || hasWorkingMisc(MiscType.F_ENVIRONMENTAL_SEALING) || hasWorkingMisc(MiscType.F_ARMORED_MOTIVE_SYSTEM))) {
+                        || hasWorkingMisc(MiscType.F_ENVIRONMENTAL_SEALING)
+                        || hasWorkingMisc(MiscType.F_ARMORED_MOTIVE_SYSTEM))) {
             typeModifier += .1;
         } else if (hasWorkingMisc(MiscType.F_FULLY_AMPHIBIOUS)
-                && !(this instanceof SupportTank)) {
+                && !isSupportVehicle()) {
             typeModifier += .2;
         }
         bvText.append(startColumn);
@@ -2790,7 +2790,6 @@ public class Tank extends Entity {
 
         if (!isSupportVehicle()) {
             if (hasWorkingMisc(MiscType.F_FLOTATION_HULL)
-                    || hasWorkingMisc(MiscType.F_VACUUM_PROTECTION)
                     || hasWorkingMisc(MiscType.F_ENVIRONMENTAL_SEALING)) {
                 cost *= 1.25;
                 costs[i++] = -1.25;
@@ -2834,15 +2833,12 @@ public class Tank extends Entity {
 
     @Override
     public boolean doomedInVacuum() {
-        for (Mounted m : getEquipment()) {
-            if ((m.getType() instanceof MiscType)
-                    && m.getType().hasFlag(MiscType.F_VACUUM_PROTECTION)) {
-                return false;
-            }
-            if ((m.getType() instanceof MiscType)
-                    && m.getType().hasFlag(MiscType.F_ENVIRONMENTAL_SEALING)) {
-                return false;
-            }
+        if (hasEngine() && (getEngine().isFusion() || getEngine().getEngineType() == Engine.FISSION
+                || getEngine().getEngineType() == Engine.FUEL_CELL)) {
+            return !hasWorkingMisc(MiscType.F_ENVIRONMENTAL_SEALING)
+                && !getMovementMode().equals(EntityMovementMode.SUBMARINE);
+            // That's right, automatic environmental sealing means submarines with the right
+            // engines can function in space. Your enemies never saw that coming.
         }
         return true;
     }

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2499,7 +2499,7 @@ public class Tank extends Entity {
         left.add("Tonnage Multiplier");
         if (!isSupportVehicle()) {
 
-            left.add("Flotation Hull/Vacuum Protection/Environmental Sealing multiplier");
+            left.add("Flotation Hull/Environmental Sealing multiplier");
             left.add("Off-Road Multiplier");
         }
 

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -365,6 +365,8 @@ public abstract class TestEntity implements TestEntityOption {
             return TestAero.eqRequiresLocation(eq, entity.isFighter());
         } else if (entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
             return TestProtomech.requiresSlot(eq);
+        } else if (entity.hasETypeFlag(Entity.ETYPE_TANK)) {
+            return !TestTank.isBodyEquipment(eq);
         }
         return true;
     }

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -440,18 +440,6 @@ public class TestTank extends TestEntity {
         if (hasIllegalEquipmentCombinations(buff)) {
             correct = false;
         }
-        // only tanks with fusion engine can be vacuum protected
-        if(tank.hasEngine() && !(tank.getEngine().isFusion() 
-                || (tank.getEngine().getEngineType() == Engine.FUEL_CELL)
-                || (tank.getEngine().getEngineType() == Engine.SOLAR)
-                || (tank.getEngine().getEngineType() == Engine.BATTERY)
-                || (tank.getEngine().getEngineType() == Engine.FISSION)
-                || (tank.getEngine().getEngineType() == Engine.NONE))
-                && !tank.doomedInVacuum()) {
-                buff.append("Vacuum protection requires fusion engine.\n");
-                correct = false;
-                }
-
         if (!correctCriticals(buff)) {
             correct = false;
         }

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -483,6 +483,10 @@ public class TestTank extends TestEntity {
             if (eq.hasFlag(MiscType.F_DUNE_BUGGY)) {
                 return mode.equals(EntityMovementMode.WHEELED);
             }
+            // Submarines have environmental sealing as part of their base construction
+            if (eq.hasFlag(MiscType.F_ENVIRONMENTAL_SEALING)) {
+                return !mode.equals(EntityMovementMode.SUBMARINE);
+            }
             if (eq.hasFlag(MiscType.F_CLUB)
                     && eq.hasSubType(MiscType.S_CHAINSAW | MiscType.S_DUAL_SAW | MiscType.S_MINING_DRILL)) {
                 return mode.equals(EntityMovementMode.WHEELED) || mode.equals(EntityMovementMode.TRACKED)

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -919,4 +919,21 @@ public class TestTank extends TestEntity {
         
         return illegal;
     }
+
+    /**
+     * Determines whether a piece of equipment should be mounted in the body location.
+     *
+     * @param eq       The equipment
+     * @return         Whether the equipment needs to be assigned to the body location.
+     */
+    public static boolean isBodyEquipment(EquipmentType eq) {
+        if (eq instanceof MiscType) {
+            return eq.hasFlag(MiscType.F_CHASSIS_MODIFICATION)
+                    || eq.hasFlag(MiscType.F_CASE)
+                    || eq.hasFlag(MiscType.F_CASEII)
+                    || eq.hasFlag(MiscType.F_JUMP_JET);
+        } else {
+            return eq instanceof AmmoType;
+        }
+    }
 }


### PR DESCRIPTION
Several related fixes to environmental cleanup MiscType entries:
1. Distinguish between industrial mech, combat vehicle, and support vehicle environmental sealing. These are all separate parts that are not interchangeable.
2. Consolidate vacuum protection with CV environmental sealing. This is not a separate part, but vacuum protection requires a fusion, fission, or fuel cell engine.
3. Add a check for the correct engine type to Tank#doomedInVacuum, and check for submarine (which has environmental sealing automatically as part of its construction) to Tank#hasEnvironmentalSealing, and removed obsolete validation test for vacuum protection (which was incorrect anyway).
4. Added some logic to TestTank to help MML determine to place chassis modifications as well as ammo and CASE in body locations automatically.

Fixes MegaMek/megameklab#480