### PR TITLE
Test fixes

### DIFF
--- a/megamek/src/megamek/common/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/EquipmentTypeLookup.java
@@ -135,7 +135,7 @@ public class EquipmentTypeLookup {
     @EquipmentName
     public static final String DUNE_BUGGY_CHASSIS_MOD = "DuneBuggyChassisMod";
     @EquipmentName
-    public static final String ENVIRONMENTAL_SEALING_CHASSIS_MOD = "EnvironmentalSealingChassisMod";
+    public static final String SV_ENVIRONMENTAL_SEALING_CHASSIS_MOD = "Environmental Sealing";
     @EquipmentName
     public static final String EXTERNAL_POWER_PICKUP_CHASSIS_MOD = "ExternalPowerPickupChassisMod";
     @EquipmentName

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -10119,7 +10119,7 @@ public class MiscType extends EquipmentType {
         misc.tankslots = 0;
         misc.cost = COST_VARIABLE;
         misc.spreadable = true;
-        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_SUPPORT_TANK_EQUIPMENT);
+        misc.flags = misc.flags.or(F_ENVIRONMENTAL_SEALING).or(F_SUPPORT_TANK_EQUIPMENT).or(F_CHASSIS_MODIFICATION);
         misc.omniFixedOnly = true;
         misc.bv = 0;
         misc.rulesRefs = "122,TM";

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -213,7 +213,7 @@ public class TestSupportVehicle extends TestEntity {
                 EnumSet.of(SVType.HOVERCRAFT, SVType.WHEELED, SVType.TRACKED)),
         DUNE_BUGGY (1.5,EquipmentTypeLookup.DUNE_BUGGY_CHASSIS_MOD,
                 EnumSet.of(SVType.WHEELED)),
-        ENVIRONMENTAL_SEALING (2.0,EquipmentTypeLookup.ENVIRONMENTAL_SEALING_CHASSIS_MOD,
+        ENVIRONMENTAL_SEALING (2.0,EquipmentTypeLookup.SV_ENVIRONMENTAL_SEALING_CHASSIS_MOD,
                 EnumSet.allOf(SVType.class)),
         EXTERNAL_POWER_PICKUP (1.1,EquipmentTypeLookup.EXTERNAL_POWER_PICKUP_CHASSIS_MOD,
                 EnumSet.of(SVType.RAIL)),

--- a/megamek/unittests/megamek/common/logging/FakeLogger.java
+++ b/megamek/unittests/megamek/common/logging/FakeLogger.java
@@ -81,6 +81,11 @@ public class FakeLogger implements MMLogger {
     }
 
     @Override
+    public void resetLogFile(String logFileName) {
+
+    }
+
+    @Override
     public <T extends Throwable> T debug(String callingClass, String methodName, String message, T throwable) {
 
         return null;

--- a/megamek/unittests/megamek/common/verifier/BayDataTest.java
+++ b/megamek/unittests/megamek/common/verifier/BayDataTest.java
@@ -26,34 +26,34 @@ public class BayDataTest {
 
     @Test
     public void testLiquidCargoBayMultiplier() {
-        final double size = 2.0;
-        Bay cargoBay = BayData.LIQUID_CARGO.newBay(size, 0);
+        final double weight = 2.0;
+        Bay cargoBay = BayData.LIQUID_CARGO.newBay(weight, 0);
         
-        assertEquals(cargoBay.getWeight(), BayData.LIQUID_CARGO.getWeight() * size, 0.01);
+        assertEquals(cargoBay.getWeight(), weight, 0.01);
     }
 
     @Test
     public void testRefrigeratedCargoBayMultiplier() {
-        final double size = 2.0;
-        Bay cargoBay = BayData.REFRIGERATED_CARGO.newBay(size, 0);
+        final double weight = 2.0;
+        Bay cargoBay = BayData.REFRIGERATED_CARGO.newBay(weight, 0);
         
-        assertEquals(cargoBay.getWeight(), BayData.REFRIGERATED_CARGO.getWeight() * size, 0.01);
+        assertEquals(cargoBay.getWeight(), weight, 0.01);
     }
 
     @Test
     public void testInsulatedCargoBayMultiplier() {
-        final double size = 2.0;
-        Bay cargoBay = BayData.INSULATED_CARGO.newBay(size, 0);
+        final double weight = 2.0;
+        Bay cargoBay = BayData.INSULATED_CARGO.newBay(weight, 0);
         
-        assertEquals(cargoBay.getWeight(), BayData.INSULATED_CARGO.getWeight() * size, 0.01);
+        assertEquals(cargoBay.getWeight(), weight, 0.01);
     }
 
     @Test
     public void testLivestockCargoBayMultiplier() {
-        final double size = 2.0;
-        Bay cargoBay = BayData.LIVESTOCK_CARGO.newBay(size, 0);
+        final double weight = 2.0;
+        Bay cargoBay = BayData.LIVESTOCK_CARGO.newBay(weight, 0);
         
-        assertEquals(cargoBay.getWeight(), BayData.LIVESTOCK_CARGO.getWeight() * size, 0.01);
+        assertEquals(cargoBay.getWeight(), weight, 0.01);
     }
 
     @Test


### PR DESCRIPTION
Fixes three problems causing build failures:
1. A new method was added to the MMLogger interface but not the FakeLogger class that implements it.
2. After sorting out IndustrialMech, combat vehicle, and support vehicle environmental sealing the SV chassis mod enum used for construction data was left pointing to the wrong one (high-five the unit test for spotting it).
3. A change in the BayData enum used for bay construction data was not reflected in the unit test, causing several of them to fail. The newBay method now takes the weight for cargo bays rather than the capacity.