### PR TITLE
Consolidate tests for valid location for equipment

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -7527,7 +7527,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 2;
         misc.bv = 0;
         misc.cost = 50000;
-        misc.flags = misc.flags.or(F_SALVAGE_ARM).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT);
+        misc.flags = misc.flags.or(F_SALVAGE_ARM).or(F_MECH_EQUIPMENT);
         misc.industrial = true;
         misc.rulesRefs = "248,TM";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -1098,7 +1098,7 @@ public class TestAero extends TestEntity {
                     }
                     return false;
                 }
-            } else if ((eq.hasFlag(MiscType.F_BLUE_SHIELD)
+            } else if ((eq.hasFlag(MiscType.F_BLUE_SHIELD) || eq.hasFlag(MiscType.F_LIFTHOIST)
                     || (eq.hasFlag(MiscType.F_CASE) && !eq.isClan())) && (location != Aero.LOC_FUSELAGE)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" must be mounted in the fuselage.\n");
@@ -1526,11 +1526,7 @@ public class TestAero extends TestEntity {
         } else if (eq instanceof MiscType) {
             if (eq.hasFlag(MiscType.F_CASE)) {
                 return eq.isClan();
-            } else if (eq.hasFlag(MiscType.F_BLUE_SHIELD)) {
-                return false;
-            } else {
-                return true;
-            }
+            } else return !eq.hasFlag(MiscType.F_BLUE_SHIELD) && !eq.hasFlag(MiscType.F_LIFTHOIST);
         } else {
             return !(eq instanceof AmmoType);
         }

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -1106,15 +1106,15 @@ public class TestAero extends TestEntity {
                 return false;
             }
         } else if (eq instanceof WeaponType) {
-            if (((((WeaponType) eq).getAmmoType() == AmmoType.T_GAUSS_HEAVY)
-                    || ((WeaponType) eq).getAmmoType() == AmmoType.T_IGAUSS_HEAVY)
+            if ((((WeaponType) eq).getAmmoType() == AmmoType.T_GAUSS_HEAVY)
                     && (location != Aero.LOC_NOSE) && (location != Aero.LOC_AFT)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" must be mounted in the nose or aft.\n");
                 }
                 return false;
             }
-            if (location < Aero.LOC_WINGS) {
+            if (!eq.hasFlag(WeaponType.F_C3M) && !eq.hasFlag(WeaponType.F_C3MBS)
+                    && !eq.hasFlag(WeaponType.F_TAG) && (location == Aero.LOC_FUSELAGE)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" must be mounted in a location with a firing arc.\n");
                 }

--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Vector;
 
 import megamek.common.*;
+import megamek.common.annotations.Nullable;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
@@ -1169,11 +1170,19 @@ public class TestBattleArmor extends TestEntity {
 
     /**
      * @param eq        The equipment
+     * @param buffer    If non-null and the location is invalid, will be appended with an explanation
      * @return          Whether the equipment can be mounted in the BattleArmor suit
      */
-    public static boolean isValidBALocation(EquipmentType eq) {
+    public static boolean isValidBALocation(EquipmentType eq, @Nullable StringBuffer buffer) {
         // Infantry weapons can only be mounted in armored gloves/APMs
-        return !((eq instanceof WeaponType) && eq.hasFlag(WeaponType.F_INFANTRY));
+        if ((eq instanceof WeaponType) && eq.hasFlag(WeaponType.F_INFANTRY)) {
+            if (buffer != null) {
+                buffer.append(eq.getName())
+                        .append(" can only be mounted in an anti-personnel mount or an armored glove.\n");
+            }
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -1167,6 +1167,15 @@ public class TestBattleArmor extends TestEntity {
         return correct;
     }
 
+    /**
+     * @param eq        The equipment
+     * @return          Whether the equipment can be mounted in the BattleArmor suit
+     */
+    public static boolean isValidBALocation(EquipmentType eq) {
+        // Infantry weapons can only be mounted in armored gloves/APMs
+        return !((eq instanceof WeaponType) && eq.hasFlag(WeaponType.F_INFANTRY));
+    }
+
     @Override
     public StringBuffer printEntity() {
         StringBuffer buff = new StringBuffer();

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 
 import megamek.common.*;
+import megamek.common.annotations.Nullable;
 import megamek.common.util.StringUtil;
 
 /**
@@ -1441,11 +1442,7 @@ public abstract class TestEntity implements TestEntityOption {
             }
         }
         for (Mounted mounted : getEntity().getEquipment()) {
-            if (!isValidLocation(getEntity(), mounted.getType(), mounted.getLocation())) {
-                buff.append(mounted.getType().getName()).append(" cannot be placed in the ")
-                        .append(getEntity().getLocationName(mounted.getLocation())).append("\n");
-                illegal = true;
-            }
+            illegal |= isValidLocation(getEntity(), mounted.getType(), mounted.getLocation(), buff);
         }
         return illegal;
     }
@@ -1454,19 +1451,21 @@ public abstract class TestEntity implements TestEntityOption {
      * @param entity    The entity
      * @param eq        The equipment
      * @param location  A location index on the Entity
+     * @param buffer    If non-null and the location is invalid, will be appended with an explanation
      * @return          Whether the equipment can be mounted in the location on the Entity
      */
-    public static boolean isValidLocation(Entity entity, EquipmentType eq, int location) {
+    public static boolean isValidLocation(Entity entity, EquipmentType eq, int location,
+                                          @Nullable StringBuffer buffer) {
         if (entity instanceof Mech) {
-            return TestMech.isValidMechLocation((Mech) entity, eq, location);
+            return TestMech.isValidMechLocation((Mech) entity, eq, location, buffer);
         } else if (entity instanceof Tank) {
-            return TestTank.isValidTankLocation((Tank) entity, eq, location);
+            return TestTank.isValidTankLocation((Tank) entity, eq, location, buffer);
         } else if (entity instanceof Protomech) {
-            return TestProtomech.isValidProtomechLocation((Protomech) entity, eq, location);
+            return TestProtomech.isValidProtomechLocation((Protomech) entity, eq, location, buffer);
         } else if (entity instanceof BattleArmor) {
-            return TestBattleArmor.isValidBALocation(eq);
+            return TestBattleArmor.isValidBALocation(eq, buffer);
         } else if (entity.isFighter()) {
-            return TestAero.isValidAeroLocation(eq, location);
+            return TestAero.isValidAeroLocation(eq, location, buffer);
         }
         return true;
     }

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1440,6 +1440,13 @@ public abstract class TestEntity implements TestEntityOption {
                 }
             }
         }
+        for (Mounted mounted : getEntity().getEquipment()) {
+            if (!isValidLocation(getEntity(), mounted.getType(), mounted.getLocation())) {
+                buff.append(mounted.getType().getName()).append(" cannot be placed in the ")
+                        .append(getEntity().getLocationName(mounted.getLocation())).append("\n");
+                illegal = true;
+            }
+        }
         return illegal;
     }
 

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1443,6 +1443,27 @@ public abstract class TestEntity implements TestEntityOption {
         return illegal;
     }
 
+    /**
+     * @param entity    The entity
+     * @param eq        The equipment
+     * @param location  A location index on the Entity
+     * @return          Whether the equipment can be mounted in the location on the Entity
+     */
+    public static boolean isValidLocation(Entity entity, EquipmentType eq, int location) {
+        if (entity instanceof Mech) {
+            return TestMech.isValidMechLocation((Mech) entity, eq, location);
+        } else if (entity instanceof Tank) {
+            return TestTank.isValidTankLocation((Tank) entity, eq, location);
+        } else if (entity instanceof Protomech) {
+            return TestProtomech.isValidProtomechLocation((Protomech) entity, eq, location);
+        } else if (entity instanceof BattleArmor) {
+            return TestBattleArmor.isValidBALocation(eq);
+        } else if (entity.isFighter()) {
+            return TestAero.isValidAeroLocation(eq, location);
+        }
+        return true;
+    }
+
     public StringBuffer printFailedEquipment(StringBuffer buff) {
         if (getEntity().getFailedEquipment().hasNext()) {
             buff.append("Equipment that Failed to Load:\n");

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1442,7 +1442,9 @@ public abstract class TestEntity implements TestEntityOption {
             }
         }
         for (Mounted mounted : getEntity().getEquipment()) {
-            illegal |= isValidLocation(getEntity(), mounted.getType(), mounted.getLocation(), buff);
+            if (!mounted.isOneShotAmmo()) {
+                illegal |= !isValidLocation(getEntity(), mounted.getType(), mounted.getLocation(), buff);
+            }
         }
         return illegal;
     }
@@ -1462,8 +1464,6 @@ public abstract class TestEntity implements TestEntityOption {
             return TestTank.isValidTankLocation((Tank) entity, eq, location, buffer);
         } else if (entity instanceof Protomech) {
             return TestProtomech.isValidProtomechLocation((Protomech) entity, eq, location, buffer);
-        } else if (entity instanceof BattleArmor) {
-            return TestBattleArmor.isValidBALocation(eq, buffer);
         } else if (entity.isFighter()) {
             return TestAero.isValidAeroLocation(eq, location, buffer);
         }

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1504,6 +1504,13 @@ public class TestMech extends TestEntity {
                     return false;
                 }
             }
+            if (eq.hasFlag(MiscType.F_SALVAGE_ARM) && (mech.entityIsQuad()
+                    || ((location != Mech.LOC_LARM) && (location != Mech.LOC_RARM)))) {
+                if (buffer != null) {
+                    buffer.append(eq.getName()).append(" must be mounted in an arm.\n");
+                }
+                return false;
+            }
             if (eq.hasFlag(MiscType.F_ACTUATOR_ENHANCEMENT_SYSTEM)
                     && ((location == Mech.LOC_HEAD) || mech.locationIsTorso(location))) {
                 if (buffer != null) {
@@ -1546,10 +1553,18 @@ public class TestMech extends TestEntity {
                 }
                 return false;
             }
-            if ((eq.hasFlag(MiscType.F_FUEL) || (eq.hasFlag(MiscType.F_CASE) && !eq.isClan()))
+            if ((eq.hasFlag(MiscType.F_FUEL) || (eq.hasFlag(MiscType.F_CASE) && !eq.isClan())
+                    || eq.hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER) || eq.hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER)
+                    || eq.hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER) || eq.hasFlag(MiscType.F_LADDER))
                     && !mech.locationIsTorso(location)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" must be placed in a torso location.\n");
+                }
+                return false;
+            }
+            if (eq.hasFlag(MiscType.F_LIFTHOIST) && ((location == Mech.LOC_HEAD) || mech.locationIsLeg(location))) {
+                if (buffer != null) {
+                    buffer.append(eq.getName()).append(" must be placed in a torso or arm location.\n");
                 }
                 return false;
             }

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1588,6 +1588,12 @@ public class TestMech extends TestEntity {
                 }
                 return false;
             }
+            if (eq.hasFlag(MiscType.F_EJECTION_SEAT) && (location != Mech.LOC_HEAD)) {
+                if (buffer != null) {
+                    buffer.append(eq.getName()).append(" must be placed in the head.\n");
+                }
+                return false;
+            }
         } else if (eq instanceof WeaponType) {
             if (eq.hasFlag(WeaponType.F_VGL) && !mech.locationIsTorso(location)) {
                 if (buffer != null) {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -39,6 +39,7 @@ import megamek.common.weapons.autocannons.UACWeapon;
 import megamek.common.weapons.gaussrifles.GaussWeapon;
 import megamek.common.weapons.lasers.EnergyWeapon;
 import megamek.common.weapons.ppc.PPCWeapon;
+import sun.util.resources.cldr.es.LocaleNames_es_CL;
 
 public class TestMech extends TestEntity {
 
@@ -1551,5 +1552,80 @@ public class TestMech extends TestEntity {
         }
         
         return illegal;
+    }
+
+    /**
+     * @param mech      The Mech
+     * @param eq        The equipment
+     * @param location  A location index on the Entity
+     * @return          Whether the equipment can be mounted in the location on the Mech
+     */
+    public static boolean isValidMechLocation(Mech mech, EquipmentType eq, int location) {
+        if (eq instanceof MiscType) {
+            if ((eq.hasFlag(MiscType.F_CLUB) || eq.hasFlag(MiscType.F_HAND_WEAPON))) {
+                if (mech.entityIsQuad()) {
+                    return ((location == Mech.LOC_LT)
+                            || (location == Mech.LOC_RT))
+                            && ((eq.getSubType() &
+                            (MiscType.S_DUAL_SAW | MiscType.S_PILE_DRIVER
+                                    | MiscType.S_WRECKING_BALL | MiscType.S_BACKHOE
+                                    | MiscType.S_COMBINE | MiscType.S_CHAINSAW
+                                    | MiscType.S_ROCK_CUTTER | MiscType.S_BUZZSAW
+                                    | MiscType.S_SPOT_WELDER | MiscType.S_PILE_DRIVER)) != 0);
+                } else {
+                    return (location == Mech.LOC_RARM) || (location == Mech.LOC_LARM);
+                }
+            }
+            if (eq.hasFlag(MiscType.F_ACTUATOR_ENHANCEMENT_SYSTEM)) {
+                return location == Mech.LOC_LARM
+                        || location == Mech.LOC_RARM
+                        || mech.locationIsLeg(location);
+            }
+            if (eq.hasFlag(MiscType.F_HEAD_TURRET)) {
+                return location == Mech.LOC_CT && mech.hasSystem(Mech.SYSTEM_COCKPIT, location);
+            }
+            if (eq.hasFlag(MiscType.F_QUAD_TURRET)) {
+                return mech.entityIsQuad() && (((location == Mech.LOC_RT) || (location == Mech.LOC_LT)));
+            }
+            if (eq.hasFlag(MiscType.F_SHOULDER_TURRET)) {
+                return !mech.entityIsQuad() && (((location == Mech.LOC_RT) || (location == Mech.LOC_LT)));
+            }
+            if (eq.hasFlag(MiscType.F_HARJEL)
+                    || eq.hasFlag(MiscType.F_HARJEL_II)
+                    || eq.hasFlag(MiscType.F_HARJEL_III)) {
+                return !mech.hasSystem(Mech.SYSTEM_COCKPIT, location);
+            }
+            if (eq.hasFlag(MiscType.F_MASS)) {
+                return mech.hasSystem(Mech.SYSTEM_COCKPIT, location);
+            }
+            if ((eq.hasFlag(MiscType.F_MASC) && eq.hasSubType(MiscType.S_SUPERCHARGER))
+                    || eq.hasFlag(MiscType.F_EMERGENCY_COOLANT_SYSTEM)) {
+                return mech.hasSystem(Mech.SYSTEM_ENGINE, location);
+            }
+            if (eq.hasFlag(MiscType.F_FUEL)) {
+                return mech.locationIsTorso(location);
+            }
+            if (eq.hasFlag(MiscType.F_JUMP_JET)) {
+                return mech.locationIsLeg(location) || mech.locationIsTorso(location);
+            }
+            if (eq.hasFlag(MiscType.F_AP_POD) || eq.hasFlag(MiscType.F_TRACKS) || eq.hasFlag(MiscType.F_TALON)) {
+                return mech.locationIsLeg(location);
+            }
+            if (eq.hasFlag(MiscType.F_MODULAR_ARMOR)) {
+                return location != Mech.LOC_HEAD;
+            }
+            if (eq.hasFlag(MiscType.F_CASE)) {
+                return eq.isClan() || mech.locationIsTorso(location);
+            }
+        } else if (eq instanceof WeaponType) {
+            if (eq.hasFlag(WeaponType.F_VGL)) {
+                return mech.locationIsTorso(location);
+            }
+            if ((((WeaponType) eq).getAmmoType() == AmmoType.T_GAUSS_HEAVY)
+                    || ((WeaponType) eq).getAmmoType() == AmmoType.T_IGAUSS_HEAVY) {
+                return mech.isSuperHeavy() || mech.locationIsTorso(location);
+            }
+        }
+        return true;
     }
 }

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -40,7 +40,6 @@ import megamek.common.weapons.autocannons.UACWeapon;
 import megamek.common.weapons.gaussrifles.GaussWeapon;
 import megamek.common.weapons.lasers.EnergyWeapon;
 import megamek.common.weapons.ppc.PPCWeapon;
-import sun.util.resources.cldr.es.LocaleNames_es_CL;
 
 public class TestMech extends TestEntity {
 

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -901,15 +901,6 @@ public class TestMech extends TestEntity {
         for (Mounted m : getEntity().getMisc()) {
             final MiscType misc = (MiscType)m.getType();
 
-            if (misc.hasFlag(MiscType.F_JUMP_JET)
-                    && m.getLocation() != Mech.LOC_CT
-                    && m.getLocation() != Mech.LOC_RT
-                    && m.getLocation() != Mech.LOC_LT
-                    && !mech.locationIsLeg(m.getLocation())) {
-                buff.append("Jump jet must be mounted in leg or torso\n");
-                illegal = true;
-            }
-            
             if (misc.hasFlag(MiscType.F_UMU) && (mech.getJumpType() != Mech.JUMP_NONE)
                     && (mech.getJumpType() != Mech.JUMP_BOOSTER)) {
                 illegal = true;
@@ -919,10 +910,6 @@ public class TestMech extends TestEntity {
 
             if (misc.hasFlag(MiscType.F_MASC)
                     && misc.hasSubType(MiscType.S_SUPERCHARGER)) {
-                if (!isEngineLocation(m.getLocation())) {
-                    buff.append("supercharger in location without engine\n");
-                    illegal = true;
-                }
                 if (mech instanceof LandAirMech) {
                     buff.append("LAMs may not mount a supercharger\n");
                     illegal = true;
@@ -937,27 +924,11 @@ public class TestMech extends TestEntity {
                 illegal = true;
             }
             
-            if (misc.hasFlag(MiscType.F_AP_POD)
-                    && !mech.locationIsLeg(m.getLocation())) {
-                buff.append("A-Pod must be mounted in leg\n");
-                illegal = true;
-            }
-
             if (misc.hasFlag(MiscType.F_REMOTE_DRONE_COMMAND_CONSOLE)) {
                 if (mech.getCockpitType() == Mech.COCKPIT_COMMAND_CONSOLE) {
                     buff.append("cockpit command console can't be combined with remote drone command console\n");
                     illegal = true;
                 }
-                if ((mech.getCockpitType() == Mech.COCKPIT_TORSO_MOUNTED) && (m.getLocation() != Mech.LOC_CT)) {
-                    buff.append("remote drone command console must be placed in same location as cockpit\n");
-                    illegal = true;
-                } else {
-                    if (m.getLocation() != Mech.LOC_HEAD) {
-                        buff.append("remote drone command console must be placed in same location as cockpit\n");
-                        illegal = true;
-                    }
-                }
-
             }
 
             if (misc.hasFlag(MiscType.F_CHAMELEON_SHIELD)) {
@@ -971,19 +942,14 @@ public class TestMech extends TestEntity {
                 }
             }
 
-            if (m.getType().hasFlag(MiscType.F_EMERGENCY_COOLANT_SYSTEM)
-                    && !isEngineLocation(m.getLocation())) {
-                buff.append("RISC emergency coolant system must be mounted in location with engine crit\n");
-                illegal = true;
-            }
-            
             if (misc.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM)
                     && !mech.isIndustrial()) {
                 illegal = true;
                 buff.append("BattleMech can't mount light fluid suction system\n");
             }
 
-            if (misc.hasFlag(MiscType.F_SALVAGE_ARM)
+            if (!mech.entityIsQuad() && mech.hasSystem(Mech.ACTUATOR_HAND, m.getLocation())
+                    && (misc.hasFlag(MiscType.F_SALVAGE_ARM)
                     || (misc.hasFlag(MiscType.F_CLUB)
                             && (misc.hasSubType(MiscType.S_CHAINSAW)
                                     || misc.hasSubType(MiscType.S_BACKHOE)
@@ -993,40 +959,12 @@ public class TestMech extends TestEntity {
                                     || misc.hasSubType(MiscType.S_ROCK_CUTTER)
                                     || misc.hasSubType(MiscType.S_SPOT_WELDER)
                                     || misc.hasSubType(MiscType.S_WRECKING_BALL)
-                                    || misc.hasSubType(MiscType.S_COMBINE)))) {
-                if (mech.entityIsQuad()) {
-                    if (m.getLocation() != Mech.LOC_LT && m.getLocation() != Mech.LOC_RT) {
-                        illegal = true;
-                        buff.append("Quad Mechs can only mount " + misc.getName() + " in side torso location.\n");
-                    }
-                } else {
-                    if ((m.getLocation() != Mech.LOC_LARM && m.getLocation() != Mech.LOC_RARM)
-                            || mech.hasSystem(Mech.ACTUATOR_HAND, m.getLocation())) {
-                        illegal = true;
-                        buff.append("Mech can only mount " + misc.getName() + " in arm with no hand actuator.\n");
-                    }
-                }
+                                    || misc.hasSubType(MiscType.S_COMBINE))))) {
+                    illegal = true;
+                    buff.append("Mech can only mount ").append(misc.getName())
+                            .append(" in arm with no hand actuator.\n");
             }
             
-            if ((misc.hasFlag(MiscType.F_HARJEL)
-                    || misc.hasFlag(MiscType.F_HARJEL_II)
-                    || misc.hasFlag(MiscType.F_HARJEL_III))
-                    && isCockpitLocation(m.getLocation())) {
-                illegal = true;
-                buff.append("Harjel can't be mounted in a location with a cockpit!\n");                    
-            }
-            
-            if (misc.hasFlag(MiscType.F_MASS) && !isCockpitLocation(m.getLocation())) {
-                illegal = true;
-                buff.append("MW aquatic survival system must be located in the same location as the cockpit.\n");
-            }
-
-            if (misc.hasFlag(MiscType.F_MODULAR_ARMOR)
-                    && (m.getLocation() == Mech.LOC_HEAD)) {
-                illegal = true;
-                buff.append("Unable to load Modular Armor in Head location\n");
-            }
-
             if (misc.hasFlag(MiscType.F_HEAD_TURRET)
                     && isCockpitLocation(Mech.LOC_HEAD)) {
                 illegal = true;
@@ -1041,9 +979,6 @@ public class TestMech extends TestEntity {
             if (misc.hasFlag(MiscType.F_SHOULDER_TURRET)) {
                 if (m.getLocation() != Mech.LOC_RT
                         && m.getLocation() != Mech.LOC_LT) {
-                    illegal = true;
-                    buff.append("shoulder turret must be mounted in side torso\n");
-
                     if (mech.countWorkingMisc(MiscType.F_SHOULDER_TURRET, m.getLocation()) > 1) {
                         illegal = true;
                         buff.append("max of 1 shoulder turret per side torso\n");
@@ -1062,25 +997,17 @@ public class TestMech extends TestEntity {
                     illegal = true;
                     buff.append("Wheels can only be used on QuadVees.\n");
                 }
-                if (!mech.locationIsLeg(m.getLocation())) {
-                    illegal = true;
-                    buff.append(misc.getName() + " are only legal in the Legs\n");
-                }
                 for (int loc = 0; loc < mech.locations(); loc++) {
                     if (mech.locationIsLeg(loc)
                             && countCriticalSlotsFromEquipInLocation(mech, m, loc) != 1) {
                         illegal = true;
-                        buff.append(misc.getName() + " require one critical slot in each leg.\n");
+                        buff.append(misc.getName()).append(" require one critical slot in each leg.\n");
                         break;
                     }
                 }
             }
             
             if (m.getType().hasFlag(MiscType.F_TALON)) {
-                if (!mech.locationIsLeg(m.getLocation())) {
-                    illegal = true;
-                    buff.append("Talons are only legal in the Legs\n");
-                }
                 for (int loc = 0; loc < mech.locations(); loc++) {
                     if (mech.locationIsLeg(loc)
                             && countCriticalSlotsFromEquipInLocation(mech, m, loc) != 2) {
@@ -1102,7 +1029,7 @@ public class TestMech extends TestEntity {
                             || misc.hasFlag(MiscType.F_ACTUATOR_ENHANCEMENT_SYSTEM)
                             || misc.hasFlag(MiscType.F_MODULAR_ARMOR)
                             || misc.hasFlag(MiscType.F_PARTIAL_WING))) {
-                buff.append("Superheavy may not mount " + m.getType().getName() + "\n");
+                buff.append("Superheavy may not mount ").append(m.getType().getName()).append("\n");
                 illegal = true;
             }
             
@@ -1110,7 +1037,7 @@ public class TestMech extends TestEntity {
                 if (misc.hasFlag(MiscType.F_TSM)
                         || misc.hasFlag(MiscType.F_SCM)
                         || (misc.hasFlag(MiscType.F_MASC) && !misc.hasSubType(MiscType.S_SUPERCHARGER))) {
-                    buff.append("industrial mech can't mount " + misc.getName() + "\n");
+                    buff.append("industrial mech can't mount ").append(misc.getName()).append("\n");
                     illegal = true;                    
                 }
                 if ((mech.getCockpitType() == Mech.COCKPIT_INDUSTRIAL
@@ -1120,7 +1047,8 @@ public class TestMech extends TestEntity {
                         || misc.hasFlag(MiscType.F_ARTEMIS_PROTO)
                         || misc.hasFlag(MiscType.F_ARTEMIS_V)
                         || misc.hasFlag(MiscType.F_BAP))) {
-                    buff.append("Industrial mech without advanced fire control can't mount " + misc.getName() + "\n");
+                    buff.append("Industrial mech without advanced fire control can't mount ")
+                            .append(misc.getName()).append("\n");
                     illegal = true;                    
                 }
             } else {
@@ -1143,11 +1071,6 @@ public class TestMech extends TestEntity {
                                     && (misc.getSubType() == MiscType.S_BACKHOE)
                                     || (misc.getSubType() == MiscType.S_COMBINE)))) {
                 buff.append("LAMs may not mount ").append(misc.getName()).append("\n");
-                illegal = true;
-            }
-            if (misc.hasFlag(MiscType.F_FUEL) && (m.getLocation() != Mech.LOC_CT)
-                    && (m.getLocation() != Mech.LOC_RT) && (m.getLocation() != Mech.LOC_LT)) {
-                buff.append("External fuel tanks must be mounted in a torso location.\n");
                 illegal = true;
             }
         }
@@ -1595,7 +1518,7 @@ public class TestMech extends TestEntity {
                     || eq.hasFlag(MiscType.F_HARJEL_III)) {
                 return !mech.hasSystem(Mech.SYSTEM_COCKPIT, location);
             }
-            if (eq.hasFlag(MiscType.F_MASS)) {
+            if (eq.hasFlag(MiscType.F_MASS) || eq.hasFlag(MiscType.F_REMOTE_DRONE_COMMAND_CONSOLE)) {
                 return mech.hasSystem(Mech.SYSTEM_COCKPIT, location);
             }
             if ((eq.hasFlag(MiscType.F_MASC) && eq.hasSubType(MiscType.S_SUPERCHARGER))

--- a/megamek/src/megamek/common/verifier/TestProtomech.java
+++ b/megamek/src/megamek/common/verifier/TestProtomech.java
@@ -525,6 +525,31 @@ public class TestProtomech extends TestEntity {
         
         return illegal;
     }
+
+    /**
+     * @param protomech  The Protomech
+     * @param eq         The equipment
+     * @param location   A location index on the Entity
+     * @return           Whether the equipment can be mounted in the location on the Protomech
+     */
+    public static boolean isValidProtomechLocation(Protomech protomech, EquipmentType eq, int location) {
+        if ((eq instanceof MiscType) && eq.hasFlag(MiscType.F_CLUB)) {
+            if (eq.hasSubType(MiscType.S_PROTOMECH_WEAPON)
+                    && (location != Protomech.LOC_LARM)
+                    && (location != Protomech.LOC_RARM)) {
+                return false;
+            }
+            if (eq.hasSubType(MiscType.S_PROTO_QMS)
+                    && (location != Protomech.LOC_TORSO)) {
+                return false;
+            }
+        }
+        if (TestProtomech.eqRequiresLocation(protomech, eq)) {
+            return TestProtomech.maxSlotsByLocation(location, protomech) > 0;
+        } else {
+            return location == Protomech.LOC_BODY;
+        }
+    }
     
     /**
      * Checks for exceeding the maximum number of armor points by location for the tonnage.

--- a/megamek/src/megamek/common/verifier/TestProtomech.java
+++ b/megamek/src/megamek/common/verifier/TestProtomech.java
@@ -467,10 +467,6 @@ public class TestProtomech extends TestEntity {
                     buff.append("Quad and glider protomechs cannot use a magnetic clamp system.\n");
                     illegal = true;
                 }
-                if (mount.getLocation() != Protomech.LOC_TORSO) {
-                    buff.append("The magnetic clamp system must be mounted in the torso.\n");
-                    illegal = true;
-                }
             }
             if ((mount.getType() instanceof MiscType) && mount.getType().hasFlag(MiscType.F_PROTOMECH_MELEE)) {
                 meleeWeapons++;
@@ -482,19 +478,8 @@ public class TestProtomech extends TestEntity {
                     buff.append(mount.getType().getName() + "can only be used by quad protomechs.\n");
                     illegal = true;
                 }
-                if (mount.getType().hasSubType(MiscType.S_PROTO_QMS)
-                        && (mount.getLocation() != Protomech.LOC_TORSO)) {
-                    buff.append(mount.getType().getName() + " must be mounted in the torso.\n");
-                    illegal = true;
-                }
                 if (mount.getType().hasSubType(MiscType.S_PROTOMECH_WEAPON) && proto.isQuad()) {
                     buff.append(mount.getType().getName() + "cannot be used by quad protomechs.\n");
-                    illegal = true;
-                }
-                if (mount.getType().hasSubType(MiscType.S_PROTOMECH_WEAPON)
-                        && (mount.getLocation() != Protomech.LOC_LARM)
-                        && (mount.getLocation() != Protomech.LOC_RARM)) {
-                    buff.append(mount.getType().getName() + " must be mounted in an arm.\n");
                     illegal = true;
                 }
             }
@@ -533,15 +518,16 @@ public class TestProtomech extends TestEntity {
      * @return           Whether the equipment can be mounted in the location on the Protomech
      */
     public static boolean isValidProtomechLocation(Protomech protomech, EquipmentType eq, int location) {
-        if ((eq instanceof MiscType) && eq.hasFlag(MiscType.F_CLUB)) {
-            if (eq.hasSubType(MiscType.S_PROTOMECH_WEAPON)
-                    && (location != Protomech.LOC_LARM)
-                    && (location != Protomech.LOC_RARM)) {
-                return false;
+        if (eq instanceof MiscType) {
+            if (eq.hasFlag(MiscType.F_PROTOMECH_MELEE) && eq.hasSubType(MiscType.S_PROTOMECH_WEAPON)) {
+                return location == Protomech.LOC_LARM
+                        || location == Protomech.LOC_RARM;
             }
-            if (eq.hasSubType(MiscType.S_PROTO_QMS)
-                    && (location != Protomech.LOC_TORSO)) {
-                return false;
+            if (eq.hasFlag(MiscType.F_PROTOMECH_MELEE) && eq.hasSubType(MiscType.S_PROTO_QMS)) {
+                return location == Protomech.LOC_TORSO;
+            }
+            if (eq.hasFlag(MiscType.F_MAGNETIC_CLAMP)) {
+                return location == Protomech.LOC_TORSO;
             }
         }
         if (TestProtomech.eqRequiresLocation(protomech, eq)) {

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -776,20 +776,6 @@ public class TestTank extends TestEntity {
                 }
             }
 
-            if (misc.hasFlag(MiscType.F_HARJEL)
-                    && ((m.getLocation() == Tank.LOC_BODY)
-                            || ((getEntity() instanceof VTOL)
-                                && (m.getLocation() == VTOL.LOC_ROTOR)))) {
-                illegal = true;
-                buff.append("Unable to load harjel in body or rotor.\n");
-            }
-
-            if (misc.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM)
-                    && m.getLocation() != Tank.LOC_BODY) {
-                illegal = true;
-                buff.append("Vehicle must not mount light fluid suction system in body\n");                
-            }
-
             if (misc.hasFlag(MiscType.F_BULLDOZER)) {
                 for (Mounted m2 : getEntity().getMisc()) {
                     if (m2.getLocation() == m.getLocation()) {
@@ -815,10 +801,6 @@ public class TestTank extends TestEntity {
                         }
                     }
                 }
-                if ((m.getLocation() != Tank.LOC_FRONT) && (m.getLocation() != Tank.LOC_REAR)) {
-                    illegal = true;
-                    buff.append("bulldozer must be mounted in front\n");
-                }
                 if ((getEntity().getMovementMode() != EntityMovementMode.TRACKED)
                         && (getEntity().getMovementMode() != EntityMovementMode.WHEELED)) {
                     illegal = true;
@@ -826,16 +808,7 @@ public class TestTank extends TestEntity {
                 }
             }
         }
-        
-        for (Mounted m : tank.getWeaponList()) {
-            if ((((WeaponType) m.getType()).getAmmoType() == AmmoType.T_IGAUSS_HEAVY)
-                    && ((m.getLocation() == Tank.LOC_TURRET)
-                        || (m.getLocation() == Tank.LOC_TURRET_2))) {
-                buff.append("Improved Heavy Gauss cannot be mounted in a turret.\n");
-                illegal = true;
-            }
-        }
-        
+
         if ((tank.getMovementMode() == EntityMovementMode.VTOL)
                 || (tank.getMovementMode() == EntityMovementMode.WIGE)
                 || (tank.getMovementMode() == EntityMovementMode.HOVER)) {

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -901,14 +901,18 @@ public class TestTank extends TestEntity {
         if (eq instanceof MiscType) {
             // Equipment explicitly forbidden to a mast mount
             if ((eq.hasFlag(MiscType.F_MODULAR_ARMOR) || eq.hasFlag(MiscType.F_HARJEL)
-                    || eq.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM))
+                    || eq.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM) || eq.hasFlag(MiscType.F_LIFTHOIST)
+                    || eq.hasFlag(MiscType.F_MANIPULATOR) || eq.hasFlag(MiscType.F_FLUID_SUCTION_SYSTEM)
+                    || eq.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM) || eq.hasFlag(MiscType.F_SPRAYER))
                     && (tank instanceof VTOL) && (location == VTOL.LOC_ROTOR)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" cannot be mounted in the rotor.\n");
                 }
                 return false;
             }
-            if ((eq.hasFlag(MiscType.F_HARJEL) || eq.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM))
+            if ((eq.hasFlag(MiscType.F_HARJEL) || eq.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM)
+                    || eq.hasFlag(MiscType.F_SPRAYER)
+                    || (eq.hasFlag(MiscType.F_LIFTHOIST) && !(tank instanceof VTOL)))
                     && (location == Tank.LOC_BODY)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" cannot be mounted in the body.\n");
@@ -918,6 +922,34 @@ public class TestTank extends TestEntity {
             if (eq.hasFlag(MiscType.F_BULLDOZER) && (location != Tank.LOC_FRONT)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" must be mounted on the front.\n");
+                }
+                return false;
+            }
+            if (eq.hasFlag(MiscType.F_CLUB) && eq.hasSubType(MiscType.S_PILE_DRIVER)
+                    && (location != Tank.LOC_FRONT) && !isRearLocation) {
+                if (buffer != null) {
+                    buffer.append(eq.getName()).append(" must be mounted on the front or rear.\n");
+                }
+                return false;
+            }
+            if (eq.hasFlag(MiscType.F_CLUB) && eq.hasSubType(MiscType.S_WRECKING_BALL) && !isTurretLocation) {
+                if (buffer != null) {
+                    buffer.append(eq.getName()).append(" must be mounted on a turret.\n");
+                }
+                return false;
+            }
+            if (eq.hasFlag(MiscType.F_CLUB) && !eq.hasSubType(MiscType.S_PILE_DRIVER | MiscType.S_SPOT_WELDER
+                    | MiscType.S_WRECKING_BALL)
+                    && (location != Tank.LOC_FRONT) && !isRearLocation && !isTurretLocation) {
+                if (buffer != null) {
+                    buffer.append(eq.getName()).append(" must be mounted on the front, rear, or turret.\n");
+                }
+                return false;
+            }
+            if (eq.hasFlag(MiscType.F_LADDER) && ((location == Tank.LOC_FRONT) || isRearLocation
+                    || ((tank instanceof VTOL) && (location == VTOL.LOC_ROTOR)))) {
+                if (buffer != null) {
+                    buffer.append(eq.getName()).append(" must be mounted on the side or turret.\n");
                 }
                 return false;
             }

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -889,7 +889,15 @@ public class TestTank extends TestEntity {
             }
             return false;
         }
-        final int rearLocation = (tank instanceof SuperHeavyTank) ? SuperHeavyTank.LOC_REAR : Tank.LOC_REAR;
+        final boolean isRearLocation;
+        final boolean isTurretLocation;
+        if (tank instanceof SuperHeavyTank) {
+            isRearLocation = location == SuperHeavyTank.LOC_REAR;
+            isTurretLocation = (location == SuperHeavyTank.LOC_TURRET) || (location == SuperHeavyTank.LOC_TURRET_2);
+        } else {
+            isRearLocation = location == Tank.LOC_REAR;
+            isTurretLocation = (location == Tank.LOC_TURRET) || (location == Tank.LOC_TURRET_2);
+        }
         if (eq instanceof MiscType) {
             // Equipment explicitly forbidden to a mast mount
             if ((eq.hasFlag(MiscType.F_MODULAR_ARMOR) || eq.hasFlag(MiscType.F_HARJEL)
@@ -920,27 +928,29 @@ public class TestTank extends TestEntity {
                 return false;
             }
         } else if (eq instanceof WeaponType) {
-            if (((((WeaponType) eq).getAmmoType() == AmmoType.T_GAUSS_HEAVY)
-                    || ((WeaponType) eq).getAmmoType() == AmmoType.T_IGAUSS_HEAVY)
-                    && (location != Tank.LOC_FRONT) && (location != rearLocation)) {
+            if ((((WeaponType) eq).getAmmoType() == AmmoType.T_GAUSS_HEAVY)
+                    && (location != Tank.LOC_FRONT) && !isRearLocation) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" cannot be mounted on the sides or turret.\n");
                 }
                 return false;
             }
-            if (eq.hasFlag(WeaponType.F_B_POD) && (location == Tank.LOC_FRONT) || (location == rearLocation)) {
+            if ((((WeaponType) eq).getAmmoType() == AmmoType.T_IGAUSS_HEAVY)
+                    && isTurretLocation) {
                 if (buffer != null) {
-                    buffer.append(eq.getName()).append(" must be mounted on the sides or turret.\n");
+                    buffer.append(eq.getName()).append(" cannot be mounted on a turret.\n");
                 }
                 return false;
             }
-            if (location == Tank.LOC_BODY) {
+            if (!eq.hasFlag(WeaponType.F_C3M) && !eq.hasFlag(WeaponType.F_C3MBS)
+                    && !eq.hasFlag(WeaponType.F_TAG) && (location == Tank.LOC_BODY)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" cannot be mounted in the body.\n");
                 }
                 return false;
             }
-            if ((tank instanceof VTOL) && (location == VTOL.LOC_ROTOR)) {
+            if ((tank instanceof VTOL) && (location == VTOL.LOC_ROTOR)
+                    && !eq.hasFlag(WeaponType.F_TAG)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" cannot be mounted in the rotor.\n");
                 }
@@ -959,7 +969,7 @@ public class TestTank extends TestEntity {
     public static boolean isBodyEquipment(EquipmentType eq) {
         if (eq instanceof MiscType) {
             return eq.hasFlag(MiscType.F_CHASSIS_MODIFICATION)
-                    || eq.hasFlag(MiscType.F_CASE)
+                    || (eq.hasFlag(MiscType.F_CASE) && !eq.isClan())
                     || eq.hasFlag(MiscType.F_CASEII)
                     || eq.hasFlag(MiscType.F_JUMP_JET)
                     || eq.hasFlag(MiscType.F_FUEL)


### PR DESCRIPTION
Checks for whether a piece of equipment is permitted in a location are currently duplicated in MM and MML and neither list is complete. This (along with a corresponding MML change) moves all the code that checks for valid location into the MM validation code, collected into a single method for each unit type. I also added a number of checks that were missing.

This fixes part of MegaMek/megameklab#500