### PR TITLE
MapEditor Resize Board & West Edge

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1157,6 +1157,7 @@ ExpandMapDialog.mapNorthField.toolTip=How many hexes to expand or contract North
 ExpandMapDialog.mapEastField.toolTip=How many hexes to expand or contract East
 ExpandMapDialog.mapSouthField.toolTip=How many hexes to expand or contract South
 ExpandMapDialog.mapWestField.toolTip=How many hexes to expand or contract West
+ExpandMapDialog.mapWestField.note=<HTML>When adding or subtracting an odd number of hexes on the west edge, some hexes<BR>on the <U>south edge will be discarded</U> unless you also <U>add at least 1 hex to the south edge.</U></HTML>
 
 #Firing Display
 FiringDisplay.Called=Called

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -1363,22 +1363,24 @@ public class BoardEditor extends JComponent
 
     public void boardResize() {
     	ResizeMapDialog emd = new ResizeMapDialog(frame, this, null, mapSettings);
-        emd.setVisible(true);
-        board = BoardUtilities.generateRandom(mapSettings);
+    	boolean userCancel = emd.activateDialog(bv.getTilesetManager().getThemes());
+    	if (!userCancel) {
+    	    board = BoardUtilities.generateRandom(mapSettings);
 
-        // Implant the old board
-        int west = emd.getExpandWest();
-        int north = emd.getExpandNorth();
-        int east = emd.getExpandEast();
-        int south = emd.getExpandSouth();
-        board = implantOldBoard(game, west, north, east, south);
+    	    // Implant the old board
+    	    int west = emd.getExpandWest();
+    	    int north = emd.getExpandNorth();
+    	    int east = emd.getExpandEast();
+    	    int south = emd.getExpandSouth();
+    	    board = implantOldBoard(game, west, north, east, south);
 
-        game.setBoard(board);
-        curfile = null;
-        butSourceFile.setEnabled(false);
-        frame.setTitle(Messages.getString("BoardEditor.title")); //$NON-NLS-1$
-        menuBar.setBoard(true);
-        bvc.doLayout();
+    	    game.setBoard(board);
+    	    curfile = null;
+    	    butSourceFile.setEnabled(false);
+    	    frame.setTitle(Messages.getString("BoardEditor.title")); //$NON-NLS-1$
+    	    menuBar.setBoard(true);
+    	    bvc.doLayout();
+    	}
     }
 
     // When we resize a board, implant the old board's hexes where they should be in the new board
@@ -1387,7 +1389,8 @@ public class BoardEditor extends JComponent
         for (int x = 0; x < oldBoard.getWidth(); x++) {
             for (int y = 0; y < oldBoard.getHeight(); y++) {
                 int newX = x+west;
-                int newY = y+north;
+                int odd = x & 1 & west;
+                int newY = y+north + odd;
                 if (oldBoard.contains(x, y) && board.contains(newX, newY)) {
                     IHex oldHex = oldBoard.getHex(x, y);
                     IHex hex = board.getHex(newX, newY);

--- a/megamek/src/megamek/client/ui/swing/RandomMapPanelAdvanced.java
+++ b/megamek/src/megamek/client/ui/swing/RandomMapPanelAdvanced.java
@@ -1853,7 +1853,7 @@ public class RandomMapPanelAdvanced extends JPanel {
 
     // Has the given field validate itself.
     private boolean isFieldVerified(VerifiableTextField field) {
-        String result = field.verifyText();
+        String result = field.verifyTextS();
         if (result != null) {
             result = field.getName() + ": " + result;
             new RuntimeException(result).printStackTrace();

--- a/megamek/src/megamek/client/ui/swing/ResizeMapDialog.java
+++ b/megamek/src/megamek/client/ui/swing/ResizeMapDialog.java
@@ -499,15 +499,15 @@ public class ResizeMapDialog extends JDialog implements ActionListener, KeyListe
     }
     
     private boolean isExpandValid() {
-        return (mapNorthField.verifyText() == null) &&
-                (mapEastField.verifyText() == null) &&
-                (mapSouthField.verifyText() == null) &&
-                (mapWestField.verifyText() == null);
+        return mapNorthField.verifyText() &&
+                mapEastField.verifyText() &&
+                mapSouthField.verifyText() &&
+                mapWestField.verifyText();
     }
-    
+
     private boolean isExpandWestProblem() {
-        return (mapSouthField.verifyText() == null) &&
-                (mapWestField.verifyText() == null) &&
+        return mapSouthField.verifyText() &&
+                mapWestField.verifyText() &&
                 ((getExpandWest() & 1) == 1) && 
                 (getExpandSouth() < 1);
     }

--- a/megamek/src/megamek/client/ui/swing/ResizeMapDialog.java
+++ b/megamek/src/megamek/client/ui/swing/ResizeMapDialog.java
@@ -130,7 +130,21 @@ public class ResizeMapDialog extends JDialog implements ActionListener, KeyListe
         setResizable(true);
         setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
         addWindowListener(new WindowAdapter() {
-            public void windowClosing(WindowEvent e) { doCancel(); }
+            public void windowClosing(WindowEvent e) { 
+                doCancel(); 
+            }
+            
+            // Hide the west edge warning when some other program is brought to foreground
+            public void windowDeactivated(WindowEvent e) {
+                westNotice.setVisible(false);
+                super.windowDeactivated(e);
+            }
+
+            public void windowIconified(WindowEvent e) {
+                westNotice.setVisible(false);
+                super.windowIconified(e);
+            }
+
         });
 
         pack();
@@ -524,7 +538,7 @@ public class ResizeMapDialog extends JDialog implements ActionListener, KeyListe
         } else {
             okayButton.setEnabled(true);
         }
-        
+
         // Give notice when having an odd west expansion and no south expansion
         if (isExpandWestProblem()) {
             Point loc = mapSouthField.getLocationOnScreen();
@@ -548,4 +562,5 @@ public class ResizeMapDialog extends JDialog implements ActionListener, KeyListe
         setVisible(true);
         return userCancel;
     }
+
 }

--- a/megamek/src/megamek/client/ui/swing/widget/VerifiableTextField.java
+++ b/megamek/src/megamek/client/ui/swing/widget/VerifiableTextField.java
@@ -172,7 +172,7 @@ public class VerifiableTextField extends JTextField implements FocusListener {
         }
 
 //        Color goodBackground = isRequired() ? BK_REQUIRED : BK_DEFAULT;
-        String verifyResult = verifyText();
+        String verifyResult = verifyTextS();
 
         // If verifyResult is null, no problems were found.
         if (verifyResult == null) {
@@ -215,7 +215,7 @@ public class VerifiableTextField extends JTextField implements FocusListener {
      *
      * @return NULL if the text in the field is valid. A description of the failure otherwise.
      */
-    public String verifyText() {
+    public String verifyTextS() {
         if (verifiers.isEmpty()) {
             return null;
         }
@@ -229,12 +229,21 @@ public class VerifiableTextField extends JTextField implements FocusListener {
         }
         return result;
     }
+    
+    /**
+     * Compares the text field's value to the list of {@link DataVerifier} objects to ensure the validity of the data.
+     *
+     * @return true if the text in the field is valid.
+     */
+    public boolean verifyText() {
+        return verifyTextS() == null;
+    }
 
     public Integer getAsInt() {
         if (!isTextNumeric()) {
             return null;
         }
-        return Integer.parseInt(getText());
+        return Integer.parseInt(getText().trim());
     }
 
     public String getOldToolTip() {


### PR DESCRIPTION
Resolves #1768 

- Using an odd number on the west edge when resizing a map in the Board Editor will no longer jumble the board but instead move everything down one half hex
- When an odd number is entered for west and also south < 1 then this *will* delete the southern-most hexes - but in this case a warning is displayed:
![image](https://user-images.githubusercontent.com/17069663/78914893-6282bf00-7a8b-11ea-96fc-d8035d48e5f9.png)
- Adding at least 1 to south solves the problem
- Also, added a cancel button and behavior to the dialog; loading a map setting will now default to the mapgen directory; corrected the verifiable text fields to now work with whitespaces around numbers; changed the text field for themes into a combobox.