### PR TITLE
Location limits

### DIFF
--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1360,7 +1360,7 @@ public abstract class TestEntity implements TestEntityOption {
                     && ((m.getType().hasFlag(MiscType.F_CLUB) && !((MiscType) m.getType()).isShield())
                     || m.getType().hasFlag(MiscType.F_BULLDOZER)
                     || m.getType().hasFlag(MiscType.F_HAND_WEAPON))) {
-                physicalWeaponsByLocation.computeIfAbsent(m.getLocation(), new ArrayList<>()).add(m.getType());
+                physicalWeaponsByLocation.computeIfAbsent(m.getLocation(), ArrayList::new).add(m.getType());
             } else if (m.getType().hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER)
                     || m.getType().hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER)
                     || m.getType().hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER)) {

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1360,8 +1360,7 @@ public abstract class TestEntity implements TestEntityOption {
                     && ((m.getType().hasFlag(MiscType.F_CLUB) && !((MiscType) m.getType()).isShield())
                     || m.getType().hasFlag(MiscType.F_BULLDOZER)
                     || m.getType().hasFlag(MiscType.F_HAND_WEAPON))) {
-                physicalWeaponsByLocation.putIfAbsent(m.getLocation(), new ArrayList<>());
-                physicalWeaponsByLocation.get(m.getLocation()).add(m.getType());
+                physicalWeaponsByLocation.computeIfAbsent(m.getLocation(), new ArrayList<>()).add(m.getType());
             } else if (m.getType().hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER)
                     || m.getType().hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER)
                     || m.getType().hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER)) {

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1435,7 +1435,7 @@ public abstract class TestEntity implements TestEntityOption {
         if ((getEntity() instanceof Mech) && (liftHoists > 2)) {
             illegal = true;
             buff.append("Can mount a maximum of two lift hoists.\n");
-        } else if (liftHoists > 4) {
+        } else if ((getEntity().isSupportVehicle() || (getEntity() instanceof Tank)) &&  (liftHoists > 4)) {
             illegal = true;
             buff.append("Can mount a maximum of four lift hoists.\n");
         }

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1356,9 +1356,10 @@ public abstract class TestEntity implements TestEntityOption {
             }
             if (m.getType().hasFlag(MiscType.F_LIFTHOIST)) {
                 liftHoists++;
-            } else if ((m.getType().hasFlag(MiscType.F_CLUB) && !((MiscType) m.getType()).isShield())
+            } else if ((m.getLocation() > 0)
+                    && ((m.getType().hasFlag(MiscType.F_CLUB) && !((MiscType) m.getType()).isShield())
                     || m.getType().hasFlag(MiscType.F_BULLDOZER)
-                    || m.getType().hasFlag(MiscType.F_HAND_WEAPON)) {
+                    || m.getType().hasFlag(MiscType.F_HAND_WEAPON))) {
                 physicalWeaponsByLocation.putIfAbsent(m.getLocation(), new ArrayList<>());
                 physicalWeaponsByLocation.get(m.getLocation()).add(m.getType());
             } else if (m.getType().hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER)
@@ -1474,7 +1475,7 @@ public abstract class TestEntity implements TestEntityOption {
             }
         }
         for (Mounted mounted : getEntity().getEquipment()) {
-            if (!mounted.isOneShotAmmo()) {
+            if (mounted.getLocation() > Entity.LOC_NONE) {
                 illegal |= !isValidLocation(getEntity(), mounted.getType(), mounted.getLocation(), buff);
             }
         }

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1434,7 +1434,7 @@ public abstract class TestEntity implements TestEntityOption {
         if ((getEntity() instanceof Mech) && (liftHoists > 2)) {
             illegal = true;
             buff.append("Can mount a maximum of two lift hoists.\n");
-        } else if ((getEntity().isSupportVehicle() || (getEntity() instanceof Tank)) &&  (liftHoists > 4)) {
+        } else if ((getEntity().isSupportVehicle() || (getEntity() instanceof Tank)) && (liftHoists > 4)) {
             illegal = true;
             buff.append("Can mount a maximum of four lift hoists.\n");
         }

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1512,8 +1512,9 @@ public class TestMech extends TestEntity {
      * @return     Whether the equipment requires the lower arm acutator
      */
     public static boolean requiresLowerArm(MiscType misc) {
-        return misc.hasFlag(MiscType.F_CLUB)
-                && misc.hasSubType(MiscType.S_LANCE | MiscType.S_RETRACTABLE_BLADE);
+        return replacesHandActuator(misc) ||
+                (misc.hasFlag(MiscType.F_CLUB)
+                && misc.hasSubType(MiscType.S_LANCE | MiscType.S_RETRACTABLE_BLADE));
     }
 
     /**

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -878,7 +878,7 @@ public class TestMech extends TestEntity {
         boolean hasMASC = false;
         boolean hasAES = false;
         EquipmentType advancedMyomer = null;
-        
+
         //First we find all the equipment that is required or incompatible with other equipment,
         //so we don't have to execute another loop each time one of those situations comes up.
         for (Mounted m : mech.getMisc()) {
@@ -896,7 +896,7 @@ public class TestMech extends TestEntity {
                 advancedMyomer = m.getType();
             }
         }
-        
+
         for (Mounted m : getEntity().getMisc()) {
             final MiscType misc = (MiscType)m.getType();
 
@@ -961,7 +961,6 @@ public class TestMech extends TestEntity {
                     buff.append("Mech requires a lower arm actuator in the arm that mounts ").append(misc.getName()).append("\n");
                 }
             }
-
             if (misc.hasFlag(MiscType.F_HEAD_TURRET)
                     && isCockpitLocation(Mech.LOC_HEAD)) {
                 illegal = true;

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -895,7 +895,6 @@ public class TestMech extends TestEntity {
                     || m.getType().hasFlag(MiscType.F_SCM)) {
                 advancedMyomer = m.getType();
             }
-                
         }
         
         for (Mounted m : getEntity().getMisc()) {
@@ -948,23 +947,21 @@ public class TestMech extends TestEntity {
                 buff.append("BattleMech can't mount light fluid suction system\n");
             }
 
-            if (!mech.entityIsQuad() && mech.hasSystem(Mech.ACTUATOR_HAND, m.getLocation())
-                    && (misc.hasFlag(MiscType.F_SALVAGE_ARM)
-                    || (misc.hasFlag(MiscType.F_CLUB)
-                            && (misc.hasSubType(MiscType.S_CHAINSAW)
-                                    || misc.hasSubType(MiscType.S_BACKHOE)
-                                    || misc.hasSubType(MiscType.S_DUAL_SAW)
-                                    || misc.hasSubType(MiscType.S_PILE_DRIVER)
-                                    || misc.hasSubType(MiscType.S_MINING_DRILL)
-                                    || misc.hasSubType(MiscType.S_ROCK_CUTTER)
-                                    || misc.hasSubType(MiscType.S_SPOT_WELDER)
-                                    || misc.hasSubType(MiscType.S_WRECKING_BALL)
-                                    || misc.hasSubType(MiscType.S_COMBINE))))) {
+            if (!mech.entityIsQuad()) {
+                if (replacesHandActuator(misc)
+                        && mech.hasSystem(Mech.ACTUATOR_HAND, m.getLocation())) {
                     illegal = true;
                     buff.append("Mech can only mount ").append(misc.getName())
                             .append(" in arm with no hand actuator.\n");
+                } else if (requiresHandActuator(misc) && !mech.hasSystem(Mech.ACTUATOR_HAND, m.getLocation())) {
+                    illegal = true;
+                    buff.append("Mech requires a hand actuator in the arm that mounts ").append(misc.getName()).append("\n");
+                } else if (requiresLowerArm(misc) && !mech.hasSystem(Mech.ACTUATOR_LOWER_ARM, m.getLocation())) {
+                    illegal = true;
+                    buff.append("Mech requires a lower arm actuator in the arm that mounts ").append(misc.getName()).append("\n");
+                }
             }
-            
+
             if (misc.hasFlag(MiscType.F_HEAD_TURRET)
                     && isCockpitLocation(Mech.LOC_HEAD)) {
                 illegal = true;
@@ -1475,6 +1472,49 @@ public class TestMech extends TestEntity {
         }
         
         return illegal;
+    }
+
+    /**
+     * @param misc A type of equipment
+     * @return     Whether the equipment replaces the hand actuator when mounted in an arm
+     */
+    public static boolean replacesHandActuator(MiscType misc) {
+        return misc.hasFlag(MiscType.F_SALVAGE_ARM)
+                || misc.hasFlag(MiscType.F_HAND_WEAPON)
+                || (misc.hasFlag(MiscType.F_CLUB)
+                    && (misc.hasSubType(MiscType.S_CHAINSAW)
+                    || misc.hasSubType(MiscType.S_BACKHOE)
+                    || misc.hasSubType(MiscType.S_DUAL_SAW)
+                    || misc.hasSubType(MiscType.S_PILE_DRIVER)
+                    || misc.hasSubType(MiscType.S_MINING_DRILL)
+                    || misc.hasSubType(MiscType.S_ROCK_CUTTER)
+                    || misc.hasSubType(MiscType.S_SPOT_WELDER)
+                    || misc.hasSubType(MiscType.S_WRECKING_BALL)
+                    || misc.hasSubType(MiscType.S_FLAIL)));
+    }
+
+    /**
+     * @param misc A type of equipment that can be mounted in a mech arm
+     * @return     Whether the equipment requires the hand acutator
+     */
+    public static boolean requiresHandActuator(MiscType misc) {
+        return misc.hasFlag(MiscType.F_CLUB)
+                && misc.hasSubType(MiscType.S_CHAIN_WHIP
+                | MiscType.S_HATCHET
+                | MiscType.S_MACE
+                | MiscType.S_SWORD
+                | MiscType.S_VIBRO_SMALL
+                | MiscType.S_VIBRO_MEDIUM
+                | MiscType.S_VIBRO_LARGE);
+    }
+
+    /**
+     * @param misc A type of equipment that can be mounted in a mech arm
+     * @return     Whether the equipment requires the lower arm acutator
+     */
+    public static boolean requiresLowerArm(MiscType misc) {
+        return misc.hasFlag(MiscType.F_CLUB)
+                && misc.hasSubType(MiscType.S_LANCE | MiscType.S_RETRACTABLE_BLADE);
     }
 
     /**

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -927,6 +927,15 @@ public class TestTank extends TestEntity {
                 }
                 return false;
             }
+            // The minesweeper is also permitted in the front-side/rear-side location for "particularly
+            // large vehicles" (TacOps, 326) but it is not clear how large this needs to be. Superheavy?
+            // multi-hex large naval support?
+            if (eq.hasFlag(MiscType.F_MINESWEEPER) && (location != Tank.LOC_FRONT) && !isRearLocation) {
+                if (buffer != null) {
+                    buffer.append(eq.getName()).append(" must be mounted on the front or rear.\n");
+                }
+                return false;
+            }
         } else if (eq instanceof WeaponType) {
             if ((((WeaponType) eq).getAmmoType() == AmmoType.T_GAUSS_HEAVY)
                     && (location != Tank.LOC_FRONT) && !isRearLocation) {

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -776,38 +776,6 @@ public class TestTank extends TestEntity {
                     illegal = true;
                 }
             }
-
-            if (misc.hasFlag(MiscType.F_BULLDOZER)) {
-                for (Mounted m2 : getEntity().getMisc()) {
-                    if (m2.getLocation() == m.getLocation()) {
-                        if (m2.getType().hasFlag(MiscType.F_CLUB)) {
-                            if (m2.getType().hasSubType(MiscType.S_BACKHOE)
-                                    || m2.getType().hasSubType(
-                                            MiscType.S_CHAINSAW)
-                                    || m2.getType().hasSubType(
-                                            MiscType.S_COMBINE)
-                                    || m2.getType().hasSubType(
-                                            MiscType.S_DUAL_SAW)
-                                    || m2.getType().hasSubType(
-                                            MiscType.S_PILE_DRIVER)
-                                    || m2.getType().hasSubType(
-                                            MiscType.S_MINING_DRILL)
-                                    || m2.getType().hasSubType(
-                                            MiscType.S_ROCK_CUTTER)
-                                    || m2.getType().hasSubType(
-                                            MiscType.S_WRECKING_BALL)) {
-                                illegal = true;
-                                buff.append("bulldozer in same location as prohibited physical weapon\n");
-                            }
-                        }
-                    }
-                }
-                if ((getEntity().getMovementMode() != EntityMovementMode.TRACKED)
-                        && (getEntity().getMovementMode() != EntityMovementMode.WHEELED)) {
-                    illegal = true;
-                    buff.append("bulldozer must be mounted in unit with tracked or wheeled movement mode\n");
-                }
-            }
         }
 
         if ((tank.getMovementMode() == EntityMovementMode.VTOL)


### PR DESCRIPTION
This is the third and final set of changes that validates equipment construction rules, mostly for vehicles. The first checked against motive type, the second against mount location, and this one takes care of the more tedious work of checking the maximum number in a location. For mechs this also streamlines and completes the checks for required or prohibited actuators.

Fixes MegaMek/megameklab#500