### PR TITLE
Trailer hitches

### DIFF
--- a/megamek/data/mechfiles/vehicles/3067/3067 IS Land/Manteuffel Attack Tank B.blk
+++ b/megamek/data/mechfiles/vehicles/3067/3067 IS Land/Manteuffel Attack Tank B.blk
@@ -87,7 +87,6 @@ ISHeavyGaussRifle:OMNI
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/3075 Support tanks/O-65 'Oppie' Hazardous Materials Recovery Vehicle O-66 HMRV.blk
+++ b/megamek/data/mechfiles/vehicles/3075 Support tanks/O-65 'Oppie' Hazardous Materials Recovery Vehicle O-66 HMRV.blk
@@ -92,7 +92,6 @@ Tank Sprayer
 <Rear Equipment>
 Backhoe
 Searchlight
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/3075/Daimyo HQ 67-NC.blk
+++ b/megamek/data/mechfiles/vehicles/3075/Daimyo HQ 67-NC.blk
@@ -74,7 +74,6 @@ IS Machine Gun Ammo - Half
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/3075/Thumper Artillery Vehicle.blk
+++ b/megamek/data/mechfiles/vehicles/3075/Thumper Artillery Vehicle.blk
@@ -80,7 +80,6 @@ Machine Gun
 <Rear Equipment>
 Machine Gun
 Machine Gun
-Hitch
 </Rear Equipment>
 
 <source>

--- a/megamek/data/mechfiles/vehicles/HB HD/Generic Expandable Services Vehicle (Command Post).blk
+++ b/megamek/data/mechfiles/vehicles/HB HD/Generic Expandable Services Vehicle (Command Post).blk
@@ -78,7 +78,6 @@ OmniChassisMod
 <Rear Equipment>
 RemoteSensorDispenser:OMNI
 RemoteSensorDispenser:OMNI
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/HB HD/Generic Expandable Services Vehicle (Kitchen).blk
+++ b/megamek/data/mechfiles/vehicles/HB HD/Generic Expandable Services Vehicle (Kitchen).blk
@@ -78,7 +78,6 @@ OmniChassisMod
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/HB HD/Generic Expandable Services Vehicle (MASH).blk
+++ b/megamek/data/mechfiles/vehicles/HB HD/Generic Expandable Services Vehicle (MASH).blk
@@ -81,7 +81,6 @@ OmniChassisMod
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/HB HD/Generic Expandable Services Vehicle Trailer (Bunk).blk
+++ b/megamek/data/mechfiles/vehicles/HB HD/Generic Expandable Services Vehicle Trailer (Bunk).blk
@@ -77,7 +77,6 @@ OmniChassisMod
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/HB HD/Generic Expandable Services Vehicle Trailer (Cargo).blk
+++ b/megamek/data/mechfiles/vehicles/HB HD/Generic Expandable Services Vehicle Trailer (Cargo).blk
@@ -76,7 +76,6 @@ OmniChassisMod
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/HB HD/Heavy Combat ATV.blk
+++ b/megamek/data/mechfiles/vehicles/HB HD/Heavy Combat ATV.blk
@@ -74,7 +74,6 @@ PintleTurret
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/HB HM/Hector Road Train Tractor (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/HB HM/Hector Road Train Tractor (Standard).blk
@@ -84,7 +84,6 @@ ISInfraredImager
 
 <Rear Equipment>
 Lift Hoist
-Hitch
 </Rear Equipment>
 
 <transporters>

--- a/megamek/data/mechfiles/vehicles/HB HM/Hector Road Train Trailer Module (Livestock).blk
+++ b/megamek/data/mechfiles/vehicles/HB HM/Hector Road Train Trailer Module (Livestock).blk
@@ -70,7 +70,6 @@ Trailer
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <transporters>

--- a/megamek/data/mechfiles/vehicles/HB HM/Hector Road Train Trailer Module (Passenger).blk
+++ b/megamek/data/mechfiles/vehicles/HB HM/Hector Road Train Trailer Module (Passenger).blk
@@ -73,7 +73,6 @@ Trailer
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <transporters>

--- a/megamek/data/mechfiles/vehicles/HB HM/Hector Road Train Trailer Module (Refrigerated).blk
+++ b/megamek/data/mechfiles/vehicles/HB HM/Hector Road Train Trailer Module (Refrigerated).blk
@@ -70,7 +70,6 @@ Trailer
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <transporters>

--- a/megamek/data/mechfiles/vehicles/HB HM/Hector Road Train Trailer Module (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/HB HM/Hector Road Train Trailer Module (Standard).blk
@@ -70,7 +70,6 @@ Trailer
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <transporters>

--- a/megamek/data/mechfiles/vehicles/Hist LOT II/Pollux ADA Heavy Tank.blk
+++ b/megamek/data/mechfiles/vehicles/Hist LOT II/Pollux ADA Heavy Tank.blk
@@ -76,7 +76,6 @@ ISSmallPulseLaser
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/House Arano/Sleipnir APC SRM.blk
+++ b/megamek/data/mechfiles/vehicles/House Arano/Sleipnir APC SRM.blk
@@ -69,7 +69,6 @@ troopspace:4.0
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/House Arano/Sleipnir APC.blk
+++ b/megamek/data/mechfiles/vehicles/House Arano/Sleipnir APC.blk
@@ -69,7 +69,6 @@ troopspace:4.0
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/House Arano/Vargr APC LRM.blk
+++ b/megamek/data/mechfiles/vehicles/House Arano/Vargr APC LRM.blk
@@ -69,7 +69,6 @@ troopspace:7.0
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/House Arano/Vargr APC.blk
+++ b/megamek/data/mechfiles/vehicles/House Arano/Vargr APC.blk
@@ -69,7 +69,6 @@ troopspace:7.0
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Rail/Adelante Passenger-Cargo Train (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Rail/Adelante Passenger-Cargo Train (Standard).blk
@@ -82,7 +82,6 @@ SV Chassis Mod [Tractor]
 </Rear Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Rail/TGV Omni Railcar Primary Configuration.blk
+++ b/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Rail/TGV Omni Railcar Primary Configuration.blk
@@ -82,7 +82,6 @@ OmniChassisMod
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Tracked/Galaport Ground Trailer (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Tracked/Galaport Ground Trailer (Standard).blk
@@ -80,7 +80,6 @@ Environmental Sealed Chassis
 </Rear Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Tracked/Galaport Ground Tug (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Tracked/Galaport Ground Tug (Standard).blk
@@ -79,7 +79,6 @@ Searchlight
 </Rear Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Tracked/Gienah-Durapaq Elite Land Train (Tractor) Series 3.blk
+++ b/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Tracked/Gienah-Durapaq Elite Land Train (Tractor) Series 3.blk
@@ -82,7 +82,6 @@ Paramedic Equipment
 Paramedic Equipment
 Paramedic Equipment
 Lift Hoist
-Hitch
 </Rear Equipment>
 
 <transporters>

--- a/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Tracked/Gienah-Durapaq Elite Land Train (Trailer) Series 3.blk
+++ b/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Tracked/Gienah-Durapaq Elite Land Train (Trailer) Series 3.blk
@@ -76,7 +76,6 @@ Trailer
 </Rear Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <transporters>

--- a/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Wheeled/Iveco Burro Heavy Support Truck (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Wheeled/Iveco Burro Heavy Support Truck (Standard).blk
@@ -77,7 +77,6 @@ HHSearchlight
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 HHSearchlight
 </Rear Equipment>
 

--- a/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Wheeled/Prairie Schooner Land Train (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/TRO Vehicle Annex/Wheeled/Prairie Schooner Land Train (Standard).blk
@@ -82,7 +82,6 @@ ISOffRoadChassis
 </Rear Left Equipment>
 
 <Rear Equipment>
-hitch
 </Rear Equipment>
 
 <transporters>

--- a/megamek/data/mechfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #1.blk
+++ b/megamek/data/mechfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #1.blk
@@ -66,7 +66,6 @@ IS Ammo MML-5 SRM
 </Body Equipment>
 
 <Front Equipment>
-Hitch
 </Front Equipment>
 
 <Right Equipment>
@@ -76,7 +75,6 @@ Hitch
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #2.blk
+++ b/megamek/data/mechfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #2.blk
@@ -67,7 +67,6 @@ IS Ammo Extended LRM-10
 </Body Equipment>
 
 <Front Equipment>
-Hitch
 </Front Equipment>
 
 <Right Equipment>
@@ -77,7 +76,6 @@ Hitch
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #3.blk
+++ b/megamek/data/mechfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #3.blk
@@ -67,7 +67,6 @@ IS Ammo Extended LRM-5
 </Body Equipment>
 
 <Front Equipment>
-Hitch
 </Front Equipment>
 
 <Right Equipment>
@@ -77,7 +76,6 @@ Hitch
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #4.blk
+++ b/megamek/data/mechfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Trailer Configuration #4.blk
@@ -65,7 +65,6 @@ IS Ammo HVAC/5
 </Body Equipment>
 
 <Front Equipment>
-Hitch
 </Front Equipment>
 
 <Right Equipment>
@@ -75,7 +74,6 @@ Hitch
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Train (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/XTRs/Periphery/Dreadnought Mk II Land Train (Standard).blk
@@ -104,7 +104,6 @@ SponsonTurret
 
 <Rear Equipment>
 Lift Hoist/Arresting Hoist
-Hitch
 </Rear Equipment>
 
 <Turret Equipment>

--- a/megamek/data/mechfiles/vehicles/XTRs/Primitives V/Apostle Self-Propelled Artillery.blk
+++ b/megamek/data/mechfiles/vehicles/XTRs/Primitives V/Apostle Self-Propelled Artillery.blk
@@ -74,7 +74,6 @@ ISSniper
 </Left Equipment>
 
 <Rear Equipment>
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/data/mechfiles/vehicles/XTRs/Primitives V/RR-3 Recovery Vehicle (Standard).blk
+++ b/megamek/data/mechfiles/vehicles/XTRs/Primitives V/RR-3 Recovery Vehicle (Standard).blk
@@ -72,7 +72,6 @@ ISOffRoadChassis
 <Rear Equipment>
 Lift Hoist/Arresting Hoist
 Lift Hoist/Arresting Hoist
-Hitch
 </Rear Equipment>
 
 <barrating>

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2859,13 +2859,8 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         
         // Disable the "Unload" button if we're in the wrong
         // gear or if the entity is not transporting units.
-        if (!legalGear || (loadedUnits.size() == 0) || (cen == Entity.NONE)
-            || (!canUnloadHere)) {
-            setUnloadEnabled(false);
-        } else {
-            setUnloadEnabled(true);
-        }
-        
+        setUnloadEnabled(legalGear && canUnloadHere && !loadedUnits.isEmpty());
+
         boolean canDropTrailerHere = false;
         if(finalCoordinatesOnBoard) {
             for (Entity en : towedUnits) {
@@ -2878,20 +2873,13 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         
         // Disable the "Disconnect" button if we're in the wrong
         // gear or if the entity is not transporting units.
-        if (!legalGear || (towedUnits.size() == 0) || (cen == Entity.NONE)
-            || (!canDropTrailerHere)) {
-            setDisconnectEnabled(false);
-        } else {
-            setDisconnectEnabled(true);
-        }
-        
+        setDisconnectEnabled(legalGear && canDropTrailerHere && !towedUnits.isEmpty());
+
         // If the current entity has moved, disable "Load" and "Tow" buttons.
-        if ((cmd.length() > 0) || (cen == Entity.NONE)) {
-            setLoadEnabled(false);
-            setTowEnabled(false);
-        } else {
+        setLoadEnabled(false);
+        setTowEnabled(false);
+        if ((cmd.length() == 0) && (cen != Entity.NONE)) {
             // Check the other entities in the current hex for friendly units.
-            boolean isGood = false;
             for (Entity other : game.getEntitiesVector(ce.getPosition())) {
                 // If the other unit is friendly and not the current entity
                 // and the current entity has at least 1 MP, if it can
@@ -2901,19 +2889,10 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 if ((ce.getWalkMP() > 0) && ce.canLoad(other)
                     && other.isLoadableThisTurn() && !ce.canTow(other.getId())) {
                     setLoadEnabled(true);
-                    isGood = true;
-
-                    // We can stop looking.
                     break;
                 }
-                // Nope. Discard it.
-                other = null;
             } // Check the next entity in this position.
-            if (!isGood) {
-                setLoadEnabled(false);
-            }
             //Now check all eligible hexes for towable trailers
-            isGood = false;
             for (Coords c : ce.getHitchLocations()) {
                 for (Entity other : game.getEntitiesVector(c)) {
                     // If the other unit is friendly and not the current entity
@@ -2921,17 +2900,9 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                     // then enable the "Tow" button.
                     if (ce.canTow(other.getId())) {
                         setTowEnabled(true);
-                        isGood = true;
-
-                        // We can stop looking.
                         break;
                     }
-                    // Nope. Discard it.
-                    other = null;
                 } // Check the next entity.
-            }
-            if (!isGood) {
-                setTowEnabled(false);
             }
         } // End ce-hasn't-moved
     } // private void updateLoadButtons

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15213,20 +15213,15 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             Entity trailer = game.getEntity(id);
             thisTrain.add(trailer);
         }
-        //Check each entity in the train for working hitches
+        //Check each Entity in the train for working hitches. When found, add the hex
+        // that Entity is in and the hex the hitch faces.
         for (Entity e : thisTrain) {
-            for (Mounted m : e.getMisc()) {
-                if (m.getType().hasFlag(MiscType.F_HITCH) && m.isReady()) {
-                    //Add the coords of the unit with the empty hitch
+            for (Transporter t : e.getTransports()) {
+                if ((t instanceof TankTrailerHitch) && (t.getUnused() > 0)) {
                     trailerPos.add(e.getPosition());
-
-                    //Now, check the location of the hitch (which should just be front or rear)
-                    //and add the hex adjacent to the entity in the appropriate direction
-                    //Offset the location value to match the directions in Coords.
                     int dir = e.getFacing();
-                    if (m.getLocation() == Tank.LOC_REAR
-                            || m.getLocation() == SuperHeavyTank.LOC_REAR) {
-                        dir = ((dir + 3) % 6);
+                    if (((TankTrailerHitch) t).getRearMounted()) {
+                        dir = (dir + 3) % 6;
                     }
                     trailerPos.add(e.getPosition().translated(dir));
                 }

--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -894,11 +894,6 @@ public class MechFileParser {
             }
         }
         
-        // If we're a tank, add a rear-mounted trailer hitch if one should be there and isn't
-        if (ent.hasETypeFlag(Entity.ETYPE_TANK)) {
-            ((Tank) ent).addTrailerHitchEquipment();
-        }
-
         // Check if it's canon; if it is, mark it as such.
         ent.setCanon(false);// Guilty until proven innocent
         try {

--- a/megamek/src/megamek/common/SupportTank.java
+++ b/megamek/src/megamek/common/SupportTank.java
@@ -573,6 +573,11 @@ public class SupportTank extends Tank {
     }
 
     @Override
+    public boolean isTractor() {
+        return hasWorkingMisc(MiscType.F_TRACTOR_MODIFICATION);
+    }
+
+    @Override
     public boolean isTrailer() {
         return hasWorkingMisc(MiscType.F_TRAILER_MODIFICATION);
     }

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -3249,12 +3249,32 @@ public class Tank extends Entity {
     }
     
     /**
-     * Add a transporter for each trailer hitch the unit is equipped with
+     * Add a transporter for each trailer hitch the unit is equipped with, with a maximum of
+     * one each in the front and the rear. Any tractor that does not have an explicit hitch
+     * installed as equipment will get a rear-facing transporter.
      */
     public void setTrailerHitches() {
         if (isTractor() && !hasTrailerHitchTransporter()) {
-            // The hitch is located in the rear unless a hitch is explicitly installed at the front.
-            addTransporter(new TankTrailerHitch(!hasWorkingMisc(MiscType.F_HITCH, 0, Tank.LOC_FRONT)));
+            // look for explicit installed trailer hitches and note location
+            boolean front = false;
+            boolean rear = false;
+            for (Mounted m : getMisc()) {
+                if (m.getType().hasFlag(MiscType.F_HITCH)) {
+                    if (m.getLocation() == Tank.LOC_FRONT) {
+                        front = true;
+                    } else {
+                        rear = true;
+                    }
+                }
+            }
+            // Install a transporter anywhere there is an explicit hitch. If no hitch is found,
+            // put it in the back.
+            if (front) {
+                addTransporter(new TankTrailerHitch(false));
+            }
+            if (rear || !front) {
+                addTransporter(new TankTrailerHitch(true));
+            }
         }
     }
     

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -3260,7 +3260,7 @@ public class Tank extends Entity {
             boolean rear = false;
             for (Mounted m : getMisc()) {
                 if (m.getType().hasFlag(MiscType.F_HITCH)) {
-                    if (m.getLocation() == Tank.LOC_FRONT) {
+                    if (m.getLocation() == Tank.LOC_FRONT && !isTrailer()) {
                         front = true;
                     } else {
                         rear = true;


### PR DESCRIPTION
The current behavior for preparing a vehicle to function as a tractor is to check whether it has a hitch installed, and if not to install one if it is eligible (any tracked or wheeled combat vehicle, or any support vehicle with the tractor chassis modification), then as a second step it adds a TankTrailerTransporter to any unit with a hitch. This has the undesired side-effects of adding a hitch automatically to certain vehicles created or modified in MML and adding an unnecessary trailer hitch line to the weapons and equipment inventory on the record sheet, or at least it did until I had the record sheet filter out hitches.

I've changed it to a single step of checking whether the unit is eligible to function as a tractor and add the TankTrailerTransporter if it is. The hitch equipment is still useful in certain situations:
1. A tractor with a hitch on the front will be configured to push the "towed" unit.
2. A tractor with a hitch on the front and another on the back will be able to push or pull the towed unit.
3. A combat vehicle trailer that is not designed to function independently (lacking either engines or control systems or both) does not have a TankTrailerTransporter added unless it has a hitch installed in the rear position, in which case it can be used as part of a tandem trailer system.

Several unit files have had hitches added because they were edited in MML to fix errors. I have removed the hitch from those, but retained it in any unit that shows the hitch as part of its TRO entry.

Fixes MegaMek/megameklab#475