### PR TITLE
Fix kg-standard weight calculations

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -347,7 +347,7 @@ public class EquipmentType implements ITechnology {
      * @return              The weight of the equipment in tons
      */
     public double getTonnage(Entity entity, int location, RoundWeight defaultMethod) {
-        return defaultMethod.round(getTonnage(entity, location));
+        return defaultMethod.round(getTonnage(entity, location), entity);
     }
 
     void setTonnage(double tonnage) {
@@ -1083,7 +1083,7 @@ public class EquipmentType implements ITechnology {
     public String getAvailabilityName(int era) {
         return getEraAvailabilityName(era);
     }
-    
+
     public boolean isClan() {
         return techAdvancement.getTechBase() == TECH_BASE_CLAN;
     }

--- a/megamek/src/megamek/common/RoundWeight.java
+++ b/megamek/src/megamek/common/RoundWeight.java
@@ -80,17 +80,6 @@ public enum RoundWeight {
     }
 
     /**
-     * Applies the rounding operation to a weight. For methods that depend on whether the unit
-     * uses the ton or kilogram standard, assumes ton.
-     *
-     * @param weight The weight to be rounded, in metric tons.
-     * @return       The result of the rounding operation.
-     */
-    public double round(double weight) {
-        return round(weight, null);
-    }
-
-    /**
      * Chops off trailing float irregularities by rounding to the gram. Used as the first step
      * in rounding operations that round up.
      *
@@ -108,7 +97,7 @@ public enum RoundWeight {
      * @return       The weight in tons, rounded to the closest half ton.
      */
     public static double nearestHalfTon(double weight) {
-        return NEAREST_HALF_TON.round(weight);
+        return NEAREST_HALF_TON.round(weight, null);
     }
 
     /**
@@ -118,7 +107,7 @@ public enum RoundWeight {
      * @return       The weight in tons, rounded to the closest ton.
      */
     public static double nearestTon(double weight) {
-        return NEAREST_TON.round(weight);
+        return NEAREST_TON.round(weight, null);
     }
 
     /**
@@ -128,7 +117,7 @@ public enum RoundWeight {
      * @return       The weight in tons, rounded to the closest kilogram.
      */
     public static double nearestKg(double weight) {
-        return NEAREST_KG.round(weight);
+        return NEAREST_KG.round(weight, null);
     }
 
     /**
@@ -138,7 +127,7 @@ public enum RoundWeight {
      * @return       The weight in tons rounded up to the half ton
      */
     public static double nextHalfTon(double weight) {
-        return NEXT_HALF_TON.round(weight);
+        return NEXT_HALF_TON.round(weight, null);
     }
 
     /**
@@ -148,7 +137,7 @@ public enum RoundWeight {
      * @return       The weight in tons rounded up to the kilogram
      */
     public static double nextKg(double weight) {
-        return NEXT_KG.round(weight);
+        return NEXT_KG.round(weight, null);
     }
 
     /**
@@ -158,7 +147,7 @@ public enum RoundWeight {
      * @return       The weight in tons rounded up to the full ton
      */
     public static double nextTon(double weight) {
-        return NEXT_TON.round(weight);
+        return NEXT_TON.round(weight, null);
     }
 
     /**


### PR DESCRIPTION
I broke this somewhere along the line by not passing the entity to the rounding method, so it couldn't figure out whether to round to the half-ton or the kg. I added the argument, then removed the version of RoundWeight#round that doesn't have an Entity parameter to prevent the same mistake in the future. It's only used internally.

This purpose of the RoundWeight parameter to EquipmentType#getTonnage is to allow the standard rounding system to be overridden to support fractional accounting.