### PR TITLE
BayData utility should generate cargo bays by weight instead of capacity

### DIFF
--- a/megamek/src/megamek/common/verifier/BayData.java
+++ b/megamek/src/megamek/common/verifier/BayData.java
@@ -138,7 +138,11 @@ public enum BayData {
      * @return        The new bay.
      */
     public Bay newBay(double size, int bayNum) {
-        return init.apply(size, bayNum);
+        if (isCargoBay()) {
+            return init.apply(size / weight, bayNum);
+        } else {
+            return init.apply(size, bayNum);
+        }
     }
     
     /**


### PR DESCRIPTION
This brings the utility class used in construction and validation in line with what the method claims to do in its own documentation.

Fixes MegaMek/megameklab#492