### PR TITLE
Various small changes around MapEditor/RndMapDialog

### DIFF
--- a/megamek/data/images/hexes/saxarba.tileset
+++ b/megamek/data/images/hexes/saxarba.tileset
@@ -649,4 +649,3 @@ base 8 "" "lunar" "saxarba/theme_lunar/base_lunar_8.png;saxarba/theme_lunar/base
 base 9 "" "lunar" "saxarba/theme_lunar/base_lunar_9.png;saxarba/theme_lunar/base_lunar_9b.png;saxarba/theme_lunar/base_lunar_9c.png;saxarba/theme_lunar/base_lunar_9d.png;saxarba/theme_lunar/base_lunar_9e.png;saxarba/theme_lunar/base_lunar_9f.png"
 base 10 "" "lunar" "saxarba/theme_lunar/base_lunar_10.png;saxarba/theme_lunar/base_lunar_10b.png;saxarba/theme_lunar/base_lunar_10c.png;saxarba/theme_lunar/base_lunar_10d.png;saxarba/theme_lunar/base_lunar_10e.png;saxarba/theme_lunar/base_lunar_10f.png"
 
-include "classic.tileset"

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -90,6 +90,7 @@ BoardEditor.butElevUp=U
 BoardEditor.butElevUp.toolTipText=Increase elevation of the tile up to a limit of 8. \nLevels above 8 can be entered as text, but they are not supported with unique textures in the tile sets.
 BoardEditor.butMiniMap=Toggle MiniMap
 BoardEditor.butTerrExits=A
+BoardEditor.butSourceFile=Source File
 BoardEditor.cheRoadsAutoExit=Exit Roads to Pavement
 BoardEditor.cheTerrExitSpecified=Exits
 BoardEditor.CouldNotInitialiseMinimap=Could not initialise minimap:\n

--- a/megamek/i18n/megamek/client/messages_de.properties
+++ b/megamek/i18n/megamek/client/messages_de.properties
@@ -17,6 +17,7 @@ BoardEditor.butElevDown=D
 BoardEditor.butElevUp=U
 BoardEditor.butMiniMap=Übersichtskarte
 BoardEditor.butTerrExits=A
+BoardEditor.butSourceFile=Quelldatei
 BoardEditor.cheRoadsAutoExit=Straßen enden in Asphaltfläche
 BoardEditor.cheTerrExitSpecified=Ausgänge setzen : 
 BoardEditor.CouldNotInitialiseMinimap=Konnte Übersichtskarte nicht initialisieren:\n

--- a/megamek/src/megamek/client/ui/ITilesetManager.java
+++ b/megamek/src/megamek/client/ui/ITilesetManager.java
@@ -19,6 +19,7 @@ package megamek.client.ui;
 
 import java.awt.Component;
 import java.awt.Image;
+import java.util.Set;
 
 import megamek.common.Entity;
 import megamek.common.IPlayer;
@@ -36,6 +37,8 @@ public interface ITilesetManager {
     public Image iconFor(Entity e);
 
     public Image loadPreviewImage(Entity entity, Image camo, int tint, Component bp);
+    
+    public Set<String> getThemes();
 
     public void reset();
 

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -1347,7 +1347,7 @@ public class BoardEditor extends JComponent
 
     public void boardNew() {
     	RandomMapDialog rmd = new RandomMapDialog(frame, this, null, mapSettings);
-    	boolean userCancel = rmd.activateDialog();
+    	boolean userCancel = rmd.activateDialog(bv.getTilesetManager().getThemes());
     	if (!userCancel) {
     		board = BoardUtilities.generateRandom(mapSettings);
     		game.setBoard(board);

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -17,6 +17,7 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
+import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
@@ -245,6 +246,7 @@ public class BoardEditor extends JComponent
     //region action commands
     private static final String FILE_BOARD_EDITOR_EXPAND = "fileBoardExpand";
     private static final String FILE_BOARD_EDITOR_VALIDATE = "fileBoardValidate";
+    private static final String FILE_SOURCEFILE = "fileSource";
     //endregion action commands
 
     JFrame frame = new JFrame();
@@ -305,6 +307,7 @@ public class BoardEditor extends JComponent
     private JButton butBoardSaveAsImage;
     private JButton butMiniMap;
     private JButton butBoardValidate;
+    private JButton butSourceFile;
     private MapSettings mapSettings = MapSettings.getInstance();
     private JButton butExpandMap;
     private Coords lastClicked;
@@ -934,17 +937,23 @@ public class BoardEditor extends JComponent
 
         butBoardValidate = new JButton(Messages.getString("BoardEditor.butBoardValidate")); //$NON-NLS-1$
         butBoardValidate.setActionCommand(FILE_BOARD_EDITOR_VALIDATE);
+        
+        butSourceFile = new JButton(Messages.getString("BoardEditor.butSourceFile")); //$NON-NLS-1$
+        butSourceFile.setActionCommand(FILE_SOURCEFILE);
 
         addManyActionListeners(butBoardValidate, butBoardSaveAsImage, butBoardSaveAs, butBoardSave);
         addManyActionListeners(butBoardOpen, butExpandMap, butBoardNew, butMiniMap);
-        addManyActionListeners(butDelTerrain, butAddTerrain);
+        addManyActionListeners(butDelTerrain, butAddTerrain, butSourceFile);
+        
 
         JPanel panButtons = new JPanel(new GridLayout(4, 2, 2, 2));
         addManyButtons(panButtons, butBoardNew, butBoardSave, butBoardOpen,
                 butExpandMap, butBoardSaveAs, butBoardSaveAsImage);
-        panButtons.add(Box.createHorizontalStrut(5));
         panButtons.add(butBoardValidate);
         panButtons.add(butMiniMap);
+        if (Desktop.isDesktopSupported()) {
+            panButtons.add(butSourceFile);
+        }
 
         // ------------------
         // Arrange everything
@@ -1343,6 +1352,7 @@ public class BoardEditor extends JComponent
     		board = BoardUtilities.generateRandom(mapSettings);
     		game.setBoard(board);
     		curfile = null;
+    		butSourceFile.setEnabled(false);
     		frame.setTitle(Messages.getString("BoardEditor.title")); //$NON-NLS-1$
     		menuBar.setBoard(true);
     		bvc.doLayout();
@@ -1365,6 +1375,7 @@ public class BoardEditor extends JComponent
 
         game.setBoard(board);
         curfile = null;
+        butSourceFile.setEnabled(false);
         frame.setTitle(Messages.getString("BoardEditor.title")); //$NON-NLS-1$
         menuBar.setBoard(true);
         bvc.doLayout();
@@ -1423,6 +1434,7 @@ public class BoardEditor extends JComponent
             return;
         }
         curfile = fc.getSelectedFile();
+        butSourceFile.setEnabled(true);
         loadPath = curfile.getPath();
         // load!
         try (InputStream is = new FileInputStream(fc.getSelectedFile())) {            
@@ -1547,6 +1559,7 @@ public class BoardEditor extends JComponent
             return; // I want a file, y'know!
         }
         curfile = fc.getSelectedFile();
+        butSourceFile.setEnabled(true);
 
         // make sure the file ends in board
         if (!curfile.getName().toLowerCase().endsWith(".board")) { //$NON-NLS-1$
@@ -1738,6 +1751,15 @@ public class BoardEditor extends JComponent
             ignoreHotKeys = true;
             boardSaveAsImage(false);
             ignoreHotKeys = false;
+        } else if (ae.getActionCommand().equals(FILE_SOURCEFILE)) {
+            if (curfile != null) {
+                try {
+                    Desktop.getDesktop().open(curfile);
+                } catch (IOException e) {
+                    JOptionPane.showMessageDialog(this, "Could not open the file "+curfile+". "+e.getMessage());
+                    e.printStackTrace();
+                }
+            }
         } else if (ae.getActionCommand().equals(FILE_BOARD_EDITOR_VALIDATE)) {
             correctExits();
             StringBuffer errBuff = new StringBuffer();

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -315,6 +315,7 @@ public class BoardEditor extends JComponent
     private HashSet<IHex> currentUndoSet;
     private HashSet<Coords> currentUndoCoords;
     private static final int [] defaultBuildingCFs = {0,15,40,90,150};
+    private String loadPath = "data" + File.separator + "boards";
     
     /**
      * Special purpose indicator, keeps terrain list 
@@ -1402,7 +1403,7 @@ public class BoardEditor extends JComponent
     }
 
     public void boardLoad() {
-        JFileChooser fc = new JFileChooser("data" + File.separator + "boards");
+        JFileChooser fc = new JFileChooser(loadPath);
         fc.setLocation(frame.getLocation().x + 150, frame.getLocation().y + 100);
         fc.setDialogTitle(Messages.getString("BoardEditor.loadBoard"));
         fc.setFileFilter(new FileFilter() {
@@ -1422,6 +1423,7 @@ public class BoardEditor extends JComponent
             return;
         }
         curfile = fc.getSelectedFile();
+        loadPath = curfile.getPath();
         // load!
         try (InputStream is = new FileInputStream(fc.getSelectedFile())) {            
             // tell the board to load!

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -193,8 +193,6 @@ public class ChatLounge extends AbstractPhaseDisplay
     /* Map Settings Panel */
     private MapSettings mapSettings;
     private JButton butConditions;
-    // private RandomMapDialog randomMapDialog;
-    private RandomMapDialog randomMapDialog;
     private JPanel panGroundMap;
     private JPanel panSpaceMap;
     private JComboBox<String> comboMapType;
@@ -697,11 +695,6 @@ public class ChatLounge extends AbstractPhaseDisplay
         panMap = new JPanel();
 
         mapSettings = MapSettings.getInstance(clientgui.getClient().getMapSettings());
-
-        randomMapDialog = new RandomMapDialog(clientgui.frame, this, clientgui.getClient(), mapSettings); // new
-                                                                                                          // RandomMapDialog(clientgui.frame,
-                                                                                                          // this,
-        // clientgui.getClient(), mapSettings);
 
         butConditions = new JButton(Messages.getString("ChatLounge.butConditions")); //$NON-NLS-1$
         butConditions.addActionListener(this);
@@ -2650,13 +2643,6 @@ public class ChatLounge extends AbstractPhaseDisplay
         refreshEntities();
         refreshPlayerInfo();
         setupMapSizes();
-        // randomMapDialog.getMapSettings().setBoardSize(
-        // (mapSettings.getBoardWidth()), mapSettings.getBoardHeight());
-        // randomMapDialog.getMapSettings().setMapSize(mapSettings.getMapWidth(),
-        // mapSettings.getMapHeight());
-        // randomMapDialog.getMapSettings().setBoardsAvailableVector(mapSettings.getBoardsAvailableVector());
-        // randomMapDialog.getMapSettings().setBoardsSelectedVector(mapSettings.getBoardsSelectedVector());
-        // randomMapDialog.loadValues();
     }
 
     @Override
@@ -2795,7 +2781,8 @@ public class ChatLounge extends AbstractPhaseDisplay
             clientgui.getPlanetaryConditionsDialog().update(clientgui.getClient().getGame().getPlanetaryConditions());
             clientgui.getPlanetaryConditionsDialog().setVisible(true);
         } else if (ev.getSource() == butRandomMap) {
-            randomMapDialog.setVisible(true);
+            RandomMapDialog rmd = new RandomMapDialog(clientgui.frame, this, clientgui.getClient(), mapSettings);
+            rmd.activateDialog(clientgui.getBoardView1().getTilesetManager().getThemes());
         } else if (ev.getSource().equals(butChange)) {
             if (lisBoardsAvailable.getSelectedIndex() != -1) {
                 changeMap(lisBoardsAvailable.getSelectedValue());

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -2782,7 +2782,7 @@ public class ChatLounge extends AbstractPhaseDisplay
             clientgui.getPlanetaryConditionsDialog().setVisible(true);
         } else if (ev.getSource() == butRandomMap) {
             RandomMapDialog rmd = new RandomMapDialog(clientgui.frame, this, clientgui.getClient(), mapSettings);
-            rmd.activateDialog(clientgui.getBoardView1().getTilesetManager().getThemes());
+            rmd.activateDialog(clientgui.getBoardView().getTilesetManager().getThemes());
         } else if (ev.getSource().equals(butChange)) {
             if (lisBoardsAvailable.getSelectedIndex() != -1) {
                 changeMap(lisBoardsAvailable.getSelectedValue());

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -324,10 +324,6 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         return bv;
     }
     
-    public BoardView1 getBoardView1() {
-        return bv;
-    }
-
     /**
      * Try to load the "bing" sound clip.
      */

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -323,6 +323,10 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
     public IBoardView getBoardView() {
         return bv;
     }
+    
+    public BoardView1 getBoardView1() {
+        return bv;
+    }
 
     /**
      * Try to load the "bing" sound clip.

--- a/megamek/src/megamek/client/ui/swing/RandomMapDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomMapDialog.java
@@ -32,9 +32,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Set;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
+import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
@@ -86,7 +88,7 @@ public class RandomMapDialog extends JDialog implements ActionListener {
     private final JLabel mapThemeLabel = new JLabel(Messages.getString("RandomMapDialog.labTheme"));
     private final VerifiableTextField mapWidthField = new VerifiableTextField(4);
     private final VerifiableTextField mapHeightField = new VerifiableTextField(4);
-    private final VerifiableTextField mapThemeField = new VerifiableTextField(10);
+    private final JComboBox<String> choTheme = new JComboBox<>();
 
     // Control buttons
     private final JButton okayButton = new JButton(Messages.getString("Okay"));
@@ -261,10 +263,9 @@ public class RandomMapDialog extends JDialog implements ActionListener {
         // Row 3, Column 2.
         constraints.gridx++;
         constraints.gridwidth = 3;
-        mapThemeField.setSelectAllTextOnGotFocus(true);
-        mapThemeField.setText(mapSettings.getTheme());
-        mapThemeField.setToolTipText(Messages.getString("RandomMapDialog.mapThemeField.toolTip"));
-        panel.add(mapThemeField, constraints);
+        choTheme.addActionListener(this);
+        choTheme.setToolTipText(Messages.getString("RandomMapDialog.mapThemeField.toolTip"));
+        panel.add(choTheme, constraints);
 
         return panel;
     }
@@ -417,7 +418,7 @@ public class RandomMapDialog extends JDialog implements ActionListener {
 
         // Get the general settings from this panel.
         newMapSettings.setBoardSize(mapWidthField.getAsInt(), mapHeightField.getAsInt());
-        newMapSettings.setTheme(mapThemeField.getText());
+        newMapSettings.setTheme((String)choTheme.getSelectedItem());
         this.mapSettings = newMapSettings;
 
         // Sent the map settings to either the server or the observer as needed.
@@ -429,7 +430,9 @@ public class RandomMapDialog extends JDialog implements ActionListener {
         return true;
     }
     
-    public boolean activateDialog() {
+    public boolean activateDialog(Set<String> themeList) {
+        for (String s: themeList) choTheme.addItem(s);
+        choTheme.setSelectedItem(mapSettings.getTheme());
     	userCancel = false;
     	setVisible(true);
     	return userCancel;


### PR DESCRIPTION
- Corrections for the RandomMapDialog behaviour when calling it from the ChatLounge (Generated Map) and a correction for the Saxarba tileset as it was not showing buildings correctly.

- The RandomMapDialog will now show a dropdown of Themes, resolving #1789 

- The MapEditor Open Board dialog will now remember the directory

- The MapEditor has a new button that will open a map's source file in the system's standard text editor if one is configured for .board files (I can't test that on anything but Win10)