### PR TITLE
Adding WeightedMap to MegaMek Utils

### DIFF
--- a/megamek/src/megamek/common/util/WeightedMap.java
+++ b/megamek/src/megamek/common/util/WeightedMap.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 The MegaMek Team. All rights reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.common.util;
+
+import megamek.common.Compute;
+
+import java.util.TreeMap;
+
+/**
+ * Constructs a table of values each with a weight that makes them more or less likely to be
+ * selected at random
+ *
+ * @param <T> The values in the table
+ */
+public class WeightedMap<T> extends TreeMap<Integer, T> {
+    private static final long serialVersionUID = -568712793616821291L;
+
+    public void add(int weight, T item) {
+        if (weight > 0) {
+            if (!isEmpty()) {
+                put(lastKey() + weight, item);
+            } else {
+                put(weight, item);
+            }
+        }
+    }
+
+    public T randomItem() {
+        if (isEmpty()) {
+            return null;
+        }
+        int random = Compute.randomInt(lastKey()) + 1;
+        return ceilingEntry(random).getValue();
+    }
+}


### PR DESCRIPTION
This can therefore be used as a standard for weighted maps in MegaMek and MekHQ, and it is utilized as part of my Personnel Improvements and in the RandomFactionGenerator class in MekHQ.