### PR TITLE
Don't run CI/CD on push with the PR job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@
 name: MegaMek CI with Gradle
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
This removes the On Push job that was running as the build scans that are handy for PR's aren't currently working (the event doesn't have a URL to reference).