### PR TITLE
forego terrain modifiers for semi-guided warheads

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4347,9 +4347,14 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         
         // Target Terrain
         
+        // BMM p. 31, semi-guided indirect missile attacks vs tagged targets ignore terrain modifiers
+        boolean semiGuidedIndirectVsTaggedTarget = isIndirect && 
+                (atype != null) && atype.getMunitionType() == AmmoType.M_SEMIGUIDED && 
+                        Compute.isTargetTagged(target, game);
+        
         // Base terrain calculations, not applicable when delivering minefields or bombs
         // also not applicable in pointblank shots from hidden units
-        if ((ttype != Targetable.TYPE_MINEFIELD_DELIVER) && !isPointBlankShot) {
+        if ((ttype != Targetable.TYPE_MINEFIELD_DELIVER) && !isPointBlankShot && !semiGuidedIndirectVsTaggedTarget) {
             toHit.append(Compute.getTargetTerrainModifier(game, target, eistatus, inSameBuilding, underWater));
             toSubtract += Compute.getTargetTerrainModifier(game, target, eistatus, inSameBuilding, underWater)
                     .getValue();


### PR DESCRIPTION
Updates toHit logic to comply with BMM page 31, as pointed out in issue #1812: semi-guided warheads indirect-fired at targets marked by TAG ignore the target's terrain modifiers for the purposes of determining the attack target number.