### PR TITLE
MM support for MML equipment tab fixes

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -1031,6 +1031,31 @@ public class EquipmentType implements ITechnology {
         return cost;
     }
 
+    /**
+     * @return Whether the item weight varies according to the unit it's installed on
+     */
+    public boolean isVariableTonnage() {
+        return tonnage == TONNAGE_VARIABLE;
+    }
+
+    /**
+     * @return Whether the item BV varies according to the unit it's installed on
+     */
+    public boolean isVariableBV() {
+        return bv == BV_VARIABLE;
+    }
+
+    /**
+     * @return Whether the item cost varies according to the unit it's installed on
+     */
+    public boolean isVariableCost() {
+        return cost == COST_VARIABLE;
+    }
+
+    public boolean isVariableCriticals() {
+        return criticals == CRITICALS_VARIABLE;
+    }
+
     public TechAdvancement getTechAdvancement() {
         return techAdvancement;
     }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -68,7 +68,7 @@ public class MiscType extends EquipmentType {
     public static final BigInteger F_JUMP_BOOSTER = BigInteger.valueOf(1).shiftLeft(28);
     public static final BigInteger F_HARJEL = BigInteger.valueOf(1).shiftLeft(29);
     public static final BigInteger F_UMU = BigInteger.valueOf(1).shiftLeft(30);
-    public static final BigInteger F_COOLANT_SYSTEM = BigInteger.valueOf(1).shiftLeft(31);
+    public static final BigInteger F_BA_VTOL = BigInteger.valueOf(1).shiftLeft(31);
     public static final BigInteger F_SPIKES = BigInteger.valueOf(1).shiftLeft(32);
     public static final BigInteger F_COMMUNICATIONS = BigInteger.valueOf(1).shiftLeft(33);
     public static final BigInteger F_PPC_CAPACITOR = BigInteger.valueOf(1).shiftLeft(34);
@@ -11453,7 +11453,7 @@ public class MiscType extends EquipmentType {
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.cost = 0;
-        misc.flags = misc.flags.or(F_BA_EQUIPMENT);
+        misc.flags = misc.flags.or(F_BA_EQUIPMENT).or(F_BA_VTOL);
         misc.rulesRefs = "271,TM";
         misc.techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setTechRating(RATING_F).setAvailability(RATING_X, RATING_X, RATING_F, RATING_E)


### PR DESCRIPTION
There is currently no way to distinguish between equipment with 0 weight/cost/BV/criticals and those with variable costs. I added methods that can be used to check the difference so that it can be clearly indicated on the equipment table in MML. I also added a flag to the BA VTOL motive equipment so it can be filtered out on the equipment table, since it's one of the components that gets set on the structure tab. The F_COOLANT_SYSTEM flag isn't being used anywhere so I repurposed that particular index.

See MegaMek/megameklab#487