### PR TITLE
Fix infantry destruction rate of Fuel-Air explosives

### DIFF
--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -289,7 +289,7 @@ public class AreaEffectHelper {
         
         int roll = Compute.d6(2);
         int result = roll + distFromCenter;
-        boolean destroyed = result < rollTarget;
+        boolean destroyed = result <= rollTarget;
         
         Report r = new Report(9987);
         r.indent(1);

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -289,7 +289,7 @@ public class AreaEffectHelper {
         
         int roll = Compute.d6(2);
         int result = roll + distFromCenter;
-        boolean destroyed = result > rollTarget;
+        boolean destroyed = result < rollTarget;
         
         Report r = new Report(9987);
         r.indent(1);


### PR DESCRIPTION
It will fix #1814. The units are destroyed if the result is under the target number, but it was reversed and the units are destroyed if the result is over than the target number