### PR TITLE
Supercharger restrictions

### DIFF
--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -279,9 +279,9 @@ public class TestSupportVehicle extends TestEntity {
                     // Can't put a turret on a convertible
                     && (!this.equals(CONVERTIBLE) || !(sv instanceof Tank)
                         || ((Tank) sv).hasNoTurret())
-                    // External power pickup is only valid for RAIL movement mode (not MAGLEV)
+                    // External power pickup (rail) is only valid with the external engine type
                     && (!this.equals(EXTERNAL_POWER_PICKUP)
-                        || sv.getMovementMode().equals(EntityMovementMode.RAIL));
+                        || (sv.getEngine().getEngineType() == Engine.EXTERNAL));
         }
 
         /**

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -412,6 +412,10 @@ public class TestTank extends TestEntity {
                     buff.append("combat vehicle escape pod must be placed in rear");
                     correct = false;
                 }
+            } else if (m.getType().hasFlag(MiscType.F_MASC) && m.getType().hasSubType(MiscType.S_SUPERCHARGER)
+                    && (tank instanceof VTOL)) {
+                buff.append("VTOLS cannot mount superchargers.");
+                correct = false;
             }
         }
         for (int loc = 0; loc < tank.locations(); loc++) {
@@ -491,6 +495,7 @@ public class TestTank extends TestEntity {
             if (eq.hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER)
                     || eq.hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER)
                     || eq.hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER)
+                    || (eq.hasFlag(MiscType.F_MASC) && eq.hasSubType(MiscType.S_SUPERCHARGER))
                     || (eq.hasFlag(MiscType.F_CLUB)
                     && eq.hasSubType(MiscType.S_BACKHOE | MiscType.S_ROCK_CUTTER
                     | MiscType.S_SPOT_WELDER | MiscType.S_WRECKING_BALL))) {


### PR DESCRIPTION
Adds supercharger to the list of equipment restricted by motive type (no VTOL), and adds restrictions by engine (no solar or rail external). Why working on this I noticed that MML is always allowing the external power pickup chassis mod with all non-maglev rail vehicles. I think this comes from before I noticed that there is a separate engine type for external power.

This takes care of the MM side of MegaMek/megameklab#497