### PR TITLE
Dependency update

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -28,17 +28,15 @@ configurations {
 }
 
 dependencies {
-    implementation 'com.thoughtworks.xstream:xstream:1.4.10'
+    implementation 'com.thoughtworks.xstream:xstream:1.4.11'
     implementation 'org.freemarker:freemarker:2.3.28'
     implementation 'log4j:log4j:1.2.17'
     implementation 'org.apache.commons:commons-text:1.8'
     implementation 'com.formdev:flatlaf:0.26'
 
-    implementation 'javax.xml.bind:jaxb-api:2.3.0'
-    runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.0'
-    runtimeOnly 'org.glassfish.jaxb:jaxb-core:2.3.0'
-    runtimeOnly 'com.sun.activation:javax.activation:1.2.0'
-    
+    implementation 'javax.xml.bind:jaxb-api:2.3.2'
+    runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.2'
+
     jarbundler 'com.ultramixer.jarbundler:jarbundler-core:3.3.0'
 
     testImplementation 'junit:junit:4.12' 

--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'org.apache.commons:commons-text:1.8'
     implementation 'com.formdev:flatlaf:0.26'
 
-    implementation 'javax.xml.bind:jaxb-api:2.3.2'
+    compile 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.2'
 
     jarbundler 'com.ultramixer.jarbundler:jarbundler-core:3.3.0'
@@ -357,6 +357,7 @@ task assemble(overwrite: true) {
 task assembleDist(overwrite: true) {
     description = 'Build unix, Windows, and source packages'
     group = 'distribution'
+    dependsOn test
     dependsOn unixDistTar
     dependsOn windowsDistZip
 //    dependsOn macDistTar


### PR DESCRIPTION
Updates the following dependencies:
1. Library
    a. JAXB from 2.3.0 to 2.3.2. This deals with the warning that there has been an illegal reflective access. There was also a change in architecture following 2.3.0 so the group and module for the api module is different.
    b. XStream from 1.40.10 to 1.40.11. This deals with a vulnerability when the security framework is not initialized. XStream has not yet dealt with the changes in Java 9 that throw out a warning when reflection is used across modules. At some point in the future Java will disable that ability and MM will not run on later versions unless XStream figures out another way to serialize and deserialize java.* classes or we move to another library for saves.
2. Added a `test` dependency to the `assembleDist` gradle task so unit tests must pass before the `release` task can run.