### PR TITLE
External fuel tanks for combat vehicles

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -818,6 +818,12 @@ public class MiscType extends EquipmentType {
             } else {
                 return 1.0;
             }
+        } else if (hasFlag(MiscType.F_FUEL)) {
+            if (entity.hasEngine()) {
+                return defaultRounding.round(entity.getEngine().getWeightEngine(entity), entity);
+            } else {
+                return 0.0;
+            }
         }
        // okay, I'm out of ideas
         return 1.0f;
@@ -9030,6 +9036,25 @@ public class MiscType extends EquipmentType {
                 .setClanAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
                 .setClanApproximate(true, false, false, false, false).setPrototypeFactions(F_TA)
                 .setProductionFactions(F_TH);
+        return misc;
+    }
+
+    public static MiscType createCVExternalFuel() {
+        MiscType misc = new MiscType();
+
+        misc.name = "Extended Fuel Tank";
+        misc.setInternalName(misc.name);
+        misc.tonnage = TONNAGE_VARIABLE;
+        misc.criticals = 1;
+        misc.cost = 2000;
+        misc.flags = misc.flags.or(F_FUEL).or(F_TANK_EQUIPMENT);
+        misc.explosive = true;
+        misc.industrial = true;
+        misc.rulesRefs = "244,TM";
+        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setTechRating(RATING_C)
+                .setAvailability(RATING_C, RATING_D, RATING_D, RATING_C)
+                .setAdvancement(DATE_NONE, 2300, 2300).setISApproximate(false, true, false)
+                .setProductionFactions(F_TA);
         return misc;
     }
 

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1579,14 +1579,7 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createMASHExtraTheater());
         EquipmentType.addType(MiscType.createParamedicEquipment());
         EquipmentType.addType(MiscType.createISMastMount());
-        EquipmentType.addType(MiscType.createFuel1());
-        EquipmentType.addType(MiscType.createFuelHalf());
-        EquipmentType.addType(MiscType.createFuel2());
-        EquipmentType.addType(MiscType.createFuel25());
-        EquipmentType.addType(MiscType.createFuel3());
-        EquipmentType.addType(MiscType.createFuel35());
-        EquipmentType.addType(MiscType.createFuel4());
-        EquipmentType.addType(MiscType.createCVExtendedFuelTank());
+        EquipmentType.addType(MiscType.createExtendedFuelTank());
         EquipmentType.addType(MiscType.createBlueShield());
         EquipmentType.addType(MiscType.createISEndoComposite());
         EquipmentType.addType(MiscType.createClanEndoComposite());
@@ -7222,28 +7215,6 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createFuel1() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Extended Fuel Tank (1 ton)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 1;
-        misc.criticals = 1;
-        misc.cost = 500;
-        misc.flags = misc.flags.or(F_FUEL).or(F_MECH_EQUIPMENT);
-        misc.explosive = true;
-        misc.industrial = true;
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_C).setAvailability(RATING_C, RATING_D, RATING_D, RATING_D)
-                .setISAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setISApproximate(true, false, false, false, false)
-                .setClanAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setClanApproximate(true, false, false, false, false).setPrototypeFactions(F_TA)
-                .setProductionFactions(F_TH);
-        return misc;
-    }
-
     public static MiscType createLightFluidSuctionSystemMech() {
         MiscType misc = new MiscType();
         misc.name = "Light Fluid Suction System (Mech)";
@@ -8908,147 +8879,22 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createFuelHalf() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Extended Fuel Tank (0.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 0.5;
-        misc.criticals = 1;
-        misc.cost = 500;
-        misc.flags = misc.flags.or(F_FUEL).or(F_MECH_EQUIPMENT);
-        misc.explosive = true;
-        misc.industrial = true;
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_C).setAvailability(RATING_C, RATING_D, RATING_D, RATING_D)
-                .setISAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setISApproximate(true, false, false, false, false)
-                .setClanAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setClanApproximate(true, false, false, false, false).setPrototypeFactions(F_TA)
-                .setProductionFactions(F_TH);
-        return misc;
-    }
-
-    public static MiscType createFuel2() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Extended Fuel Tank (2 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 2;
-        misc.criticals = 2;
-        misc.cost = 1000;
-        misc.flags = misc.flags.or(F_FUEL).or(F_MECH_EQUIPMENT);
-        misc.explosive = true;
-        misc.industrial = true;
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_C).setAvailability(RATING_C, RATING_D, RATING_D, RATING_D)
-                .setISAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setISApproximate(true, false, false, false, false)
-                .setClanAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setClanApproximate(true, false, false, false, false).setPrototypeFactions(F_TA)
-                .setProductionFactions(F_TH);
-        return misc;
-    }
-
-    public static MiscType createFuel25() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Extended Fuel Tank (2.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 2.5;
-        misc.criticals = 3;
-        misc.cost = 1500;
-        misc.flags = misc.flags.or(F_FUEL).or(F_MECH_EQUIPMENT);
-        misc.explosive = true;
-        misc.industrial = true;
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_C).setAvailability(RATING_C, RATING_D, RATING_D, RATING_D)
-                .setISAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setISApproximate(true, false, false, false, false)
-                .setClanAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setClanApproximate(true, false, false, false, false).setPrototypeFactions(F_TA)
-                .setProductionFactions(F_TH);
-        return misc;
-    }
-
-    public static MiscType createFuel3() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Extended Fuel Tank (3 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 3;
-        misc.criticals = 3;
-        misc.cost = 1500;
-        misc.flags = misc.flags.or(F_FUEL).or(F_MECH_EQUIPMENT);
-        misc.explosive = true;
-        misc.industrial = true;
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_C).setAvailability(RATING_C, RATING_D, RATING_D, RATING_D)
-                .setISAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setISApproximate(true, false, false, false, false)
-                .setClanAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setClanApproximate(true, false, false, false, false).setPrototypeFactions(F_TA)
-                .setProductionFactions(F_TH);
-        return misc;
-    }
-
-    public static MiscType createFuel35() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Extended Fuel Tank (3.5 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 3.5;
-        misc.criticals = 4;
-        misc.cost = 2000;
-        misc.flags = misc.flags.or(F_FUEL).or(F_MECH_EQUIPMENT);
-        misc.explosive = true;
-        misc.industrial = true;
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_C).setAvailability(RATING_C, RATING_D, RATING_D, RATING_D)
-                .setISAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setISApproximate(true, false, false, false, false)
-                .setClanAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setClanApproximate(true, false, false, false, false).setPrototypeFactions(F_TA)
-                .setProductionFactions(F_TH);
-        return misc;
-    }
-
-    public static MiscType createFuel4() {
-        MiscType misc = new MiscType();
-
-        misc.name = "Extended Fuel Tank (4 tons)";
-        misc.setInternalName(misc.name);
-        misc.tonnage = 4;
-        misc.criticals = 4;
-        misc.cost = 2000;
-        misc.flags = misc.flags.or(F_FUEL).or(F_MECH_EQUIPMENT);
-        misc.explosive = true;
-        misc.industrial = true;
-        misc.rulesRefs = "244,TM";
-        misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
-                .setTechRating(RATING_C).setAvailability(RATING_C, RATING_D, RATING_D, RATING_D)
-                .setISAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setISApproximate(true, false, false, false, false)
-                .setClanAdvancement(2300, 2350, 2490, DATE_NONE, DATE_NONE)
-                .setClanApproximate(true, false, false, false, false).setPrototypeFactions(F_TA)
-                .setProductionFactions(F_TH);
-        return misc;
-    }
-
-    public static MiscType createCVExtendedFuelTank() {
+    public static MiscType createExtendedFuelTank() {
         MiscType misc = new MiscType();
 
         misc.name = "Extended Fuel Tank";
         misc.setInternalName(misc.name);
+        misc.addLookupName("Extended Fuel Tank (1 ton)");
+        misc.addLookupName("Extended Fuel Tank (0.5 tons)");
+        misc.addLookupName("Extended Fuel Tank (2 tons)");
+        misc.addLookupName("Extended Fuel Tank (2.5 tons)");
+        misc.addLookupName("Extended Fuel Tank (3 tons)");
+        misc.addLookupName("Extended Fuel Tank (3.5 tons)");
+        misc.addLookupName("Extended Fuel Tank (4 tons)");
         misc.tonnage = TONNAGE_VARIABLE;
-        misc.criticals = 1;
+        misc.criticals = CRITICALS_VARIABLE;
         misc.cost = 2000;
-        misc.flags = misc.flags.or(F_FUEL).or(F_TANK_EQUIPMENT);
+        misc.flags = misc.flags.or(F_FUEL).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT);
         misc.explosive = true;
         misc.industrial = true;
         misc.rulesRefs = "244,TM";

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -820,7 +820,7 @@ public class MiscType extends EquipmentType {
             }
         } else if (hasFlag(MiscType.F_FUEL)) {
             if (entity.hasEngine()) {
-                return defaultRounding.round(entity.getEngine().getWeightEngine(entity), entity);
+                return defaultRounding.round(entity.getEngine().getWeightEngine(entity) * 0.1, entity);
             } else {
                 return 0.0;
             }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1586,6 +1586,7 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createFuel3());
         EquipmentType.addType(MiscType.createFuel35());
         EquipmentType.addType(MiscType.createFuel4());
+        EquipmentType.addType(MiscType.createCVExtendedFuelTank());
         EquipmentType.addType(MiscType.createBlueShield());
         EquipmentType.addType(MiscType.createISEndoComposite());
         EquipmentType.addType(MiscType.createClanEndoComposite());
@@ -9039,7 +9040,7 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createCVExternalFuel() {
+    public static MiscType createCVExtendedFuelTank() {
         MiscType misc = new MiscType();
 
         misc.name = "Extended Fuel Tank";

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1250,6 +1250,8 @@ public class MiscType extends EquipmentType {
                 return 7;
             }
             // Clan Endo Composite doesn't have variable crits
+        } else if (hasFlag(F_FUEL)) {
+            return (int) Math.ceil(getTonnage(entity));
         }
         // right, well I'll just guess then
         return 1;

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -3576,8 +3576,9 @@ public class Tank extends Entity {
                 }
             }
             if ((mount.getType() instanceof MiscType)
-                    && mount.getType().hasFlag(MiscType.F_JUMP_JET)) {
-                // Only one slot for all jump jets, added later.
+                    && (mount.getType().hasFlag(MiscType.F_JUMP_JET)
+                        || mount.getType().hasFlag(MiscType.F_FUEL))) {
+                // Only one slot each for all jump jets or fuel tanks, added later.
                 continue;
             }
             if (!((mount.getType() instanceof AmmoType) || Arrays.asList(
@@ -3588,6 +3589,10 @@ public class Tank extends Entity {
         }
         // JJs take just 1 slot
         if (this.getJumpMP(false) > 0) {
+            usedSlots++;
+        }
+        // So do fuel tanks
+        if (hasWorkingMisc(MiscType.F_FUEL)) {
             usedSlots++;
         }
         // different engines take different amounts of slots

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -4206,7 +4206,14 @@ public class Tank extends Entity {
         }
         double fuelUnit = fuelTonnagePer100km();
         if (fuelUnit > 0) {
-            return (int) (getFuelTonnage() / fuelUnit * 100);
+            int range = (int) (getFuelTonnage() / fuelUnit * 100);
+            int fuelTanks = countWorkingMisc(MiscType.F_FUEL);
+            if (getEngine().getEngineType() == Engine.COMBUSTION_ENGINE) {
+                range += fuelTanks * 600;
+            } else if (getEngine().getEngineType() == Engine.FUEL_CELL) {
+                range += fuelTanks * 450;
+            }
+            return range;
         }
         return Integer.MAX_VALUE;
     }

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1302,6 +1302,7 @@ public abstract class TestEntity implements TestEntityOption {
         boolean hasHarjelIII = false;
         boolean hasCoolantPod = false;
         int emergencyCoolantCount = 0;
+        boolean hasExternalFuelTank = false;
         for (Mounted m : getEntity().getAmmo()) {
             if (((AmmoType)m.getType()).getAmmoType() == AmmoType.T_COOLANT_POD) {
                 hasCoolantPod = true;
@@ -1335,6 +1336,9 @@ public abstract class TestEntity implements TestEntityOption {
             if (m.getType().hasFlag(MiscType.F_HARJEL_III)) {
                 hasHarjelIII = true;
             }
+            if (m.getType().hasFlag(MiscType.F_FUEL)) {
+                hasExternalFuelTank = true;
+            }
         }
         if ((isMech() || isTank() || isAero())
                 && (!getEntity().hasEngine()
@@ -1352,7 +1356,13 @@ public abstract class TestEntity implements TestEntityOption {
                     illegal = true;
                 }
             }
-        }        
+        }
+        if (hasExternalFuelTank
+                && (!getEntity().hasEngine() ||((getEntity().getEngine().getEngineType() != Engine.COMBUSTION_ENGINE)
+                && (getEntity().getEngine().getEngineType() != Engine.FUEL_CELL)))) {
+            illegal = true;
+            buff.append("Extended fuel tanks can only be used with internal combustion or fuel cell engines.\n");
+        }
 
         if (minesweeperCount > 1) {
             buff.append("Unit has more than one minesweeper!\n");

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1124,8 +1124,9 @@ public class TestMech extends TestEntity {
                 }
             } else {
                 if (misc.hasFlag(MiscType.F_INDUSTRIAL_TSM)
-                        || misc.hasFlag(MiscType.F_ENVIRONMENTAL_SEALING)) {
-                    buff.append("Non-industrial mech can't mount " + misc.getName() + "\n");
+                        || misc.hasFlag(MiscType.F_ENVIRONMENTAL_SEALING)
+                        || misc.hasFlag(MiscType.F_FUEL)) {
+                    buff.append("Non-industrial mech can't mount ").append(misc.getName()).append("\n");
                 }
             }
             
@@ -1141,6 +1142,11 @@ public class TestMech extends TestEntity {
                                     && (misc.getSubType() == MiscType.S_BACKHOE)
                                     || (misc.getSubType() == MiscType.S_COMBINE)))) {
                 buff.append("LAMs may not mount ").append(misc.getName()).append("\n");
+                illegal = true;
+            }
+            if (misc.hasFlag(MiscType.F_FUEL) && (m.getLocation() != Mech.LOC_CT)
+                    && (m.getLocation() != Mech.LOC_RT) && (m.getLocation() != Mech.LOC_LT)) {
+                buff.append("External fuel tanks must be mounted in a torso location.\n");
                 illegal = true;
             }
         }

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -936,6 +936,7 @@ public class TestTank extends TestEntity {
                     || eq.hasFlag(MiscType.F_CASE)
                     || eq.hasFlag(MiscType.F_CASEII)
                     || eq.hasFlag(MiscType.F_JUMP_JET)
+                    || eq.hasFlag(MiscType.F_FUEL)
                     || eq.hasFlag(MiscType.F_BLUE_SHIELD);
         } else {
             return eq instanceof AmmoType;

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -770,7 +770,7 @@ public class TestTank extends TestEntity {
         boolean illegal = super.hasIllegalEquipmentCombinations(buff);
         
         boolean hasSponsonTurret = false;
-        
+
         for (Mounted m : getEntity().getMisc()) {
             if (m.getType().hasFlag(MiscType.F_SPONSON_TURRET)) {
                 hasSponsonTurret = true;
@@ -842,6 +842,12 @@ public class TestTank extends TestEntity {
                     illegal = true;
                     buff.append("bulldozer must be mounted in unit with tracked or wheeled movement mode\n");
                 }
+            }
+            if (m.getType().hasFlag(MiscType.F_FUEL)
+                    && (!tank.hasEngine() ||((tank.getEngine().getEngineType() != Engine.COMBUSTION_ENGINE)
+                        && (tank.getEngine().getEngineType() != Engine.FUEL_CELL)))) {
+                illegal = true;
+                buff.append("Extended fuel tanks can only be used with internal combustion or fuel cell engines.\n");
             }
         }
         

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -843,12 +843,6 @@ public class TestTank extends TestEntity {
                     buff.append("bulldozer must be mounted in unit with tracked or wheeled movement mode\n");
                 }
             }
-            if (m.getType().hasFlag(MiscType.F_FUEL)
-                    && (!tank.hasEngine() ||((tank.getEngine().getEngineType() != Engine.COMBUSTION_ENGINE)
-                        && (tank.getEngine().getEngineType() != Engine.FUEL_CELL)))) {
-                illegal = true;
-                buff.append("Extended fuel tanks can only be used with internal combustion or fuel cell engines.\n");
-            }
         }
         
         for (Mounted m : tank.getWeaponList()) {


### PR DESCRIPTION
External fuel tank rules are found in TM, p. 244. They are available to IndustrialMechs and combat vehicles with an internal combustion or fuel cell engine. Each weighs 10% of the engine weight. A unit may mount multiple tanks.

We currently have construction data available for external fuel tanks for IndustrialMechs, but not for combat vehicles. The mech version is divided into a separate instance for each available weight up to four tons in half ton increments like cargo and communications equipments. But unlike those types of equipment, the external fuel tank has a set weight and (for mechs) slot requirement. So I combined them all into a single entry available to mechs and combat vehicles. The existing IndustrialMechs that use them work fine with the calculated values instead of the previous static values.

I also added validation checks to flag as illegal any non-industrial mech using a fuel tank, or any unit without a combustion or fuel cell engine.

Fixes MegaMek/megameklab#515