### PR TITLE
Issue #1639 MapEditor Building button, default CF

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -313,6 +313,7 @@ public class BoardEditor extends JComponent
     private Stack<HashSet<IHex>> redoStack = new Stack<>();
     private HashSet<IHex> currentUndoSet;
     private HashSet<Coords> currentUndoCoords;
+    private static final int [] defaultBuildingCFs = {0,15,40,90,150};
     
     /**
      * Special purpose indicator, keeps terrain list 
@@ -682,41 +683,40 @@ public class BoardEditor extends JComponent
         buttonMg.addMouseWheelListener(wheelListener);
 
         // Mouse wheel behaviour for the BUILDINGS button
-        // This always ADDS the building because clearing all terrain except
-        // buildings is too complicated. User can click the X button to clear terrain.
+        // Always ADDS the building. 
         buttonBu.addMouseWheelListener(e -> {
+        	// Restore mandatory building parts if some are missing
             setBasicBuilding(false);
             int wheelDir = (e.getWheelRotation() < 0) ? 1 : -1;
-            int terrainType;
-            int newLevel;
 
             if (e.isShiftDown()) {
-                terrainType = Terrains.BLDG_CF;
-                int oldLevel = curHex.getTerrain(terrainType).getLevel();
-                newLevel = Math.max(10, oldLevel + wheelDir*10);
+                int oldLevel = curHex.getTerrain(Terrains.BLDG_CF).getLevel();
+                int newLevel = Math.max(10, oldLevel + wheelDir*5);
+                curHex.addTerrain(TF.createTerrain(Terrains.BLDG_CF, newLevel));
             }
             else if (e.isControlDown()) {
-                terrainType = Terrains.BUILDING;
-                int oldLevel = curHex.getTerrain(terrainType).getLevel();
-                if ((oldLevel == 1) && (wheelDir == -1)) {
-                    newLevel = oldLevel;
-                } else if ((oldLevel == 4) && (wheelDir == 1)) { //TODO : Implement Walls
-                    newLevel = oldLevel;
-                } else {
-                    newLevel = oldLevel + wheelDir;
+                int oldLevel = curHex.getTerrain(Terrains.BUILDING).getLevel();
+                int newLevel = Math.max(1, Math.min(4, oldLevel + wheelDir)); // keep between 1 and 4
+
+                if (newLevel != oldLevel) {
+                	ITerrain curTerr = curHex.getTerrain(Terrains.BUILDING);
+                	curHex.addTerrain(TF.createTerrain(Terrains.BUILDING, 
+                			newLevel, curTerr.hasExitsSpecified(), curTerr.getExits()));
+
+                	// Set the CF to the appropriate standard value *IF* it is the appropriate value now,
+                	// i.e. if the user has not manually set it to something else
+                	int curCF = curHex.getTerrain(Terrains.BLDG_CF).getLevel();
+                	if (curCF == defaultBuildingCFs[oldLevel]) 
+                		curHex.addTerrain(TF.createTerrain(Terrains.BLDG_CF, defaultBuildingCFs[newLevel]));
                 }
+                //TODO : Walls
             }
             else {
-                terrainType = Terrains.BLDG_ELEV;
-                int oldLevel = curHex.getTerrain(terrainType).getLevel();
-                newLevel = Math.max(1, oldLevel + wheelDir);
+                int oldLevel = curHex.getTerrain(Terrains.BLDG_ELEV).getLevel();
+                int newLevel = Math.max(1, oldLevel + wheelDir);
+                curHex.addTerrain(TF.createTerrain(Terrains.BLDG_ELEV, newLevel));
             }
 
-            if (e.isAltDown()) {
-                curHex.addTerrain(TF.createTerrain(terrainType, newLevel, true, 0));
-            } else {
-                curHex.addTerrain(TF.createTerrain(terrainType, newLevel));
-            }
             refreshTerrainList();
             repaintWorkingHex();
         });
@@ -1282,22 +1282,23 @@ public class BoardEditor extends JComponent
     }
     
     /**
-     * Sets valid basic bridge values as far as they are missing
+     * Sets valid basic Building values as far as they are missing
      */
-    private void setBasicBuilding(boolean singleHex) {
+    private void setBasicBuilding(boolean ALT_Held) {
         if (!curHex.containsTerrain(Terrains.BLDG_CF)) 
-            curHex.addTerrain(TF.createTerrain(Terrains.BLDG_CF, 40, false, 0));
+            curHex.addTerrain(TF.createTerrain(Terrains.BLDG_CF, 15, false, 0));
 
         if (!curHex.containsTerrain(Terrains.BLDG_ELEV)) 
             curHex.addTerrain(TF.createTerrain(Terrains.BLDG_ELEV, 1, false, 0));
 
         if (!curHex.containsTerrain(Terrains.BUILDING))
-        {
-            if (singleHex) {
-                curHex.addTerrain(TF.createTerrain(Terrains.BUILDING, 1, true, 0));
-            } else {
-                curHex.addTerrain(TF.createTerrain(Terrains.BUILDING, 1, false, 0));
-            }
+        	curHex.addTerrain(TF.createTerrain(Terrains.BUILDING, 1, ALT_Held, 0));
+
+        // When clicked with ALT and a Building is present, only toggle the exits
+        if (curHex.containsTerrain(Terrains.BUILDING) && ALT_Held) {
+        	ITerrain curTerr = curHex.getTerrain(Terrains.BUILDING);
+        	curHex.addTerrain(TF.createTerrain(Terrains.BUILDING, 
+        			curTerr.getLevel(), !curTerr.hasExitsSpecified(), curTerr.getExits()));
         }
 
         refreshTerrainList();
@@ -1864,7 +1865,8 @@ public class BoardEditor extends JComponent
             lastClicked = null;
         } else if (ae.getSource().equals(buttonBu)) { 
             buttonUpDn.setSelected(false);
-            if ((ae.getModifiers() & InputEvent.SHIFT_MASK) == 0) curHex.removeAllTerrains();
+            if ((ae.getModifiers() & InputEvent.SHIFT_MASK) == 0 && (ae.getModifiers() & InputEvent.ALT_MASK) == 0) 
+				curHex.removeAllTerrains();
             if ((ae.getModifiers() & InputEvent.ALT_MASK) != 0) {
                 setBasicBuilding(true);
             } else {


### PR DESCRIPTION
Hi guys, this changes the Building button behaviour in the MapEditor as per #1639. The CF will be set to the standard CF when changing the building type (Ctrl-Wheel). I thought it made sense to do that only if the CF was the standard for the building type before, i.e. if the user had not changed it. In addition, ALT-Click will now toggle the exits. Also, I changed the CF increment of wheeling the button from 10 down to 5. Should be able to actually reach CF 15 when this is a standard value.

I could not find standard values for buildings in TW, only the upper end of the respective ranges. CF 150 seems to be the "standard" for Hardened; I couldn't find CF 120. So I used 150.

No change to bridges or anything else as the terrain display is different from buildings (doesn't show "Hardened" etc.)

