### PR TITLE
Removing initialization listener from the RandomNameGenerator

### DIFF
--- a/megamek/src/megamek/client/RandomNameGenerator.java
+++ b/megamek/src/megamek/client/RandomNameGenerator.java
@@ -15,8 +15,6 @@
  */
 package megamek.client;
 
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
 import java.io.*;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -77,8 +75,6 @@ import megamek.common.util.WeightedMap;
  */
 public class RandomNameGenerator implements Serializable {
     //region Variable Declarations
-    private static final String PROP_INITIALIZED = "initialized";
-
     /** Default directory containing the faction-specific name files. */
     private static final String DIR_NAME_FACTIONS = "factions";
 
@@ -134,7 +130,6 @@ public class RandomNameGenerator implements Serializable {
     private String chosenFaction;
 
     private static final MMLogger logger = DefaultMmLogger.getInstance();
-    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
     private static volatile boolean initialized = false; // volatile to ensure readers get the current version
     //endregion Variable Declarations
 
@@ -302,21 +297,10 @@ public class RandomNameGenerator implements Serializable {
     private void runThreadLoader() {
         Thread loader = new Thread(() -> {
             rng.populateNames();
-            rng.removeInitializationListener();
+            initialized = true;
         }, "Random Name Generator name initializer");
         loader.setPriority(Thread.NORM_PRIORITY - 1);
         loader.start();
-    }
-
-    public void addInitializationListener(PropertyChangeListener listener) {
-        pcs.addPropertyChangeListener(listener);
-    }
-
-    private void removeInitializationListener() {
-        pcs.firePropertyChange(PROP_INITIALIZED, initialized, initialized = true);
-        for (PropertyChangeListener listener : pcs.getPropertyChangeListeners()) {
-            pcs.removePropertyChangeListener(listener);
-        }
     }
 
     private void populateNames() {

--- a/megamek/src/megamek/client/RandomNameGenerator.java
+++ b/megamek/src/megamek/client/RandomNameGenerator.java
@@ -297,7 +297,6 @@ public class RandomNameGenerator implements Serializable {
     private void runThreadLoader() {
         Thread loader = new Thread(() -> {
             rng.populateNames();
-            initialized = true;
         }, "Random Name Generator name initializer");
         loader.setPriority(Thread.NORM_PRIORITY - 1);
         loader.start();
@@ -406,6 +405,7 @@ public class RandomNameGenerator implements Serializable {
                 }
             }
         }
+        initialized = true;
         //endregion Faction Files
     }
 

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -229,18 +229,14 @@ public class ChatLounge extends AbstractPhaseDisplay
     // keep track of portrait images
     private DirectoryItems portraits;
 
-    private boolean mscLoaded = false;
-    private boolean rngLoaded = false;
-
     private String cmdSelectedTab = null;
 
     private MechSummaryCache.Listener mechSummaryCacheListener = new MechSummaryCache.Listener() {
         @Override
         public void doneLoading() {
-            mscLoaded = true;
-            butLoad.setEnabled(mscLoaded && rngLoaded);
-            butArmy.setEnabled(mscLoaded && rngLoaded);
-            butLoadList.setEnabled(mscLoaded);
+            butLoad.setEnabled(true);
+            butArmy.setEnabled(true);
+            butLoadList.setEnabled(true);
         }
     };
 
@@ -369,18 +365,14 @@ public class ChatLounge extends AbstractPhaseDisplay
         butSkills = new JButton(Messages.getString("ChatLounge.butSkills")); //$NON-NLS-1$
         butNames = new JButton(Messages.getString("ChatLounge.butNames")); //$NON-NLS-1$
 
-        RandomNameGenerator rng = RandomNameGenerator.getInstance();
-        rng.addInitializationListener(evt -> {
-            rngLoaded = (boolean) evt.getNewValue();
-            butLoad.setEnabled(mscLoaded && rngLoaded);
-            butArmy.setEnabled(mscLoaded && rngLoaded);
+        // Initialize the RandomNameGenerator
+        RandomNameGenerator.getInstance();
 
-        });
         MechSummaryCache mechSummaryCache = MechSummaryCache.getInstance();
         mechSummaryCache.addListener(mechSummaryCacheListener);
-        mscLoaded = mechSummaryCache.isInitialized();
-        butLoad.setEnabled(mscLoaded && rngLoaded);
-        butArmy.setEnabled(mscLoaded && rngLoaded);
+        boolean mscLoaded = mechSummaryCache.isInitialized();
+        butLoad.setEnabled(mscLoaded);
+        butArmy.setEnabled(mscLoaded);
         butLoadList.setEnabled(mscLoaded);
         butSkills.setEnabled(true);
         butNames.setEnabled(true);


### PR DESCRIPTION
The name generator now properly handles not being initialized, and will produce a name if it is hit, so the check is not needed