### PR TITLE
Random Map theme is kept for editing

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -1346,6 +1346,7 @@ public class BoardEditor extends JComponent
     		menuBar.setBoard(true);
     		bvc.doLayout();
     		resetUndo();
+    		choTheme.setSelectedItem(mapSettings.getTheme());
     	}
     }
 


### PR DESCRIPTION
After generating a random map with a theme that theme is also set for editing hexes.

Resolves #1767 (as I understand it).