### PR TITLE
Adding portraits to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,10 @@ build/
 /megamek/data/images/hexes/defaulthexset.txt
 /megamek/data/images/*_atlas.png
 /megamek/data/images/imgFileAtlasMap.xml
+#Portraits
+/megamek/data/images/Portraits/
+!/megamek/data/images/portraits/default.gif
+
 
 # Boards
 /megamek/data/boards/


### PR DESCRIPTION
I missed this one in my gitignore merge, and figured it out when I moved portrait into MegaMek to fix a MekHQ issue. 