### PR TITLE
Only apply default rounding to variable-weight equipment.

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -347,7 +347,8 @@ public class EquipmentType implements ITechnology {
      * @return              The weight of the equipment in tons
      */
     public double getTonnage(Entity entity, int location, RoundWeight defaultMethod) {
-        return defaultMethod.round(getTonnage(entity, location), entity);
+        // Default implementation does not deal with variable-weight equipment.
+        return getTonnage(entity, location);
     }
 
     void setTonnage(double tonnage) {

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -570,11 +570,12 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         }
         double retVal = getType().getTonnage(getEntity(), getLocation(), defaultRounding);
         if (isDWPMounted()) {
-            retVal *= 0.75;
+            return defaultRounding.round(retVal * 0.75, getEntity());
         } else if (isSquadSupportWeapon()) {
             retVal *= getEntity().isClan() ? 1.4 : 1.5;
+            return defaultRounding.round(retVal, getEntity());
         }
-        return defaultRounding.round(retVal, getEntity());
+        return retVal;
     }
 
     public boolean isReady() {


### PR DESCRIPTION
Corrects an overlooked assumption that was applying rounding indiscriminately. The RoundWeight parameter should only be applied by subclasses that deal with variable-weight equipment (i.e. MiscType), which then determines whether to use it or not -- some equipment is always kg-scale, and other has a set rounding (e.g. up to the next ton).

This is a bug introduced in the work toward calculating dumper weight correctly and supporting fractional accounting.

Fixes #1759 