### PR TITLE
Add Entity.getPriceMultiplier() method

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -2912,16 +2912,17 @@ public class Aero extends Entity implements IAero, IBomber {
         // weapons
         cost += getWeaponsAndEquipmentCost(ignoreAmmo);
 
-        // omni multiplier
-        double omniMultiplier = 1;
+        return Math.round(cost * getPriceMultiplier());
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        double priceModifier = 1.0;
         if (isOmni()) {
-            omniMultiplier = 1.25f;
+            priceModifier *= 1.25f;
         }
-
-        double weightMultiplier = 1 + (weight / 200f);
-
-        return Math.round(cost * omniMultiplier * weightMultiplier);
-
+        priceModifier *= 1 + (weight / 200f);
+        return priceModifier;
     }
 
     @Override

--- a/megamek/src/megamek/common/ConvFighter.java
+++ b/megamek/src/megamek/common/ConvFighter.java
@@ -144,18 +144,19 @@ public class ConvFighter extends Aero {
         // power amplifiers, if any
         cost += 20000 * getPowerAmplifierWeight();
 
-        // omni multiplier (leaving this in for now even though conventional
-        // fighters
-        // don't make for legal omnis)
-        double omniMultiplier = 1;
+        return Math.round(cost * getPriceMultiplier());
+
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        double priceMultiplier = 1.0;
+        // omni multiplier (leaving this in for now even though conventional fighters don't make for legal omnis)
         if (isOmni()) {
-            omniMultiplier = 1.25f;
+            priceMultiplier *= 1.25f;
         }
-
-        double weightMultiplier = 1 + (weight / 200.0);
-
-        return Math.round(cost * omniMultiplier * weightMultiplier);
-
+        priceMultiplier *= 1 + (weight / 200.0); // weight multiplier
+        return priceMultiplier;
     }
 
     @Override

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -458,6 +458,7 @@ public class Dropship extends SmallCraft {
         // Life Boats and Escape Pods
         costs[costIdx++] += 5000 * (getLifeBoats() + getEscapePods());
 
+        // TODO Decouple cost calculation from addCostDetails and eliminate duplicate code in getPriceMultiplier
         double weightMultiplier = 36.0;
         if (isSpheroid()) {
             weightMultiplier = 28.0;
@@ -472,6 +473,11 @@ public class Dropship extends SmallCraft {
         cost = Math.round(cost * weightMultiplier);
         addCostDetails(cost, costs);
         return cost;
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        return isSpheroid() ? 28.0 : 36.0;
     }
 
     private void addCostDetails(double cost, double[] costs) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10525,6 +10525,21 @@ public abstract class Entity extends TurnOrdered implements Transporter,
 
     public abstract double getCost(boolean ignoreAmmo);
 
+    /**
+     * Returns a multiplier that combines multiplicative construction cost modifiers for this Entity.
+     *
+     * This includes only modifiers that apply to an Entity's final, total cost (e.g. - the 1.25x modifier for being
+     * an omni-unit, or the 32.0x for being an aerodyne dropship). It does NOT include multipliers that only apply to
+     * a sub-part of the unit (e.g. the weight based multiplier that applies to a vehicle's internal structure cost).
+     *
+     * This allows MekHQ to scale the price of a Unit's Parts in a more appropriate manner.
+     *
+     * Defaults to 1.0
+     */
+    public double getPriceMultiplier() {
+        return 1.0;
+    };
+
     public long getWeaponsAndEquipmentCost(boolean ignoreAmmo) {
         // bvText = new StringBuffer();
         long cost = 0;

--- a/megamek/src/megamek/common/FixedWingSupport.java
+++ b/megamek/src/megamek/common/FixedWingSupport.java
@@ -397,23 +397,28 @@ public class FixedWingSupport extends ConvFighter {
             costs[i++] = 0;
         }
 
-        double multiplier = 1.0;
-        switch (movementMode) {
-            case AERODYNE:
-                multiplier += weight / 50.0;
-                break;
-            case AIRSHIP:
-                multiplier += weight / 10000;
-                break;
-            case STATION_KEEPING:
-                multiplier += weight / 75.0;
-                break;
-        }
-        cost *= multiplier;
-        costs[i++] = -multiplier;
+        cost *= getPriceMultiplier();
+        costs[i++] = -getPriceMultiplier();
 
         addCostDetails(cost, costs);
         return Math.round(cost);
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        double priceMultiplier = 1.0;
+        switch (movementMode) {
+            case AERODYNE:
+                priceMultiplier = 1 + weight / 50.0;
+                break;
+            case AIRSHIP:
+                priceMultiplier = 1 + weight / 10000;
+                break;
+            case STATION_KEEPING:
+                priceMultiplier = 1 + weight / 75.0;
+                break;
+        }
+        return priceMultiplier;
     }
 
     private void addCostDetails(double cost, double[] costs) {

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1507,7 +1507,6 @@ public class Infantry extends Entity {
   */
     @Override
     public double getCost(boolean ignoreAmmo) {
-        double multiplier = 1;     //Cost Multiplier per TM
         double pweaponCost = 0;  //Primary Weapon Cost
         double sweaponCost = 0; // Secondary Weapon Cost
         double armorcost = 0; //Armor Cost
@@ -1577,67 +1576,8 @@ public class Infantry extends Entity {
         //Cost of armor on a per man basis added
         cost += (armorcost * menStarting);
 
-
-        //Anti-Mek Trained Multiplier
-        if (isAntiMekTrained()) {
-            multiplier = 1;
-        }
-
-        //Add in motive type costs
-        switch (getMovementMode()){
-            case INF_UMU:
-            	multiplier *= getAllUMUCount() > 1? 2.5 : 2;
-            	break;
-            case INF_LEG:
-                multiplier *= 1.0;
-                break;
-            case INF_MOTORIZED:
-                multiplier *= 1.6;
-                break;
-            case INF_JUMP:
-                multiplier *= 2.6;
-                break;
-            case HOVER:
-                multiplier *= 3.2;
-                break;
-            case WHEELED:
-                multiplier *= 3.2;
-                break;
-            case TRACKED:
-                multiplier *= 3.2;
-                break;
-            case VTOL:
-                multiplier *= hasMicrolite()? 4 : 4.5;
-                break;
-            case SUBMARINE:
-            	/* No cost given in TacOps, using basic mechanized cost for now */
-                multiplier *= 3.2;
-            	break;
-            default:
-                break;
-        }
-
-        //add in specialization costs
-        if (hasSpecialization(COMBAT_ENGINEERS)) {
-        	multiplier *= 5;
-        }
-        if (hasSpecialization(MARINES)) {
-        	multiplier *= 3;
-        }
-        if (hasSpecialization(MOUNTAIN_TROOPS)) {
-        	multiplier *= 2;
-        }
-        if (hasSpecialization(PARATROOPS)) {
-        	multiplier *= 3;
-        }
-
-        if (hasSpecialization(XCT)) {
-            multiplier *= 5;
-        }
-
-        /* TODO: paramedics cost an addition x0.375 per paramedic */
-
-        cost = cost * multiplier;
+        // Price multiplier includes anti-mech training, motive type, and specializations
+        cost = cost * getPriceMultiplier();
 
         //add in field gun costs
         for (Mounted mounted : getEquipment()) {
@@ -1646,6 +1586,69 @@ public class Infantry extends Entity {
             }
         }
         return cost;
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        double priceMultiplier = 1.0;
+
+        //Anti-Mek Trained Multiplier
+        if (isAntiMekTrained()) {
+            priceMultiplier *= 5.0;
+        }
+
+        // Motive type costs
+        switch (getMovementMode()){
+            case INF_UMU:
+                priceMultiplier *= getAllUMUCount() > 1? 2.5 : 2;
+                break;
+            case INF_LEG:
+                priceMultiplier *= 1.0;
+                break;
+            case INF_MOTORIZED:
+                priceMultiplier *= 1.6;
+                break;
+            case INF_JUMP:
+                priceMultiplier *= 2.6;
+                break;
+            case HOVER:
+                priceMultiplier *= 3.2;
+                break;
+            case WHEELED:
+                priceMultiplier *= 3.2;
+                break;
+            case TRACKED:
+                priceMultiplier *= 3.2;
+                break;
+            case VTOL:
+                priceMultiplier *= hasMicrolite()? 4 : 4.5;
+                break;
+            case SUBMARINE:
+                /* No cost given in TacOps, using basic mechanized cost for now */
+                priceMultiplier *= 3.2;
+                break;
+            default:
+                break;
+        }
+
+        // Specialization costs
+        if (hasSpecialization(COMBAT_ENGINEERS)) {
+            priceMultiplier *= 5;
+        }
+        if (hasSpecialization(MARINES)) {
+            priceMultiplier *= 3;
+        }
+        if (hasSpecialization(MOUNTAIN_TROOPS)) {
+            priceMultiplier *= 2;
+        }
+        if (hasSpecialization(PARATROOPS)) {
+            priceMultiplier *= 3;
+        }
+        if (hasSpecialization(XCT)) {
+            priceMultiplier *= 5;
+        }
+        // TODO: paramedics cost an addition x0.375 per paramedic
+        return priceMultiplier;
     }
 
     /**

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -2116,18 +2116,21 @@ public class Jumpship extends Aero {
         // Weapons and Equipment
         costs[costIdx++] += getWeaponsAndEquipmentCost(ignoreAmmo);
 
-        double weightMultiplier = 1.25f;
-
         // Sum Costs
         for (int i = 0; i < costIdx; i++) {
             cost += costs[i];
         }
 
-        costs[costIdx++] = -weightMultiplier; // Negative indicates multiplier
-        cost = Math.round(cost * weightMultiplier);
+        costs[costIdx++] = -getPriceMultiplier(); // Negative indicates multiplier
+        cost = Math.round(cost * getPriceMultiplier());
         addCostDetails(cost, costs);
         return cost;
 
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        return 1.25; // weight multiplier
     }
 
     private void addCostDetails(double cost, double[] costs) {

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -5457,7 +5457,7 @@ public abstract class Mech extends Entity {
         for (int x = 0; x < i; x++) {
             cost += costs[x];
         }
-
+        // TODO Decouple cost calculation from addCostDetails and eliminate duplicate code in getPriceMultiplier
         double quirkMultiplier = 0;
         if (hasQuirk(OptionsConstants.QUIRK_POS_GOOD_REP_1)) {
         	quirkMultiplier = 1.1f;
@@ -5483,6 +5483,28 @@ public abstract class Mech extends Entity {
         cost = Math.round(cost * weightMultiplier);
         addCostDetails(cost, costs);
         return cost;
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        double priceMultiplier = 1.0f;
+        if (hasQuirk(OptionsConstants.QUIRK_POS_GOOD_REP_1)) {
+            priceMultiplier *= 1.1f;
+        } else if (hasQuirk(OptionsConstants.QUIRK_POS_GOOD_REP_2)) {
+            priceMultiplier *= 1.25f;
+        }
+        // TODO Negative price quirks (Bad Reputation)
+
+        if (isOmni()) {
+            priceMultiplier *= 1.25f;
+        }
+
+        // Weight multiplier
+        priceMultiplier *= 1 + (weight / 100f);
+        if (isIndustrial()) {
+            priceMultiplier = 1 + (weight / 400f);
+        }
+        return priceMultiplier;
     }
 
     @Override

--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -2037,9 +2037,14 @@ public class Protomech extends Entity {
         retVal += getWeaponsAndEquipmentCost(ignoreAmmo);
 
         // Finally, apply the Final ProtoMech Cost Multiplier
-        retVal *= 1 + (weight / 100.0);
+        retVal *= getPriceMultiplier();
 
         return retVal;
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        return 1 + (weight / 100.0); // weight multiplier
     }
 
     @Override

--- a/megamek/src/megamek/common/SmallCraft.java
+++ b/megamek/src/megamek/common/SmallCraft.java
@@ -713,10 +713,13 @@ public class SmallCraft extends Aero {
         // weapons
         cost += getWeaponsAndEquipmentCost(ignoreAmmo);
 
-        double weightMultiplier = 1 + (weight / 50f);
+        return Math.round(cost * getPriceMultiplier());
 
-        return Math.round(cost * weightMultiplier);
+    }
 
+    @Override
+    public double getPriceMultiplier() {
+        return 1 + (weight / 50f);
     }
 
     @Override

--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -160,21 +160,21 @@ public class SpaceStation extends Jumpship {
         // Weapons and Equipment
         costs[costIdx++] += getWeaponsAndEquipmentCost(ignoreAmmo);
 
-        double weightMultiplier = 5.00f;
-        if (modular) {
-            weightMultiplier = 50.00f;
-        }
-
         // Sum Costs
         for (int i = 0; i < costIdx; i++) {
             cost += costs[i];
         }
 
-        costs[costIdx++] = -weightMultiplier; // Negative indicates multiplier
-        cost = Math.round(cost * weightMultiplier);
+        costs[costIdx++] = -getPriceMultiplier(); // Negative indicates multiplier
+        cost = Math.round(cost * getPriceMultiplier());
         addCostDetails(cost, costs);
         return cost;
 
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        return modular ? 50.0 : 5.0; // weight multiplier
     }
 
     private void addCostDetails(double cost, double[] costs) {

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2737,6 +2737,8 @@ public class Tank extends Entity {
         for (int x = structCostIdx; x < i; x++) {
             cost += costs[x];
         }
+
+        // TODO Decouple cost calculation from addCostDetails and eliminate duplicate code in getPriceMultiplier
         if (isOmni()) { // Omni conversion cost goes here.
             cost *= 1.25;
             costs[i++] = -1.25;
@@ -2799,6 +2801,59 @@ public class Tank extends Entity {
 
         addCostDetails(cost, costs);
         return Math.round(cost);
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        double priceMultiplier = 1.0;
+        if (isOmni()) {
+            priceMultiplier *= 1.25;
+        }
+        if (isSupportVehicle()
+                && (movementMode.equals(EntityMovementMode.NAVAL)
+                || movementMode.equals(EntityMovementMode.HYDROFOIL)
+                || movementMode.equals(EntityMovementMode.SUBMARINE))) {
+            priceMultiplier *= weight / 100000.0;
+        } else {
+            switch (movementMode) {
+                case HOVER:
+                case SUBMARINE:
+                    priceMultiplier *= weight / 50.0;
+                    break;
+                case HYDROFOIL:
+                    priceMultiplier *= weight / 75.0;
+                    break;
+                case NAVAL:
+                case WHEELED:
+                    priceMultiplier *= weight / 200.0;
+                    break;
+                case TRACKED:
+                    priceMultiplier *= weight / 100.0;
+                    break;
+                case VTOL:
+                    priceMultiplier *= weight / 30.0;
+                    break;
+                case WIGE:
+                    priceMultiplier *= weight / 25.0;
+                    break;
+                case RAIL:
+                case MAGLEV:
+                    priceMultiplier *= weight / 250.0;
+                    break;
+            }
+        }
+        if (!isSupportVehicle()) {
+            if (hasWorkingMisc(MiscType.F_FLOTATION_HULL)
+                    || hasWorkingMisc(MiscType.F_VACUUM_PROTECTION)
+                    || hasWorkingMisc(MiscType.F_ENVIRONMENTAL_SEALING)) {
+                priceMultiplier *= 1.25;
+
+            }
+            if (hasWorkingMisc(MiscType.F_OFF_ROAD)) {
+                priceMultiplier *= 1.2;
+            }
+        }
+        return priceMultiplier;
     }
 
     @Override

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -297,17 +297,20 @@ public class Warship extends Jumpship {
         // Weapons and Equipment
         costs[costIdx++] += getWeaponsAndEquipmentCost(ignoreAmmo);
 
-        double weightMultiplier = 2.00f;
-
         // Sum Costs
         for (int i = 0; i < costIdx; i++) {
             cost += costs[i];
         }
 
-        costs[costIdx++] = -weightMultiplier; // Negative indicates multiplier
-        cost = Math.round(cost * weightMultiplier);
+        costs[costIdx++] = -getPriceMultiplier(); // Negative indicates multiplier
+        cost = Math.round(cost * getPriceMultiplier());
         addCostDetails(cost, costs);
         return cost;
+    }
+
+    @Override
+    public double getPriceMultiplier() {
+        return 2.0; // Weight multiplier
     }
     
     private void addCostDetails(double cost, double[] costs) {


### PR DESCRIPTION
Refactor various Entity subtypes to move multiplier data from getCost() into getPriceMultiplier().

This enables external access to the multiplicative construction cost modifiers, which is needed to support
more accurate price calculations in MekHQ.