### PR TITLE
Don't show Standard on unit summary panel

### DIFF
--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -957,7 +957,8 @@ public class MechView {
                     || name.contains("BA Standard")
                     || name.contains("BA Advanced")
                     || name.contains("Reflective")
-                    || name.contains("Ferro-Lamellor")) {
+                    || name.contains("Ferro-Lamellor")
+                    || name.contains("Standard")) {
                 // These items are displayed elsewhere, so skip them here.
                 continue;
             }


### PR DESCRIPTION
In order to show the smart robotic control system (SRSC) in the unit summary I stopped it from excluding Misc equipment in LOC_NONE if the equipment is zero-slot, thinking that the only other MiscType in that location would be heat sinks. I forgot about the Standard placeholder type used for armor and internal structure.