### PR TITLE
Move primary determination of equipment weight to Mounted.

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1959,7 +1959,7 @@ public class FireControl {
                     continue;
                 } else if (!(shooter instanceof BattleArmor) && Infantry.LOC_FIELD_GUNS == weaponFireInfo.getWeapon()
                                                                                                          .getLocation()) {
-                    final double fieldGunMass = weaponFireInfo.getWeapon().getType().getTonnage(shooter);
+                    final double fieldGunMass = weaponFireInfo.getWeapon().getTonnage();
                     //Only fire field guns up until we no longer have the men to fire more, since going over that limit results in nothing firing.
                     //In theory we could adapt the heat system to handle this(with tonnage as heat and shooting strength as heat capacity, no heat tolerance).
                     //This would behave much better for units with mixed type field guns, but given that those are rare, this should serve for now.

--- a/megamek/src/megamek/client/ui/swing/BayMunitionsChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BayMunitionsChoicePanel.java
@@ -138,7 +138,7 @@ public class BayMunitionsChoicePanel extends JPanel {
                 Mounted m = row.ammoMounts.get(0);
                 AmmoType at = (AmmoType) m.getType();
                 m.setAmmoCapacity(m.getAmmoCapacity() + remainingWeight);
-                m.setOriginalShots((int) Math.floor(m.getAmmoCapacity() / (at.getShots() * at.getTonnage(entity))));
+                m.setOriginalShots((int) Math.floor(m.getAmmoCapacity() / (at.getShots() * m.getTonnage())));
             }
         }
     }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -6914,7 +6914,7 @@ public class Compute {
         } else {
             // Medium and large support vehicle gunner requirements are based on weapon tonnage
             double tonnage = entity.getWeaponList().stream().filter(m -> !m.getType().hasFlag(WeaponType.F_AMS))
-                    .mapToDouble(m -> m.getType().getTonnage(entity)).sum();
+                    .mapToDouble(m -> m.getTonnage()).sum();
             if (advFireCon) {
                 if (entity.getStructuralTechRating() == ITechnology.RATING_F) {
                     return (int) Math.ceil(tonnage / 6.0);
@@ -6941,7 +6941,7 @@ public class Compute {
         int crew = 0;
         for (Mounted m : entity.getMisc()) {
             if (m.getType().hasFlag(MiscType.F_COMMUNICATIONS)) {
-                crew += (int) m.getType().getTonnage(entity);
+                crew += (int) m.getTonnage();
             } else if (m.getType().hasFlag(MiscType.F_FIELD_KITCHEN)) {
                 crew += 3;
             } else if (m.getType().hasFlag(MiscType.F_MASH)

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3496,8 +3496,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
             mounted.setByShot(true);
             mounted.setShotsLeft(nAmmo);
             mounted.setOriginalShots(nAmmo);
-            double tonnage = Math.max(1, nAmmo / ((AmmoType) mounted.getType()).getShots())
-                    * ((AmmoType) mounted.getType()).getTonnage(this);
+            double tonnage = Math.max(1, nAmmo / ((AmmoType) mounted.getType()).getShots()) * mounted.getTonnage();
             mounted.setAmmoCapacity(tonnage);
         }
 
@@ -12180,7 +12179,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         for (Mounted mounted : miscList) {
             if (mounted.getType().hasFlag(MiscType.F_COMMUNICATIONS)
                 && !mounted.isInoperable()) {
-                i += mounted.getType().getTonnage(this);
+                i += mounted.getTonnage();
             }
         }
         return i;
@@ -13398,9 +13397,9 @@ public abstract class Entity extends TurnOrdered implements Transporter,
     		} else if (m.getType().hasFlag(MiscType.F_MOBILE_HPG)) {
     			specialAbilities.put(BattleForceSPA.HPG, null);
     		} else if (m.getType().hasFlag(MiscType.F_COMMUNICATIONS)) {
-    			specialAbilities.merge(BattleForceSPA.MHQ, (int)m.getType().getTonnage(this) * 2,
+    			specialAbilities.merge(BattleForceSPA.MHQ, (int) m.getTonnage() * 2,
     					Integer::sum);
-    			if (m.getType().getTonnage(this) >= getWeight() / 20.0) {
+    			if (m.getTonnage() >= getWeight() / 20.0) {
     				specialAbilities.put(BattleForceSPA.RCN, null);
     			}
     		} else if (m.getType().hasFlag(MiscType.F_SENSOR_DISPENSER)) {
@@ -13641,7 +13640,7 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                 || wt.hasFlag(WeaponType.F_PLASMA)
                 || wt.hasFlag(WeaponType.F_PLASMA_MFUK)
                 || (wt.hasFlag(WeaponType.F_FLAMER) && (wt.getAmmoType() == AmmoType.T_NA))) {
-                total += wt.getTonnage(this);
+                total += m.getTonnage();
             }
         }
         // Finally use that total to compute and return the actual power

--- a/megamek/src/megamek/common/FixedWingSupport.java
+++ b/megamek/src/megamek/common/FixedWingSupport.java
@@ -374,7 +374,7 @@ public class FixedWingSupport extends ConvFighter {
             WeaponType wt = (WeaponType) m.getType();
             if (wt.hasFlag(WeaponType.F_LASER) || wt.hasFlag(WeaponType.F_PPC)) {
                 sinks += wt.getHeat();
-                paWeight += wt.getTonnage(this) / 10.0;
+                paWeight += m.getTonnage() / 10.0;
             }
         }
         paWeight = Math.ceil(paWeight * 2) / 2;

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -2390,7 +2390,7 @@ public class Infantry extends Entity {
         //add in field gun weight
         for (Mounted mounted : getEquipment()) {
             if(mounted.getLocation() == LOC_FIELD_GUNS) {
-                ton += mounted.getType().getTonnage(this);
+                ton += mounted.getTonnage();
             }
         }
 
@@ -2469,8 +2469,8 @@ public class Infantry extends Entity {
             }
             if(wpn.getType().hasFlag(WeaponType.F_ARTILLERY)) {
                 hasArtillery = true;
-                if(wpn.getType().getTonnage(this) < smallestGun) {
-                    smallestGun = wpn.getType().getTonnage(this);
+                if(wpn.getTonnage() < smallestGun) {
+                    smallestGun = wpn.getTonnage();
                 }
             }
         }

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -1618,7 +1618,7 @@ public class Jumpship extends Aero {
             if (atype.getAmmoType() == AmmoType.T_AR10) {
                 key2 = "AR10 Ammo;" + key;
             }
-            double ammoWeight = mounted.getType().getTonnage(this);
+            double ammoWeight = mounted.getTonnage();
             if (atype.isCapital()) {
                 ammoWeight = mounted.getUsableShotsLeft() * atype.getAmmoRatio();
             }

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -1635,7 +1635,7 @@ public class MULParser {
                                          * ((AmmoType) mounted.getType()).getKgPerShot() * 1000);
                             } else {
                                 mounted.setAmmoCapacity(mounted.getOriginalShots()
-                                        * mounted.getType().getTonnage(entity)
+                                        * mounted.getTonnage()
                                         / ((AmmoType) mounted.getType()).getShots());
                             }
                         }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -524,7 +524,7 @@ public class MiscType extends EquipmentType {
             double weaponWeight = 0;
             for (Mounted m : entity.getWeaponList()) {
                 if ((m.getLocation() == locationToCheck) && m.isMechTurretMounted()) {
-                    weaponWeight += m.getType().getTonnage(entity);
+                    weaponWeight += m.getTonnage();
                 }
             }
             // round to half ton
@@ -545,7 +545,7 @@ public class MiscType extends EquipmentType {
             double weaponWeight = 0;
             for (Mounted m : entity.getWeaponList()) {
                 if (m.isSponsonTurretMounted()) {
-                    weaponWeight += m.getType().getTonnage(entity);
+                    weaponWeight += m.getTonnage();
                 }
             }
             return defaultRounding.round(weaponWeight / 10.0,
@@ -562,7 +562,7 @@ public class MiscType extends EquipmentType {
             // 5% of linked weapons' weight
             for (Mounted m : entity.getWeaponList()) {
                 if (m.isPintleTurretMounted() && (m.getLocation() == location)) {
-                    weaponWeight += m.getType().getTonnage(entity);
+                    weaponWeight += m.getTonnage();
                 }
             }
             return defaultRounding.round(weaponWeight / 20.0, entity);
@@ -578,13 +578,13 @@ public class MiscType extends EquipmentType {
             for (Mounted m : entity.getWeaponList()) {
                 WeaponType wt = (WeaponType) m.getType();
                 if (wt.hasFlag(WeaponType.F_DIRECT_FIRE)) {
-                    fTons += wt.getTonnage(entity);
+                    fTons += m.getTonnage();
                 }
             }
             for (Mounted m : entity.getMisc()) {
                 MiscType mt = (MiscType) m.getType();
                 if (mt.hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
-                    fTons += mt.getTonnage(entity);
+                    fTons += m.getTonnage();
                 }
             }
             if (isClan()) {
@@ -688,15 +688,6 @@ public class MiscType extends EquipmentType {
             return defaultRounding.round(entity.getWeight() / 25.0, entity);
         } else if (hasFlag(F_FULLY_AMPHIBIOUS)) {
             return defaultRounding.round(entity.getWeight() / 10.0, entity);
-        } else if (hasFlag(F_DUMPER)) {
-            // 5% of cargo
-            double cargoTonnage = 0;
-            for (Mounted mount : entity.getMisc()) {
-                if (mount.getType().hasFlag(F_CARGO) && (mount.getLocation() == location)) {
-                    cargoTonnage += mount.getType().getTonnage(entity);
-                }
-            }
-            return defaultRounding.round(cargoTonnage / 20.0, entity);
         } else if (hasFlag(F_BASIC_FIRECONTROL) || hasFlag(F_ADVANCED_FIRECONTROL)) {
             // Omni support vees have a fixed weight for the chassis, which may be
             // higher than what is required for the current configuration
@@ -710,7 +701,7 @@ public class MiscType extends EquipmentType {
                 if (!mount.getType().hasFlag(WeaponType.F_AMS)
                         && (!mount.getType().hasFlag(WeaponType.F_INFANTRY)
                         || mount.getType().hasFlag(WeaponType.F_INF_SUPPORT))) {
-                    weaponWeight += mount.getType().getTonnage(entity);
+                    weaponWeight += mount.getTonnage();
                 }
             }
             double weight = weaponWeight / (hasFlag(F_BASIC_FIRECONTROL) ? 20.0 : 10.0);
@@ -889,14 +880,14 @@ public class MiscType extends EquipmentType {
                 for (Mounted mo : entity.getWeaponList()) {
                     WeaponType wt = (WeaponType) mo.getType();
                     if (wt.hasFlag(WeaponType.F_DIRECT_FIRE)) {
-                        fTons += wt.getTonnage(entity);
+                        fTons += mo.getTonnage();
                     }
                 }
 
                 for (Mounted mo : entity.getMisc()) {
                     MiscType mt = (MiscType) mo.getType();
                     if (mt.hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
-                        fTons += mt.getTonnage(entity);
+                        fTons += mo.getTonnage();
                     }
                 }
                 if (getInternalName().equals("ISTargeting Computer")) {
@@ -1040,14 +1031,14 @@ public class MiscType extends EquipmentType {
             for (Mounted m : entity.getWeaponList()) {
                 WeaponType wt = (WeaponType) m.getType();
                 if (wt.hasFlag(WeaponType.F_DIRECT_FIRE)) {
-                    fTons += wt.getTonnage(entity);
+                    fTons += m.getTonnage();
                 }
             }
 
             for (Mounted mo : entity.getMisc()) {
                 MiscType mt = (MiscType) mo.getType();
                 if (mt.hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
-                    fTons += mt.getTonnage(entity);
+                    fTons += mo.getTonnage();
                 }
             }
             if (TechConstants.isClan(getTechLevel(entity.getTechLevelYear()))) {

--- a/megamek/src/megamek/common/RoundWeight.java
+++ b/megamek/src/megamek/common/RoundWeight.java
@@ -64,7 +64,7 @@ public enum RoundWeight {
     public static boolean usesKilogramStandard(Entity entity) {
         return entity instanceof Protomech
                 || entity instanceof BattleArmor
-                || entity.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT;
+                || (entity.isSupportVehicle() && entity.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT);
     }
 
     /**

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2697,13 +2697,13 @@ public class Tank extends Entity {
             WeaponType wt = (WeaponType) m.getType();
             if (wt.hasFlag(WeaponType.F_LASER) || wt.hasFlag(WeaponType.F_PPC)) {
                 sinks += wt.getHeat();
-                paWeight += wt.getTonnage(this) / 10.0;
+                paWeight += m.getTonnage() / 10.0;
             }
             if (!hasNoTurret() && (m.getLocation() == getLocTurret())) {
-                turretWeight += wt.getTonnage(this) / 10.0;
+                turretWeight += m.getTonnage() / 10.0;
             }
             if (!hasNoDualTurret() && (m.getLocation() == getLocTurret2())) {
-                turretWeight += wt.getTonnage(this) / 10.0;
+                turretWeight += m.getTonnage() / 10.0;
             }
         }
         paWeight = Math.ceil(paWeight * 2) / 2;

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -2155,14 +2155,14 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                             return Messages.getString("WeaponAttackAction.FieldGunOrSAOnly");
                         }
                         if ((weapon.getLocation() == Infantry.LOC_FIELD_GUNS) && (weaponId != prevAttack.getWeaponId())) {
-                            fieldGunWeight += prevWeapon.getType().getTonnage(ae);
+                            fieldGunWeight += prevWeapon.getTonnage();
                         }
                     }
                 }
                 // the total tonnage of field guns fired has to be less than or
                 // equal to the men in the platoon
                 if (weapon.getLocation() == Infantry.LOC_FIELD_GUNS) {
-                    if (((Infantry) ae).getShootingStrength() < Math.ceil(fieldGunWeight + wtype.getTonnage(ae))) {
+                    if (((Infantry) ae).getShootingStrength() < Math.ceil(fieldGunWeight + weapon.getTonnage())) {
                         return Messages.getString("WeaponAttackAction.NoFieldGunCrew");
                     }
                 }

--- a/megamek/src/megamek/common/templates/BattleArmorTROView.java
+++ b/megamek/src/megamek/common/templates/BattleArmorTROView.java
@@ -131,7 +131,7 @@ public class BattleArmorTROView extends TROView {
                 name = name.replaceAll(".*\\[", "").replaceAll("\\].*", "");
             }
             retVal.put("eqName", name);
-            retVal.put("eqMass", manipulator.getType().getTonnage(null) * 1000);
+            retVal.put("eqMass", manipulator.getTonnage() * 1000);
         }
         return retVal;
     }
@@ -166,7 +166,7 @@ public class BattleArmorTROView extends TROView {
             if (m.getType() instanceof AmmoType) {
                 row.put("mass", ((AmmoType) m.getType()).getKgPerShot() * m.getOriginalShots());
             } else {
-                row.put("mass", m.getType().getTonnage(ba) * 1000);
+                row.put("mass", m.getTonnage() * 1000);
             }
             if (m.getBaMountLoc() == BattleArmor.MOUNT_LOC_TURRET) {
                 row.put("location", "-");

--- a/megamek/src/megamek/common/templates/ProtomechTROView.java
+++ b/megamek/src/megamek/common/templates/ProtomechTROView.java
@@ -77,11 +77,11 @@ public class ProtomechTROView extends TROView {
             setModelData("jumpMP", proto.getOriginalJumpMP());
             setModelData("jumpMass",
                     Math.round(1000 * proto.getMisc().stream().filter(m -> m.getType().hasFlag(MiscType.F_JUMP_JET))
-                            .mapToDouble(m -> m.getType().getTonnage(proto)).sum()));
+                            .mapToDouble(Mounted::getTonnage).sum()));
         } else {
             setModelData("umuMP", umu.size());
             setModelData("umuMass",
-                    Math.round(1000 * umu.stream().mapToDouble(m -> m.getType().getTonnage(proto)).sum()));
+                    Math.round(1000 * umu.stream().mapToDouble(Mounted::getTonnage).sum()));
         }
         setModelData("hsCount", testproto.getCountHeatSinks());
         setModelData("hsMass", NumberFormat.getInstance().format(testproto.getWeightHeatSinks() * 1000));

--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -254,7 +254,7 @@ public class TROView {
         double podSpace = 0.0;
         for (final Mounted m : entity.getEquipment()) {
             if (m.isOmniPodMounted()) {
-                podSpace += m.getType().getTonnage(entity, m.getLocation());
+                podSpace += m.getTonnage();
             } else if (m.getType() instanceof WeaponType) {
                 weaponCount.merge(m.getType().getName(), 1, Integer::sum);
             }
@@ -518,7 +518,7 @@ public class TROView {
                     } else if (!crit.getMount().isWeaponGroup()) {
                         final String key = stripNotes(crit.getMount().getType().getName());
                         fixedCount.merge(key, 1, Integer::sum);
-                        fixedWeight.merge(key, crit.getMount().getType().getTonnage(entity), Double::sum);
+                        fixedWeight.merge(key, crit.getMount().getTonnage(), Double::sum);
                     }
                 }
             }

--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -236,10 +236,10 @@ public class TestAdvancedAerospace extends TestAero {
                 } else {
                     weaponsPerArc[arc]++;
                 }
-                weaponTonnage[arc] += m.getType().getTonnage(vessel);
+                weaponTonnage[arc] += m.getTonnage();
             }
         }
-        double retVal[] = new double[arcs];
+        double[] retVal = new double[arcs];
         for (int arc = 0; arc < arcs; arc++) {
             int excess = (weaponsPerArc[arc] - 1) / slotsPerArc;
             if (excess > 0) {
@@ -550,8 +550,8 @@ public class TestAdvancedAerospace extends TestAero {
             }
 
             AmmoType mt = (AmmoType) m.getType();
-            int slots = (int)Math.ceil(m.getBaseShotsLeft() / mt.getShots());
-            weight += ceil(mt.getTonnage(getEntity()) * slots, Ceil.HALFTON);
+            int slots = (int) Math.ceil((double) m.getBaseShotsLeft() / mt.getShots());
+            weight += ceil(m.getTonnage() * slots, Ceil.HALFTON);
         }
         return weight;
     }
@@ -642,12 +642,12 @@ public class TestAdvancedAerospace extends TestAero {
             for (Integer wNum : m.getBayWeapons()) {
                 final Mounted w = getEntity().getEquipment(wNum);
                 buffer.append("   ").append(StringUtil.makeLength(w.getName(),
-                        getPrintSize() - 25)).append(w.getType().getTonnage(getEntity()))
+                        getPrintSize() - 25)).append(w.getTonnage())
                     .append("\n");
             }
             for (Integer aNum : m.getBayAmmo()) {
                 final Mounted a = getEntity().getEquipment(aNum);
-                double weight = ceil(a.getType().getTonnage(getEntity())
+                double weight = ceil(a.getTonnage()
                         * a.getBaseShotsLeft() / ((AmmoType)a.getType()).getShots(), Ceil.HALFTON);
                 buffer.append("   ").append(StringUtil.makeLength(a.getName(),
                         getPrintSize() - 25)).append(weight).append("\n");

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -597,13 +597,13 @@ public class TestAero extends TestEntity {
                 if (wt.hasFlag(WeaponType.F_ENERGY) && 
                         !(wt instanceof CLChemicalLaserWeapon) && 
                         !(wt instanceof VehicleFlamerWeapon)) {
-                    weight += wt.getTonnage(aero);
+                    weight += m.getTonnage();
                 }
                 Mounted linkedBy = m.getLinkedBy();
                 if ((linkedBy != null) && 
                         (linkedBy.getType() instanceof MiscType) && 
                         linkedBy.getType().hasFlag(MiscType.F_PPC_CAPACITOR)){
-                    weight += linkedBy.getType().getTonnage(aero);
+                    weight += linkedBy.getTonnage();
                 }
             }
             // Power amp weighs:

--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -1260,7 +1260,7 @@ public class TestBattleArmor extends TestEntity {
                     || mt.hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)) {
                 continue;
             }
-            weightSum += mt.getTonnage(getEntity(), m.getLocation());
+            weightSum += m.getTonnage();
         }
         return weightSum;
     }
@@ -1288,18 +1288,7 @@ public class TestBattleArmor extends TestEntity {
                 continue;
             }
 
-            WeaponType wt = (WeaponType) m.getType();
-            if (m.isDWPMounted()) {
-                weight += wt.getTonnage(getEntity()) * 0.75;
-            } else if (m.isSquadSupportWeapon()){
-                if (ba.isClan()){
-                    weight += wt.getTonnage(getEntity()) * 0.4;
-                } else {
-                    weight += wt.getTonnage(getEntity()) * 0.5;
-                }
-            } else {
-                weight += wt.getTonnage(getEntity());
-            }
+            weight += m.getTonnage();
         }
         // Round weight to prevent odd behavior
         return Math.round(weight * 1000) / 1000.0;

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -530,7 +530,7 @@ public abstract class TestEntity implements TestEntityOption {
                     || mt.hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)) {
                 continue;
             }
-            weightSum += mt.getTonnage(getEntity(), m.getLocation());
+            weightSum += m.getTonnage();
         }
         return weightSum;
     }
@@ -566,7 +566,7 @@ public abstract class TestEntity implements TestEntityOption {
                 continue;
             }
 
-            if (mt.getTonnage(getEntity(), m.getLocation()) == 0f) {
+            if (m.getTonnage() == 0f) {
                 continue;
             }
 
@@ -574,7 +574,7 @@ public abstract class TestEntity implements TestEntityOption {
             buff.append(
                     StringUtil.makeLength(getLocationAbbr(m.getLocation()),
                             getPrintSize() - 5 - 20)).append(
-                    TestEntity.makeWeightString(mt.getTonnage(getEntity()), usesKgStandard()));
+                    TestEntity.makeWeightString(m.getTonnage(), usesKgStandard()));
             buff.append("\n");
         }
         return buff;
@@ -586,12 +586,7 @@ public abstract class TestEntity implements TestEntityOption {
             if (m.isWeaponGroup()) {
                 continue;
             }
-            WeaponType wt = (WeaponType) m.getType();
-            if (m.isDWPMounted()){
-                weight += wt.getTonnage(getEntity()) * 0.75;
-            } else {
-                weight += wt.getTonnage(getEntity());
-            }
+            weight += m.getTonnage();
         }
         return weight;
     }
@@ -617,8 +612,7 @@ public abstract class TestEntity implements TestEntityOption {
             buff.append(
                     StringUtil.makeLength(getLocationAbbr(m.getLocation()),
                             getPrintSize() - 5 - 20))
-                    .append(TestEntity.makeWeightString(mt
-                            .getTonnage(getEntity()), usesKgStandard())).append("\n");
+                    .append(TestEntity.makeWeightString(m.getTonnage(), usesKgStandard())).append("\n");
         }
         return buff;
     }
@@ -637,8 +631,7 @@ public abstract class TestEntity implements TestEntityOption {
                 continue;
             }
 
-            AmmoType mt = (AmmoType) m.getType();
-            weight += mt.getTonnage(getEntity());
+            weight += m.getTonnage();
         }
         return weight;
     }
@@ -666,8 +659,7 @@ public abstract class TestEntity implements TestEntityOption {
             buff.append(" ").append(
                     StringUtil.makeLength(getLocationAbbr(m.getLocation()),
                             getPrintSize() - 5 - 20))
-                    .append(TestEntity.makeWeightString(mt
-                            .getTonnage(getEntity()), usesKgStandard())).append("\n");
+                    .append(TestEntity.makeWeightString(m.getTonnage(), usesKgStandard())).append("\n");
         }
         return buff;
     }
@@ -742,13 +734,13 @@ public abstract class TestEntity implements TestEntityOption {
             for (Mounted mo : getEntity().getWeaponList()) {
                 WeaponType wt = (WeaponType) mo.getType();
                 if (wt.hasFlag(WeaponType.F_DIRECT_FIRE)) {
-                    fTons += wt.getTonnage(getEntity());
+                    fTons += mo.getTonnage();
                 }
             }
             for (Mounted mo : getEntity().getMisc()) {
                 MiscType mt2 = (MiscType) mo.getType();
                 if (mt2.hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
-                    fTons += mt.getTonnage(getEntity());
+                    fTons += mo.getTonnage();
                 }
             }
             double weight = 0.0f;

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -238,13 +238,12 @@ public class TestMech extends TestEntity {
             for (Mounted m : mech.getWeaponList()) {
                 WeaponType wt = (WeaponType) m.getType();
                 if (wt instanceof EnergyWeapon) {
-                    powerAmpWeight += wt.getTonnage(mech);
+                    powerAmpWeight += m.getTonnage();
                 }
                 if ((m.getLinkedBy() != null)
                         && (m.getLinkedBy().getType() instanceof MiscType)
                         && m.getLinkedBy().getType().hasFlag(MiscType.F_PPC_CAPACITOR)) {
-                    powerAmpWeight += ((MiscType) m.getLinkedBy().getType())
-                            .getTonnage(mech);
+                    powerAmpWeight += m.getLinkedBy().getTonnage();
                 }
             }
             return TestEntity.ceil(powerAmpWeight / 10f, getWeightCeilingPowerAmp());
@@ -324,7 +323,7 @@ public class TestMech extends TestEntity {
         for (Mounted misc : mech.getMisc()) {
             if (misc.getType().hasFlag(MiscType.F_COMPACT_HEAT_SINK)) {
                 hasCompact = true;
-                compactHsTons += misc.getType().getTonnage(mech);
+                compactHsTons += misc.getTonnage();
             }
         }
         if (hasCompact) {

--- a/megamek/src/megamek/common/verifier/TestProtomech.java
+++ b/megamek/src/megamek/common/verifier/TestProtomech.java
@@ -448,7 +448,7 @@ public class TestProtomech extends TestEntity {
                 continue;
             }
             slotsByLoc.merge(mount.getLocation(), 1, Integer::sum);
-            weightByLoc.merge(mount.getLocation(),  mount.getTonnage(), Double::sum);
+            weightByLoc.merge(mount.getLocation(), mount.getTonnage(), Double::sum);
             if (mount.isRearMounted() && (mount.getLocation() != Protomech.LOC_TORSO)) {
                 buff.append("Equipment can only be rear-mounted on the torso\n");
                 illegal = true;

--- a/megamek/src/megamek/common/verifier/TestProtomech.java
+++ b/megamek/src/megamek/common/verifier/TestProtomech.java
@@ -348,7 +348,7 @@ public class TestProtomech extends TestEntity {
             buff.append(
                     StringUtil.makeLength(getLocationAbbr(m.getLocation()),
                             getPrintSize() - 5 - 20)).append(
-                    TestEntity.makeWeightString(round(mt.getTonnage(getEntity()), Ceil.KILO), true));
+                    TestEntity.makeWeightString(round(m.getTonnage(), Ceil.KILO), true));
             buff.append("\n");
         }
         return buff;
@@ -363,8 +363,7 @@ public class TestProtomech extends TestEntity {
             buff.append(
                     StringUtil.makeLength(getLocationAbbr(m.getLocation()),
                             getPrintSize() - 5 - 20))
-                    .append(TestEntity.makeWeightString(round(mt
-                            .getTonnage(getEntity()), Ceil.KILO), true)).append("\n");
+                    .append(TestEntity.makeWeightString(m.getTonnage(), true)).append("\n");
         }
         return buff;
     }
@@ -449,8 +448,7 @@ public class TestProtomech extends TestEntity {
                 continue;
             }
             slotsByLoc.merge(mount.getLocation(), 1, Integer::sum);
-            weightByLoc.merge(mount.getLocation(),
-                    mount.getType().getTonnage(proto, mount.getLocation()), Double::sum);
+            weightByLoc.merge(mount.getLocation(),  mount.getTonnage(), Double::sum);
             if (mount.isRearMounted() && (mount.getLocation() != Protomech.LOC_TORSO)) {
                 buff.append("Equipment can only be rear-mounted on the torso\n");
                 illegal = true;

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -187,10 +187,10 @@ public class TestSmallCraft extends TestAero {
                     arc += 3;
                 }
                 weaponsPerArc[arc]++;
-                weaponTonnage[arc] += m.getType().getTonnage(sc);
+                weaponTonnage[arc] += m.getTonnage();
             }
         }
-        double retVal[] = new double[arcs];
+        double[] retVal = new double[arcs];
         for (int arc = 0; arc < arcs; arc++) {
             int excess = (weaponsPerArc[arc] - 1) / slotsPerArc(sc);
             if (excess > 0) {
@@ -422,8 +422,8 @@ public class TestSmallCraft extends TestAero {
             }
 
             AmmoType mt = (AmmoType) m.getType();
-            int slots = (int)Math.ceil(m.getBaseShotsLeft() / mt.getShots());
-            weight += mt.getTonnage(getEntity()) * slots;
+            int slots = (int) Math.ceil((double) m.getBaseShotsLeft() / mt.getShots());
+            weight += m.getTonnage() * slots;
         }
         return weight;
     }
@@ -467,13 +467,12 @@ public class TestSmallCraft extends TestAero {
             for (Integer wNum : m.getBayWeapons()) {
                 final Mounted w = getEntity().getEquipment(wNum);
                 buffer.append("   ").append(StringUtil.makeLength(w.getName(),
-                        getPrintSize() - 25)).append(w.getType().getTonnage(getEntity()))
+                        getPrintSize() - 25)).append(w.getTonnage())
                     .append("\n");
             }
             for (Integer aNum : m.getBayAmmo()) {
                 final Mounted a = getEntity().getEquipment(aNum);
-                double weight = a.getType().getTonnage(getEntity())
-                        * a.getBaseShotsLeft() / ((AmmoType)a.getType()).getShots();
+                double weight = a.getTonnage() * a.getBaseShotsLeft() / ((AmmoType) a.getType()).getShots();
                 buffer.append("   ").append(StringUtil.makeLength(a.getName(),
                         getPrintSize() - 25)).append(weight).append("\n");
             }

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -744,7 +744,7 @@ public class TestSupportVehicle extends TestEntity {
         for (Mounted m : supportVee.getMisc()) {
             if (m.getType().hasFlag(MiscType.F_BASIC_FIRECONTROL)
                     || m.getType().hasFlag(MiscType.F_ADVANCED_FIRECONTROL)) {
-                return m.getType().getTonnage(supportVee);
+                return m.getTonnage();
             }
         }
         return 0.0;
@@ -799,17 +799,17 @@ public class TestSupportVehicle extends TestEntity {
             for (Mounted m : supportVee.getWeaponList()) {
                 WeaponType wt = (WeaponType) m.getType();
                 if (wt.hasFlag(WeaponType.F_ENERGY) && !(wt instanceof CLChemicalLaserWeapon) && !(wt instanceof VehicleFlamerWeapon)) {
-                    weight += wt.getTonnage(supportVee);
+                    weight += m.getTonnage();
                 }
                 if ((m.getLinkedBy() != null) && (m.getLinkedBy().getType() instanceof
                         MiscType) && m.getLinkedBy().getType().
                         hasFlag(MiscType.F_PPC_CAPACITOR)) {
-                    weight += m.getLinkedBy().getType().getTonnage(supportVee);
+                    weight += m.getLinkedBy().getTonnage();
                 }
             }
             for (Mounted m : supportVee.getMisc()) {
                 if (m.getType().hasFlag(MiscType.F_CLUB) && m.getType().hasSubType(MiscType.S_SPOT_WELDER)) {
-                    weight += m.getType().getTonnage(supportVee);
+                    weight += m.getTonnage();
                 }
             }
             return ceilWeight(weight / 10);
@@ -864,7 +864,7 @@ public class TestSupportVehicle extends TestEntity {
             if (m.getType().hasFlag(MiscType.F_BASIC_FIRECONTROL)
                     || m.getType().hasFlag(MiscType.F_ADVANCED_FIRECONTROL)) {
                 fireCon = StringUtil.makeLength(m.getName(), getPrintSize() - 5)
-                        + TestEntity.makeWeightString(m.getType().getTonnage(supportVee), usesKgStandard()) + "\n";
+                        + TestEntity.makeWeightString(m.getTonnage(), usesKgStandard()) + "\n";
                 break;
             }
         }
@@ -1004,7 +1004,7 @@ public class TestSupportVehicle extends TestEntity {
                 buff.append(m.getType().getName()).append(" is not a valid weapon for this unit.\n");
                 correct = false;
             }
-            weaponWeight += m.getType().getTonnage(supportVee, m.getLocation());
+            weaponWeight += m.getTonnage();
         }
         if (supportVee.isOmni() && (supportVee.hasWorkingMisc(MiscType.F_BASIC_FIRECONTROL)
                     || supportVee.hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL))

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -211,7 +211,7 @@ public class TestTank extends TestEntity {
                         && !(m.getType() instanceof AmmoType)
                         // Skip any patchwork armor mounts
                         && (EquipmentType.getArmorType(m.getType()) == EquipmentType.T_ARMOR_UNKNOWN)) {
-                    weight += m.getType().getTonnage(tank);
+                    weight += m.getTonnage();
                 }
             }
             // Turrets weight 10% of the weight of weapons in them
@@ -240,7 +240,7 @@ public class TestTank extends TestEntity {
             for (Mounted m : tank.getEquipment()) {
                 if ((m.getLocation() == tank.getLocTurret2())
                         && !(m.getType() instanceof AmmoType)) {
-                    weight += m.getType().getTonnage(tank);
+                    weight += m.getTonnage();
                 }
             }
             // Turrets weight 10% of the weight of weapons in them
@@ -734,17 +734,17 @@ public class TestTank extends TestEntity {
             for (Mounted m : tank.getWeaponList()) {
                 WeaponType wt = (WeaponType) m.getType();
                 if (wt.hasFlag(WeaponType.F_ENERGY) && !(wt instanceof CLChemicalLaserWeapon) && !(wt instanceof VehicleFlamerWeapon)) {
-                    weight += wt.getTonnage(tank);
+                    weight += m.getTonnage();
                 }
                 if ((m.getLinkedBy() != null) && (m.getLinkedBy().getType() instanceof
                         MiscType) && m.getLinkedBy().getType().
                         hasFlag(MiscType.F_PPC_CAPACITOR)) {
-                    weight += (m.getLinkedBy().getType()).getTonnage(tank);
+                    weight += m.getLinkedBy().getTonnage();
                 }
             }
             for (Mounted m : tank.getMisc()) {
                 if (m.getType().hasFlag(MiscType.F_CLUB) && m.getType().hasSubType(MiscType.S_SPOT_WELDER)) {
-                    weight += m.getType().getTonnage(tank);
+                    weight += m.getTonnage();
                 }
             }
             return TestEntity.ceil(weight / 10, getWeightCeilingPowerAmp());
@@ -868,11 +868,11 @@ public class TestTank extends TestEntity {
             for (Mounted m : tank.getEquipment()) {
                 if ((m.getLocation() == tank.getLocTurret2())
                         && !(m.getType() instanceof AmmoType)) {
-                    turret2Weight += m.getType().getTonnage(tank);
+                    turret2Weight += m.getTonnage();
                 }
                 if ((m.getLocation() == tank.getLocTurret())
                         && !(m.getType() instanceof AmmoType)) {
-                    turretWeight += m.getType().getTonnage(tank);
+                    turretWeight += m.getTonnage();
                 }
             }
             turretWeight *= 0.1;


### PR DESCRIPTION
This adds a getTonnage method to Mounted and changes all the places in MM where getTonnage is called on the mounted EquipmentType to use Mounted instead. The immediate reason for doing this is that the weight of the dumper depends on the size of the cargo bay it's connected to, and the EquipmentType itself has no way of determining that, even with the Entity and location provided. I have also moved some of the effects of BA mount types on weight into this method.

This is something I've been contemplating for some time, though it had nothing to do with the peculiar needs of dumpers. The next step in this process is to add a size field to Mounted so we can eliminate the need for multiple versions of equipment in different sizes such as communications equipment and ladders. It also provides an easier-to-use way of adding capacity to equipment like MASH theaters and drone operating systems without having to have a second piece of equipment just to expand.