### PR TITLE
Couple of bot fixes

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1846,13 +1846,25 @@ public class FireControl {
         		continue;
         	}
         	
-        	
-            final double toHitThreshold = ammoConservation.get(weapon);
-            final WeaponFireInfo shoot = buildWeaponFireInfo(shooter, target, weapon, game, false);
+        	final double toHitThreshold = ammoConservation.get(weapon);
+            WeaponFireInfo shoot = buildWeaponFireInfo(shooter, target, weapon, game, false);
+            
+            // if we're below the threshold, try switching missile modes
+            if ((shoot.getProbabilityToHit() <= toHitThreshold)) {
+                
+                int updatedMissileMode = switchMissileMode(weapon);
+                
+                if(updatedMissileMode > -1) {
+                    shoot = buildWeaponFireInfo(shooter, target, weapon, game, false);
+                    shoot.setUpdatedFiringMode(updatedMissileMode);
+                }
+            }
+            
             if ((shoot.getProbabilityToHit() > toHitThreshold)) {
                 myPlan.add(shoot);
                 continue;
-            }
+            }            
+            
             owner.log(getClass(), METHOD_NAME, LogLevel.DEBUG,
                       "\nTo Hit Chance (" + DECF.format(shoot.getProbabilityToHit()) + ") for " + weapon.getName() +
                       " is less than threshold (" + DECF.format(toHitThreshold) + ")");
@@ -3272,5 +3284,27 @@ public class FireControl {
         }
         
         return null;
+    }
+    
+    /**
+     * Attempts to switch the current weapon's firing mode between direct and indirect
+     * or vice versa. Returns -1 if the mode switch fails, or the weapon mode index if it succeeds.
+     * @return Mode switch result.
+     */
+    private int switchMissileMode(Mounted weapon) {
+        // check that we're operating a missile weapon that can switch direct/indirect modes
+        // don't bother checking non-missile weapons
+        if(weapon.getType().hasFlag(Weapon.F_MISSILE) &&
+                weapon.getType().hasModeType(Weapon.MODE_MISSILE_INDIRECT)) {
+            
+            // if we are able to switch the weapon to indirect fire mode, do so and try again
+            if(!weapon.curMode().equals(Weapon.MODE_MISSILE_INDIRECT)) {
+                return weapon.setMode(Weapon.MODE_MISSILE_INDIRECT);
+            } else {
+                return weapon.setMode("");
+            }
+        }       
+        
+        return -1;
     }
 }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -3298,7 +3298,7 @@ public class FireControl {
                 weapon.getType().hasModeType(Weapon.MODE_MISSILE_INDIRECT)) {
             
             // if we are able to switch the weapon to indirect fire mode, do so and try again
-            if(!weapon.curMode().equals(Weapon.MODE_MISSILE_INDIRECT)) {
+            if (!weapon.curMode().equals(Weapon.MODE_MISSILE_INDIRECT)) {
                 return weapon.setMode(Weapon.MODE_MISSILE_INDIRECT);
             } else {
                 return weapon.setMode("");

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1854,7 +1854,7 @@ public class FireControl {
                 
                 int updatedMissileMode = switchMissileMode(weapon);
                 
-                if(updatedMissileMode > -1) {
+                if (updatedMissileMode > -1) {
                     shoot = buildWeaponFireInfo(shooter, target, weapon, game, false);
                     shoot.setUpdatedFiringMode(updatedMissileMode);
                 }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1850,7 +1850,7 @@ public class FireControl {
             WeaponFireInfo shoot = buildWeaponFireInfo(shooter, target, weapon, game, false);
             
             // if we're below the threshold, try switching missile modes
-            if ((shoot.getProbabilityToHit() <= toHitThreshold)) {
+            if (shoot.getProbabilityToHit() <= toHitThreshold) {
                 
                 int updatedMissileMode = switchMissileMode(weapon);
                 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -3294,7 +3294,7 @@ public class FireControl {
     private int switchMissileMode(Mounted weapon) {
         // check that we're operating a missile weapon that can switch direct/indirect modes
         // don't bother checking non-missile weapons
-        if(weapon.getType().hasFlag(Weapon.F_MISSILE) &&
+        if (weapon.getType().hasFlag(Weapon.F_MISSILE) &&
                 weapon.getType().hasModeType(Weapon.MODE_MISSILE_INDIRECT)) {
             
             // if we are able to switch the weapon to indirect fire mode, do so and try again

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -520,7 +520,6 @@ public class WeaponFireInfo {
             } else {
                 setToHit(calcToHit());
             }
-            
             // If we can't hit, set everything zero and return..
             if (12 < getToHit().getValue()) {
                 owner.log(getClass(), METHOD_NAME, LogLevel.DEBUG, msg.append("\n\tImpossible toHit: ")

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -35,7 +35,6 @@ import megamek.common.actions.WeaponAttackAction;
 import megamek.common.annotations.Nullable;
 import megamek.common.logging.LogLevel;
 import megamek.common.options.OptionsConstants;
-import megamek.common.weapons.Weapon;
 import megamek.common.weapons.capitalweapons.CapitalMissileWeapon;
 
 /**
@@ -521,19 +520,10 @@ public class WeaponFireInfo {
             } else {
                 setToHit(calcToHit());
             }
-
+            
             // If we can't hit, set everything zero and return..
             if (12 < getToHit().getValue()) {
-                int indirectMode = switchMissileMode();
-                
-                if(indirectMode > -1) {
-                    setUpdatedFiringMode(indirectMode);
-                    initDamage(shooterPath, assumeUnderFlightPath, guess, bombPayload);
-                    getWeapon().setMode(""); // make sure to reset the weapon firing mode
-                    return;
-                }
-                
-            	owner.log(getClass(), METHOD_NAME, LogLevel.DEBUG, msg.append("\n\tImpossible toHit: ")
+                owner.log(getClass(), METHOD_NAME, LogLevel.DEBUG, msg.append("\n\tImpossible toHit: ")
                                                                       .append(getToHit().getValue()).toString());
                 setProbabilityToHit(0);
                 setMaxDamage(0);
@@ -631,25 +621,6 @@ public class WeaponFireInfo {
         }
     }
     
-    /**
-     * Attempts to switch the current weapon's firing mode between direct and indirect
-     * or vice versa. Returns -1 if the mode switch fails, or the weapon mode index if it succeeds.
-     * @return Mode switch result.
-     */
-    int switchMissileMode() {
-        //if we've already switched before, don't do it again
-        if(getUpdatedFiringMode() != null) {
-            return -1;
-        }
-        
-        // if we are able to switch the weapon to indirect fire mode, do so and try again
-        if(!getWeapon().curMode().equals(Weapon.MODE_MISSILE_INDIRECT)) {
-            return getWeapon().setMode(Weapon.MODE_MISSILE_INDIRECT);
-        } else {
-            return getWeapon().setMode("");
-        }
-    }
-
     WeaponAttackAction getWeaponAttackAction() {
         final String METHOD_NAME = "getWeaponAttackAction(IGame)";
         owner.methodBegin(getClass(), METHOD_NAME);

--- a/megamek/src/megamek/common/pathfinder/InfantryPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/InfantryPathFinder.java
@@ -71,9 +71,13 @@ public class InfantryPathFinder {
             
             // now that we've got all our possible destinations, make sure to try every possible rotation,
             // since facing matters for field guns and if using the "dig in" and "vehicle cover" tacops rules.
+            List<MovePath> rotatedPaths = new ArrayList<>();
+            
             for(MovePath path : infantryPaths) {
-                infantryPaths.addAll(AeroPathUtil.generateValidRotations(path));
+                rotatedPaths.addAll(AeroPathUtil.generateValidRotations(path));
             }
+            
+            infantryPaths.addAll(rotatedPaths);
             
             // add "flee" option if we haven't done anything else
             if(startingEdge.getFinalCoords().isOnBoardEdge(game.getBoard()) &&


### PR DESCRIPTION
This fixes two issues:

- a "concurrent modification exception" that occasionally, but not always would occur when generating infantry paths.
- if the bot engaged in indirect fire with LRMs but then the LRM-equipped unit got into line-of-sight of a target, it wouldn't properly switch the LRMs back to direct fire. Moved the LRM firing mode switching logic further up the call stack to avoid recursion and unnecessary firing mode switches.