### PR TITLE
1050: Changing MegaMekFile name to OldMegaMekFile

### DIFF
--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -58,7 +58,7 @@ import megamek.common.logging.LogLevel;
 import megamek.common.logging.MMLogger;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.AbstractCommandLineParser;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestBattleArmor;
@@ -681,7 +681,7 @@ public class MegaMek {
                         displayMessage("Validating Entity: " +
                                        entity.getShortNameRaw(), METHOD_NAME); //$NON-NLS-1$
                         EntityVerifier entityVerifier = EntityVerifier.getInstance(
-                                new MegaMekFile(Configuration.unitsDir(),
+                                new OldMegaMekFile(Configuration.unitsDir(),
                                                 EntityVerifier.CONFIG_FILENAME).getFile());
                         MechView mechView = new MechView(entity, false);
                         StringBuffer sb = new StringBuffer(

--- a/megamek/src/megamek/client/RandomNameGenerator.java
+++ b/megamek/src/megamek/client/RandomNameGenerator.java
@@ -28,7 +28,7 @@ import megamek.common.Configuration;
 import megamek.common.Crew;
 import megamek.common.logging.DefaultMmLogger;
 import megamek.common.logging.MMLogger;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.util.WeightedMap;
 
 /**
@@ -326,7 +326,7 @@ public class RandomNameGenerator implements Serializable {
         factionEthnicCodes = new HashMap<>();
 
         // Determine the number of ethnic codes
-        File masterAncestryFile = new MegaMekFile(Configuration.namesDir(), FILENAME_MASTER_ANCESTRY).getFile();
+        File masterAncestryFile = new OldMegaMekFile(Configuration.namesDir(), FILENAME_MASTER_ANCESTRY).getFile();
         try (InputStream is = new FileInputStream(masterAncestryFile);
              Scanner input = new Scanner(is, "UTF-8")) {
 
@@ -355,7 +355,7 @@ public class RandomNameGenerator implements Serializable {
 
         //region Faction Files
         // all faction files should be in the faction directory
-        File factionsDir = new MegaMekFile(Configuration.namesDir(), DIR_NAME_FACTIONS).getFile();
+        File factionsDir = new OldMegaMekFile(Configuration.namesDir(), DIR_NAME_FACTIONS).getFile();
         String[] fileNames = factionsDir.list();
 
         if ((fileNames == null) || (fileNames.length == 0)) {
@@ -391,7 +391,7 @@ public class RandomNameGenerator implements Serializable {
                 factionGivenNames.put(key, new HashMap<>());
                 factionEthnicCodes.put(key, new WeightedMap<>());
 
-                File factionFile = new MegaMekFile(factionsDir, filename).getFile();
+                File factionFile = new OldMegaMekFile(factionsDir, filename).getFile();
                 try (InputStream is = new FileInputStream(factionFile);
                      Scanner input = new Scanner(is, "UTF-8")) {
 
@@ -422,7 +422,7 @@ public class RandomNameGenerator implements Serializable {
 
     private void readNamesFileToMap(Map<Integer, WeightedMap<String>> map, String fileName) {
         int lineNumber = 0;
-        File file = new MegaMekFile(Configuration.namesDir(), fileName).getFile();
+        File file = new OldMegaMekFile(Configuration.namesDir(), fileName).getFile();
 
         try (InputStream is = new FileInputStream(file);
              Scanner input = new Scanner(is, "UTF-8")) {

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -36,7 +36,7 @@ import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
 import megamek.common.UnitType;
 import megamek.common.logging.DefaultMmLogger;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.utils.MegaMekXmlUtil;
 
 /**
@@ -868,7 +868,7 @@ public class RATGenerator {
 	private void loadFactions(File dir) {
 	    final String METHOD_NAME = "loadFactions(File)";
 	    
-		File file = new MegaMekFile(dir, "factions.xml").getFile();
+		File file = new OldMegaMekFile(dir, "factions.xml").getFile();
 		FileInputStream fis;
 		try {
 			fis = new FileInputStream(file);
@@ -918,7 +918,7 @@ public class RATGenerator {
 		}
 		chassisIndex.put(era, new HashMap<>());
 		modelIndex.put(era, new HashMap<>());
-		File file = new MegaMekFile(dir, era + ".xml").getFile();
+		File file = new OldMegaMekFile(dir, era + ".xml").getFile();
 		FileInputStream fis;
 		try {
 			fis = new FileInputStream(file);

--- a/megamek/src/megamek/client/ui/swing/AbstractPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/AbstractPhaseDisplay.java
@@ -56,7 +56,7 @@ import megamek.common.event.GameVictoryEvent;
 import megamek.common.logging.DefaultMmLogger;
 import megamek.common.util.Distractable;
 import megamek.common.util.DistractableAdapter;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 public abstract class AbstractPhaseDisplay extends JPanel implements 
         BoardViewListener, GameListener, Distractable {
@@ -98,7 +98,7 @@ public abstract class AbstractPhaseDisplay extends JPanel implements
 
         try {
             if (pdSkinSpec.backgrounds.size() > 0){
-                File file = new MegaMekFile(Configuration.widgetsDir(), 
+                File file = new OldMegaMekFile(Configuration.widgetsDir(),
                         pdSkinSpec.backgrounds.get(0)).getFile();
                 URI imgURL = file.toURI();
                 if (!file.exists()){

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -104,7 +104,7 @@ import megamek.common.MapSettings;
 import megamek.common.Terrains;
 import megamek.common.util.BoardUtilities;
 import megamek.common.util.ImageUtil;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 // TODO: center map
 // TODO: background on the whole screen
@@ -522,7 +522,7 @@ public class BoardEditor extends JComponent
         JButton button = new JButton(buttonName);
         button.addActionListener(this);
         // Get the normal icon
-        File file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+".png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
+        File file = new OldMegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+".png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
         Image imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton != null) {
             button.setIcon(new ImageIcon(imageButton));
@@ -531,14 +531,14 @@ public class BoardEditor extends JComponent
         }
 
         // Get the hover icon
-        file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_H.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
+        file = new OldMegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_H.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
         imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton != null) {
             button.setRolloverIcon(new ImageIcon(imageButton));
         }
         
         // Get the disabled icon, if any
-        file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_G.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
+        file = new OldMegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_G.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
         imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton != null) {
             button.setDisabledIcon(new ImageIcon(imageButton));
@@ -561,7 +561,7 @@ public class BoardEditor extends JComponent
         button.addActionListener(this);
         
         // Get the normal icon
-        File file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+".png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
+        File file = new OldMegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+".png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
         Image imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton != null) {
             button.setIcon(new ImageIcon(imageButton));
@@ -570,13 +570,13 @@ public class BoardEditor extends JComponent
         }
         
         // Get the hover icon
-        file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_H.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
+        file = new OldMegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_H.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
         imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton != null)
             button.setRolloverIcon(new ImageIcon(imageButton));
         
         // Get the selected icon
-        file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_S.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
+        file = new OldMegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_S.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
         imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton != null)
             button.setSelectedIcon(new ImageIcon(imageButton));

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -144,7 +144,7 @@ import megamek.common.options.PilotOptions;
 import megamek.common.options.Quirks;
 import megamek.common.util.BoardUtilities;
 import megamek.common.util.DirectoryItems;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 public class ChatLounge extends AbstractPhaseDisplay
         implements ActionListener, ItemListener, ListSelectionListener, MouseListener, IMapSettingsObserver {
@@ -1176,7 +1176,7 @@ public class ChatLounge extends AbstractPhaseDisplay
         String boardName = lisBoardsAvailable.getSelectedValue();
         if (lisBoardsAvailable.getSelectedIndex() > 2) {
             IBoard board = new Board(16, 17);
-            board.load(new MegaMekFile(Configuration.boardsDir(), boardName + ".board").getFile());
+            board.load(new OldMegaMekFile(Configuration.boardsDir(), boardName + ".board").getFile());
             if (chkRotateBoard.isSelected()) {
                 BoardUtilities.flip(board, true, true);
             }
@@ -1205,7 +1205,7 @@ public class ChatLounge extends AbstractPhaseDisplay
             if (name.startsWith(MapSettings.BOARD_GENERATED) || (temp.getMedium() == MapSettings.MEDIUM_SPACE)) {
                 sheetBoards[i] = BoardUtilities.generateRandom(temp);
             } else {
-                sheetBoards[i].load(new MegaMekFile(Configuration.boardsDir(), name
+                sheetBoards[i].load(new OldMegaMekFile(Configuration.boardsDir(), name
                         + ".board").getFile());
                 BoardUtilities.flip(sheetBoards[i], isRotated, isRotated);
             }
@@ -2572,7 +2572,7 @@ public class ChatLounge extends AbstractPhaseDisplay
             IBoard b = new Board(16, 17);
             if (!MapSettings.BOARD_GENERATED.equals(board) && !MapSettings.BOARD_RANDOM.equals(board)
                     && !MapSettings.BOARD_SURPRISE.equals(board)) {
-                b.load(new MegaMekFile(Configuration.boardsDir(), board + ".board").getFile());
+                b.load(new OldMegaMekFile(Configuration.boardsDir(), board + ".board").getFile());
                 if (!b.isValid()) {
                     JOptionPane.showMessageDialog(this, "The Selected board is invalid, please select another.");
                     return;
@@ -3413,7 +3413,7 @@ public class ChatLounge extends AbstractPhaseDisplay
                             clearImage();
                         } else {
                             Image image = getToolkit().getImage(
-                                    new MegaMekFile(Configuration.miscImagesDir(),
+                                    new OldMegaMekFile(Configuration.miscImagesDir(),
                                             FILENAME_UNKNOWN_UNIT).toString());
                             image = image.getScaledInstance(-1, 72,
                                     Image.SCALE_DEFAULT);
@@ -3424,7 +3424,7 @@ public class ChatLounge extends AbstractPhaseDisplay
                             clearImage();
                         } else {
                             Image image = getToolkit().getImage(
-                                    new MegaMekFile(Configuration.portraitImagesDir(),
+                                    new OldMegaMekFile(Configuration.portraitImagesDir(),
                                             FILENAME_PORTRAIT_DEFAULT)
                                             .toString());
                             image = image.getScaledInstance(-1, 50,

--- a/megamek/src/megamek/client/ui/swing/ChatterBox2.java
+++ b/megamek/src/megamek/client/ui/swing/ChatterBox2.java
@@ -47,7 +47,7 @@ import megamek.common.event.GameEntityNewEvent;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GamePlayerChatEvent;
 import megamek.common.preference.PreferenceManager;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.util.StringUtil;
 
 /**
@@ -156,19 +156,19 @@ public class ChatterBox2 implements KeyListener, IDisplayable {
         fm = bv.getFontMetrics(FONT_CHAT);
 
         Toolkit toolkit = bv.getToolkit();
-        upbutton = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), 
+        upbutton = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(),
                 FILENAME_BUTTON_UP).toString());
         PMUtil.setImage(upbutton, client);
-        downbutton = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), 
+        downbutton = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(),
                 FILENAME_BUTTON_DOWN).toString());
         PMUtil.setImage(downbutton, client);
-        minbutton = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), 
+        minbutton = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(),
                 FILENAME_BUTTON_MINIMISE).toString());
         PMUtil.setImage(minbutton, client);
-        maxbutton = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), 
+        maxbutton = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(),
                 FILENAME_BUTTON_MAXIMISE).toString());
         PMUtil.setImage(maxbutton, client);
-        resizebutton = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), 
+        resizebutton = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(),
                 FILENAME_BUTTON_RESIZE).toString());
         PMUtil.setImage(resizebutton, client);
 

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -114,7 +114,7 @@ import megamek.common.net.Packet;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.AddBotUtil;
 import megamek.common.util.Distractable;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.util.SharedConfiguration;
 import megamek.common.util.StringUtil;
 
@@ -406,16 +406,16 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         frame.setForeground(SystemColor.menuText);
         List<Image> iconList = new ArrayList<>();
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_16X16).toString()
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_16X16).toString()
         ));
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_32X32).toString()
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_32X32).toString()
         ));
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_48X48).toString()
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_48X48).toString()
         ));
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_256X256).toString()
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_256X256).toString()
         ));
         frame.setIconImages(iconList);
     }

--- a/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
@@ -38,7 +38,7 @@ import javax.swing.JTextArea;
 
 import megamek.client.ui.Messages;
 import megamek.common.Configuration;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Every about dialog in MegaMek should have an identical look-and-feel.
@@ -66,7 +66,7 @@ public class CommonAboutDialog extends JDialog {
         if (imgTitleImage == null) {
             // Nope. Load it.
             Image image = frame.getToolkit().getImage(
-                    new MegaMekFile(Configuration.miscImagesDir(), FILENAME_MEGAMEK_SPLASH2).toString()
+                    new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_MEGAMEK_SPLASH2).toString()
             );
             MediaTracker tracker = new MediaTracker(frame);
             tracker.addImage(image, 0);

--- a/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
@@ -86,7 +86,7 @@ import megamek.common.options.PartialRepairs;
 import megamek.common.options.PilotOptions;
 import megamek.common.options.Quirks;
 import megamek.common.options.WeaponQuirks;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestBattleArmor;
@@ -1361,7 +1361,7 @@ public class CustomMechDialog extends ClientDialog implements ActionListener,
 
         // Check validity of units after customization
         for (Entity entity : entities) {
-            EntityVerifier verifier = EntityVerifier.getInstance(new MegaMekFile(
+            EntityVerifier verifier = EntityVerifier.getInstance(new OldMegaMekFile(
                     Configuration.unitsDir(), EntityVerifier.CONFIG_FILENAME).getFile());
             TestEntity testEntity = null;
             if (entity instanceof Mech) {

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -62,7 +62,7 @@ import megamek.common.TechConstants;
 import megamek.common.WeaponType;
 import megamek.common.options.IOptions;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestBattleArmor;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -263,7 +263,7 @@ public class EquipChoicePanel extends JPanel implements Serializable {
             //  pick legal combinations of manipulators
             BattleArmor ba = (BattleArmor) entity;
             EntityVerifier verifier = EntityVerifier.getInstance(
-                    new MegaMekFile(Configuration.unitsDir(),
+                    new OldMegaMekFile(Configuration.unitsDir(),
                             EntityVerifier.CONFIG_FILENAME).getFile());
             TestBattleArmor testBA = new TestBattleArmor(ba, 
                     verifier.baOption, null);

--- a/megamek/src/megamek/client/ui/swing/ExitsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/ExitsDialog.java
@@ -34,7 +34,7 @@ import javax.swing.JPanel;
 import megamek.client.ui.Messages;
 import megamek.common.Configuration;
 import megamek.common.util.ImageUtil;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * A dialog of which exits are connected for terrain.
@@ -120,7 +120,7 @@ public class ExitsDialog extends JDialog implements ActionListener {
         JToggleButton button = new JToggleButton(buttonName);
 
         // Get the normal icon
-        File file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+".png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
+        File file = new OldMegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+".png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
         Image imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton != null) {
             button.setIcon(new ImageIcon(imageButton));
@@ -129,13 +129,13 @@ public class ExitsDialog extends JDialog implements ActionListener {
         }
 
         // Get the hover icon
-        file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_H.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
+        file = new OldMegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_H.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
         imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton != null)
             button.setRolloverIcon(new ImageIcon(imageButton));
 
         // Get the selected icon
-        file = new MegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_S.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
+        file = new OldMegaMekFile(Configuration.widgetsDir(), "/MapEditor/"+iconName+"_S.png").getFile(); //$NON-NLS-1$ //$NON-NLS-2$
         imageButton = ImageUtil.loadImageFromFile(file.getAbsolutePath());
         if (imageButton != null)
             button.setSelectedIcon(new ImageIcon(imageButton));

--- a/megamek/src/megamek/client/ui/swing/HexTileset.java
+++ b/megamek/src/megamek/client/ui/swing/HexTileset.java
@@ -43,7 +43,7 @@ import megamek.common.IHex;
 import megamek.common.ITerrain;
 import megamek.common.Terrains;
 import megamek.common.util.ImageUtil;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.util.StringUtil;
 
 /**
@@ -240,7 +240,7 @@ public class HexTileset {
     public void loadFromFile(String filename) throws IOException {
         long startTime = System.currentTimeMillis();
         // make input stream for board
-        Reader r = new BufferedReader(new FileReader(new MegaMekFile(Configuration.hexesDir(), filename).getFile()));
+        Reader r = new BufferedReader(new FileReader(new OldMegaMekFile(Configuration.hexesDir(), filename).getFile()));
         // read board, looking for "size"
         StreamTokenizer st = new StreamTokenizer(r);
         st.eolIsSignificant(true);
@@ -547,7 +547,7 @@ public class HexTileset {
         public void loadImage(Component comp) {
             images = new Vector<Image>();
             for (String filename: filenames) {
-                File imgFile = new MegaMekFile(Configuration.hexesDir(), filename).getFile();
+                File imgFile = new OldMegaMekFile(Configuration.hexesDir(), filename).getFile();
                 Image image = ImageUtil.loadImageFromFile(imgFile.toString());
                 if (null != image) {
                     images.add(image);

--- a/megamek/src/megamek/client/ui/swing/MechTileset.java
+++ b/megamek/src/megamek/client/ui/swing/MechTileset.java
@@ -52,7 +52,7 @@ import megamek.common.TeleMissile;
 import megamek.common.TripodMech;
 import megamek.common.Warship;
 import megamek.common.util.ImageUtil;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * MechTileset is a misleading name, as this matches any unit, not just mechs
@@ -417,7 +417,7 @@ public class MechTileset {
 
     public void loadFromFile(String filename) throws IOException {
         // make inpustream for board
-        Reader r = new BufferedReader(new FileReader(new MegaMekFile(dir, filename).getFile()));
+        Reader r = new BufferedReader(new FileReader(new OldMegaMekFile(dir, filename).getFile()));
         // read board, looking for "size"
         StreamTokenizer st = new StreamTokenizer(r);
         st.eolIsSignificant(true);
@@ -540,7 +540,7 @@ public class MechTileset {
 
         public void loadImage(Component comp) {
             // System.out.println("loading mech image...");
-            File fin = new MegaMekFile(dir, imageFile).getFile();
+            File fin = new OldMegaMekFile(dir, imageFile).getFile();
             image = ImageUtil.loadImageFromFile(fin.toString());
             if (image == null) {
                 System.out.println("Received null image from "

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -91,7 +91,7 @@ import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.ImageUtil;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.server.ScenarioLoader;
 import megamek.server.Server;
 
@@ -126,7 +126,7 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
     private void createGUI() {
         try {
             GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
-            File btFontFile = new MegaMekFile(Configuration.fontsDir(), FILENAME_BT_CLASSIC_FONT).getFile();
+            File btFontFile = new OldMegaMekFile(Configuration.fontsDir(), FILENAME_BT_CLASSIC_FONT).getFile();
             Font btFont = Font.createFont(Font.TRUETYPE_FONT, btFontFile);
             System.out.println("Loaded Font: " + btFont.getName());
             ge.registerFont(btFont);
@@ -199,13 +199,13 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
 
         List<Image> iconList = new ArrayList<>();
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_16X16).toString()));
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_16X16).toString()));
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_32X32).toString()));
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_32X32).toString()));
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_48X48).toString()));
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_48X48).toString()));
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_256X256).toString()));
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_256X256).toString()));
         frame.setIconImages(iconList);
         CommonMenuBar menuBar = new CommonMenuBar();
         menuBar.addActionListener(actionListener);
@@ -312,7 +312,7 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
             splashFilename = determineSplashScreen(skinSpec.backgrounds, 
             		currentMonitor.getWidth(), currentMonitor.getHeight());
             if (skinSpec.backgrounds.size() > 1) {
-                File file = new MegaMekFile(Configuration.widgetsDir(),
+                File file = new OldMegaMekFile(Configuration.widgetsDir(),
                         skinSpec.backgrounds.get(1)).getFile();
                 if (!file.exists()){
                     System.err.println("MainMenu Error: background icon doesn't exist: "
@@ -332,7 +332,7 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
         }
         // initialize splash image
         Image imgSplash = frame.getToolkit()
-                .getImage(new MegaMekFile(Configuration.widgetsDir(), splashFilename).toString());
+                .getImage(new OldMegaMekFile(Configuration.widgetsDir(), splashFilename).toString());
 
         // wait for splash image to load completely
         MediaTracker tracker = new MediaTracker(frame);

--- a/megamek/src/megamek/client/ui/swing/MiniMap.java
+++ b/megamek/src/megamek/client/ui/swing/MiniMap.java
@@ -98,7 +98,7 @@ import megamek.common.event.GameListener;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Displays all the mapsheets in a scaled-down size. TBD refactorings: -make a
@@ -440,7 +440,7 @@ public class MiniMap extends JPanel {
         int green;
         int blue;
 
-        File coloursFile = new MegaMekFile(
+        File coloursFile = new OldMegaMekFile(
                 Configuration.hexesDir(), GUIPreferences.getInstance().getMinimapColours()
         ).getFile();
 

--- a/megamek/src/megamek/client/ui/swing/TilesetManager.java
+++ b/megamek/src/megamek/client/ui/swing/TilesetManager.java
@@ -66,7 +66,7 @@ import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.DirectoryItems;
 import megamek.common.util.ImageUtil;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Handles loading and manipulating images from both the mech tileset and the
@@ -103,7 +103,7 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
     // mech images
     private MechTileset mechTileset = new MechTileset(Configuration.unitImagesDir());
     private MechTileset wreckTileset = new MechTileset(
-            new MegaMekFile(Configuration.unitImagesDir(), DIR_NAME_WRECKS).getFile());
+            new OldMegaMekFile(Configuration.unitImagesDir(), DIR_NAME_WRECKS).getFile());
     private ArrayList<EntityImage> mechImageList = new ArrayList<EntityImage>();
     private HashMap<ArrayList<Integer>, EntityImage> mechImages = new HashMap<ArrayList<Integer>, EntityImage>();
 
@@ -151,7 +151,7 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
             System.out.println("Error loading tileset, "
                     + "reverting to default hexset! " + "Could not find file: "
                     + PreferenceManager.getClientPreferences().getMapTileset());
-            if (!new MegaMekFile(Configuration.hexesDir(), FILENAME_DEFAULT_HEX_SET).getFile().exists()){
+            if (!new OldMegaMekFile(Configuration.hexesDir(), FILENAME_DEFAULT_HEX_SET).getFile().exists()){
                 createDefaultHexSet();
             }
             hexTileset.loadFromFile(FILENAME_DEFAULT_HEX_SET);
@@ -415,39 +415,39 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
 
         // load minefield sign
         minefieldSign = ImageUtil
-                .loadImageFromFile(new MegaMekFile(Configuration.hexesDir(), Minefield.FILENAME_IMAGE).toString());
+                .loadImageFromFile(new OldMegaMekFile(Configuration.hexesDir(), Minefield.FILENAME_IMAGE).toString());
         if (minefieldSign.getWidth(null) <= 0 || minefieldSign.getHeight(null) <= 0) {
             System.out.println("Error opening minefield sign image!");
         }
 
         // load night overlay
         nightFog = ImageUtil
-                .loadImageFromFile(new MegaMekFile(Configuration.hexesDir(), FILENAME_NIGHT_IMAGE).toString());
+                .loadImageFromFile(new OldMegaMekFile(Configuration.hexesDir(), FILENAME_NIGHT_IMAGE).toString());
         if (nightFog.getWidth(null) <= 0 || nightFog.getHeight(null) <= 0) {
             System.out.println("Error opening nightFog image!");
         }
 
         // load the hexMask
-        hexMask = ImageUtil.loadImageFromFile(new MegaMekFile(Configuration.hexesDir(), FILENAME_HEX_MASK).toString());
+        hexMask = ImageUtil.loadImageFromFile(new OldMegaMekFile(Configuration.hexesDir(), FILENAME_HEX_MASK).toString());
         if (hexMask.getWidth(null) <= 0 || hexMask.getHeight(null) <= 0) {
             System.out.println("Error opening hexMask image!");
         }
 
         // load artillery targets
         artilleryAutohit = ImageUtil.loadImageFromFile(
-                new MegaMekFile(Configuration.hexesDir(), FILENAME_ARTILLERY_AUTOHIT_IMAGE).toString());
+                new OldMegaMekFile(Configuration.hexesDir(), FILENAME_ARTILLERY_AUTOHIT_IMAGE).toString());
         if (artilleryAutohit.getWidth(null) <= 0 || artilleryAutohit.getHeight(null) <= 0) {
             System.out.println("Error opening artilleryAutohit image!");
         }
 
         artilleryAdjusted = ImageUtil.loadImageFromFile(
-                new MegaMekFile(Configuration.hexesDir(), FILENAME_ARTILLERY_ADJUSTED_IMAGE).toString());
+                new OldMegaMekFile(Configuration.hexesDir(), FILENAME_ARTILLERY_ADJUSTED_IMAGE).toString());
         if (artilleryAdjusted.getWidth(null) <= 0 || artilleryAdjusted.getHeight(null) <= 0) {
             System.out.println("Error opening artilleryAdjusted image!");
         }
 
         artilleryIncoming = ImageUtil.loadImageFromFile(
-                new MegaMekFile(Configuration.hexesDir(), FILENAME_ARTILLERY_INCOMING_IMAGE).toString());
+                new OldMegaMekFile(Configuration.hexesDir(), FILENAME_ARTILLERY_INCOMING_IMAGE).toString());
         if (artilleryIncoming.getWidth(null) <= 0 || artilleryIncoming.getHeight(null) <= 0) {
             System.out.println("Error opening artilleryIncoming image!");
         }
@@ -832,7 +832,7 @@ public class TilesetManager implements IPreferenceChangeListener, ITilesetManage
 
     public static void createDefaultHexSet(){
         try {
-            FileOutputStream fos = new FileOutputStream(new MegaMekFile(Configuration.hexesDir(), FILENAME_DEFAULT_HEX_SET).getFile());
+            FileOutputStream fos = new FileOutputStream(new OldMegaMekFile(Configuration.hexesDir(), FILENAME_DEFAULT_HEX_SET).getFile());
             PrintStream p = new PrintStream(fos);
 
             p.println("# suggested hex tileset");

--- a/megamek/src/megamek/client/ui/swing/UnitOverview.java
+++ b/megamek/src/megamek/client/ui/swing/UnitOverview.java
@@ -45,7 +45,7 @@ import megamek.common.Mech;
 import megamek.common.Protomech;
 import megamek.common.Tank;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.util.StringUtil;
 
 public class UnitOverview implements IDisplayable {
@@ -91,21 +91,21 @@ public class UnitOverview implements IDisplayable {
         fm = clientgui.getFontMetrics(FONT);
 
         Toolkit toolkit = clientgui.getToolkit();
-        scrollUp = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "scrollUp2.png").toString()); //$NON-NLS-1$
+        scrollUp = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(), "scrollUp2.png").toString()); //$NON-NLS-1$
         PMUtil.setImage(scrollUp, clientgui);
-        scrollDown = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "scrollDown2.png").toString()); //$NON-NLS-1$
+        scrollDown = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(), "scrollDown2.png").toString()); //$NON-NLS-1$
         PMUtil.setImage(scrollDown, clientgui);
-        pageUp = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "pageUp2.png").toString()); //$NON-NLS-1$
+        pageUp = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(), "pageUp2.png").toString()); //$NON-NLS-1$
         PMUtil.setImage(pageUp, clientgui);
-        pageDown = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "pageDown2.png").toString()); //$NON-NLS-1$
+        pageDown = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(), "pageDown2.png").toString()); //$NON-NLS-1$
         PMUtil.setImage(pageDown, clientgui);
-        scrollUpG = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "scrollUp2_G.png").toString()); //$NON-NLS-1$
+        scrollUpG = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(), "scrollUp2_G.png").toString()); //$NON-NLS-1$
         PMUtil.setImage(scrollUp, clientgui);
-        scrollDownG = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "scrollDown2_G.png").toString()); //$NON-NLS-1$
+        scrollDownG = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(), "scrollDown2_G.png").toString()); //$NON-NLS-1$
         PMUtil.setImage(scrollDown, clientgui);
-        pageUpG = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "pageUp2_G.png").toString()); //$NON-NLS-1$
+        pageUpG = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(), "pageUp2_G.png").toString()); //$NON-NLS-1$
         PMUtil.setImage(pageUp, clientgui);
-        pageDownG = toolkit.getImage(new MegaMekFile(Configuration.widgetsDir(), "pageDown2_G.png").toString()); //$NON-NLS-1$
+        pageDownG = toolkit.getImage(new OldMegaMekFile(Configuration.widgetsDir(), "pageDown2_G.png").toString()); //$NON-NLS-1$
         PMUtil.setImage(pageDown, clientgui);
         
         visible = GUIPreferences.getInstance().getShowUnitOverview();

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView1.java
@@ -183,7 +183,7 @@ import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.FiringSolution;
 import megamek.common.util.ImageUtil;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Displays the board; lets the user scroll around and select points on it.
@@ -745,10 +745,10 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         fovHighlightingAndDarkening = new FovHighlightingAndDarkening(this);
 
         flareImage = ImageUtil.loadImageFromFile(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_FLARE_IMAGE)
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_FLARE_IMAGE)
                         .toString());
         radarBlipImage = ImageUtil.loadImageFromFile(
-                new MegaMekFile(Configuration.miscImagesDir(),
+                new OldMegaMekFile(Configuration.miscImagesDir(),
                         FILENAME_RADAR_BLIP_IMAGE).toString());
     }
 
@@ -6073,7 +6073,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
         try {
             File file;
             if (bvSkinSpec.backgrounds.size() > 0) {
-                file = new MegaMekFile(Configuration.widgetsDir(),
+                file = new OldMegaMekFile(Configuration.widgetsDir(),
                                 bvSkinSpec.backgrounds.get(0)).getFile();
                 if (!file.exists()) {
                     System.err.println("BoardView1 Error: icon doesn't exist: "
@@ -6085,7 +6085,7 @@ public class BoardView1 extends JPanel implements IBoardView, Scrollable,
                 }
             }
             if (bvSkinSpec.backgrounds.size() > 1) {
-                file = new MegaMekFile(Configuration.widgetsDir(),
+                file = new OldMegaMekFile(Configuration.widgetsDir(),
                                 bvSkinSpec.backgrounds.get(1)).getFile();
                 if (!file.exists()) {
                     System.err.println("BoardView1 Error: icon doesn't exist: "

--- a/megamek/src/megamek/client/ui/swing/skinEditor/SkinEditorMainGUI.java
+++ b/megamek/src/megamek/client/ui/swing/skinEditor/SkinEditorMainGUI.java
@@ -80,7 +80,7 @@ import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.util.Distractable;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 public class SkinEditorMainGUI extends JPanel implements WindowListener,
         BoardViewListener, ActionListener, ComponentListener {
@@ -221,16 +221,16 @@ public class SkinEditorMainGUI extends JPanel implements WindowListener,
         frame.setForeground(SystemColor.menuText);
         List<Image> iconList = new ArrayList<Image>();
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_16X16)
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_16X16)
                         .toString()));
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_32X32)
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_32X32)
                         .toString()));
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_48X48)
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_48X48)
                         .toString()));
         iconList.add(frame.getToolkit().getImage(
-                new MegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_256X256)
+                new OldMegaMekFile(Configuration.miscImagesDir(), FILENAME_ICON_256X256)
                         .toString()));
         frame.setIconImages(iconList);
 

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
@@ -45,7 +45,7 @@ import megamek.common.Mounted;
 import megamek.common.Sensor;
 import megamek.common.Tank;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.weapons.other.TSEMPWeapon;
 
 /**
@@ -291,7 +291,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
 
         Image tile = getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, this);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -299,28 +299,28 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -328,7 +328,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -336,7 +336,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -345,7 +345,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -353,7 +353,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
@@ -51,7 +51,7 @@ import megamek.common.Protomech;
 import megamek.common.Tank;
 import megamek.common.WeaponType;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * This class shows the critical hits and systems for a mech
@@ -717,7 +717,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
 
         Image tile = getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, this);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -725,28 +725,28 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString()); //$NON-NLS-1$
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString()); //$NON-NLS-1$
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -754,7 +754,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -762,7 +762,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -771,7 +771,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -779,7 +779,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener,
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -71,7 +71,7 @@ import megamek.common.WeaponComparatorNum;
 import megamek.common.WeaponComparatorRange;
 import megamek.common.WeaponType;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.gaussrifles.HAGWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -869,7 +869,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
 
         Image tile = getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, this);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -877,28 +877,28 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -907,7 +907,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopLeftCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -915,7 +915,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -924,7 +924,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));
@@ -932,7 +932,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener,
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, this);
         addBgDrawer(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
+++ b/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
@@ -26,7 +26,7 @@ import megamek.common.BattleArmor;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Tank;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * 
@@ -96,7 +96,7 @@ public class FluffImageHelper {
         }
 
         File fluff_image_file = findFluffImage(
-                new MegaMekFile(Configuration.fluffImagesDir(), dir).getFile(), unit);
+                new OldMegaMekFile(Configuration.fluffImagesDir(), dir).getFile(), unit);
         if (fluff_image_file != null) {
             fluff = new ImageIcon(fluff_image_file.toString()).getImage();
         }
@@ -129,10 +129,10 @@ public class FluffImageHelper {
         String sanitizedModel = unit.getModel().replace("\"", "")
                 .replace("/", "");
         String[] basenames = {
-                new MegaMekFile(directory, sanitizedChassis + " " + sanitizedModel)
+                new OldMegaMekFile(directory, sanitizedChassis + " " + sanitizedModel)
                         .toString(),
-                new MegaMekFile(directory, sanitizedModel).toString(),
-                new MegaMekFile(directory, sanitizedChassis).toString(), };
+                new OldMegaMekFile(directory, sanitizedModel).toString(),
+                new OldMegaMekFile(directory, sanitizedChassis).toString(), };
 
         for (String basename : basenames) {
             for (String extension : EXTENSIONS_FLUFF_IMAGE_FORMATS) {

--- a/megamek/src/megamek/client/ui/swing/widget/AeroMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/AeroMapSet.java
@@ -31,7 +31,7 @@ import megamek.common.Configuration;
 import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.SmallCraft;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent ASF unit in
@@ -253,7 +253,7 @@ public class AeroMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -261,28 +261,28 @@ public class AeroMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -290,7 +290,7 @@ public class AeroMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -298,7 +298,7 @@ public class AeroMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -307,7 +307,7 @@ public class AeroMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -315,7 +315,7 @@ public class AeroMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/ArmlessMechMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/ArmlessMechMapSet.java
@@ -32,7 +32,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Mech;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Very cumbersome class that handles set of polygonal areas and labels for
@@ -368,13 +368,13 @@ public class ArmlessMechMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
                         .toString());
         PMUtil.setImage(tile, comp);
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_CENTER

--- a/megamek/src/megamek/client/ui/swing/widget/BattleArmorMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/BattleArmorMapSet.java
@@ -29,7 +29,7 @@ import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.BattleArmor;
 import megamek.common.Configuration;
 import megamek.common.Entity;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Battle Armor unit in
@@ -74,7 +74,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
         FontMetrics fm = comp.getFontMetrics(FONT_VALUE);
 
         battleArmorImage = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), "battle_armor.gif").toString()); //$NON-NLS-1$
+                new OldMegaMekFile(Configuration.widgetsDir(), "battle_armor.gif").toString()); //$NON-NLS-1$
         PMUtil.setImage(battleArmorImage, comp);
         for (int i = 0; i < BattleArmor.BA_MAX_MEN; i++) {
             int shiftY = i * stepY;
@@ -146,7 +146,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -154,28 +154,28 @@ public class BattleArmorMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -183,7 +183,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -191,7 +191,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -200,7 +200,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -208,7 +208,7 @@ public class BattleArmorMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/CapitalFighterMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/CapitalFighterMapSet.java
@@ -29,7 +29,7 @@ import megamek.common.Aero;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Capital Fighter unit
@@ -160,50 +160,50 @@ public class CapitalFighterMapSet implements DisplayMapSet {
         UnitDisplaySkinSpecification udSpec = SkinXMLHandler.getUnitDisplaySkin();
 
         Image tile = comp.getToolkit()
-                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
+                .getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit()
-                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
+                .getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
-                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
+                .getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
     }

--- a/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/GeneralInfoMapSet.java
@@ -48,7 +48,7 @@ import megamek.common.options.IOptionGroup;
 import megamek.common.options.IOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Set of elements to represent general unit information in MechDisplay
@@ -613,52 +613,52 @@ public class GeneralInfoMapSet implements DisplayMapSet {
         UnitDisplaySkinSpecification udSpec = SkinXMLHandler
                 .getUnitDisplaySkin();
 
-        Image tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString()); //$NON-NLS-1$
+        Image tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString()); //$NON-NLS-1$
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString()); //$NON-NLS-1$
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString()); //$NON-NLS-1$
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 

--- a/megamek/src/megamek/client/ui/swing/widget/GunEmplacementMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/GunEmplacementMapSet.java
@@ -24,7 +24,7 @@ import javax.swing.JComponent;
 
 import megamek.common.Configuration;
 import megamek.common.Entity;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent GunEmplacement unit
@@ -78,7 +78,7 @@ public class GunEmplacementMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -86,28 +86,28 @@ public class GunEmplacementMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -115,7 +115,7 @@ public class GunEmplacementMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -123,7 +123,7 @@ public class GunEmplacementMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -132,7 +132,7 @@ public class GunEmplacementMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -140,7 +140,7 @@ public class GunEmplacementMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/InfantryMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/InfantryMapSet.java
@@ -29,7 +29,7 @@ import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Infantry;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Set of areas for PicMap to represent infantry platoon in MechDisplay
@@ -90,7 +90,7 @@ public class InfantryMapSet implements DisplayMapSet {
     private void setAreas() {
         int stepX = 30;
         int stepY = 42;
-        infImage = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), "inf.gif").toString()); //$NON-NLS-1$
+        infImage = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), "inf.gif").toString()); //$NON-NLS-1$
         PMUtil.setImage(infImage, comp);
         for (int i = 0; i < Infantry.INF_PLT_MAX_MEN; i++) {
             int shiftX = (i % 5) * stepX;
@@ -124,7 +124,7 @@ public class InfantryMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -132,28 +132,28 @@ public class InfantryMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -161,7 +161,7 @@ public class InfantryMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -169,7 +169,7 @@ public class InfantryMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -178,7 +178,7 @@ public class InfantryMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -186,7 +186,7 @@ public class InfantryMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/JumpshipMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/JumpshipMapSet.java
@@ -30,7 +30,7 @@ import megamek.common.Configuration;
 import megamek.common.DockingCollar;
 import megamek.common.Entity;
 import megamek.common.Jumpship;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to 
@@ -256,7 +256,7 @@ public class JumpshipMapSet implements DisplayMapSet{
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -264,28 +264,28 @@ public class JumpshipMapSet implements DisplayMapSet{
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -293,7 +293,7 @@ public class JumpshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -301,7 +301,7 @@ public class JumpshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -310,7 +310,7 @@ public class JumpshipMapSet implements DisplayMapSet{
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -318,7 +318,7 @@ public class JumpshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/LargeSupportTankMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/LargeSupportTankMapSet.java
@@ -31,7 +31,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.LargeSupportTank;
 import megamek.common.SupportTank;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Tank unit in
@@ -271,7 +271,7 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -279,28 +279,28 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -308,7 +308,7 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -316,7 +316,7 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -325,7 +325,7 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -333,7 +333,7 @@ public class LargeSupportTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/MechMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MechMapSet.java
@@ -32,7 +32,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Mech;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Very cumbersome class that handles set of polygonal areas and labels for
@@ -415,13 +415,13 @@ public class MechMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
                         .toString());
         PMUtil.setImage(tile, comp);
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_CENTER

--- a/megamek/src/megamek/client/ui/swing/widget/MechPanelTabStrip.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MechPanelTabStrip.java
@@ -15,7 +15,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import megamek.client.ui.swing.unitDisplay.UnitDisplay;
 import megamek.common.Configuration;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 public class MechPanelTabStrip extends PicMap {
 
@@ -59,20 +59,20 @@ public class MechPanelTabStrip extends PicMap {
                 .getUnitDisplaySkin();
         MediaTracker mt = new MediaTracker(this);
         Toolkit tk = getToolkit();
-        idleImage[0] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getGeneralTabIdle()).toString());
-        idleImage[1] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getPilotTabIdle()).toString());
-        idleImage[2] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getArmorTabIdle()).toString());
-        idleImage[3] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getSystemsTabIdle()).toString());
-        idleImage[4] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getWeaponsTabIdle()).toString());
-        idleImage[5] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getExtrasTabIdle()).toString());
-        activeImage[0] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getGeneralTabActive()).toString());
-        activeImage[1] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getPilotTabActive()).toString());
-        activeImage[2] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getArmorTabActive()).toString());
-        activeImage[3] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getSystemsTabActive()).toString());
-        activeImage[4] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getWeaponsTabActive()).toString());
-        activeImage[5] = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getExtraTabActive()).toString());
-        idleCorner = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getCornerIdle()).toString());
-        selectedCorner = tk.getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getCornerActive()).toString());
+        idleImage[0] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getGeneralTabIdle()).toString());
+        idleImage[1] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getPilotTabIdle()).toString());
+        idleImage[2] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getArmorTabIdle()).toString());
+        idleImage[3] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getSystemsTabIdle()).toString());
+        idleImage[4] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getWeaponsTabIdle()).toString());
+        idleImage[5] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getExtrasTabIdle()).toString());
+        activeImage[0] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getGeneralTabActive()).toString());
+        activeImage[1] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getPilotTabActive()).toString());
+        activeImage[2] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getArmorTabActive()).toString());
+        activeImage[3] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getSystemsTabActive()).toString());
+        activeImage[4] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getWeaponsTabActive()).toString());
+        activeImage[5] = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getExtraTabActive()).toString());
+        idleCorner = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getCornerIdle()).toString());
+        selectedCorner = tk.getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getCornerActive()).toString());
 
         // If we don't flush, we might have stale data
         idleCorner.flush();

--- a/megamek/src/megamek/client/ui/swing/widget/MegamekBorder.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MegamekBorder.java
@@ -27,7 +27,7 @@ import javax.swing.ImageIcon;
 import javax.swing.border.EtchedBorder;
 
 import megamek.common.Configuration;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * A Border that has an image for each corner as well as images for the line
@@ -99,7 +99,7 @@ public class MegamekBorder extends EtchedBorder {
         java.net.URI imgURL;
         File file;
 
-        file = new MegaMekFile(Configuration.widgetsDir(), path).getFile();
+        file = new OldMegaMekFile(Configuration.widgetsDir(), path).getFile();
         imgURL = file.toURI();
         icon = new ImageIcon(imgURL.toURL());
         if (!file.exists()){
@@ -146,7 +146,7 @@ public class MegamekBorder extends EtchedBorder {
             leftLine = new ArrayList<ImageIcon>();
             leftShouldTile = new ArrayList<Boolean>();
             for (int i = 0; i < skin.leftEdge.size(); i++){
-                file = new MegaMekFile(Configuration.widgetsDir(),
+                file = new OldMegaMekFile(Configuration.widgetsDir(),
                         skin.leftEdge.get(i)).getFile();
                 imgURL = file.toURI();
                 if (!file.exists()){
@@ -168,7 +168,7 @@ public class MegamekBorder extends EtchedBorder {
             rightLine = new ArrayList<ImageIcon>();
             rightShouldTile = new ArrayList<Boolean>();
             for (int i = 0; i < skin.rightEdge.size(); i++){
-                file = new MegaMekFile(Configuration.widgetsDir(),
+                file = new OldMegaMekFile(Configuration.widgetsDir(),
                         skin.rightEdge.get(i)).getFile();
                 imgURL = file.toURI();
                 if (!file.exists()){
@@ -190,7 +190,7 @@ public class MegamekBorder extends EtchedBorder {
             topLine = new ArrayList<ImageIcon>();
             topShouldTile = new ArrayList<Boolean>();
             for (int i = 0; i < skin.topEdge.size(); i++){
-                file = new MegaMekFile(Configuration.widgetsDir(),
+                file = new OldMegaMekFile(Configuration.widgetsDir(),
                         skin.topEdge.get(i)).getFile();
                 imgURL = file.toURI();
                 if (!file.exists()){
@@ -212,7 +212,7 @@ public class MegamekBorder extends EtchedBorder {
             bottomLine = new ArrayList<ImageIcon>();
             bottomShouldTile = new ArrayList<Boolean>();
             for (int i = 0; i < skin.bottomEdge.size(); i++){
-                file = new MegaMekFile(Configuration.widgetsDir(),
+                file = new OldMegaMekFile(Configuration.widgetsDir(),
                         skin.bottomEdge.get(i)).getFile();
                 imgURL = file.toURI();
                 if (!file.exists()){

--- a/megamek/src/megamek/client/ui/swing/widget/MegamekButton.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MegamekButton.java
@@ -27,7 +27,7 @@ import javax.swing.JLabel;
 import javax.swing.SwingConstants;
 
 import megamek.common.Configuration;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * A subclass of JButton that supports specifying the look and feel of the
@@ -215,10 +215,10 @@ public class MegamekButton extends JButton implements MouseListener {
                         + "2 background images!");
                 iconsLoaded = false;
             }
-            java.net.URI imgURL = new MegaMekFile(Configuration.widgetsDir(),
+            java.net.URI imgURL = new OldMegaMekFile(Configuration.widgetsDir(),
                     spec.backgrounds.get(0)).getFile().toURI();
             backgroundIcon = new ImageIcon(imgURL.toURL());
-            imgURL = new MegaMekFile(Configuration.widgetsDir(),
+            imgURL = new OldMegaMekFile(Configuration.widgetsDir(),
                     spec.backgrounds.get(1)).getFile().toURI();
             backgroundPressedIcon = new ImageIcon(imgURL.toURL());
         } catch (Exception e) {

--- a/megamek/src/megamek/client/ui/swing/widget/PilotMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/PilotMapSet.java
@@ -36,7 +36,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.DirectoryItems;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Set of elements to represent pilot information in MechDisplay
@@ -290,50 +290,50 @@ public class PilotMapSet implements DisplayMapSet {
         UnitDisplaySkinSpecification udSpec = SkinXMLHandler.getUnitDisplaySkin();
 
         Image tile = comp.getToolkit()
-                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
+                .getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit()
-                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
+                .getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
-                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
+                .getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
     }

--- a/megamek/src/megamek/client/ui/swing/widget/ProtomechMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/ProtomechMapSet.java
@@ -29,7 +29,7 @@ import megamek.client.ui.swing.unitDisplay.UnitDisplay;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Protomech;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Protomech unit in
@@ -175,7 +175,7 @@ public class ProtomechMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -183,28 +183,28 @@ public class ProtomechMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -212,7 +212,7 @@ public class ProtomechMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -220,7 +220,7 @@ public class ProtomechMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -229,7 +229,7 @@ public class ProtomechMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -237,7 +237,7 @@ public class ProtomechMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/QuadMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/QuadMapSet.java
@@ -32,7 +32,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Mech;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Very cumbersome class that handles set of polygonal areas and labels for
@@ -370,13 +370,13 @@ public class QuadMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
                         .toString());
         PMUtil.setImage(tile, comp);
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_CENTER

--- a/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
@@ -35,7 +35,7 @@ import javax.xml.parsers.DocumentBuilder;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.widget.SkinSpecification.UIComponents;
 import megamek.common.Configuration;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.utils.MegaMekXmlUtil;
 
 import org.w3c.dom.Document;
@@ -150,7 +150,7 @@ public class SkinXMLHandler {
      * @return
      */
     public static boolean validSkinSpecFile(String fileName) {
-        File file = new MegaMekFile(Configuration.skinsDir(), fileName).getFile();
+        File file = new OldMegaMekFile(Configuration.skinsDir(), fileName).getFile();
         if (!file.exists() || !file.isFile()) {
             return false;
         }
@@ -194,7 +194,7 @@ public class SkinXMLHandler {
             return false;
         }
 
-        File file = new MegaMekFile(Configuration.skinsDir(), fileName).getFile();
+        File file = new OldMegaMekFile(Configuration.skinsDir(), fileName).getFile();
         if (!file.exists() || !file.isFile()) {
             System.out.println("ERROR: Bad skin specification file: " +
                     "file doesn't exist!  File name: " + fileName);
@@ -549,7 +549,7 @@ public class SkinXMLHandler {
      * @param filename
      */
     public static void writeSkinToFile(String filename) {
-        File filePath = new MegaMekFile(Configuration.skinsDir(),
+        File filePath = new OldMegaMekFile(Configuration.skinsDir(),
                 filename).getFile();
 
         try (Writer output = new BufferedWriter(new OutputStreamWriter(

--- a/megamek/src/megamek/client/ui/swing/widget/SpheroidMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SpheroidMapSet.java
@@ -31,7 +31,7 @@ import megamek.common.Configuration;
 import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.SmallCraft;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to 
@@ -227,7 +227,7 @@ public class SpheroidMapSet implements DisplayMapSet{
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -235,28 +235,28 @@ public class SpheroidMapSet implements DisplayMapSet{
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -264,7 +264,7 @@ public class SpheroidMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -272,7 +272,7 @@ public class SpheroidMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -281,7 +281,7 @@ public class SpheroidMapSet implements DisplayMapSet{
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -289,7 +289,7 @@ public class SpheroidMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/SquadronMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SquadronMapSet.java
@@ -32,7 +32,7 @@ import megamek.common.FighterSquadron;
 import megamek.common.IAero;
 import megamek.common.IGame;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Capital Fighter unit
@@ -238,50 +238,50 @@ public class SquadronMapSet implements DisplayMapSet {
         UnitDisplaySkinSpecification udSpec = SkinXMLHandler.getUnitDisplaySkin();
 
         Image tile = comp.getToolkit()
-                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
+                .getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_LEFT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit()
-                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
+                .getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP | BackGroundDrawer.HALIGN_RIGHT;
-        tile = comp.getToolkit().getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
+        tile = comp.getToolkit().getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
-                .getImage(new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
+                .getImage(new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
     }

--- a/megamek/src/megamek/client/ui/swing/widget/SuperHeavyTankMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SuperHeavyTankMapSet.java
@@ -30,7 +30,7 @@ import megamek.client.ui.swing.unitDisplay.UnitDisplay;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.SuperHeavyTank;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Tank unit in
@@ -266,7 +266,7 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -274,28 +274,28 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -303,7 +303,7 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -311,7 +311,7 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -320,7 +320,7 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -328,7 +328,7 @@ public class SuperHeavyTankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/TankMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/TankMapSet.java
@@ -31,7 +31,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.SupportTank;
 import megamek.common.Tank;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Tank unit in
@@ -242,7 +242,7 @@ public class TankMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -250,28 +250,28 @@ public class TankMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -279,7 +279,7 @@ public class TankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -287,7 +287,7 @@ public class TankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -296,7 +296,7 @@ public class TankMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -304,7 +304,7 @@ public class TankMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/TripodMechMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/TripodMechMapSet.java
@@ -32,7 +32,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.Mech;
 import megamek.common.options.OptionsConstants;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Very cumbersome class that handles set of polygonal areas and labels for
@@ -424,13 +424,13 @@ public class TripodMechMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getMechOutline())
                         .toString());
         PMUtil.setImage(tile, comp);
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_CENTER

--- a/megamek/src/megamek/client/ui/swing/widget/VTOLMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/VTOLMapSet.java
@@ -31,7 +31,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.SupportVTOL;
 import megamek.common.VTOL;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Class which keeps set of all areas required to represent Tank unit in
@@ -333,7 +333,7 @@ public class VTOLMapSet implements DisplayMapSet {
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -341,28 +341,28 @@ public class VTOLMapSet implements DisplayMapSet {
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -370,7 +370,7 @@ public class VTOLMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -378,7 +378,7 @@ public class VTOLMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -387,7 +387,7 @@ public class VTOLMapSet implements DisplayMapSet {
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -395,7 +395,7 @@ public class VTOLMapSet implements DisplayMapSet {
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/client/ui/swing/widget/WarshipMapSet.java
+++ b/megamek/src/megamek/client/ui/swing/widget/WarshipMapSet.java
@@ -30,7 +30,7 @@ import megamek.common.Configuration;
 import megamek.common.DockingCollar;
 import megamek.common.Entity;
 import megamek.common.Jumpship;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 /**
  * Class which keeps set of all areas required to 
  * represent ASF unit in MechDsiplay.ArmorPanel class.
@@ -249,7 +249,7 @@ public class WarshipMapSet implements DisplayMapSet{
 
         Image tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getBackgroundTile()).toString());
         PMUtil.setImage(tile, comp);
         int b = BackGroundDrawer.TILING_BOTH;
@@ -257,28 +257,28 @@ public class WarshipMapSet implements DisplayMapSet{
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_TOP;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_HORIZONTAL | BackGroundDrawer.VALIGN_BOTTOM;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getBottomLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getLeftLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
 
         b = BackGroundDrawer.TILING_VERTICAL | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getRightLine())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -286,7 +286,7 @@ public class WarshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_TOP
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec.getTopLeftCorner())
                         .toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -294,7 +294,7 @@ public class WarshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_LEFT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomLeftCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -303,7 +303,7 @@ public class WarshipMapSet implements DisplayMapSet{
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit()
                 .getImage(
-                        new MegaMekFile(Configuration.widgetsDir(), udSpec
+                        new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                                 .getTopRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));
@@ -311,7 +311,7 @@ public class WarshipMapSet implements DisplayMapSet{
         b = BackGroundDrawer.NO_TILING | BackGroundDrawer.VALIGN_BOTTOM
                 | BackGroundDrawer.HALIGN_RIGHT;
         tile = comp.getToolkit().getImage(
-                new MegaMekFile(Configuration.widgetsDir(), udSpec
+                new OldMegaMekFile(Configuration.widgetsDir(), udSpec
                         .getBottomRightCorner()).toString());
         PMUtil.setImage(tile, comp);
         bgDrawers.addElement(new BackGroundDrawer(tile, b));

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -47,7 +47,7 @@ import megamek.common.Building.BasementType;
 import megamek.common.annotations.Nullable;
 import megamek.common.event.BoardEvent;
 import megamek.common.event.BoardListener;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 public class Board implements Serializable, IBoard {
     private static final long serialVersionUID = -5744058872091016636L;
@@ -798,7 +798,7 @@ public class Board implements Serializable, IBoard {
     @Override
     @Deprecated
     public void load(final String filename) {
-        load(new MegaMekFile(Configuration.boardsDir(), filename).getFile());
+        load(new OldMegaMekFile(Configuration.boardsDir(), filename).getFile());
     }
 
     /**
@@ -886,7 +886,7 @@ public class Board implements Serializable, IBoard {
                     }
                 } else if ((st.ttype == StreamTokenizer.TT_WORD) && st.sval.equalsIgnoreCase("background")) {
                     st.nextToken();
-                    File bgFile = new MegaMekFile(Configuration.boardBackgroundsDir(),
+                    File bgFile = new OldMegaMekFile(Configuration.boardBackgroundsDir(),
                             st.sval).getFile();
                     if (bgFile.exists()) {
                         backgroundPaths.add(bgFile.getPath());

--- a/megamek/src/megamek/common/KeyBindParser.java
+++ b/megamek/src/megamek/common/KeyBindParser.java
@@ -27,7 +27,7 @@ import javax.xml.parsers.DocumentBuilder;
 
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.client.ui.swing.util.MegaMekController;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.utils.MegaMekXmlUtil;
 
 import org.w3c.dom.Document;
@@ -58,7 +58,7 @@ public class KeyBindParser {
     
     public static void parseKeyBindings(MegaMekController controller){
         // Get the path to the default bindings file.
-        File file = new MegaMekFile(Configuration.configDir(), DEFAULT_BINDINGS_FILE).getFile();
+        File file = new OldMegaMekFile(Configuration.configDir(), DEFAULT_BINDINGS_FILE).getFile();
         if (!file.exists() || !file.isFile()) {
             registerDefaultKeyBinds(controller);
             return;
@@ -162,7 +162,7 @@ public class KeyBindParser {
     public static void writeKeyBindings(){
         try {
             Writer output = new BufferedWriter(new OutputStreamWriter(
-                    new FileOutputStream(new MegaMekFile(Configuration.configDir(), 
+                    new FileOutputStream(new OldMegaMekFile(Configuration.configDir(),
                             DEFAULT_BINDINGS_FILE).getFile())));
             output.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
             output.write("<KeyBindings " +

--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -56,7 +56,7 @@ import megamek.common.loaders.MepFile;
 import megamek.common.loaders.MtfFile;
 import megamek.common.loaders.TdbFile;
 import megamek.common.util.BuildingBlock;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.weapons.ppc.CLERPPC;
 import megamek.common.weapons.ppc.ISERPPC;
 import megamek.common.weapons.ppc.ISHeavyPPC;
@@ -900,7 +900,7 @@ public class MechFileParser {
             if (canonUnitNames == null) {
                 canonUnitNames = new Vector<String>();
                 // init the list.
-                try(BufferedReader br = new BufferedReader(new FileReader(new MegaMekFile(
+                try(BufferedReader br = new BufferedReader(new FileReader(new OldMegaMekFile(
                             Configuration.docsDir(), FILENAME_OFFICIAL_UNITS).getFile()))) {
                     String s;
                     String name;

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -35,7 +35,7 @@ import java.util.zip.ZipFile;
 
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.logging.DefaultMmLogger;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.verifier.*;
 
 /**
@@ -180,7 +180,7 @@ public class MechSummaryCache {
         Vector<MechSummary> vMechs = new Vector<>();
         Set<String> sKnownFiles = new HashSet<>();
         long lLastCheck = 0;
-        entityVerifier = EntityVerifier.getInstance(new MegaMekFile(getUnitCacheDir(),
+        entityVerifier = EntityVerifier.getInstance(new OldMegaMekFile(getUnitCacheDir(),
                 EntityVerifier.CONFIG_FILENAME).getFile());
         hFailedFiles = new HashMap<>();
 
@@ -190,7 +190,7 @@ public class MechSummaryCache {
         loadReport.append("Reading unit files:\n");
 
         if (!ignoreUnofficial) {
-            File unit_cache_path = new MegaMekFile(getUnitCacheDir(),
+            File unit_cache_path = new OldMegaMekFile(getUnitCacheDir(),
                     FILENAME_UNITS_CACHE).getFile();
             // check the cache
             try {
@@ -324,7 +324,7 @@ public class MechSummaryCache {
 
     private void saveCache() throws Exception {
         loadReport.append("Saving unit cache.\n");
-        File unit_cache_path = new MegaMekFile(getUnitCacheDir(), FILENAME_UNITS_CACHE).getFile();
+        File unit_cache_path = new OldMegaMekFile(getUnitCacheDir(), FILENAME_UNITS_CACHE).getFile();
         ObjectOutputStream wr = new ObjectOutputStream(
                 new BufferedOutputStream(new FileOutputStream(unit_cache_path)));
         wr.writeObject(m_data.length);
@@ -500,8 +500,8 @@ public class MechSummaryCache {
                     done();
                     return false;
                 }
-                File f = new MegaMekFile(fDir, element).getFile();
-                if (f.equals(new MegaMekFile(getUnitCacheDir(), FILENAME_UNITS_CACHE).getFile())) {
+                File f = new OldMegaMekFile(fDir, element).getFile();
+                if (f.equals(new OldMegaMekFile(getUnitCacheDir(), FILENAME_UNITS_CACHE).getFile())) {
                     continue;
                 }
                 if (f.isDirectory()) {
@@ -703,7 +703,7 @@ public class MechSummaryCache {
 
     private boolean addLookupNames() {
         final String METHOD_NAME = "addLookupNames(long)"; //$NON-NLS-1$
-        File lookupNames = new MegaMekFile(getUnitCacheDir(),
+        File lookupNames = new OldMegaMekFile(getUnitCacheDir(),
                 FILENAME_LOOKUP).getFile();
         boolean needsUpdate = false;
         if (lookupNames.exists()) {

--- a/megamek/src/megamek/common/SpecialHexDisplay.java
+++ b/megamek/src/megamek/common/SpecialHexDisplay.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import megamek.common.util.ImageUtil;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * @author dirk
@@ -32,7 +32,7 @@ public class SpecialHexDisplay implements Serializable {
     private static final long serialVersionUID = 27470795993329492L;
 
     public enum Type {
-        ARTILLERY_AUTOHIT(new MegaMekFile(Configuration.hexesDir(), 
+        ARTILLERY_AUTOHIT(new OldMegaMekFile(Configuration.hexesDir(),
                 "artyauto.gif").toString()) { //$NON-NLS-1$
             @Override
             public boolean drawBefore() {
@@ -44,7 +44,7 @@ public class SpecialHexDisplay implements Serializable {
                 return true;
             }
         },
-        ARTILLERY_ADJUSTED(new MegaMekFile(Configuration.hexesDir(), 
+        ARTILLERY_ADJUSTED(new OldMegaMekFile(Configuration.hexesDir(),
                 "artyadj.gif").toString()) { //$NON-NLS-1$
             @Override
             public boolean drawBefore() {
@@ -56,23 +56,23 @@ public class SpecialHexDisplay implements Serializable {
                 return true;
             }
         },
-        ARTILLERY_INCOMING(new MegaMekFile(Configuration.hexesDir(), 
+        ARTILLERY_INCOMING(new OldMegaMekFile(Configuration.hexesDir(),
                 "artyinc.gif").toString()), //$NON-NLS-1$
-        ARTILLERY_TARGET(new MegaMekFile(Configuration.hexesDir(), 
+        ARTILLERY_TARGET(new OldMegaMekFile(Configuration.hexesDir(),
                 "artytarget.gif").toString()) { //$NON-NLS-1$
             @Override
             public boolean drawBefore() {
                 return false;
             }
         },
-        ARTILLERY_HIT(new MegaMekFile(Configuration.hexesDir(), 
+        ARTILLERY_HIT(new OldMegaMekFile(Configuration.hexesDir(),
                 "artyhit.gif").toString()) { //$NON-NLS-1$
             @Override
             public boolean drawBefore() {
                 return false;
             }
         },
-        PLAYER_NOTE(new MegaMekFile(Configuration.hexesDir(), 
+        PLAYER_NOTE(new OldMegaMekFile(Configuration.hexesDir(),
                 "note.png").toString()) { //$NON-NLS-1$
             @Override
             public boolean drawBefore() {

--- a/megamek/src/megamek/common/UnitRoleHandler.java
+++ b/megamek/src/megamek/common/UnitRoleHandler.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 import megamek.common.logging.DefaultMmLogger;
 import megamek.common.logging.LogLevel;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 /**
  * Singleton class that loads the canon unit roles from a text file and provides lookup access.
@@ -116,7 +116,7 @@ public class UnitRoleHandler {
      */
     private void loadRoles() {
         final String METHOD_NAME = "loadRoles()"; //$NON-NLS-1$
-        File f = new MegaMekFile(Configuration.dataDir(), FILE_LOC).getFile();
+        File f = new OldMegaMekFile(Configuration.dataDir(), FILE_LOC).getFile();
         FileInputStream is = null;
         BufferedReader reader = null;
         try {

--- a/megamek/src/megamek/common/WeaponOrderHandler.java
+++ b/megamek/src/megamek/common/WeaponOrderHandler.java
@@ -31,7 +31,7 @@ import javax.xml.parsers.DocumentBuilder;
 
 import megamek.common.Entity.WeaponSortOrder;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.utils.MegaMekXmlUtil;
 
 import org.w3c.dom.Document;
@@ -98,7 +98,7 @@ public class WeaponOrderHandler {
         }
 
         String path = CUSTOM_WEAPON_ORDER_FILENAME;
-        File file = new MegaMekFile(Configuration.configDir(), path).getFile();
+        File file = new OldMegaMekFile(Configuration.configDir(), path).getFile();
         if (file.exists() && !file.canWrite()) {
             System.err.println("WARN: Could not save custom weapon orders " +
                     "from " + path);
@@ -180,7 +180,7 @@ public class WeaponOrderHandler {
         Map<String, WeaponOrder> weapOrderMap = new HashMap<>();
 
         String path = CUSTOM_WEAPON_ORDER_FILENAME;
-        File file = new MegaMekFile(Configuration.configDir(), path).getFile();
+        File file = new OldMegaMekFile(Configuration.configDir(), path).getFile();
         if (!file.exists() || !file.isFile()) {
             System.err.println("WARN: Could not load custom weapon orders " +
                     "from " + path);

--- a/megamek/src/megamek/common/preference/PreferenceManager.java
+++ b/megamek/src/megamek/common/preference/PreferenceManager.java
@@ -43,7 +43,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.xml.sax.SAXException;
 
 import megamek.common.Configuration;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.utils.MegaMekXmlUtil;
 
 public class PreferenceManager {
@@ -88,7 +88,7 @@ public class PreferenceManager {
         clientPreferenceStore = new PreferenceStore();
         String cfgName = System.getProperty(
                 CFG_FILE_OPTION_NAME,
-                new MegaMekFile(Configuration.configDir(), DEFAULT_CFG_FILE_NAME).toString()
+                new OldMegaMekFile(Configuration.configDir(), DEFAULT_CFG_FILE_NAME).toString()
         );
         load(cfgName);
         clientPreferences = new ClientPreferences(clientPreferenceStore);
@@ -128,7 +128,7 @@ public class PreferenceManager {
     }
 
     public void save() {
-        save(new MegaMekFile(Configuration.configDir(), DEFAULT_CFG_FILE_NAME).getFile());
+        save(new OldMegaMekFile(Configuration.configDir(), DEFAULT_CFG_FILE_NAME).getFile());
     }
     
     public void save(final File file) {

--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -59,7 +59,7 @@ import megamek.common.logging.DefaultMmLogger;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.Quirks;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.verifier.BayData;
 import megamek.common.verifier.EntityVerifier;
 
@@ -74,7 +74,7 @@ public class TROView {
     private Template template;
     private final Map<String, Object> model = new HashMap<>();
     private final EntityVerifier verifier = EntityVerifier
-            .getInstance(new MegaMekFile(Configuration.unitsDir(), EntityVerifier.CONFIG_FILENAME).getFile());
+            .getInstance(new OldMegaMekFile(Configuration.unitsDir(), EntityVerifier.CONFIG_FILENAME).getFile());
 
     private boolean includeFluff = true;
 

--- a/megamek/src/megamek/common/util/OldMegaMekFile.java
+++ b/megamek/src/megamek/common/util/OldMegaMekFile.java
@@ -15,15 +15,14 @@ import megamek.common.Configuration;
  * @author arlith
  *
  */
-public class MegaMekFile {
-    
+public class OldMegaMekFile {
     File file;
     
-    public MegaMekFile(File parent, String child) {
+    public OldMegaMekFile(File parent, String child) {
         this(new File(parent, child).toString());
     }
     
-    public MegaMekFile(String pathname) {
+    public OldMegaMekFile(String pathname) {
         File userdataVersion = new File(Configuration.userdataDir(), pathname);
         if (userdataVersion.exists()) {
             file = userdataVersion;
@@ -39,5 +38,4 @@ public class MegaMekFile {
     public String toString() {
         return file.toString();
     }
-    
 }

--- a/megamek/src/megamek/server/ScenarioLoader.java
+++ b/megamek/src/megamek/server/ScenarioLoader.java
@@ -74,7 +74,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.BoardUtilities;
 import megamek.common.util.DirectoryItems;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 
 public class ScenarioLoader {
     private static final String COMMENT_MARK = "#"; //$NON-NLS-1$
@@ -406,7 +406,7 @@ public class ScenarioLoader {
         if (optionFile == null) {
             g.getOptions().loadOptions();
         } else {
-            g.getOptions().loadOptions(new MegaMekFile(scenarioFile.getParentFile(), optionFile).getFile(), true);
+            g.getOptions().loadOptions(new OldMegaMekFile(scenarioFile.getParentFile(), optionFile).getFile(), true);
         }
 
         // set wind
@@ -907,12 +907,12 @@ public class ScenarioLoader {
                 } else {
                     sBoardFile = board + FILE_SUFFIX_BOARD;
                 }
-                File fBoard = new MegaMekFile(Configuration.boardsDir(), sBoardFile).getFile();
+                File fBoard = new OldMegaMekFile(Configuration.boardsDir(), sBoardFile).getFile();
                 if (!fBoard.exists()) {
                     throw new ScenarioLoaderException("nonexistantBoard", board); //$NON-NLS-1$
                 }
                 ba[n] = new Board();
-                ba[n].load(new MegaMekFile(Configuration.boardsDir(), sBoardFile).getFile());
+                ba[n].load(new OldMegaMekFile(Configuration.boardsDir(), sBoardFile).getFile());
                 if(cf > 0) {
                     ba[n].setBridgeCF(cf);
                 }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -120,7 +120,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.BoardUtilities;
-import megamek.common.util.MegaMekFile;
+import megamek.common.util.OldMegaMekFile;
 import megamek.common.util.StringUtil;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestAero;
@@ -3429,7 +3429,7 @@ public class Server implements Runnable {
                     || (mapSettings.getMedium() == MapSettings.MEDIUM_SPACE)) {
                 sheetBoards[i] = BoardUtilities.generateRandom(mapSettings);
             } else {
-                sheetBoards[i].load(new MegaMekFile(Configuration.boardsDir(), name
+                sheetBoards[i].load(new OldMegaMekFile(Configuration.boardsDir(), name
                         + ".board").getFile());
                 BoardUtilities.flip(sheetBoards[i], isRotated, isRotated);
             }
@@ -29434,9 +29434,9 @@ public class Server implements Runnable {
         String[] fileList = boardDir.list();
         if (fileList != null) {
             for (String filename : fileList) {
-                File filePath = new MegaMekFile(boardDir, filename).getFile();
+                File filePath = new OldMegaMekFile(boardDir, filename).getFile();
                 if (filePath.isDirectory()) {
-                    scanForBoardsInDir(new MegaMekFile(boardDir, filename).getFile(),
+                    scanForBoardsInDir(new OldMegaMekFile(boardDir, filename).getFile(),
                             basePath.concat(File.separator).concat(filename), dimensions, boards);
                 } else {
                     if (filename.endsWith(".board")) { //$NON-NLS-1$
@@ -30199,7 +30199,7 @@ public class Server implements Runnable {
 
             // Verify the entity's design
             if (Server.entityVerifier == null) {
-                Server.entityVerifier = EntityVerifier.getInstance(new MegaMekFile(
+                Server.entityVerifier = EntityVerifier.getInstance(new OldMegaMekFile(
                         Configuration.unitsDir(), EntityVerifier.CONFIG_FILENAME).getFile());
             }
 


### PR DESCRIPTION
This is phase 1 of the userData fix, and **ALL** it includes is a bulk rename of MegaMekFile to OldMegaMekFile. Phase 2 will add the new version of MegaMekFile, and Phase 3+ will be implementing the new version to finish https://github.com/MegaMek/megamek/issues/1050.
I'd recommend reviewing 5 random files, as they are all the same with regards to the changes made.

I'd prefer the whole thing be named MegaMekFile, and as such I've renamed the current version to OldMegaMekFile. To implement the new version will require significant changes, which I will be splitting up over multiple PRs to make it possible to review. This is phase 1, as described above.


This MUST be added IMMEDIATELY BEFORE https://github.com/MegaMek/megamek/pull/1770