### PR TITLE
Mech zero crit equipment

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -6721,6 +6721,14 @@ public abstract class Mech extends Entity {
             sb.append(hasEngine() ? getEngine().getBaseChassisHeatSinks(hasCompactHeatSinks()) : 0);
             sb.append(newLine);
         }
+        for (Mounted mounted : getMisc()) {
+            if ((mounted.getType().getCriticals(this) == 0)
+                    && !mounted.getType().hasFlag(MiscType.F_CASE)) {
+                sb.append(MtfFile.NO_CRIT).append(mounted.getType().getInternalName())
+                        .append(":").append(getLocationAbbr(mounted.getLocation()))
+                        .append(newLine);
+            }
+        }
 
         sb.append(MtfFile.WALK_MP).append(walkMP).append(newLine);
         sb.append(MtfFile.JUMP_MP).append(jumpMP).append(newLine);
@@ -6738,7 +6746,7 @@ public abstract class Mech extends Entity {
             if ((element == Mech.LOC_CLEG) && !(this instanceof TripodMech)) {
                 continue;
             }
-            sb.append(getLocationAbbr(element)).append(MtfFile.ARMOR);
+            sb.append(getLocationAbbr(element)).append(" ").append(MtfFile.ARMOR);
             if (hasPatchworkArmor()) {
                 sb.append(EquipmentType.getArmorTypeName(getArmorType(element), isClan()))
                         .append('(').append(TechConstants.getTechName(getArmorTechLevel(element)))
@@ -6747,7 +6755,7 @@ public abstract class Mech extends Entity {
             sb.append(getOArmor(element, false)).append(newLine);
         }
         for (int element : MtfFile.rearLocationOrder) {
-            sb.append("RT").append(getLocationAbbr(element).charAt(0)).append(MtfFile.ARMOR);
+            sb.append("RT").append(getLocationAbbr(element).charAt(0)).append(" ").append(MtfFile.ARMOR);
             sb.append(getOArmor(element, true)).append(newLine);
         }
         sb.append(newLine);
@@ -6758,7 +6766,6 @@ public abstract class Mech extends Entity {
                     .append(getLocationName(m.getLocation())).append(newLine);
         }
         sb.append(newLine);
-
         for (int l : MtfFile.locationOrder) {
             if ((l == Mech.LOC_CLEG) && !(this instanceof TripodMech)) {
                 continue;

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -6594,8 +6594,8 @@ public abstract class Mech extends Entity {
      * Known missing level 3 features: mixed tech, laser heatsinks
      */
     public String getMtf() {
-        StringBuffer sb = new StringBuffer();
-        String newLine = "\r\n"; // DOS friendly
+        StringBuilder sb = new StringBuilder();
+        String newLine = "\n";
 
         boolean standard = (getCockpitType() == Mech.COCKPIT_STANDARD)
                 && (getGyroType() == Mech.GYRO_STANDARD);
@@ -6629,7 +6629,7 @@ public abstract class Mech extends Entity {
         }
 
         sb.append(newLine);
-        sb.append("TechBase:");
+        sb.append(MtfFile.TECH_BASE);
         if (isMixedTech()) {
             if (isClan()) {
                 sb.append("Mixed (Clan Chassis)");
@@ -6640,18 +6640,17 @@ public abstract class Mech extends Entity {
             sb.append(TechConstants.getTechName(techLevel));
         }
         sb.append(newLine);
-        sb.append("Era:").append(year).append(newLine);
+        sb.append(MtfFile.ERA).append(year).append(newLine);
         if ((source != null) && (source.trim().length() > 0)) {
-            sb.append("Source:").append(source).append(newLine);
+            sb.append(MtfFile.SOURCE).append(source).append(newLine);
         }
-        sb.append("Rules Level:").append(
+        sb.append(MtfFile.RULES_LEVEL).append(
                 TechConstants.T_SIMPLE_LEVEL[techLevel]);
         sb.append(newLine);
         sb.append(newLine);
 
-        Double tonnage = Double.valueOf(weight);
-        sb.append("Mass:").append(tonnage.intValue()).append(newLine);
-        sb.append("Engine:");
+        sb.append(MtfFile.MASS).append((int) weight).append(newLine);
+        sb.append(MtfFile.ENGINE);
         if(hasEngine()) {
                 sb.append(getEngine().getEngineName())
                 .append(" Engine")
@@ -6661,12 +6660,12 @@ public abstract class Mech extends Entity {
             sb.append("(none)");
         }
         sb.append(newLine);
-        sb.append("Structure:");
+        sb.append(MtfFile.STRUCTURE);
         sb.append(EquipmentType.getStructureTypeName(getStructureType(),
                 TechConstants.isClan(structureTechLevel)));
         sb.append(newLine);
 
-        sb.append("Myomer:");
+        sb.append(MtfFile.MYOMER);
         if (hasTSM()) {
             sb.append("Triple-Strength");
         } else if (hasIndustrialTSM()) {
@@ -6679,38 +6678,33 @@ public abstract class Mech extends Entity {
         sb.append(newLine);
 
         if (this instanceof LandAirMech) {
-            sb.append("LAM:");
+            sb.append(MtfFile.LAM);
             sb.append(((LandAirMech)this).getLAMTypeString());
             sb.append(newLine);
         } else if (this instanceof QuadVee) {
-            sb.append("Motive:");
+            sb.append(MtfFile.MOTIVE);
             sb.append(((QuadVee)this).getMotiveTypeString());
             sb.append(newLine);
         }
 
 
         if (!standard) {
-            sb.append("Cockpit:");
+            sb.append(MtfFile.COCKPIT);
             sb.append(getCockpitTypeString());
             sb.append(newLine);
 
-            sb.append("Gyro:");
+            sb.append(MtfFile.GYRO);
             sb.append(getGyroTypeString());
             sb.append(newLine);
         }
         if (hasFullHeadEject()) {
-            sb.append("Ejection:");
+            sb.append(MtfFile.EJECTION);
             sb.append(Mech.FULL_HEAD_EJECT_STRING);
-            sb.append(newLine);
-        }
-        if (this instanceof LandAirMech) {
-            sb.append("LAM:");
-            sb.append(((LandAirMech)this).getLAMTypeString());
             sb.append(newLine);
         }
         sb.append(newLine);
 
-        sb.append("Heat Sinks:").append(heatSinks()).append(" ");
+        sb.append(MtfFile.HEAT_SINKS).append(heatSinks()).append(" ");
         if (hasCompactHeatSinks()) {
             sb.append("Compact");
         } else if (hasLaserHeatSinks()) {
@@ -6723,24 +6717,20 @@ public abstract class Mech extends Entity {
         sb.append(newLine);
 
         if (isOmni()) {
-            sb.append("Base Chassis Heat Sinks:");
+            sb.append(MtfFile.BASE_CHASSIS_HEAT_SINKS);
             sb.append(hasEngine() ? getEngine().getBaseChassisHeatSinks(hasCompactHeatSinks()) : 0);
             sb.append(newLine);
         }
 
-        sb.append("Walk MP:").append(walkMP).append(newLine);
-        sb.append("Jump MP:").append(jumpMP).append(newLine);
+        sb.append(MtfFile.WALK_MP).append(walkMP).append(newLine);
+        sb.append(MtfFile.JUMP_MP).append(jumpMP).append(newLine);
         sb.append(newLine);
 
         if (hasPatchworkArmor()) {
-            sb.append("Armor:").append(
-                    EquipmentType
-                            .getArmorTypeName(EquipmentType.T_ARMOR_PATCHWORK));
+            sb.append(MtfFile.ARMOR).append(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_PATCHWORK));
         } else {
-            sb.append("Armor:").append(
-                    EquipmentType.getArmorTypeName(getArmorType(0)));
-            sb.append("(" + TechConstants.getTechName(getArmorTechLevel(0))
-                    + ")");
+            sb.append(MtfFile.ARMOR).append(EquipmentType.getArmorTypeName(getArmorType(0)))
+                .append("(").append(TechConstants.getTechName(getArmorTechLevel(0))).append(")");
         }
         sb.append(newLine);
 
@@ -6748,28 +6738,22 @@ public abstract class Mech extends Entity {
             if ((element == Mech.LOC_CLEG) && !(this instanceof TripodMech)) {
                 continue;
             }
-            sb.append(getLocationAbbr(element)).append(" Armor:");
+            sb.append(getLocationAbbr(element)).append(MtfFile.ARMOR);
             if (hasPatchworkArmor()) {
-                sb.append(
-                        EquipmentType.getArmorTypeName(getArmorType(element),
-                                isClan()))
-                        .append('(')
-                        .append(TechConstants
-                                .getTechName(getArmorTechLevel(element)))
+                sb.append(EquipmentType.getArmorTypeName(getArmorType(element), isClan()))
+                        .append('(').append(TechConstants.getTechName(getArmorTechLevel(element)))
                         .append("):");
             }
             sb.append(getOArmor(element, false)).append(newLine);
         }
         for (int element : MtfFile.rearLocationOrder) {
-            sb.append("RT").append(getLocationAbbr(element).charAt(0))
-                    .append(" Armor:");
+            sb.append("RT").append(getLocationAbbr(element).charAt(0)).append(MtfFile.ARMOR);
             sb.append(getOArmor(element, true)).append(newLine);
         }
         sb.append(newLine);
 
         sb.append("Weapons:").append(weaponList.size()).append(newLine);
-        for (int i = 0; i < weaponList.size(); i++) {
-            Mounted m = weaponList.get(i);
+        for (Mounted m : weaponList) {
             sb.append(m.getName()).append(", ")
                     .append(getLocationName(m.getLocation())).append(newLine);
         }
@@ -6780,7 +6764,7 @@ public abstract class Mech extends Entity {
                 continue;
             }
             String locationName = getLocationName(l);
-            sb.append(locationName + ":");
+            sb.append(locationName).append(":");
             sb.append(newLine);
             for (int y = 0; y < 12; y++) {
                 if (y < getNumberOfCriticals(l)) {
@@ -6794,62 +6778,62 @@ public abstract class Mech extends Entity {
         }
 
         if (getFluff().getOverview().trim().length() > 0) {
-            sb.append("overview:");
+            sb.append(MtfFile.OVERVIEW);
             sb.append(getFluff().getOverview());
             sb.append(newLine);
         }
 
         if (getFluff().getCapabilities().trim().length() > 0) {
-            sb.append("capabilities:");
+            sb.append(MtfFile.CAPABILITIES);
             sb.append(getFluff().getCapabilities());
             sb.append(newLine);
         }
 
         if (getFluff().getDeployment().trim().length() > 0) {
-            sb.append("deployment:");
+            sb.append(MtfFile.DEPLOYMENT);
             sb.append(getFluff().getDeployment());
             sb.append(newLine);
         }
 
         if (getFluff().getHistory().trim().length() > 0) {
-            sb.append("history:");
+            sb.append(MtfFile.HISTORY);
             sb.append(getFluff().getHistory());
             sb.append(newLine);
         }
 
         if (getFluff().getManufacturer().trim().length() > 0) {
-            sb.append("manufacturer:");
+            sb.append(MtfFile.MANUFACTURER);
             sb.append(getFluff().getManufacturer());
             sb.append(newLine);
         }
 
         if (getFluff().getPrimaryFactory().trim().length() > 0) {
-            sb.append("primaryFactory:");
+            sb.append(MtfFile.PRIMARY_FACTORY);
             sb.append(getFluff().getPrimaryFactory());
             sb.append(newLine);
         }
 
         if (getFluff().getNotes().trim().length() > 0) {
-            sb.append("notes:");
+            sb.append(MtfFile.NOTES);
             sb.append(getFluff().getNotes());
             sb.append(newLine);
         }
 
         if (getFluff().getMMLImagePath().trim().length() > 0) {
-            sb.append("imagefile:");
+            sb.append(MtfFile.IMAGE_FILE);
             sb.append(getFluff().getMMLImagePath());
             sb.append(newLine);
         }
 
         for (EntityFluff.System system : EntityFluff.System.values()) {
         	if (getFluff().getSystemManufacturer(system).length() > 0) {
-        		sb.append("systemmanufacturer:");
+        		sb.append(MtfFile.SYSTEM_MANUFACTURER);
         		sb.append(system.toString()).append(":");
         		sb.append(getFluff().getSystemManufacturer(system));
         		sb.append(newLine);
         	}
         	if (getFluff().getSystemModel(system).length() > 0) {
-        		sb.append("systemmodel:");
+        		sb.append(MtfFile.SYSTEM_MODEL);
         		sb.append(system.toString()).append(":");
         		sb.append(getFluff().getSystemModel(system));
         		sb.append(newLine);
@@ -6857,7 +6841,7 @@ public abstract class Mech extends Entity {
         }
 
         if (getUseManualBV()) {
-            sb.append("bv:");
+            sb.append(MtfFile.BV);
             sb.append(getManualBV());
             sb.append(newLine);
         }
@@ -6877,12 +6861,12 @@ public abstract class Mech extends Entity {
             armoredText = " " + MtfFile.ARMORED;
         }
         if (type == CriticalSlot.TYPE_SYSTEM) {
-            if ((getRawSystemName(index).indexOf("Upper") != -1)
-                    || (getRawSystemName(index).indexOf("Lower") != -1)
-                    || (getRawSystemName(index).indexOf("Hand") != -1)
-                    || (getRawSystemName(index).indexOf("Foot") != -1)) {
+            if ((getRawSystemName(index).contains("Upper"))
+                    || (getRawSystemName(index).contains("Lower"))
+                    || (getRawSystemName(index).contains("Hand"))
+                    || (getRawSystemName(index).contains("Foot"))) {
                 return getRawSystemName(index) + " Actuator" + armoredText;
-            } else if (getRawSystemName(index).indexOf("Engine") != -1) {
+            } else if (getRawSystemName(index).contains("Engine")) {
                 return "Fusion " + getRawSystemName(index) + armoredText;
             } else {
                 return getRawSystemName(index) + armoredText;

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -939,7 +939,9 @@ public class MechView {
         int nEquip = 0;
         for (Mounted mounted : entity.getMisc()) {
             String name = mounted.getName();
-            if ((mounted.getLocation() == Entity.LOC_NONE)
+            if ((((mounted.getLocation() == Entity.LOC_NONE)
+                        // Mechs can have zero-slot equipment in LOC_NONE that needs to be shown.
+                        && (!isMech || mounted.getType().getCriticals(entity) > 0)))
                     || name.contains("Jump Jet")
                     || (name.contains("CASE")
                         && !name.contains("II")

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -20,10 +20,7 @@
 
 package megamek.common.loaders;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.*;
 
 import megamek.common.AmmoType;
@@ -102,6 +99,37 @@ public class MtfFile implements IMechLoader {
     public static final int[] rearLocationOrder =
             {Mech.LOC_LT, Mech.LOC_RT, Mech.LOC_CT};
 
+    public static final String COCKPIT = "cockpit:";
+    public static final String GYRO = "gyro:";
+    public static final String MOTIVE = "motive:";
+    public static final String EJECTION = "ejection:";
+    public static final String MASS = "mass:";
+    public static final String ENGINE = "engine:";
+    public static final String STRUCTURE = "structure:";
+    public static final String MYOMER = "myomer:";
+    public static final String LAM = "lam:";
+    public static final String CONFIG = "config:";
+    public static final String TECH_BASE = "techbase:";
+    public static final String ERA = "era:";
+    public static final String SOURCE = "source:";
+    public static final String RULES_LEVEL = "rules level:";
+    public static final String HEAT_SINKS = "heat sinks:";
+    public static final String BASE_CHASSIS_HEAT_SINKS = "base chassis heat sinks:";
+    public static final String WALK_MP = "walk mp:";
+    public static final String JUMP_MP = "jump mp:";
+    public static final String ARMOR = "armor:";
+    public static final String OVERVIEW = "overview:";
+    public static final String CAPABILITIES = "capabilities:";
+    public static final String DEPLOYMENT = "deployment:";
+    public static final String HISTORY = "history:";
+    public static final String MANUFACTURER = "manufacturer:";
+    public static final String PRIMARY_FACTORY = "primaryfactory:";
+    public static final String SYSTEM_MANUFACTURER = "systemmanufacturer:";
+    public static final String SYSTEM_MODEL = "systemmode:";
+    public static final String NOTES = "notes:";
+    public static final String IMAGE_FILE = "imagefile:";
+    public static final String BV = "bv:";
+    public static final String WEAPONS = "weapons:";
     public static final String EMPTY = "-Empty-";
     public static final String ARMORED = "(armored)";
     public static final String OMNIPOD = "(omnipod)";
@@ -148,7 +176,7 @@ public class MtfFile implements IMechLoader {
         int armorLocation;
         while (r.ready()) {
             crit = r.readLine();
-            if (crit.trim().length() < 1) {
+            if (crit.trim().isEmpty()) {
                 continue;
             }
 
@@ -246,7 +274,6 @@ public class MtfFile implements IMechLoader {
                 mech = new BipedMech(iGyroType, iCockpitType);
             }
             mech.setFullHeadEject(fullHead);
-
             mech.setChassis(name.trim());
             mech.setModel(model.trim());
             mech.setYear(Integer.parseInt(techYear.substring(4).trim()));
@@ -255,91 +282,7 @@ public class MtfFile implements IMechLoader {
             if (chassisConfig.contains("Omni")) {
                 mech.setOmni(true);
             }
-
-            switch (techBase.substring(9).trim()) {
-                case "Inner Sphere":
-                    switch (Integer.parseInt(rulesLevel.substring(12).trim())) {
-                        case 1:
-                            mech.setTechLevel(TechConstants.T_INTRO_BOXSET);
-                            break;
-                        case 2:
-                            mech.setTechLevel(TechConstants.T_IS_TW_NON_BOX);
-                            break;
-                        case 3:
-                            mech.setTechLevel(TechConstants.T_IS_ADVANCED);
-                            break;
-                        case 4:
-                            mech.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
-                            break;
-                        case 5:
-                            mech.setTechLevel(TechConstants.T_IS_UNOFFICIAL);
-                            break;
-                        default:
-                            throw new EntityLoadingException("Unsupported tech level: " + rulesLevel.substring(12).trim());
-                    }
-                    break;
-                case "Clan":
-                    switch (Integer.parseInt(rulesLevel.substring(12).trim())) {
-                        case 2:
-                            mech.setTechLevel(TechConstants.T_CLAN_TW);
-                            break;
-                        case 3:
-                            mech.setTechLevel(TechConstants.T_CLAN_ADVANCED);
-                            break;
-                        case 4:
-                            mech.setTechLevel(TechConstants.T_CLAN_EXPERIMENTAL);
-                            break;
-                        case 5:
-                            mech.setTechLevel(TechConstants.T_CLAN_UNOFFICIAL);
-                            break;
-                        default:
-                            throw new EntityLoadingException("Unsupported tech level: " + rulesLevel.substring(12).trim());
-                    }
-                    break;
-                case "Mixed (IS Chassis)":
-                    switch (Integer.parseInt(rulesLevel.substring(12).trim())) {
-                        case 2:
-                            mech.setTechLevel(TechConstants.T_IS_TW_NON_BOX);
-                            break;
-                        case 3:
-                            mech.setTechLevel(TechConstants.T_IS_ADVANCED);
-                            break;
-                        case 4:
-                            mech.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
-                            break;
-                        case 5:
-                            mech.setTechLevel(TechConstants.T_IS_UNOFFICIAL);
-                            break;
-                        default:
-                            throw new EntityLoadingException("Unsupported tech level: " + rulesLevel.substring(12).trim());
-                    }
-                    mech.setMixedTech(true);
-                    break;
-                case "Mixed (Clan Chassis)":
-                    switch (Integer.parseInt(rulesLevel.substring(12).trim())) {
-                        case 2:
-                            mech.setTechLevel(TechConstants.T_CLAN_TW);
-                            break;
-                        case 3:
-                            mech.setTechLevel(TechConstants.T_CLAN_ADVANCED);
-                            break;
-                        case 4:
-                            mech.setTechLevel(TechConstants.T_CLAN_EXPERIMENTAL);
-                            break;
-                        case 5:
-                            mech.setTechLevel(TechConstants.T_CLAN_UNOFFICIAL);
-                            break;
-                        default:
-                            throw new EntityLoadingException("Unsupported tech level: " + rulesLevel.substring(12).trim());
-                    }
-                    mech.setMixedTech(true);
-                    break;
-                case "Mixed":
-                    throw new EntityLoadingException("Unsupported tech base: \"Mixed\" is no longer allowed by itself.  You must specify \"Mixed (IS Chassis)\" or \"Mixed (Clan Chassis)\".");
-                default:
-                    throw new EntityLoadingException("Unsupported tech base: " + techBase.substring(9).trim());
-            }
-
+            setTechLevel(mech);
             mech.setWeight(Integer.parseInt(tonnage.substring(5)));
 
             int engineFlags = 0;
@@ -554,6 +497,92 @@ public class MtfFile implements IMechLoader {
         } catch (StringIndexOutOfBoundsException ex) {
             ex.printStackTrace();
             throw new EntityLoadingException("StringIndexOutOfBoundsException parsing file");
+        }
+    }
+
+    private void setTechLevel(Mech mech) throws EntityLoadingException {
+        switch (techBase.substring(9).trim()) {
+            case "Inner Sphere":
+                switch (Integer.parseInt(rulesLevel.substring(12).trim())) {
+                    case 1:
+                        mech.setTechLevel(TechConstants.T_INTRO_BOXSET);
+                        break;
+                    case 2:
+                        mech.setTechLevel(TechConstants.T_IS_TW_NON_BOX);
+                        break;
+                    case 3:
+                        mech.setTechLevel(TechConstants.T_IS_ADVANCED);
+                        break;
+                    case 4:
+                        mech.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
+                        break;
+                    case 5:
+                        mech.setTechLevel(TechConstants.T_IS_UNOFFICIAL);
+                        break;
+                    default:
+                        throw new EntityLoadingException("Unsupported tech level: " + rulesLevel.substring(12).trim());
+                }
+                break;
+            case "Clan":
+                switch (Integer.parseInt(rulesLevel.substring(12).trim())) {
+                    case 2:
+                        mech.setTechLevel(TechConstants.T_CLAN_TW);
+                        break;
+                    case 3:
+                        mech.setTechLevel(TechConstants.T_CLAN_ADVANCED);
+                        break;
+                    case 4:
+                        mech.setTechLevel(TechConstants.T_CLAN_EXPERIMENTAL);
+                        break;
+                    case 5:
+                        mech.setTechLevel(TechConstants.T_CLAN_UNOFFICIAL);
+                        break;
+                    default:
+                        throw new EntityLoadingException("Unsupported tech level: " + rulesLevel.substring(12).trim());
+                }
+                break;
+            case "Mixed (IS Chassis)":
+                switch (Integer.parseInt(rulesLevel.substring(12).trim())) {
+                    case 2:
+                        mech.setTechLevel(TechConstants.T_IS_TW_NON_BOX);
+                        break;
+                    case 3:
+                        mech.setTechLevel(TechConstants.T_IS_ADVANCED);
+                        break;
+                    case 4:
+                        mech.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
+                        break;
+                    case 5:
+                        mech.setTechLevel(TechConstants.T_IS_UNOFFICIAL);
+                        break;
+                    default:
+                        throw new EntityLoadingException("Unsupported tech level: " + rulesLevel.substring(12).trim());
+                }
+                mech.setMixedTech(true);
+                break;
+            case "Mixed (Clan Chassis)":
+                switch (Integer.parseInt(rulesLevel.substring(12).trim())) {
+                    case 2:
+                        mech.setTechLevel(TechConstants.T_CLAN_TW);
+                        break;
+                    case 3:
+                        mech.setTechLevel(TechConstants.T_CLAN_ADVANCED);
+                        break;
+                    case 4:
+                        mech.setTechLevel(TechConstants.T_CLAN_EXPERIMENTAL);
+                        break;
+                    case 5:
+                        mech.setTechLevel(TechConstants.T_CLAN_UNOFFICIAL);
+                        break;
+                    default:
+                        throw new EntityLoadingException("Unsupported tech level: " + rulesLevel.substring(12).trim());
+                }
+                mech.setMixedTech(true);
+                break;
+            case "Mixed":
+                throw new EntityLoadingException("Unsupported tech base: \"Mixed\" is no longer allowed by itself.  You must specify \"Mixed (IS Chassis)\" or \"Mixed (Clan Chassis)\".");
+            default:
+                throw new EntityLoadingException("Unsupported tech base: " + techBase.substring(9).trim());
         }
     }
 
@@ -932,132 +961,131 @@ public class MtfFile implements IMechLoader {
     }
 
     private boolean isProcessedComponent(String line) {
-
-        if (line.trim().toLowerCase().startsWith("cockpit:")) {
+        if (line.trim().toLowerCase().startsWith(COCKPIT)) {
             cockpitType = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("gyro:")) {
+        if (line.trim().toLowerCase().startsWith(GYRO)) {
             gyroType = line;
             return true;
         }
         
-        if (line.trim().toLowerCase().startsWith("motive:")) {
+        if (line.trim().toLowerCase().startsWith(MOTIVE)) {
             motiveType = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("ejection:")) {
+        if (line.trim().toLowerCase().startsWith(EJECTION)) {
             ejectionType = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("mass:")) {
+        if (line.trim().toLowerCase().startsWith(MASS)) {
             tonnage = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("engine:")) {
+        if (line.trim().toLowerCase().startsWith(ENGINE)) {
             engine = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("structure:")) {
+        if (line.trim().toLowerCase().startsWith(STRUCTURE)) {
             internalType = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("myomer:")) {
+        if (line.trim().toLowerCase().startsWith(MYOMER)) {
             myomerType = line;
             return true;
         }
         
-        if (line.trim().toLowerCase().startsWith("lam:")) {
+        if (line.trim().toLowerCase().startsWith(LAM)) {
             lamType = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("config:")) {
+        if (line.trim().toLowerCase().startsWith(CONFIG)) {
             chassisConfig = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("techbase:")) {
+        if (line.trim().toLowerCase().startsWith(TECH_BASE)) {
             techBase = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("era:")) {
+        if (line.trim().toLowerCase().startsWith(ERA)) {
             techYear = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("source:")) {
+        if (line.trim().toLowerCase().startsWith(SOURCE)) {
             source = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("rules level:")) {
+        if (line.trim().toLowerCase().startsWith(RULES_LEVEL)) {
             rulesLevel = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("heat sinks:")) {
+        if (line.trim().toLowerCase().startsWith(HEAT_SINKS)) {
             heatSinks = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("base chassis heat sinks:")) {
+        if (line.trim().toLowerCase().startsWith(BASE_CHASSIS_HEAT_SINKS)) {
             baseChassieHeatSinks = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("walk mp:")) {
+        if (line.trim().toLowerCase().startsWith(WALK_MP)) {
             walkMP = line;
             return true;
         }
-        if (line.trim().toLowerCase().startsWith("jump mp:")) {
+        if (line.trim().toLowerCase().startsWith(JUMP_MP)) {
             jumpMP = line;
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("armor:")) {
+        if (line.trim().toLowerCase().startsWith(ARMOR)) {
             armorType = line;
             return true;
         }
         
-        if (line.trim().toLowerCase().startsWith("overview:")) {
-            overview = line.substring("overview:".length());
+        if (line.trim().toLowerCase().startsWith(OVERVIEW)) {
+            overview = line.substring(OVERVIEW.length());
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("capabilities:")) {
-            capabilities = line.substring("capabilities:".length());
+        if (line.trim().toLowerCase().startsWith(CAPABILITIES)) {
+            capabilities = line.substring(CAPABILITIES.length());
             return true;
         }
                 
-        if (line.trim().toLowerCase().startsWith("deployment:")) {
-            deployment = line.substring("deployment:".length());
+        if (line.trim().toLowerCase().startsWith(DEPLOYMENT)) {
+            deployment = line.substring(DEPLOYMENT.length());
             return true;
         }
         
-        if (line.trim().toLowerCase().startsWith("history:")) {
-            history = line.substring("history:".length());
+        if (line.trim().toLowerCase().startsWith(HISTORY)) {
+            history = line.substring(HISTORY.length());
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("manufacturer:")) {
-        	manufacturer = line.substring("manufacturer:".length());
+        if (line.trim().toLowerCase().startsWith(MANUFACTURER)) {
+        	manufacturer = line.substring(MANUFACTURER.length());
         	return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("primaryfactory:")) {
-        	primaryFactory = line.substring("primaryfactory:".length());
+        if (line.trim().toLowerCase().startsWith(PRIMARY_FACTORY)) {
+        	primaryFactory = line.substring(PRIMARY_FACTORY.length());
         	return true;
         }
 
-        if (line.toLowerCase().startsWith("systemmanufacturer:")) {
+        if (line.toLowerCase().startsWith(SYSTEM_MANUFACTURER)) {
         	String[] fields = line.split(":");
         	if (fields.length > 2) {
         		EntityFluff.System system = EntityFluff.System.parse(fields[1]);
@@ -1068,7 +1096,7 @@ public class MtfFile implements IMechLoader {
         	return true;
         }
 
-        if (line.toLowerCase().startsWith("systemmodel:")) {
+        if (line.toLowerCase().startsWith(SYSTEM_MODEL)) {
         	String[] fields = line.split(":");
         	if (fields.length > 2) {
         		EntityFluff.System system = EntityFluff.System.parse(fields[1]);
@@ -1080,18 +1108,18 @@ public class MtfFile implements IMechLoader {
         }
 
 
-        if (line.trim().toLowerCase().startsWith("notes:")) {
-            notes = line.substring("notes:".length());
+        if (line.trim().toLowerCase().startsWith(NOTES)) {
+            notes = line.substring(NOTES.length());
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("imagefile:")) {
-            imagePath = line.substring("imagefile:".length());
+        if (line.trim().toLowerCase().startsWith(IMAGE_FILE)) {
+            imagePath = line.substring(IMAGE_FILE.length());
             return true;
         }
 
-        if (line.trim().toLowerCase().startsWith("bv:")) {
-            bv = Integer.parseInt(line.substring("bv:".length()));
+        if (line.trim().toLowerCase().startsWith(BV)) {
+            bv = Integer.parseInt(line.substring(BV.length()));
             return true;
         }
 
@@ -1099,8 +1127,8 @@ public class MtfFile implements IMechLoader {
     }
 
     private int weaponsList(String line) {
-        if (line.trim().toLowerCase().startsWith("weapons:")) {
-            return Integer.parseInt(line.substring(8));
+        if (line.trim().toLowerCase().startsWith(WEAPONS)) {
+            return Integer.parseInt(line.substring(WEAPONS.length()));
         }
 
         return -1;

--- a/megamek/src/megamek/common/templates/MechTROView.java
+++ b/megamek/src/megamek/common/templates/MechTROView.java
@@ -16,15 +16,7 @@ package megamek.common.templates;
 import java.text.NumberFormat;
 import java.util.StringJoiner;
 
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EntityFluff;
-import megamek.common.EquipmentType;
-import megamek.common.LandAirMech;
-import megamek.common.Mech;
-import megamek.common.Messages;
-import megamek.common.Mounted;
-import megamek.common.QuadVee;
+import megamek.common.*;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestMech;
 
@@ -145,8 +137,8 @@ public class MechTROView extends TROView {
     protected void addFluff() {
         addMechVeeAeroFluff(mech);
         setModelData("chassisDesc",
-                formatSystemFluff(EntityFluff.System.CHASSIS, mech.getFluff(), () -> formatChassisDesc()));
-        setModelData("jjDesc", formatSystemFluff(EntityFluff.System.JUMPJET, mech.getFluff(), () -> formatJJDesc()));
+                formatSystemFluff(EntityFluff.System.CHASSIS, mech.getFluff(), this::formatChassisDesc));
+        setModelData("jjDesc", formatSystemFluff(EntityFluff.System.JUMPJET, mech.getFluff(), this::formatJJDesc));
         setModelData("jumpCapacity", mech.getJumpMP() * 30);
     }
 
@@ -157,8 +149,8 @@ public class MechTROView extends TROView {
 
     private void addArmorAndStructure() {
         setModelData("structureValues",
-                addArmorStructureEntries(mech, (en, loc) -> en.getOInternal(loc), MECH_ARMOR_LOCS));
-        setModelData("armorValues", addArmorStructureEntries(mech, (en, loc) -> en.getOArmor(loc), MECH_ARMOR_LOCS));
+                addArmorStructureEntries(mech, Entity::getOInternal, MECH_ARMOR_LOCS));
+        setModelData("armorValues", addArmorStructureEntries(mech, Entity::getOArmor, MECH_ARMOR_LOCS));
         setModelData("rearArmorValues",
                 addArmorStructureEntries(mech, (en, loc) -> en.getOArmor(loc, true), MECH_ARMOR_LOCS_REAR));
         if (mech.hasPatchworkArmor()) {
@@ -251,5 +243,14 @@ public class MechTROView extends TROView {
             loc += "(R)";
         }
         return loc;
+    }
+
+    @Override
+    protected boolean skipMount(Mounted mount, boolean includeAmmo) {
+        if (mount.getLocation() == Entity.LOC_NONE) {
+            return (mount.getType().getCriticals(mech) > 0)
+                    || mount.getType().hasFlag(MiscType.F_CASE);
+        }
+        return super.skipMount(mount, includeAmmo);
     }
 }

--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -147,16 +147,14 @@ public class TROView {
     public String processTemplate() {
         if (null != template) {
             model.put("includeFluff", includeFluff);
-
-            final ByteArrayOutputStream os = new ByteArrayOutputStream();
-            final Writer out = new OutputStreamWriter(os);
-            try {
+            try (final ByteArrayOutputStream os = new ByteArrayOutputStream();
+                 final Writer out = new OutputStreamWriter(os)) {
                 template.process(model, out);
+                return os.toString();
             } catch (TemplateException | IOException e) {
                 DefaultMmLogger.getInstance().error(getClass(), "processTemplate()", e);
                 e.printStackTrace();
             }
-            return os.toString();
         }
         return null;
     }
@@ -408,12 +406,18 @@ public class TROView {
         return addEquipment(entity, true);
     }
 
+    protected boolean skipMount(Mounted mount, boolean includeAmmo) {
+        return mount.getLocation() < 0
+                || mount.isWeaponGroup()
+                || (!includeAmmo && (mount.getType() instanceof AmmoType));
+    }
+
     protected int addEquipment(Entity entity, boolean includeAmmo) {
         final int structure = entity.getStructureType();
         final Map<String, Map<EquipmentType, Integer>> equipment = new HashMap<>();
         int nameWidth = 20;
         for (final Mounted m : entity.getEquipment()) {
-            if ((m.getLocation() < 0) || m.isWeaponGroup() || (!includeAmmo && (m.getType() instanceof AmmoType))) {
+            if (skipMount(m, includeAmmo)) {
                 continue;
             }
             if (!m.getType().isHittable()) {

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1397,7 +1397,7 @@ public abstract class TestEntity implements TestEntityOption {
             illegal = true;
         }
         if (networks > 1) {
-            buff.append("Cannot multiple multiple network types on the same unit.\n");
+            buff.append("Cannot have multiple network types on the same unit.\n");
             illegal = true;
         }
         if (robotics > 1) {
@@ -1652,4 +1652,3 @@ class Structure {
     }
 
 } // End class Structure
-

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1302,6 +1302,9 @@ public abstract class TestEntity implements TestEntityOption {
         boolean hasHarjelIII = false;
         boolean hasCoolantPod = false;
         int emergencyCoolantCount = 0;
+        int networks = 0;
+        boolean countedC3 = false;
+        int robotics = 0;
         for (Mounted m : getEntity().getAmmo()) {
             if (((AmmoType)m.getType()).getAmmoType() == AmmoType.T_COOLANT_POD) {
                 hasCoolantPod = true;
@@ -1335,6 +1338,24 @@ public abstract class TestEntity implements TestEntityOption {
             if (m.getType().hasFlag(MiscType.F_HARJEL_III)) {
                 hasHarjelIII = true;
             }
+            if ((m.getType().hasFlag(MiscType.F_C3S) || m.getType().hasFlag(MiscType.F_C3SBS)) && !countedC3) {
+                networks++;
+                countedC3 = true;
+            }
+            if (m.getType().hasFlag(MiscType.F_C3I) || m.getType().hasFlag(MiscType.F_NOVA)) {
+                networks++;
+            }
+            if (m.getType().hasFlag(MiscType.F_SRCS) || m.getType().hasFlag(MiscType.F_SASRCS)
+                    || m.getType().hasFlag(MiscType.F_CASPAR) || m.getType().hasFlag(MiscType.F_CASPARII)) {
+                robotics++;
+            }
+        }
+        if ((networks > 0) && !countedC3) {
+            for (Mounted m : getEntity().getIndividualWeaponList()) {
+                if (m.getType().hasFlag(WeaponType.F_C3M) || m.getType().hasFlag(WeaponType.F_C3MBS)) {
+                    networks++;
+                }
+            }
         }
         if ((isMech() || isTank() || isAero())
                 && (!getEntity().hasEngine()
@@ -1352,7 +1373,7 @@ public abstract class TestEntity implements TestEntityOption {
                     illegal = true;
                 }
             }
-        }        
+        }
 
         if (minesweeperCount > 1) {
             buff.append("Unit has more than one minesweeper!\n");
@@ -1375,7 +1396,14 @@ public abstract class TestEntity implements TestEntityOption {
             buff.append("Cannot mount HarJel repair system on non-Mech\n");
             illegal = true;
         }
-        
+        if (networks > 1) {
+            buff.append("Cannot multiple multiple network types on the same unit.\n");
+            illegal = true;
+        }
+        if (robotics > 1) {
+            buff.append("Unit has multiple drone control systems.\n");
+            illegal = true;
+        }
         if (getEntity().hasStealth() && !getEntity().hasWorkingMisc(MiscType.F_ECM)) {
             buff.append("Stealth armor requires an ECM generator.\n");
             illegal = true;
@@ -1385,13 +1413,13 @@ public abstract class TestEntity implements TestEntityOption {
             for (Mounted m : getEntity().getEquipment()) {
                 if (m.isOmniPodMounted() && m.getType().isOmniFixedOnly()) {
                     illegal = true;
-                    buff.append(m.getType().getName() + " cannot be pod mounted.");
+                    buff.append(m.getType().getName()).append(" cannot be pod mounted.");
                 }
             }
         } else {
             for (Mounted m : getEntity().getEquipment()) {
                 if (m.isOmniPodMounted()) {
-                    buff.append(m.getType().getName() + " is pod mounted in non-omni unit\n");
+                    buff.append(m.getType().getName()).append(" is pod mounted in non-omni unit\n");
                     illegal = true;
                 }
             }


### PR DESCRIPTION
This involves a series of exceptions to the way nearly everything else works in order to support the construction of 'Mechs with the smart robotic control system (SRCS; IO, p. 140-1). It occupies no critical slots, so it's not assigned a location. Since 'Mechs don't have a generic location like the vehicle body or aerospace hull/fuselage, it doesn't get written to the mtf file or displayed on the summary or TRO view.

I started with a bit of cleanup on the MTF file processing, including replacing String literals with named constants. I tried to make this generic rather than specific to the SRCS, so any equipment that takes up zero crits gets added to the MTF on a line that has the format "nocrits:[internalName]:[location abbrev]". Except Clan CASE, which gets handled differently for now.

I added some checks to the validation code to flag any unit that mounts multiple robotics systems, and added C3 system type counting at the same time.

The most awkward code is the part that shows the SRCS on the MechView summary and the TRO view.

Fixes MegaMek/megameklab#496