### PR TITLE
Tank blue shield

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -358,7 +358,7 @@ public class EquipmentType implements ITechnology {
         return criticals;
     }
 
-    public int getTankslots(Entity entity) {
+    public int getTankSlots(Entity entity) {
         return tankslots;
     }
 

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1235,6 +1235,10 @@ public class MiscType extends EquipmentType {
                 return 4;
             } else if ((entity instanceof BipedMech) || (entity instanceof QuadMech)) {
                 return 7;
+            } else if (entity instanceof TripodMech) {
+                return 8;
+            } else if (entity instanceof Tank) {
+                return entity.locations();
             }
 
         } else if (hasFlag(F_ENDO_STEEL)) {

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1233,14 +1233,12 @@ public class MiscType extends EquipmentType {
         } else if (hasFlag(F_BLUE_SHIELD)) {
             if (entity instanceof Aero) {
                 return 4;
-            } else if ((entity instanceof BipedMech) || (entity instanceof QuadMech)) {
-                return 7;
-            } else if (entity instanceof TripodMech) {
-                return 8;
-            } else if (entity instanceof Tank) {
-                return entity.locations();
+            } else {
+                // Mechs: one per location except head
+                // Support vehicles: one per location except body
+                // Combat vehicles: Handled by getTankSlots
+                return entity.locations() - 1;
             }
-
         } else if (hasFlag(F_ENDO_STEEL)) {
             if ((entity instanceof Mech) && ((Mech) entity).isSuperHeavy()) {
                 return 7;
@@ -1258,6 +1256,14 @@ public class MiscType extends EquipmentType {
         }
         // right, well I'll just guess then
         return 1;
+    }
+
+    @Override
+    public int getTankSlots(Entity entity) {
+        if (hasFlag(MiscType.F_BLUE_SHIELD)) {
+            return entity.locations() - 1;
+        }
+        return super.getTankSlots(entity);
     }
 
     public double getBV(Entity entity, Mounted linkedTo) {

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -3568,7 +3568,7 @@ public class Tank extends Entity {
             if ((mount.getType() instanceof MiscType)
                     && mount.getType().hasFlag(MiscType.F_CARGO)) {
                 if (!addedCargo) {
-                    usedSlots += mount.getType().getTankslots(this);
+                    usedSlots += mount.getType().getTankSlots(this);
                     addedCargo = true;
                     continue;
                 } else {
@@ -3583,7 +3583,7 @@ public class Tank extends Entity {
             if (!((mount.getType() instanceof AmmoType) || Arrays.asList(
                     EquipmentType.armorNames).contains(
                     mount.getType().getName()))) {
-                usedSlots += mount.getType().getTankslots(this);
+                usedSlots += mount.getType().getTankSlots(this);
             }
         }
         // JJs take just 1 slot

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -617,7 +617,7 @@ public class TestTank extends TestEntity {
                     && mount.getType().hasFlag(MiscType.F_CARGO)) {
                 if (!addedCargo) {
                     buff.append(StringUtil.makeLength(mount.getType().getName(), 30));
-                    buff.append(mount.getType().getTankslots(tank)).append("\n");
+                    buff.append(mount.getType().getTankSlots(tank)).append("\n");
                     addedCargo = true;
                     continue;
                 } else {
@@ -628,7 +628,7 @@ public class TestTank extends TestEntity {
                     EquipmentType.armorNames).contains(
                     mount.getType().getName()))) {
                 buff.append(StringUtil.makeLength(mount.getType().getName(), 30));
-                buff.append(mount.getType().getTankslots(tank)).append("\n");
+                buff.append(mount.getType().getTankSlots(tank)).append("\n");
             }
         }
         if (tank.getExtraCrewSeats() > 0) {

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -924,7 +924,8 @@ public class TestTank extends TestEntity {
             return eq.hasFlag(MiscType.F_CHASSIS_MODIFICATION)
                     || eq.hasFlag(MiscType.F_CASE)
                     || eq.hasFlag(MiscType.F_CASEII)
-                    || eq.hasFlag(MiscType.F_JUMP_JET);
+                    || eq.hasFlag(MiscType.F_JUMP_JET)
+                    || eq.hasFlag(MiscType.F_BLUE_SHIELD);
         } else {
             return eq instanceof AmmoType;
         }


### PR DESCRIPTION
Correct vehicle slot cost for Blue Shield PFD (one per location, including turret(s) but not body) and automatically place it in the body in MML.

While doing this I noticed that the slot cost for Mechs wasn't taking into account the extra leg location in tripods.

Fixes MegaMek/megameklab#493.