### PR TITLE
rat generator update; fix rat generator panel;

### DIFF
--- a/megamek/data/forcegenerator/2398.xml
+++ b/megamek/data/forcegenerator/2398.xml
@@ -168,29 +168,29 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover Primitive)'>
+		<model name='(Tracked Primitive)'>
 			<roles>apc,support</roles>
-			<availability>General:7</availability>
+			<availability>General:9</availability>
 		</model>
 		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Wheeled Primitive)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Tracked Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:9</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Tracked LRM)'>
 			<roles>apc</roles>
 			<availability>IS.pm:3</availability>
 		</model>
-		<model name='(Wheeled MG)'>
+		<model name='(Wheeled Primitive)'>
 			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Hover Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -201,10 +201,6 @@
 	</chassis>
 	<chassis name='Bonaventure Corvette' unitType='Warship'>
 		<availability>TH:5</availability>
-		<model name='(2317)'>
-			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2317)'>
 			<roles>corvette</roles>
 			<availability>General:8</availability>
@@ -239,13 +235,13 @@
 	</chassis>
 	<chassis name='Chi-Ha Infantry Combat Vehicle' unitType='Tank'>
 		<availability>DC:8</availability>
-		<model name='(Original)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Original)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra VTOL Transport' unitType='VTOL'>
@@ -341,13 +337,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebird' unitType='Aero'>
@@ -358,17 +354,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -376,9 +370,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
@@ -396,6 +392,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -403,14 +407,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hurricane Conventional Fighter' unitType='Conventional Fighter'>
@@ -435,17 +431,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -483,11 +479,11 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:8</availability>
-		<model name='MSK-5S'>
-			<availability>LA:4,General:4</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>General:6,FWL:6</availability>
+		</model>
+		<model name='MSK-5S'>
+			<availability>LA:4,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -501,17 +497,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -519,31 +515,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -552,11 +548,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -583,6 +579,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -591,12 +593,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -620,6 +616,12 @@
 		<availability>DC:6</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stoat Scout Car' unitType='Tank'>
@@ -650,17 +652,13 @@
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
 		<availability>DC:8</availability>
+		<model name='(2312)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Cargo)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(2312)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2312)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Winchester Cruiser' unitType='Warship'>

--- a/megamek/data/forcegenerator/2440.xml
+++ b/megamek/data/forcegenerator/2440.xml
@@ -188,29 +188,29 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover Primitive)'>
+		<model name='(Tracked Primitive)'>
 			<roles>apc,support</roles>
-			<availability>General:7</availability>
+			<availability>General:9</availability>
 		</model>
 		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Wheeled Primitive)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Tracked Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:9</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Tracked LRM)'>
 			<roles>apc</roles>
 			<availability>IS.pm:3</availability>
 		</model>
-		<model name='(Wheeled MG)'>
+		<model name='(Wheeled Primitive)'>
 			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Hover Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
@@ -238,20 +238,16 @@
 			<roles>corvette</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2317)'>
-			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>LA:4</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Caravan Heavy Transport' unitType='Conventional Fighter'>
@@ -276,13 +272,13 @@
 	</chassis>
 	<chassis name='Chi-Ha Infantry Combat Vehicle' unitType='Tank'>
 		<availability>DC:8</availability>
-		<model name='(Original)'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Original)'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra VTOL Transport' unitType='VTOL'>
@@ -388,9 +384,6 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2448)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
@@ -413,13 +406,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebird' unitType='Aero'>
@@ -430,17 +423,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -448,9 +439,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
@@ -468,6 +461,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -475,14 +476,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hurricane Conventional Fighter' unitType='Conventional Fighter'>
@@ -507,17 +500,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -572,11 +565,11 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:8,LA:3</availability>
-		<model name='MSK-5S'>
-			<availability>LA:2,General:2</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>General:6,FWL:6</availability>
+		</model>
+		<model name='MSK-5S'>
+			<availability>LA:2,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
@@ -601,17 +594,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -619,31 +612,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -652,11 +645,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -683,6 +676,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -691,12 +690,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -713,9 +706,6 @@
 		<availability>TH:3</availability>
 		<model name='(2447)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2447)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -735,19 +725,25 @@
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:2</availability>
-		<model name='(Primitive)'>
-			<roles>sr_fire_support</roles>
-			<availability>IS:5,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Primitive)'>
+			<roles>sr_fire_support</roles>
+			<availability>IS:5,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>DC:6</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stoat Scout Car' unitType='Tank'>

--- a/megamek/data/forcegenerator/2460.xml
+++ b/megamek/data/forcegenerator/2460.xml
@@ -188,29 +188,29 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover Primitive)'>
+		<model name='(Tracked Primitive)'>
 			<roles>apc,support</roles>
-			<availability>General:7</availability>
+			<availability>General:9</availability>
 		</model>
 		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Wheeled Primitive)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Tracked Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:9</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Tracked LRM)'>
 			<roles>apc</roles>
 			<availability>IS.pm:3</availability>
 		</model>
-		<model name='(Wheeled MG)'>
+		<model name='(Wheeled Primitive)'>
 			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Hover Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
@@ -244,20 +244,16 @@
 			<roles>corvette</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2317)'>
-			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>LA:4</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Caravan Heavy Transport' unitType='Conventional Fighter'>
@@ -282,13 +278,13 @@
 	</chassis>
 	<chassis name='Chi-Ha Infantry Combat Vehicle' unitType='Tank'>
 		<availability>DC:6</availability>
-		<model name='(Original)'>
-			<roles>apc</roles>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Original)'>
+			<roles>apc</roles>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra VTOL Transport' unitType='VTOL'>
@@ -314,11 +310,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -417,9 +413,6 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2448)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
@@ -442,28 +435,26 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -471,9 +462,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -503,6 +496,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -510,14 +511,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -549,17 +542,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -632,11 +625,11 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:8,LA:4,IS:4,FWL:4</availability>
-		<model name='MSK-5S'>
-			<availability>LA:1,General:1</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>General:6,FWL:6</availability>
+		</model>
+		<model name='MSK-5S'>
+			<availability>LA:1,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
@@ -667,17 +660,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -685,31 +678,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -718,11 +711,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -752,6 +745,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -760,12 +759,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -790,9 +783,6 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2447)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
 		<availability>TH:5</availability>
@@ -810,13 +800,13 @@
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:3</availability>
-		<model name='(Primitive)'>
-			<roles>sr_fire_support</roles>
-			<availability>IS:4,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Primitive)'>
+			<roles>sr_fire_support</roles>
+			<availability>IS:4,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
@@ -829,6 +819,12 @@
 		<availability>TH:3</availability>
 		<model name='SHD-1R'>
 			<availability>CC:8,IS:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stoat Scout Car' unitType='Tank'>

--- a/megamek/data/forcegenerator/2470.xml
+++ b/megamek/data/forcegenerator/2470.xml
@@ -198,42 +198,42 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover Primitive)'>
+		<model name='(Tracked Primitive)'>
 			<roles>apc,support</roles>
-			<availability>General:7</availability>
+			<availability>General:9</availability>
 		</model>
 		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(Wheeled Primitive)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>General:6</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Hover)'>
 			<roles>apc,support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Tracked Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='(Tracked LRM)'>
 			<roles>apc</roles>
 			<availability>IS.pm:3</availability>
 		</model>
-		<model name='(Wheeled MG)'>
+		<model name='(Wheeled Primitive)'>
 			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Hover Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>TH:6-,LA:3,FS:3,MERC:3,DC:3</availability>
-		<model name='BNC-3E'>
-			<availability>General:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='BNC-1E'>
 			<availability>TH:6,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleAxe' unitType='Mek'>
@@ -241,11 +241,11 @@
 		<model name='BKX-7K'>
 			<availability>FS:6</availability>
 		</model>
-		<model name='BKX-1X'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='BKX-7NC'>
 			<availability>FS:3</availability>
+		</model>
+		<model name='BKX-1X'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Eagle' unitType='Dropship'>
@@ -267,20 +267,16 @@
 			<roles>corvette</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2317)'>
-			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>LA:4</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Caravan Heavy Transport' unitType='Conventional Fighter'>
@@ -315,25 +311,25 @@
 	</chassis>
 	<chassis name='Cobra VTOL Transport' unitType='VTOL'>
 		<availability>TH:5</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>PoR:1,LA:8</availability>
-		<model name='COM-1A'>
-			<roles>recon</roles>
-			<availability>PoR:8,LA:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1A'>
+			<roles>recon</roles>
+			<availability>PoR:8,LA:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -350,14 +346,14 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
+		<model name='CRS-6B'>
+			<availability>General:8</availability>
 		</model>
 		<model name='CRS-X'>
 			<availability>General:4</availability>
 		</model>
-		<model name='CRS-6B'>
-			<availability>General:8</availability>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -397,11 +393,11 @@
 	</chassis>
 	<chassis name='DroST IIa Transport' unitType='Dropship'>
 		<availability>TH:6</availability>
-		<model name='(2470)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2445)'>
 			<availability>TH:6</availability>
+		</model>
+		<model name='(2470)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='DroST IIb Transport' unitType='Dropship'>
@@ -462,9 +458,6 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2448)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
@@ -487,13 +480,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -504,17 +497,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -522,9 +513,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -553,15 +546,23 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:2,TH:7,LA:1,FWL:2,IS:1,FS:2,DC:2</availability>
-		<model name='HMR-HC'>
-			<availability>TH:4,IS:8</availability>
-		</model>
 		<model name='HMR-HA'>
 			<availability>TH:6</availability>
+		</model>
+		<model name='HMR-HC'>
+			<availability>TH:4,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:3-,IS.pm:2,Periphery:3-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:4-,Periphery.Deep:4-,IS.pm:2,Periphery:4-</availability>
@@ -570,21 +571,9 @@
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:3-,IS.pm:2,Periphery:3-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -592,6 +581,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -600,6 +593,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -607,14 +608,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -651,11 +644,11 @@
 	</chassis>
 	<chassis name='Intrepid Assault Craft' unitType='Small Craft'>
 		<availability>FS:3</availability>
-		<model name='(2478)'>
+		<model name='(2331)'>
 			<roles>assault</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2331)'>
+		<model name='(2478)'>
 			<roles>assault</roles>
 			<availability>General:6</availability>
 		</model>
@@ -669,17 +662,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -758,11 +751,11 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:6-,LA:5,IS:4,FWL:4,Periphery:3</availability>
-		<model name='MSK-6S'>
-			<availability>General:5,FWL:5</availability>
-		</model>
 		<model name='MSK-7A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='MSK-6S'>
+			<availability>General:5,FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
@@ -778,11 +771,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='II-A'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:2</availability>
 		</model>
 		<model name='II (Primitive)'>
 			<availability>General:3</availability>
@@ -799,17 +792,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -817,31 +810,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -850,11 +843,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -884,6 +877,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -892,12 +891,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -920,9 +913,6 @@
 		<availability>TH:3</availability>
 		<model name='(2447)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2447)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -964,13 +954,13 @@
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Primitive)'>
-			<roles>sr_fire_support</roles>
-			<availability>IS:3,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Primitive)'>
+			<roles>sr_fire_support</roles>
+			<availability>IS:3,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
@@ -990,6 +980,12 @@
 		<availability>TH:4</availability>
 		<model name='SHD-1R'>
 			<availability>CC:8,IS:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
@@ -1044,10 +1040,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:5,MERC:1,DC:1</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -1055,6 +1047,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vendetta Medium Fighter' unitType='Conventional Fighter'>

--- a/megamek/data/forcegenerator/2490.xml
+++ b/megamek/data/forcegenerator/2490.xml
@@ -206,45 +206,21 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover Primitive)'>
+		<model name='(Tracked Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Wheeled Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:3,IS:2,Periphery:2</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:4,General:6</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -254,7 +230,27 @@
 			<roles>apc</roles>
 			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:4,General:6</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:3-,IS.pm:2,Periphery.Deep:2-,Periphery:2-</availability>
 		</model>
@@ -262,18 +258,22 @@
 			<roles>apc,support</roles>
 			<availability>PIR:4,General:6</availability>
 		</model>
-		<model name='(Wheeled MG)'>
+		<model name='(Wheeled Primitive)'>
 			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Hover Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>TH:6-,LA:4,FS:4,MERC:4,DC:4</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-1E'>
 			<availability>TH:4,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleAxe' unitType='Mek'>
@@ -281,11 +281,11 @@
 		<model name='BKX-7K'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BKX-1X'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='BKX-7NC'>
 			<availability>FS:3</availability>
+		</model>
+		<model name='BKX-1X'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -314,20 +314,16 @@
 			<roles>corvette</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2317)'>
-			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>LA:4</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Caravan Heavy Transport' unitType='Conventional Fighter'>
@@ -369,25 +365,25 @@
 	</chassis>
 	<chassis name='Cobra VTOL Transport' unitType='VTOL'>
 		<availability>TH:4</availability>
-		<model name='(Standard)'>
-			<roles>cargo</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>cargo</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>cargo</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>PoR:2,LA:9</availability>
-		<model name='COM-1A'>
-			<roles>recon</roles>
-			<availability>PoR:8,LA:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1A'>
+			<roles>recon</roles>
+			<availability>PoR:8,LA:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -411,11 +407,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -473,11 +469,11 @@
 	</chassis>
 	<chassis name='DroST IIa Transport' unitType='Dropship'>
 		<availability>TH:4</availability>
-		<model name='(2470)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2445)'>
 			<availability>TH:4</availability>
+		</model>
+		<model name='(2470)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='DroST IIb Transport' unitType='Dropship'>
@@ -505,14 +501,14 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:3,OA:1,LA:3,FWL:8,IS:1,FS:2,DC:2,TC:1</availability>
+		<model name='EGL-R4'>
+			<availability>LA:6,General:6,FS:6</availability>
+		</model>
 		<model name='EGL-R1'>
 			<availability>General:4</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>LA:4,General:6,FS:4</availability>
-		</model>
-		<model name='EGL-R4'>
-			<availability>LA:6,General:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
@@ -523,11 +519,11 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>TH:6</availability>
-		<model name='EMP-1A'>
-			<availability>TH:5,General:8</availability>
-		</model>
 		<model name='EMP-5A'>
 			<availability>General:5</availability>
+		</model>
+		<model name='EMP-1A'>
+			<availability>TH:5,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Essex I Destroyer' unitType='Warship'>
@@ -553,9 +549,6 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2448)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
@@ -578,13 +571,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -601,17 +594,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -619,9 +610,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Frogmen' unitType='Infantry'>
@@ -664,11 +657,11 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:2,TH:8,LA:2,IS:2,DC:2</availability>
-		<model name='GRF-1N'>
-			<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='GRF-1A'>
 			<availability>LA:6,IS:6,Periphery.Deep:8,MERC:6,Periphery:8,TC:8</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -689,11 +682,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:3,TH:7,LA:2,FWL:3,IS:2,FS:3,DC:3</availability>
-		<model name='HMR-HC'>
-			<availability>TH:6,IS:8</availability>
-		</model>
 		<model name='HMR-HA'>
 			<availability>TH:5</availability>
+		</model>
+		<model name='HMR-HC'>
+			<availability>TH:6,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -705,6 +698,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -713,21 +714,9 @@
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -735,6 +724,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -743,6 +736,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -750,14 +751,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -813,13 +806,13 @@
 	</chassis>
 	<chassis name='Intrepid Assault Craft' unitType='Small Craft'>
 		<availability>FS:2</availability>
-		<model name='(2478)'>
-			<roles>assault</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2331)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(2478)'>
+			<roles>assault</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -831,17 +824,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -906,11 +899,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8</availability>
-		<model name='LTN-G14'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:6</availability>
+		</model>
+		<model name='LTN-G14'>
+			<availability>CC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
@@ -935,13 +928,13 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:5</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -953,11 +946,11 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:5-,LA:5-,IS:3-,FWL:3-,Periphery.Deep:4,Periphery:4</availability>
-		<model name='MSK-6S'>
-			<availability>General:4,FWL:4</availability>
-		</model>
 		<model name='MSK-7A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='MSK-6S'>
+			<availability>General:4,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
@@ -973,11 +966,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='II-A'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:3</availability>
 		</model>
 		<model name='II (Primitive)'>
 			<availability>General:2</availability>
@@ -1013,17 +1006,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1031,31 +1024,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -1064,11 +1057,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Merchant Jumpship' unitType='Jumpship'>
@@ -1110,6 +1103,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -1118,12 +1117,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -1146,9 +1139,6 @@
 		<availability>TH:3</availability>
 		<model name='(2447)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2447)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -1178,9 +1168,6 @@
 		<availability>OA:1,RWR:4,TC:2</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -1227,13 +1214,13 @@
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:5</availability>
-		<model name='(Primitive)'>
-			<roles>sr_fire_support</roles>
-			<availability>IS:2,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Primitive)'>
+			<roles>sr_fire_support</roles>
+			<availability>IS:2,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -1244,11 +1231,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>DC:6-</availability>
-		<model name='SB-26'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='SB-27'>
 			<availability>General:4</availability>
+		</model>
+		<model name='SB-26'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -1282,6 +1269,12 @@
 		<availability>TH:6,LA:1,IS:2</availability>
 		<model name='SHD-1R'>
 			<availability>CC:8,IS:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SpecOps Paratrooper' unitType='Infantry'>
@@ -1331,10 +1324,6 @@
 		<model name='(2499)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2499)'>
-			<roles>cargo</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>TH:3</availability>
@@ -1374,10 +1363,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:5,MERC:2,DC:2</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -1385,6 +1370,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vendetta Medium Fighter' unitType='Conventional Fighter'>

--- a/megamek/data/forcegenerator/2520.xml
+++ b/megamek/data/forcegenerator/2520.xml
@@ -178,22 +178,22 @@
 <units>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,FWL:4,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
 		<model name='(Primitive)'>
 			<roles>fire_support</roles>
 			<availability>IS:6,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>TH:4</availability>
-		<model name='Mk I'>
-			<availability>TH:3</availability>
-		</model>
 		<model name='Mk II'>
 			<availability>TH:4</availability>
+		</model>
+		<model name='Mk I'>
+			<availability>TH:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -231,45 +231,21 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Hover Primitive)'>
+		<model name='(Tracked Primitive)'>
 			<roles>apc,support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
-		<model name='(Wheeled Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:2</availability>
 		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked Primitive)'>
-			<roles>apc,support</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -279,26 +255,47 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
+		<model name='(Wheeled Primitive)'>
 			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Hover Primitive)'>
+			<roles>apc,support</roles>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Athena Cruiser' unitType='Warship'>
 		<availability>MOC:1</availability>
 		<model name='(2569)'>
 			<roles>cruiser</roles>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='(2569)'>
 			<availability>MOC:8</availability>
 		</model>
 	</chassis>
@@ -308,9 +305,6 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>TH:4</availability>
@@ -318,17 +312,14 @@
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2531)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>TH:6-,LA:5,FS:5,MERC:5,DC:5</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-1E'>
 			<availability>TH:2,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -337,20 +328,17 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2520)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='BattleAxe' unitType='Mek'>
 		<availability>FS:7</availability>
 		<model name='BKX-7K'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BKX-1X'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='BKX-7NC'>
 			<availability>FS:3</availability>
+		</model>
+		<model name='BKX-1X'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -379,20 +367,16 @@
 			<roles>corvette</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2317)'>
-			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>LA:4</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -445,25 +429,25 @@
 	</chassis>
 	<chassis name='Cobra VTOL Transport' unitType='VTOL'>
 		<availability>TH:2</availability>
-		<model name='(Standard)'>
+		<model name='(Fusion)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Fusion)'>
+		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>LA:9,RWR:3,MERC:3</availability>
-		<model name='COM-1A'>
-			<roles>recon</roles>
-			<availability>LA:6,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1A'>
+			<roles>recon</roles>
+			<availability>LA:6,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -500,11 +484,11 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -530,13 +514,13 @@
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
 		<availability>FS:4</availability>
-		<model name='Block II'>
-			<roles>destroyer</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='Block I'>
 			<roles>destroyer</roles>
 			<availability>FS:6</availability>
+		</model>
+		<model name='Block II'>
+			<roles>destroyer</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Defender Battlecruiser' unitType='Warship'>
@@ -559,11 +543,11 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>LA:4,RWR:2,FS:3</availability>
-		<model name='DV-1S'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='DV-6M'>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='DV-1S'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dreadnought Battleship' unitType='Warship'>
@@ -575,11 +559,11 @@
 	</chassis>
 	<chassis name='DroST IIa Transport' unitType='Dropship'>
 		<availability>TH:2</availability>
-		<model name='(2470)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2445)'>
 			<availability>TH:2</availability>
+		</model>
+		<model name='(2470)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='DroST IIb Transport' unitType='Dropship'>
@@ -614,14 +598,14 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:3,MOC:1,OA:1,LA:3,FWL:8,IS:1,FS:3,DC:3,TC:1</availability>
+		<model name='EGL-R4'>
+			<availability>LA:6,General:5,FS:6</availability>
+		</model>
 		<model name='EGL-R1'>
 			<availability>General:2</availability>
 		</model>
 		<model name='EGL-R6'>
 			<availability>LA:4,General:8,FS:4</availability>
-		</model>
-		<model name='EGL-R4'>
-			<availability>LA:6,General:5,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
@@ -632,11 +616,11 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>TH:6</availability>
-		<model name='EMP-1A'>
-			<availability>TH:4,General:8</availability>
-		</model>
 		<model name='EMP-5A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='EMP-1A'>
+			<availability>TH:4,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -667,9 +651,6 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2448)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>IS:3,Periphery:3</availability>
@@ -692,13 +673,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -712,15 +693,15 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:6,IS:5,Periphery:3</availability>
-		<model name='FS9-A'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>LA:6,RWR:6</availability>
-		</model>
 		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:4</availability>
+		</model>
+		<model name='FS9-A'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>LA:6,RWR:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -728,26 +709,24 @@
 		<model name='FLE-4'>
 			<availability>FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:4-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -755,9 +734,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Frogmen' unitType='Infantry'>
@@ -807,11 +788,11 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:4,TH:8,LA:4,IS:4,DC:3</availability>
-		<model name='GRF-1N'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='GRF-1A'>
 			<availability>LA:4,IS:4,Periphery.Deep:8,MERC:4,Periphery:8,TC:8</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -832,11 +813,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:3,TH:7,LA:2,FWL:3,IS:2,FS:3,DC:3</availability>
-		<model name='HMR-HC'>
-			<availability>TH:6,IS:8</availability>
-		</model>
 		<model name='HMR-HA'>
 			<availability>TH:4</availability>
+		</model>
+		<model name='HMR-HC'>
+			<availability>TH:6,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -848,6 +829,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -856,21 +845,9 @@
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -878,6 +855,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -886,6 +867,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -893,14 +882,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -950,13 +931,13 @@
 	</chassis>
 	<chassis name='Intrepid Assault Craft' unitType='Small Craft'>
 		<availability>FS:1</availability>
-		<model name='(2478)'>
-			<roles>assault</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2331)'>
 			<roles>assault</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(2478)'>
+			<roles>assault</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jabberwocky EngineerMech' unitType='Mek'>
@@ -975,17 +956,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1060,11 +1041,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8</availability>
-		<model name='LTN-G14'>
-			<availability>CC:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LTN-G14'>
+			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
@@ -1087,12 +1068,12 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>FWL:9</availability>
+		<model name='LGB-0C'>
+			<availability>FWL:6</availability>
+		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='LGB-0C'>
-			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
@@ -1103,13 +1084,13 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -1121,11 +1102,11 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:4-,LA:4-,IS:3-,FWL:3-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='MSK-6S'>
-			<availability>General:3,FWL:3</availability>
-		</model>
 		<model name='MSK-7A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='MSK-6S'>
+			<availability>General:3,FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
@@ -1141,11 +1122,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 		<model name='II (Primitive)'>
 			<availability>General:1</availability>
@@ -1181,17 +1162,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1199,31 +1180,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -1232,11 +1213,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Merchant Jumpship' unitType='Jumpship'>
@@ -1275,6 +1256,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -1283,12 +1270,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -1318,9 +1299,6 @@
 		<availability>TH:3</availability>
 		<model name='(2447)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2447)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -1393,9 +1371,6 @@
 			<roles>corvette</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2502)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
 		<availability>PIR:4</availability>
@@ -1426,13 +1401,13 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:2,TH:6,IS:2,FWL:2,FS:2</availability>
-		<model name='RFL-1N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,MOC:8,IS:6,FWL:6,Periphery.Deep:8,FS:6,MERC:6,Periphery:8</availability>
-		</model>
 		<model name='RFL-2N'>
 			<roles>fire_support</roles>
 			<availability>IS:6,Periphery:4</availability>
+		</model>
+		<model name='RFL-1N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:8,IS:6,FWL:6,Periphery.Deep:8,FS:6,MERC:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Riga Frigate' unitType='Warship'>
@@ -1451,13 +1426,13 @@
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:5</availability>
-		<model name='(Primitive)'>
-			<roles>sr_fire_support</roles>
-			<availability>IS:1,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Primitive)'>
+			<roles>sr_fire_support</roles>
+			<availability>IS:1,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -1468,11 +1443,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:3-,MOC:5-,OA:5-,LA:5-,FWL:5-,IS:5-,Periphery.Deep:5-,FS:5-,MERC:5-,DC:6-,Periphery:5-</availability>
-		<model name='SB-26'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='SB-27'>
 			<availability>General:6</availability>
+		</model>
+		<model name='SB-26'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -1504,11 +1479,17 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>TH:7,LA:2,IS:3</availability>
+		<model name='SHD-1R'>
+			<availability>CC:6,MOC:8,IS:6,FWL:6,Periphery.Deep:8,MERC:6,Periphery:8</availability>
+		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='SHD-1R'>
-			<availability>CC:6,MOC:8,IS:6,FWL:6,Periphery.Deep:8,MERC:6,Periphery:8</availability>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
@@ -1565,10 +1546,6 @@
 		<model name='(2499)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2499)'>
-			<roles>cargo</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>TH:5</availability>
@@ -1619,10 +1596,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:5,MERC:2,DC:2</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -1630,6 +1603,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vendetta Medium Fighter' unitType='Conventional Fighter'>

--- a/megamek/data/forcegenerator/2571.xml
+++ b/megamek/data/forcegenerator/2571.xml
@@ -236,13 +236,13 @@
 <units>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:5,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Primitive)'>
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -254,31 +254,31 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CC:3,LA:2,SL:4,FWL:3,FS:3,DC:3</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(2372)'>
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:8</availability>
 		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>TH:5,SL:6</availability>
-		<model name='Mk III'>
-			<availability>General:2</availability>
+		<model name='Mk II'>
+			<availability>TH:2</availability>
 		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
-		<model name='Mk IV'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Mk I'>
 			<availability>TH:1</availability>
 		</model>
-		<model name='Mk II'>
-			<availability>TH:2</availability>
+		<model name='Mk IV'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Mk III'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -317,37 +317,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -357,26 +337,43 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Athena Cruiser' unitType='Warship'>
 		<availability>MOC:1</availability>
 		<model name='(2569)'>
 			<roles>cruiser</roles>
-			<availability>MOC:8</availability>
-		</model>
-		<model name='(2569)'>
 			<availability>MOC:8</availability>
 		</model>
 	</chassis>
@@ -386,9 +383,6 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>TH:4,SL:4</availability>
@@ -396,29 +390,23 @@
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2531)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:5-,OA:5-,TH:6,LA:7-,Periphery.Deep:4-,RWR:5-,FS:7-,MERC:7-,Periphery:4-,TC:5-,DC:7-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-1E'>
 			<availability>TH:2,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='BNC-3M'>
 			<availability>FWL:3</availability>
 		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
 		<availability>TH:4,SL:6</availability>
 		<model name='(2520)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2520)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -469,20 +457,16 @@
 			<roles>corvette</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2317)'>
-			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:4,SL:2,FWL:2,RWR:2,FS:2,MERC:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -514,10 +498,6 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Carter Medical Emergency Response Vehicle' unitType='Tank'>
 		<availability>IS:1</availability>
@@ -528,21 +508,21 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>TH:5,SL:7</availability>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:8,MERC:8,Periphery:8</availability>
-		</model>
-		<model name='CPLT-A1'>
-			<roles>fire_support</roles>
-			<availability>CC:4,SL:4,FWL:4,SL.R:4</availability>
-		</model>
 		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:8,MERC:8,Periphery:8</availability>
+		</model>
 		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,OA:4</availability>
+		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:4,SL:4,FWL:4,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -603,22 +583,18 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,LA:4,SL:5,FWL:4,SL.R:4,FS:6,DC:4</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:2,SL:2,FS:2</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>TH:6,SL:6</availability>
-		<model name='(Command)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Original)'>
 			<availability>General:6</availability>
 		</model>
@@ -626,17 +602,21 @@
 			<roles>cargo</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Command)'>
+			<roles>support</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>LA:9,RWR:3,MERC:5</availability>
-		<model name='COM-1A'>
-			<roles>recon</roles>
-			<availability>LA:4-,Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1A'>
+			<roles>recon</roles>
+			<availability>LA:4-,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -687,26 +667,26 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -745,13 +725,13 @@
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
 		<availability>SL:2,FS:6</availability>
-		<model name='Block II'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='Block I'>
 			<roles>destroyer</roles>
 			<availability>SL:8,FS:4</availability>
+		</model>
+		<model name='Block II'>
+			<roles>destroyer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Defender Battlecruiser' unitType='Warship'>
@@ -780,13 +760,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>SL:6</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dreadnought Battleship' unitType='Warship'>
@@ -831,14 +811,14 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:2,OA:1,LA:4,SL:5,FWL:8,IS:2,FS:4,DC:4,TC:2</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:6,General:3,FS:6</availability>
 		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:4,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
@@ -849,14 +829,14 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>TH:6,SL:6</availability>
-		<model name='EMP-1A'>
-			<availability>TH:3,General:6,SL:2</availability>
-		</model>
 		<model name='EMP-5A'>
 			<availability>General:8,SL:8,SL.R:8</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>SL:4+,SL.R:5</availability>
+		</model>
+		<model name='EMP-1A'>
+			<availability>TH:3,General:6,SL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -883,13 +863,13 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>SL:4+</availability>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>SL:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>LA:0,General:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>SL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
@@ -911,9 +891,6 @@
 		<availability>TH:4,SL:4</availability>
 		<model name='(2448)'>
 			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2448)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -938,13 +915,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -958,34 +935,34 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:8,SL:4,IS:7,Periphery.Deep:5,Periphery:5</availability>
-		<model name='FS9-A'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>LA:6,SL:6,RWR:6</availability>
-		</model>
 		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:4</availability>
 		</model>
+		<model name='FS9-A'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>LA:6,SL:6,RWR:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
@@ -997,26 +974,24 @@
 		<model name='FLE-4'>
 			<availability>FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:4-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>SL:10,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1024,9 +999,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1106,11 +1083,11 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:5,MOC:3,OA:3,TH:8,LA:5,SL:7,IS:5,RWR:2,MERC:3,TC:3,DC:4</availability>
-		<model name='GRF-1N'>
-			<availability>General:8,SL:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
-		</model>
 		<model name='GRF-1A'>
 			<availability>LA:2,IS:2,Periphery.Deep:6,MERC:2,Periphery:6,TC:6</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>General:8,SL:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1131,11 +1108,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:4,MOC:1,OA:1,TH:7,LA:3,SL:7,FWL:4,IS:3,FS:4,DC:4,TC:1</availability>
-		<model name='HMR-HD'>
-			<availability>General:4,SL.R:4</availability>
-		</model>
 		<model name='HMR-HC'>
 			<availability>TH:6,SL:5,IS:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:4,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1147,6 +1124,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -1155,21 +1140,9 @@
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1177,6 +1150,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -1185,6 +1162,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1192,14 +1177,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -1288,10 +1265,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:6,LA:6,SL:7,FWL:6,IS:4,FS:6</availability>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -1321,17 +1298,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>SL:8,IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1377,11 +1354,11 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:7+</availability>
-		<model name='KSC-3I'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='KSC-3L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='KSC-3I'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -1420,13 +1397,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CC:2,LA:2,SL:5,IS:2,MERC:2,DC:2</availability>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>SL:8,IS:8,DC:8</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>SL:8,IS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -1465,11 +1442,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,SL:5</availability>
-		<model name='LTN-G14'>
-			<availability>CC:2,Periphery.Deep:4,Periphery:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LTN-G14'>
+			<availability>CC:2,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -1503,12 +1480,12 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:3,CC:4,IS:4,RWR:3,FS:5,Periphery:2,TC:3,OA:3,LA:6,SL:5,FWL:9,SL.R:4,DC:4</availability>
+		<model name='LGB-0C'>
+			<availability>FWL:4-,IS:4-,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='LGB-0C'>
-			<availability>FWL:4-,IS:4-,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
@@ -1526,13 +1503,13 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -1544,17 +1521,17 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:4-,LA:2-,SL:2-,IS:2-,FWL:2-,Periphery.Deep:5,SL.R:0,TH.HM:4-,Periphery:5</availability>
+		<model name='MSK-7A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='MSK-6S'>
 			<availability>General:2,FWL:2</availability>
 		</model>
-		<model name='MSK-7A'>
+		<model name='MSK-9H'>
 			<availability>General:6</availability>
 		</model>
 		<model name='MSK-8B'>
 			<availability>General:4</availability>
-		</model>
-		<model name='MSK-9H'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Manatee' unitType='Dropship'>
@@ -1576,11 +1553,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:4,LA:5,Periphery.MW:4,Periphery.HR:3,Periphery.CM:3,IS:4,Periphery:3</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -1620,17 +1597,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1638,31 +1615,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -1671,11 +1648,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Merchant Jumpship' unitType='Jumpship'>
@@ -1699,13 +1676,13 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>SL:4,IS:2,MERC:2,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -1728,10 +1705,6 @@
 	</chassis>
 	<chassis name='Monsoon Battleship' unitType='Warship'>
 		<availability>TH:4,SL:4</availability>
-		<model name='(2574)'>
-			<roles>battleship</roles>
-			<availability>SL:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
 		<availability>SL:3</availability>
@@ -1753,6 +1726,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>SL:9,IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -1761,12 +1740,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -1782,9 +1755,6 @@
 		<availability>SL:5</availability>
 		<model name='(2645)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2645)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -1821,9 +1791,6 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2447)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>CC:3,MOC:1,OA:1,TH:5,LA:4,SL:6,FWL:3,IS:3,RWR:1,FS:3,DC:3,TC:1</availability>
@@ -1840,22 +1807,22 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>SL:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,SL.R:4</availability>
 		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>SL.R:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>SL.R:2</availability>
-		<model name='OWR-2Mb'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='OWR-2M'>
 			<availability>General:8,SL:0</availability>
+		</model>
+		<model name='OWR-2Mb'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -1894,21 +1861,21 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>TH:4,SL:6,IS:4,FWL:4,Periphery:3</availability>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,SL:4,Periphery:8</availability>
-		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>SL:8,SL.R:8</availability>
 		</model>
+		<model name='PXH-1D'>
+			<roles>recon</roles>
+			<availability>FS:6</availability>
+		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,SL:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -1933,9 +1900,6 @@
 		<availability>MOC:7,OA:6,RWR:7,TC:7</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -1973,13 +1937,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
@@ -2007,13 +1971,13 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:5,TH:6,SL:7,IS:5,FWL:5,SL.R:7,FS:5,Periphery:3</availability>
-		<model name='RFL-1N'>
-			<roles>fire_support</roles>
-			<availability>CC:4,MOC:6,IS:4,FWL:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6</availability>
-		</model>
 		<model name='RFL-2N'>
 			<roles>fire_support</roles>
 			<availability>IS:8,Periphery:5</availability>
+		</model>
+		<model name='RFL-1N'>
+			<roles>fire_support</roles>
+			<availability>CC:4,MOC:6,IS:4,FWL:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Riga Frigate' unitType='Warship'>
@@ -2032,22 +1996,22 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>SL:4</availability>
-		<model name='RGU-133F'>
-			<availability>General:6,SL.R:6</availability>
-		</model>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:8</availability>
+		</model>
+		<model name='RGU-133F'>
+			<availability>General:6,SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:6</availability>
-		<model name='(Primitive)'>
-			<roles>sr_fire_support</roles>
-			<availability>Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Primitive)'>
+			<roles>sr_fire_support</roles>
+			<availability>Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -2058,11 +2022,11 @@
 	</chassis>
 	<chassis name='Sabre' unitType='Aero'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
-		<model name='SB-26'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='SB-27'>
 			<availability>General:8,SL:8,SL.R:8</availability>
+		</model>
+		<model name='SB-26'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Samarkand Carrier' unitType='Warship'>
@@ -2107,17 +2071,23 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>TH:7,LA:4,SL:7,IS:5,Periphery:2</availability>
-		<model name='SHD-2H'>
-			<availability>General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
-		</model>
 		<model name='SHD-1R'>
 			<availability>CC:4,MOC:6,IS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:6</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shootist' unitType='Mek'>
 		<availability>SL:3,SL.R:5</availability>
 		<model name='ST-8A'>
 			<availability>General:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
@@ -2142,11 +2112,11 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:4,MOC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery:4,TC:4,OA:4,LA:4,SL:8,FWL:4,DC:4</availability>
-		<model name='STK-3H'>
-			<availability>MOC:1,OA:1,IS:1,TC:1</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,SL.R:3,Periphery:8</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:1,OA:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Dagger' unitType='Aero'>
@@ -2222,10 +2192,6 @@
 	<chassis name='Sylvester Transport' unitType='Warship'>
 		<availability>LA:2</availability>
 		<model name='(2499)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2499)'>
-			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2317,10 +2283,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:5,MERC:1,DC:1</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -2328,6 +2290,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vendetta Medium Fighter' unitType='Conventional Fighter'>
@@ -2388,10 +2354,6 @@
 	<chassis name='Wagon Wheel Frigate' unitType='Warship'>
 		<availability>TC:4</availability>
 		<model name='(2570)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
 			<availability>General:8</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/2650.xml
+++ b/megamek/data/forcegenerator/2650.xml
@@ -238,13 +238,13 @@
 <units>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='(Primitive)'>
 			<roles>fire_support</roles>
 			<availability>Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -256,19 +256,19 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CC:4,LA:3,SL:5,FWL:4,FS:5,DC:4</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CC:2,General:6</availability>
-		</model>
 		<model name='(2372)'>
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:6</availability>
 		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CC:2,General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:3+,MOC:2+,OA:2+,TH:5,LA:3+,SL:7,FWL:3+,RWR:2+,FS:3+,MERC:3+,DC:3+,TC:2+</availability>
-		<model name='Mk III'>
-			<availability>General:2</availability>
+		<model name='Mk II'>
+			<availability>TH:1</availability>
 		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
@@ -276,8 +276,8 @@
 		<model name='Mk IV'>
 			<availability>General:2</availability>
 		</model>
-		<model name='Mk II'>
-			<availability>TH:1</availability>
+		<model name='Mk III'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -316,37 +316,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -356,17 +336,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -381,9 +381,6 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atreus Battleship' unitType='Warship'>
 		<availability>FWL:8</availability>
@@ -391,17 +388,11 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>SL:3</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -416,23 +407,20 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:7-,OA:7-,TH:6,LA:7-,Periphery.Deep:6-,RWR:7-,FS:7-,MERC:7-,Periphery:6-,TC:7-,DC:7-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-1E'>
 			<availability>TH:2,Periphery:2</availability>
 		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:3,FWL:4</availability>
 		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
 		<availability>SL:6</availability>
 		<model name='(2520)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2520)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -490,20 +478,16 @@
 			<roles>corvette</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2317)'>
-			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:4,SL:2,FWL:2,RWR:2,FS:2,MERC:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -541,10 +525,6 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Carter Medical Emergency Response Vehicle' unitType='Tank'>
 		<availability>IS:1</availability>
@@ -555,25 +535,25 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:4,MOC:2,IS:2,RWR:2,FS:2,MERC:2,TC:2,Periphery:2,TH:6,LA:2,SL:7,FWL:2,DC:2</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:6,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,SL:4,FWL:4,SL.R:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,SL:4,FWL:4,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -600,12 +580,12 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:4,LA:4,SL:7,FWL:3,IS:3,FS:3,MERC:2,DC:3</availability>
+		<model name='CHP-1N2'>
+			<availability>CC:4+,LA:4+,SL.R:4</availability>
+		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:8+,SL:8,SL.R:8</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4+,LA:4+,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -644,32 +624,32 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:7,LA:5,SL:4,FWL:5,IS:3,SL.R:4,FS:7,MERC:3,DC:5</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>TH:5,SL:7</availability>
-		<model name='(Command)'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Original)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(MASH)'>
+			<roles>support</roles>
+			<availability>SL:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>SL:2</availability>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
@@ -681,14 +661,14 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>LA:9,RWR:3,MERC:5</availability>
-		<model name='COM-1A'>
-			<roles>recon</roles>
-			<availability>LA:2-,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1A'>
+			<roles>recon</roles>
+			<availability>LA:2-,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -739,26 +719,26 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -828,13 +808,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>SL:6</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -853,9 +833,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:3,OA:2,LA:4,SL:5,FWL:8,IS:3,RWR:2,FS:4,DC:4,Periphery:2,TC:3</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:6,General:2,FS:6</availability>
 		</model>
@@ -866,6 +843,9 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,FS:4</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:1-</availability>
@@ -875,14 +855,14 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:3,MOC:3,OA:3,TH:5,SL:7,FWL:3,RWR:3,FS:3,MERC:3,TC:3</availability>
-		<model name='EMP-1A'>
-			<availability>TH:3,General:4</availability>
-		</model>
 		<model name='EMP-5A'>
 			<availability>General:8,SL:6,SL.R:6</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>SL:6+,SL.R:6</availability>
+		</model>
+		<model name='EMP-1A'>
+			<availability>TH:3,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -909,13 +889,13 @@
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>SL:5+,FS:2+,DC:2+</availability>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>SL:4</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>LA:0,General:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>SL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
@@ -937,9 +917,6 @@
 		<availability>SL:2</availability>
 		<model name='(2448)'>
 			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2448)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -964,13 +941,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -991,34 +968,34 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:8,SL:4,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-A'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>LA:6,SL:6,RWR:6</availability>
-		</model>
 		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:4</availability>
 		</model>
+		<model name='FS9-A'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>LA:6,SL:6,RWR:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
@@ -1030,26 +1007,24 @@
 		<model name='FLE-4'>
 			<availability>FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:3-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>SL:10,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1057,9 +1032,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1141,11 +1118,11 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:3,MOC:2,OA:2,LA:2,SL:8,IS:2,FWL:8,RWR:2,FS:2,MERC:2,TC:2,DC:2</availability>
-		<model name='GTHA-300'>
-			<availability>SL:6,FWL:6,SL.R:6</availability>
-		</model>
 		<model name='GTHA-500'>
 			<availability>SL:8,FWL:6,Periphery.Deep:6,SL.R:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='GTHA-300'>
+			<availability>SL:6,FWL:6,SL.R:6</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:6</availability>
@@ -1153,11 +1130,11 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:5,OA:4,TH:8,LA:7,SL:7,IS:7,RWR:4,MERC:4,DC:6,TC:5</availability>
-		<model name='GRF-1N'>
-			<availability>General:8,SL:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
-		</model>
 		<model name='GRF-1A'>
 			<availability>Periphery.Deep:5,Periphery:5,TC:5</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>General:8,SL:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1178,14 +1155,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:4,MOC:3,OA:3,TH:6,LA:4,SL:7,FWL:4,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
-		<model name='HMR-HD'>
-			<availability>General:6,SL.R:6</availability>
+		<model name='HMR-HC'>
+			<availability>TH:5,SL:4,IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>General:6,SL.R:6</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>TH:5,SL:4,IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:6,SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1197,6 +1174,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -1204,14 +1189,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
@@ -1222,10 +1199,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1233,6 +1206,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -1241,6 +1218,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1248,14 +1233,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -1294,11 +1271,11 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:4,MOC:4,OA:4,LA:4,SL:5,FWL:4,RWR:4,FS:4,DC:4,TC:3</availability>
-		<model name='HOP-4C'>
-			<availability>MOC:8,OA:8,SL:8,FS:8</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>CC:2,SL:2</availability>
+		</model>
+		<model name='HOP-4C'>
+			<availability>MOC:8,OA:8,SL:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -1348,10 +1325,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:7,MOC:6,IS:6,Periphery.Deep:5,RWR:6,FS:7,Periphery:5,TC:6,OA:6,LA:7,PIR:2,SL:8,FWL:7</availability>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -1389,17 +1366,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>SL:8,IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1451,11 +1428,11 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:6</availability>
-		<model name='KSC-3I'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='KSC-3L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='KSC-3I'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -1494,13 +1471,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CC:4,MOC:2,OA:2,LA:4,SL:6,IS:4,RWR:2,MERC:4,DC:4,TC:2</availability>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>SL:8,IS:8,DC:8</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>SL:8,IS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -1532,12 +1509,12 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
+		<model name='Owl'>
+			<availability>LA:3</availability>
+		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:3,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:1,Periphery:4</availability>
-		</model>
-		<model name='Owl'>
-			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
@@ -1548,11 +1525,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:2,FS:3,DC:3,Periphery:2,TC:2</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery.Deep:4,Periphery:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LTN-G14'>
+			<availability>Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -1593,12 +1570,12 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:5,CC:5,IS:6,RWR:5,FS:6,Periphery:3,TC:5,OA:6,LA:7,SL:5,FWL:9,SL.R:4,DC:6</availability>
+		<model name='LGB-0C'>
+			<availability>FWL:2-,IS:2-,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='LGB-0C'>
-			<availability>FWL:2-,IS:2-,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
@@ -1616,13 +1593,13 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -1641,17 +1618,17 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>TH:3-,LA:1-,IS:1-,FWL:1-,Periphery.Deep:4,SL.R:0,TH.HM:4-,Periphery:4</availability>
-		<model name='MSK-6S'>
-			<availability>General:1,FWL:1</availability>
-		</model>
 		<model name='MSK-7A'>
 			<availability>General:4</availability>
 		</model>
-		<model name='MSK-8B'>
-			<availability>General:6</availability>
+		<model name='MSK-6S'>
+			<availability>General:1,FWL:1</availability>
 		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MSK-8B'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mako Corvette' unitType='Warship'>
@@ -1692,11 +1669,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:4,LA:4,Periphery.MW:4,Periphery.HR:3,Periphery.CM:3,IS:4,Periphery:3</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -1750,17 +1727,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1768,31 +1745,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -1801,11 +1778,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Merchant Jumpship' unitType='Jumpship'>
@@ -1829,13 +1806,13 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>SL:4,IS:2,MERC:2,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -1865,10 +1842,6 @@
 	</chassis>
 	<chassis name='Monsoon Battleship' unitType='Warship'>
 		<availability>SL:2</availability>
-		<model name='(2574)'>
-			<roles>battleship</roles>
-			<availability>SL:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
 		<availability>SL:4</availability>
@@ -1890,6 +1863,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>SL:9,IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -1898,12 +1877,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -1919,9 +1892,6 @@
 		<availability>SL:5</availability>
 		<model name='(2645)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2645)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -1958,9 +1928,6 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2447)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>CC:5,MOC:3,IS:5,RWR:4,FS:5,Periphery:3,TC:3,OA:3,TH:5,LA:5,Periphery.MW:3,SL:8,Periphery.ME:3,FWL:5,DC:5</availability>
@@ -1977,22 +1944,22 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:3,LA:3,SL:5,FWL:3,IS:3,FS:3,MERC:3,DC:3</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,SL.R:4</availability>
 		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>SL.R:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>SL.R:2</availability>
-		<model name='OWR-2Mb'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='OWR-2M'>
 			<availability>General:8,SL:0</availability>
+		</model>
+		<model name='OWR-2Mb'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -2042,21 +2009,21 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>TH:5,SL:6,FWL:5,IS:5,Periphery.Deep:4,Periphery:4</availability>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,SL:4,Periphery:8</availability>
-		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>SL:8,SL.R:8</availability>
 		</model>
+		<model name='PXH-1D'>
+			<roles>recon</roles>
+			<availability>FS:6</availability>
+		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,SL:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -2081,9 +2048,6 @@
 		<availability>MOC:7,OA:6,RWR:7,TC:7</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2121,13 +2085,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -2154,24 +2118,24 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:6,OA:6,LA:6,SL:7,Periphery.Deep:5,IS:6,RWR:6,FS:6,MERC:5,Periphery:5,TC:6,DC:6</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,TH:6,SL:7,IS:6,FWL:6,Periphery.Deep:4,SL.R:6,FS:6,Periphery:4</availability>
-		<model name='RFL-1N'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:5,IS:2,FWL:2,Periphery.Deep:5,FS:2,MERC:2,Periphery:5</availability>
-		</model>
 		<model name='RFL-2N'>
 			<roles>fire_support</roles>
 			<availability>IS:8,Periphery:6</availability>
+		</model>
+		<model name='RFL-1N'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:5,IS:2,FWL:2,Periphery.Deep:5,FS:2,MERC:2,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Riga Frigate' unitType='Warship'>
@@ -2201,25 +2165,25 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:4,MOC:2,OA:2,LA:4,SL:5,FWL:4,IS:3,RWR:2,FS:3,DC:3,TC:2</availability>
+		<model name='RGU-133E'>
+			<availability>General:8,SL.R:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>General:3,SL.R:3</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>General:6,SL.R:6</availability>
 		</model>
-		<model name='RGU-133E'>
-			<availability>General:8,SL.R:8</availability>
-		</model>
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:8,SL.R:7</availability>
-		<model name='(Primitive)'>
-			<roles>sr_fire_support</roles>
-			<availability>Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Primitive)'>
+			<roles>sr_fire_support</roles>
+			<availability>Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -2295,17 +2259,23 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>TH:7,LA:6,SL:7,IS:7,Periphery:3</availability>
-		<model name='SHD-2H'>
-			<availability>General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
-		</model>
 		<model name='SHD-1R'>
 			<availability>CC:2,MOC:5,IS:2,FWL:2,Periphery.Deep:5,MERC:2,Periphery:5</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shootist' unitType='Mek'>
 		<availability>SL:4,SL.R:5</availability>
 		<model name='ST-8A'>
 			<availability>General:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
@@ -2349,11 +2319,11 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:5,MOC:6,IS:5,Periphery.Deep:6,RWR:6,FS:5,Periphery:6,TC:6,OA:6,LA:5,SL:10,FWL:6,DC:5</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,SL.R:3,Periphery:8</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Dagger' unitType='Aero'>
@@ -2424,10 +2394,6 @@
 	<chassis name='Sylvester Transport' unitType='Warship'>
 		<availability>LA:1</availability>
 		<model name='(2499)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2499)'>
-			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2504,16 +2470,16 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>SL:8</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>SL:4,IS:4</availability>
 		</model>
 		<model name='THK-33'>
 			<availability>General:3</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
@@ -2553,10 +2519,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:5</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -2564,6 +2526,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
@@ -2614,20 +2580,20 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:5,LA:6,SL:8,IS:5,FWL:6,MERC:5,FS:6,DC:6</availability>
-		<model name='(Star League)'>
-			<availability>SL:5</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>SL:6,IS:8</availability>
+		</model>
+		<model name='(Star League)'>
+			<availability>SL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>RWR:6</availability>
-		<model name='VLC-5N'>
-			<availability>General:8</availability>
-		</model>
 		<model name='VLC-3N'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VLC-5N'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -2646,10 +2612,6 @@
 		<model name='(2570)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>TH:6,LA:8,SL:8,FWL:8,IS:8,RWR:2,TC:2,Periphery:2</availability>
@@ -2662,11 +2624,11 @@
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>SL:4</availability>
-		<model name='WSP-100'>
-			<availability>SL:5</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>SL:4</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>SL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
@@ -2711,13 +2673,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,SL:5,DC:4</availability>
-		<model name='WVE-5Nb'>
-			<roles>urban</roles>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
+		</model>
+		<model name='WVE-5Nb'>
+			<roles>urban</roles>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='XCT Marine' unitType='Infantry'>

--- a/megamek/data/forcegenerator/2700.xml
+++ b/megamek/data/forcegenerator/2700.xml
@@ -264,13 +264,13 @@
 <units>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='(Primitive)'>
 			<roles>fire_support</roles>
 			<availability>Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -282,13 +282,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CC:5,LA:3,SL:5,FWL:4,FS:5,DC:4</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CC:2,General:8</availability>
-		</model>
 		<model name='(2372)'>
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:4</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CC:2,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -302,13 +302,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:4+,MOC:3+,OA:3+,TH:4,LA:4+,SL:7,FWL:4+,RWR:3+,FS:4+,MERC:4+,DC:4+,TC:3+</availability>
-		<model name='Mk III'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -335,13 +335,13 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,TH:7,LA:9,SL:5,IS:5,FWL:9,Periphery.Deep:4,RWR:5,FS:8,Periphery:4,DC:8</availability>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>LA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:6,DC:8,Periphery:8</availability>
-		</model>
 		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
 			<availability>SL.R:6</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>LA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:6,DC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -352,37 +352,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -392,17 +372,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -417,9 +417,6 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atreus Battleship' unitType='Warship'>
 		<availability>FWL:8</availability>
@@ -427,17 +424,11 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>SL:2</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -452,23 +443,20 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,OA:10-,TH:5,LA:7-,Periphery.Deep:8-,RWR:10-,FS:7-,MERC:7-,TC:10-,Periphery:8-,DC:7-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-1E'>
 			<availability>TH:1,Periphery:1</availability>
 		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:4,FWL:4</availability>
 		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
 		<availability>CC:3,LA:3,SL:4,FWL:4,FS:3,DC:4</availability>
 		<model name='(2520)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2520)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -483,17 +471,17 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,LA:5,PIR:4,SL:7,FWL:5,IS:5,RWR:4,FS:5,DC:5,TC:4</availability>
+		<model name='BLR-1Gc'>
+			<availability>SL:4</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>SL.R:6</availability>
+		</model>
 		<model name='BLR-1Gbc'>
 			<availability>SL:2</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:6,FS:8,Periphery:8</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>SL.R:6</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>SL:4</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:3+</availability>
@@ -522,11 +510,11 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>SL:8,FWL:4,FWL.OH:4,RWR:3,FS:4</availability>
-		<model name='BL-6-KNT'>
-			<availability>SL:8,FWL:8+,RWR:4+,FS:8+</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>SL.R:4</availability>
+		</model>
+		<model name='BL-6-KNT'>
+			<availability>SL:8,FWL:8+,RWR:4+,FS:8+</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -561,10 +549,6 @@
 			<roles>corvette</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2317)'>
-			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:5,MERC:4,Periphery:5</availability>
@@ -575,13 +559,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:4,SL:2,FWL:2,RWR:2,FS:2,MERC:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -619,32 +603,28 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:4,MOC:2,IS:4,RWR:3,FS:4,MERC:3,TC:2,Periphery:2,TH:6,LA:4,SL:6,FWL:4,DC:4</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,SL:4,FWL:4,SL.R:2,RWR:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>SL.R:8,DC:2+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,SL:4,FWL:4,SL.R:2,RWR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -671,15 +651,15 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:6,LA:6,SL:7,FWL:5,IS:5,RWR:3,FS:5,MERC:4,DC:5</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:8+,SL:8,SL.R:8,RWR:6</availability>
-		</model>
 		<model name='CHP-1Nb'>
 			<availability>SL.R:4</availability>
 		</model>
 		<model name='CHP-1N2'>
 			<availability>CC:4+,LA:4+,SL.R:2</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:8+,SL:8,SL.R:8,RWR:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -712,64 +692,64 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>CC:4,MOC:3,OA:3,LA:4,SL:7,FWL:4,RWR:3,FS:4,MERC:4,DC:4,Periphery:2,TC:3</availability>
-		<model name='CHP-W7'>
-			<availability>SL:5</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,SL:6,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,SL:6,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>SL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:7,MOC:2,OA:2,LA:5,SL:4,IS:4,FWL:5,RWR:3,FS:7,MERC:4,DC:5</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,RWR:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>TH:4,SL:8</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>SL:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>SL:2</availability>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
 		<availability>SL:2</availability>
-		<model name='Mk I'>
-			<roles>artillery,missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery,missile_artillery,assault,troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Mk I'>
+			<roles>artillery,missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>LA:9,RWR:4,MERC:5</availability>
-		<model name='COM-1A'>
-			<roles>recon</roles>
-			<availability>Periphery.Deep:4-,Periphery:4-</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1A'>
+			<roles>recon</roles>
+			<availability>Periphery.Deep:4-,Periphery:4-</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -799,13 +779,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:5,MOC:3,OA:3,LA:4,SL:7,FWL:4,IS:5,RWR:3,FS:5,DC:4,TC:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -824,17 +804,17 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -853,20 +833,20 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:2,LA:2,SL:7,FWL:2,FS:2,DC:2</availability>
-		<model name='CRK-5003-1'>
-			<availability>General:8+,SL.R:7</availability>
-		</model>
 		<model name='CRK-5003-1b'>
 			<availability>SL.R:6</availability>
+		</model>
+		<model name='CRK-5003-1'>
+			<availability>General:8+,SL.R:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:2</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -878,15 +858,15 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>SL.R:7</availability>
-		<model name='CRD-2R'>
-			<availability>SL.R:8</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:7</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,Periphery.Deep:8,SL.R:7,Periphery:8</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:7</availability>
+		<model name='CRD-2R'>
+			<availability>SL.R:8</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:4</availability>
@@ -903,16 +883,16 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:6,MOC:6,OA:6,LA:6,SL:7,FWL:6,IS:4,RWR:6,FS:6,DC:6,TC:6,Periphery:2</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>SL.R:4</availability>
-		</model>
 		<model name='(Fury)'>
 			<availability>SL:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Czar Dropship' unitType='Dropship'>
@@ -969,14 +949,14 @@
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
 		<availability>SL:8</availability>
+		<model name='(Horned Demon)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:4</availability>
-		</model>
-		<model name='(Horned Demon)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:3</availability>
@@ -993,13 +973,13 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>SL:5,IS:4</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
@@ -1024,9 +1004,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:4,OA:3,LA:4,SL:4,IS:4,FWL:8,RWR:3,FS:4,Periphery:3,TC:4,DC:4</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:6,General:1,FS:6</availability>
 		</model>
@@ -1037,17 +1014,20 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,FS:4</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,OA:4,TH:5,SL:7,FWL:5,RWR:4,FS:5,MERC:5,TC:4</availability>
-		<model name='EMP-1A'>
-			<availability>TH:2</availability>
-		</model>
 		<model name='EMP-5A'>
 			<availability>General:8,SL:5,SL.R:4</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>SL:8+,SL.R:8</availability>
+		</model>
+		<model name='EMP-1A'>
+			<availability>TH:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -1085,13 +1065,13 @@
 			<roles>fire_support</roles>
 			<availability>SL.R:4</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>SL:3</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>LA:0,General:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>SL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1103,11 +1083,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>SL:8</availability>
-		<model name='EXT-4Db'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>General:8+,SL.R:6</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>SL.R:6</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>SL:1+,SL.R:2</availability>
@@ -1125,9 +1105,6 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2448)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
 		<availability>SL:3,IS:3,Periphery:3</availability>
@@ -1142,6 +1119,10 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>SL:1,IS:1,Periphery:1</availability>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
@@ -1150,17 +1131,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -1178,20 +1155,20 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:8,SL:4,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
+		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>General:7,Periphery.Deep:7,Periphery:7</availability>
+			<availability>CC:2</availability>
 		</model>
 		<model name='FS9-A'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>LA:1,SL:2,RWR:1</availability>
 		</model>
-		<model name='FS9-K'>
+		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>CC:2</availability>
+			<availability>General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
@@ -1202,21 +1179,21 @@
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
@@ -1228,26 +1205,24 @@
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:3-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>SL:10,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1255,9 +1230,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1352,14 +1329,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:4,MOC:3,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:2,SL:9,Periphery.ME:2,FWL:9,DC:3</availability>
-		<model name='GTHA-300'>
-			<availability>SL:6,FWL:6,SL.R:6</availability>
+		<model name='GTHA-500b'>
+			<availability>SL.R:4</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>SL:8,FWL:6,Periphery.Deep:6,SL.R:6,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>SL.R:4</availability>
+		<model name='GTHA-300'>
+			<availability>SL:6,FWL:6,SL.R:6</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:6</availability>
@@ -1370,11 +1347,11 @@
 		<model name='GRF-2N'>
 			<availability>SL:3+,SL.R:6</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,SL:8-,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
-		</model>
 		<model name='GRF-1A'>
 			<availability>Periphery.Deep:4,Periphery:4,TC:4</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>General:8,SL:8-,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1395,14 +1372,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:5,MOC:4,OA:4,TH:5,LA:5,SL:7,FWL:5,IS:5,RWR:4,FS:5,DC:5,TC:4</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,SL.R:8</availability>
+		<model name='HMR-HC'>
+			<availability>TH:4,SL:2,IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>General:6,SL.R:5</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>TH:4,SL:2,IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8,SL.R:8</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>SL.R:4</availability>
@@ -1417,6 +1394,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -1424,14 +1409,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
@@ -1442,10 +1419,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1453,6 +1426,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -1461,6 +1438,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1468,14 +1453,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -1494,6 +1471,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>SL:5</availability>
+		<model name='HCT-213C'>
+			<availability>SL.R:6</availability>
+		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>SL:8,IS:8,SL.R:6,DC:8,Periphery:8</availability>
@@ -1501,35 +1481,32 @@
 		<model name='HCT-214'>
 			<availability>IS:4,SL.R:3</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>SL.R:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:4-,OA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,MERC:6-,Periphery:4-,TC:4-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:3,FS:4</availability>
+		<model name='HCT-213S'>
+			<availability>LA:5,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:5,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:3,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:4,CC:4,OA:4,SL:4,FWL:5,SL.R:5,RWR:4,DC:4</availability>
-		<model name='HER-1Sb'>
-			<roles>recon</roles>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>General:8-</availability>
+		</model>
+		<model name='HER-1Sb'>
+			<roles>recon</roles>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -1543,11 +1520,11 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:5,MOC:4,OA:4,LA:5,SL:5-,FWL:5,RWR:4,FS:5,DC:4,TC:5</availability>
-		<model name='HOP-4C'>
-			<availability>MOC:8,OA:8,SL:8,FS:8</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>CC:2,SL:2</availability>
+		</model>
+		<model name='HOP-4C'>
+			<availability>MOC:8,OA:8,SL:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -1577,12 +1554,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>LA:2,SL:10,RWR:1,FS:2,DC:1</availability>
-		<model name='HSR-200-Db'>
-			<availability>SL.R:4</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -1593,13 +1570,13 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>RWR:1</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -1611,10 +1588,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:8,MOC:6,IS:7,Periphery.Deep:6,RWR:6,FS:8,Periphery:6,TC:6,OA:6,LA:8,PIR:4,SL:9,FWL:8</availability>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -1669,17 +1646,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>SL:8,IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1719,11 +1696,11 @@
 		<model name='KGC-000b'>
 			<availability>SL.R:4</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>SL.R:2</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>General:8,SL:8,SL.R:4</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>SL.R:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -1757,14 +1734,14 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:6,MOC:3,OA:3</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -1799,13 +1776,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CC:5,MOC:3,OA:3,LA:5,SL:7,IS:5,RWR:3,MERC:5,DC:5,TC:3</availability>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>SL:8,IS:8,DC:8</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>SL:8,IS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -1837,15 +1814,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:3</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,LA:4</availability>
@@ -1863,14 +1840,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:2,FS:3,DC:3,Periphery:2,TC:2</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:3</availability>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -1882,13 +1859,13 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>TH:9,SL:6,IS:9,Periphery.Deep:5,Periphery:5</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -1912,9 +1889,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2622)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>SL:6</availability>
@@ -1925,12 +1899,12 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,IS:7,Periphery.Deep:5,RWR:7,FS:8,Periphery:5,TC:7,OA:7,LA:7,SL:4,FWL:9,SL.R:2,DC:6</availability>
+		<model name='LGB-0C'>
+			<availability>Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='LGB-0C'>
-			<availability>Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
@@ -1948,22 +1922,19 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Luxor Heavy Cruiser' unitType='Warship'>
 		<availability>SL:3</availability>
 		<model name='(2727)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2727)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -1992,11 +1963,11 @@
 		<model name='MSK-7A'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='MSK-8B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MSK-8B'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
@@ -2053,11 +2024,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3,Periphery.MW:3,Periphery.HR:3,Periphery.CM:3,IS:3,Periphery:3</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -2111,17 +2082,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2129,31 +2100,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -2162,11 +2133,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2203,13 +2174,13 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>SL:4,IS:2,MERC:2,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -2225,32 +2196,28 @@
 	</chassis>
 	<chassis name='Model 96 &apos;Elephant&apos;' unitType='Dropship'>
 		<availability>SL:5</availability>
-		<model name='Mk I'>
-			<roles>tug</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>assault,tug</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Mk I'>
+			<roles>tug</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>SL:6,FWL:5+,RWR:2+,FS:5+,DC:5+</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>SL:8,IS:8,SL.R:8,RWR:8,Periphery:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>SL.R:5</availability>
 		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>SL:8,IS:8,SL.R:8,RWR:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Monsoon Battleship' unitType='Warship'>
 		<availability>RWR:3</availability>
-		<model name='(2574)'>
-			<roles>battleship</roles>
-			<availability>SL:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
 		<availability>SL:4</availability>
@@ -2272,6 +2239,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>SL:9,IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -2280,12 +2253,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2311,9 +2278,6 @@
 		<availability>SL:4</availability>
 		<model name='(2645)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2645)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2366,9 +2330,6 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2447)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:5,FS:5,Periphery:4,TC:4,OA:4,TH:5,LA:5,Periphery.MW:4,SL:7,Periphery.ME:4,FWL:5,DC:5</availability>
@@ -2396,13 +2357,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:4,LA:4,SL:5,FWL:4,IS:4,RWR:2,FS:4,MERC:4,DC:4,Periphery:2</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,SL.R:4</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -2413,11 +2374,11 @@
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>SL.R:1</availability>
-		<model name='OWR-2Mb'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='OWR-2M'>
 			<availability>General:8,SL:0</availability>
+		</model>
+		<model name='OWR-2Mb'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
@@ -2436,12 +2397,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>SL:4,SL.R:0</availability>
+		<model name='PNT-8Z'>
+			<availability>SL:2-</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>SL:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>SL:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -2466,54 +2427,54 @@
 	</chassis>
 	<chassis name='Pentagon' unitType='Dropship'>
 		<availability>TH:6,SL:5</availability>
-		<model name='(2751)'>
-			<roles>assault</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>assault</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2751)'>
+			<roles>assault</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>SL:4,IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>SL:5,IS:4</availability>
-        </model>
-        <model name='PHX-HK1R'>
-            <availability>SL:3,IS:2+</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:2</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>SL:4,IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>SL:5,IS:4</availability>
+		</model>
+		<model name='PHX-HK1R'>
+			<availability>SL:3,IS:2+</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:2</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>TH:6,SL:6,FWL:6,IS:6,Periphery.Deep:5,Periphery:5</availability>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,SL:4-,Periphery:8</availability>
-		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:2+,MOC:2+,OA:2+,SL:8,FWL:2+,SL.R:7</availability>
 		</model>
-		<model name='PXH-1K'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>DC:6</availability>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1Kk'>
+			<availability>DC:2+</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>SL.R:5</availability>
 		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:2+</availability>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,SL:4-,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -2538,9 +2499,6 @@
 		<availability>MOC:8,OA:7,RWR:8,TC:8</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2578,13 +2536,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -2601,9 +2559,6 @@
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:6,SL:8</availability>
-		<model name='RPR-100b'>
-			<availability>SL.R:4</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,SL.R:4</availability>
@@ -2614,16 +2569,19 @@
 		<model name='RPR-200'>
 			<availability>SL.R:3</availability>
 		</model>
+		<model name='RPR-100b'>
+			<availability>SL.R:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,OA:7,LA:7,SL:8,Periphery.Deep:7,IS:7,RWR:7,FS:7,MERC:7,Periphery:7,TC:7,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>fire_support</roles>
@@ -2639,13 +2597,13 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,TH:6,SL:6-,IS:6,FWL:6,Periphery.Deep:4,SL.R:3,FS:6,Periphery:4</availability>
-		<model name='RFL-1N'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
 		<model name='RFL-2N'>
 			<roles>fire_support</roles>
 			<availability>IS:6,Periphery:6</availability>
+		</model>
+		<model name='RFL-1N'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Riga Frigate' unitType='Warship'>
@@ -2659,9 +2617,6 @@
 		<availability>SL:2</availability>
 		<model name='(2747)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2747)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2678,28 +2633,28 @@
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
 		<availability>FS:6</availability>
-		<model name='Block I'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Block II'>
 			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='Block I'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:5,MOC:3,OA:3,LA:5,SL:5,FWL:5,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
-		<model name='RGU-133L'>
-			<availability>General:4,SL.R:3</availability>
-		</model>
-		<model name='RGU-133F'>
-			<availability>General:6,SL.R:6</availability>
-		</model>
 		<model name='RGU-133Eb'>
 			<availability>SL.R:4</availability>
 		</model>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:8</availability>
+		</model>
+		<model name='RGU-133L'>
+			<availability>General:4,SL.R:3</availability>
+		</model>
+		<model name='RGU-133F'>
+			<availability>General:6,SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -2712,13 +2667,13 @@
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:8,SL.R:7</availability>
-		<model name='(Primitive)'>
-			<roles>sr_fire_support</roles>
-			<availability>Periphery.Deep:4,Periphery:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Primitive)'>
+			<roles>sr_fire_support</roles>
+			<availability>Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -2738,11 +2693,11 @@
 		<model name='SB-27'>
 			<availability>General:8,SL:8,SL.R:6</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>SL:4</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Samarkand Carrier' unitType='Warship'>
@@ -2809,20 +2764,26 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>TH:7,LA:6,SL:7,IS:7,Periphery:3</availability>
-		<model name='SHD-2Hb'>
-			<availability>SL.R:4</availability>
+		<model name='SHD-1R'>
+			<availability>MOC:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 		</model>
-		<model name='SHD-1R'>
-			<availability>MOC:4,Periphery.Deep:4,Periphery:4</availability>
+		<model name='SHD-2Hb'>
+			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shootist' unitType='Mek'>
 		<availability>LA:3+,SL:4,SL.R:6</availability>
 		<model name='ST-8A'>
 			<availability>General:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
@@ -2889,9 +2850,6 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:6,MOC:6,IS:6,Periphery.Deep:6,RWR:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:9,FWL:6,DC:6</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 		</model>
@@ -2900,6 +2858,9 @@
 		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Dagger' unitType='Aero'>
@@ -2967,11 +2928,11 @@
 		<model name='STU-K5'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>SL.R:4</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -2988,11 +2949,11 @@
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>SL:8</availability>
-		<model name='TLN-5W'>
-			<availability>LA:8,SL:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>SL:6,FWL:8,RWR:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>LA:8,SL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
@@ -3018,11 +2979,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CC:2,MOC:4+,OA:4+,TH:4,SL:6,FWL:4,FS:4,MERC:4,DC:4,Periphery:4+,TC:4+</availability>
-		<model name='THE-F'>
-			<availability>TH:8,SL:2</availability>
-		</model>
 		<model name='THE-Nb'>
 			<availability>SL.R:4</availability>
+		</model>
+		<model name='THE-F'>
+			<availability>TH:8,SL:2</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>General:4+,SL:8</availability>
@@ -3036,11 +2997,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>LA:5+,SL:7,FWL:5+,IS:5+,RWR:4+,FS:5+,TC:3+</availability>
-		<model name='THG-11Eb'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>SL:8,FWL:8+,IS:8+,SL.R:8,RWR:8,FS:8+,DC:8+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -3056,28 +3017,28 @@
 			<roles>escort,ground_support</roles>
 			<availability>LA:4+,SL:4+,SL.R:6</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,SL.R:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>SL.R:6</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,SL.R:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,LA:8,SL:7-,IS:5,Periphery.Deep:5,FS:7,MERC:5,DC:8,Periphery:5,TC:5</availability>
-		<model name='TDR-5Sd'>
-			<availability>FS:3+</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>SL.R:4</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>MOC:4,Periphery.Deep:4,TC:4,Periphery:4</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,SL.R:7,Periphery:8</availability>
+		</model>
+		<model name='TDR-5Sd'>
+			<availability>FS:3+</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
@@ -3089,23 +3050,23 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:3,MOC:2,OA:2,LA:4,SL:9,FWL:3,RWR:2,FS:2,MERC:2,DC:2,TC:2</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:3</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>SL:2,IS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>SL.R:4</availability>
-		</model>
 		<model name='THK-33'>
 			<availability>General:1</availability>
+		</model>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:3</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:6,SL.R:6</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
@@ -3130,9 +3091,6 @@
 		<availability>CC:3,MOC:3,LA:3,SL:5,FWL:3,IS:3,RWR:3,FS:3,MERC:3,DC:3,Periphery:3</availability>
 		<model name='(2755) (LF)'>
 			<availability>SL:6</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,SL.R:6</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,SL.R:6</availability>
@@ -3176,10 +3134,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:3</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -3187,6 +3141,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -3252,23 +3210,23 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:5,LA:7,SL:8,IS:5,FWL:6,MERC:5,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>SL:4,IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>SL:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:5</availability>
 		</model>
-		<model name='VNL-K65N'>
-			<availability>SL:4,IS:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>MOC:3,OA:3,RWR:6,TC:3</availability>
-		<model name='VLC-5N'>
-			<availability>General:8</availability>
-		</model>
 		<model name='VLC-3N'>
 			<availability>General:4</availability>
+		</model>
+		<model name='VLC-5N'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
@@ -3287,15 +3245,14 @@
 		<model name='(2570)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>TH:6,LA:9,SL:7,FWL:9,IS:8,RWR:3,TC:2,Periphery:2</availability>
 		<model name='WHM-6R'>
 			<availability>General:8,SL:8,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
+		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:3+</availability>
 		</model>
 		<model name='WHM-7A'>
 			<availability>SL.R:4</availability>
@@ -3303,20 +3260,17 @@
 		<model name='WHM-6Rb'>
 			<availability>CC:3+,LA:3+,FWL:3+,SL.R:8,FS:3+</availability>
 		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>SL:4,IS:3</availability>
-		<model name='WSP-100'>
-			<availability>SL:5,IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>SL:4,IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>SL:2+</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>SL:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -3349,12 +3303,12 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>RWR:5</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>SL:3,RWR:2,DC:6</availability>
+		</model>
+		<model name='WTH-0'>
+			<availability>RWR:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
@@ -3370,16 +3324,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:6,SL:6,RWR:3,DC:6</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>SL.R:8</availability>
+			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>SL:8</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='XCT Marine' unitType='Infantry'>
@@ -3436,11 +3390,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CC:3,MOC:2,OA:2,LA:3,SL:4,FWL:3,IS:3,RWR:2,FS:3,DC:4,Periphery:2,TC:2</availability>
-		<model name='ZRO-116b'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>General:8,SL.R:6</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2765.xml
+++ b/megamek/data/forcegenerator/2765.xml
@@ -278,13 +278,13 @@
 <units>
 	<chassis name='AC/2 Carrier' unitType='Tank'>
 		<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
 		<model name='(Primitive)'>
 			<roles>fire_support</roles>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -296,13 +296,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CC:5,LA:3,SL:5,FWL:4,FS:5,DC:4</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2372)'>
 			<roles>cruiser</roles>
 			<availability>CC:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -316,13 +316,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:5+,MOC:3+,OA:3+,TH:4,LA:5+,SL:7,FWL:5+,RWR:3+,FS:5+,MERC:5+,DC:5+,TC:3+</availability>
-		<model name='Mk III'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -349,13 +349,13 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,TH:7,LA:9,SL:3,IS:6,FWL:9,Periphery.Deep:5,RWR:6,FS:8,Periphery:5,DC:8</availability>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>LA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:5,DC:8,Periphery:8</availability>
-		</model>
 		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
 			<availability>SL.R:7</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>LA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:5,DC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -366,37 +366,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -406,17 +386,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -431,9 +431,6 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>SL:2,SL.R:4</availability>
@@ -443,11 +440,11 @@
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>CC:2,LA:2,SL:4,FWL:2,IS:2,RWR:2,FS:2,DC:2</availability>
-		<model name='AS7-D'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atreus Battleship' unitType='Warship'>
@@ -456,17 +453,11 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>SL:2,RWR:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -481,20 +472,17 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,OA:10-,TH:4,LA:7-,Periphery.Deep:10-,RWR:10-,FS:6-,MERC:7-,Periphery:10-,TC:10-,DC:6-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:4,OA:3,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
 		<availability>CC:3,LA:1,FWL:4,FS:3,DC:4</availability>
 		<model name='(2520)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2520)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -509,17 +497,17 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:7,LA:7,PIR:5,SL:5,FWL:7,IS:7,RWR:4,FS:7,DC:6,TC:5</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:2+,LA:2+,SL:4,FWL:2+</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CC:2+,SL.R:8</availability>
+		</model>
 		<model name='BLR-1Gbc'>
 			<availability>SL:2</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,FS:8,Periphery:8</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:2+,SL.R:8</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:2+,LA:2+,SL:4,FWL:2+</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:3+</availability>
@@ -548,11 +536,11 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>SL:9,FWL:5,FWL.OH:5,RWR:4,FS:4</availability>
-		<model name='BL-6-KNT'>
-			<availability>SL:8,FWL:7+,RWR:6+,FS:7+</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>FWL:2+,SL.R:5,RWR:4+</availability>
+		</model>
+		<model name='BL-6-KNT'>
+			<availability>SL:8,FWL:7+,RWR:6+,FS:7+</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -587,10 +575,6 @@
 			<roles>corvette</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2317)'>
-			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
 		<availability>IS:5,Periphery.Deep:5,MERC:4,Periphery:5</availability>
@@ -601,13 +585,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:4,SL:2,FWL:2,RWR:2,FS:2,MERC:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -645,32 +629,28 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:4,MOC:2,IS:4,RWR:4,FS:4,MERC:3,TC:2,Periphery:2,TH:6,LA:4,SL:4,FWL:4,DC:4</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:2,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,SL:4,FWL:4,SL.R:1,RWR:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>SL.R:8,DC:2+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,SL:4,FWL:4,SL.R:1,RWR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -700,15 +680,15 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:6,LA:6,SL:5,IS:6,FWL:6,RWR:5,FS:6,MERC:6,DC:6</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:8+,SL:8,SL.R:6,RWR:8</availability>
-		</model>
 		<model name='CHP-1Nb'>
 			<availability>SL.R:5</availability>
 		</model>
 		<model name='CHP-1N2'>
 			<availability>CC:4+,LA:4+</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:8+,SL:8,SL.R:6,RWR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -741,14 +721,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:3,CC:5,OA:3,LA:5,SL:7,FWL:5,RWR:3,MERC:5,FS:5,Periphery:2,TC:3,DC:4</availability>
-		<model name='CHP-W7'>
-			<availability>SL:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,SL:4,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>SL.R:8</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,SL:4,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>SL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -760,52 +740,52 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:7,MOC:3,OA:3,LA:5,SL:4,IS:5,FWL:5,RWR:5,FS:7,MERC:5,DC:5</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,RWR:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>TH:4,SL:8</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>SL:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>SL:2</availability>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
 		<availability>SL:3</availability>
-		<model name='Mk I'>
-			<roles>artillery,missile_artillery</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery,missile_artillery,assault,troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Mk I'>
+			<roles>artillery,missile_artillery</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>LA:9,RWR:4,MERC:5</availability>
-		<model name='COM-1A'>
-			<roles>recon</roles>
-			<availability>Periphery:3-</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1A'>
+			<roles>recon</roles>
+			<availability>Periphery:3-</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -839,13 +819,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:6,MOC:3,OA:3,LA:4,SL:7,FWL:4,IS:6,RWR:3,FS:5,DC:4,TC:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -864,26 +844,26 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>SL:6</availability>
-		<model name='CSR-V12'>
-			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
-		</model>
 		<model name='CSR-V12b'>
 			<availability>SL.R:6</availability>
+		</model>
+		<model name='CSR-V12'>
+			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -902,20 +882,20 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:5,LA:5,SL:9,FWL:5,RWR:4,FS:5,DC:5</availability>
-		<model name='CRK-5003-1'>
-			<availability>General:8+,SL.R:5</availability>
-		</model>
 		<model name='CRK-5003-1b'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='CRK-5003-1'>
+			<availability>General:8+,SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:2</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -927,8 +907,9 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>SL:7,IS:6,Periphery.Deep:4,SL.R:7,Periphery:4</availability>
-		<model name='CRD-2R'>
-			<availability>IS:2+,SL.R:8,Periphery:2+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
@@ -936,9 +917,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>IS:2+,SL.R:8,Periphery:2+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -955,16 +935,16 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:6,MOC:6,OA:6,LA:6,SL:7,IS:4,FWL:6,RWR:6,FS:6,TC:6,Periphery:2,DC:6</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>SL.R:5</availability>
-		</model>
 		<model name='(Fury)'>
 			<availability>SL:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Czar Dropship' unitType='Dropship'>
@@ -1021,14 +1001,14 @@
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
 		<availability>CC:5,LA:5,SL:9,FWL:5,RWR:5,FS:5,MERC:5,DC:5</availability>
+		<model name='(Horned Demon)'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:5</availability>
-		</model>
-		<model name='(Horned Demon)'>
-			<availability>General:3</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:3</availability>
@@ -1045,22 +1025,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>SL:5,IS:4,RWR:2</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:8</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1079,14 +1059,11 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:4,OA:4,LA:4,SL:4-,IS:4,FWL:8,RWR:4,FS:4,Periphery:3,TC:4,DC:4</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R6b'>
+			<availability>SL.R:4</availability>
 		</model>
 		<model name='EGL-R4'>
 			<availability>LA:6,FS:6</availability>
-		</model>
-		<model name='EGL-R6b'>
-			<availability>SL.R:4</availability>
 		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:4,FS:4</availability>
@@ -1094,6 +1071,9 @@
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1146,13 +1126,13 @@
 			<roles>fire_support</roles>
 			<availability>SL.R:5</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>SL:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>LA:0,General:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>SL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1164,11 +1144,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CC:2,LA:2,SL:8,FWL:2,RWR:4,FS:2,DC:2</availability>
-		<model name='EXT-4Db'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>General:8+,SL.R:5</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>SL.R:8</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>SL:1+,SL.R:2</availability>
@@ -1196,6 +1176,10 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>SL:1,IS:1,Periphery:1</availability>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
@@ -1204,17 +1188,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -1232,20 +1212,20 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:8,SL:4-,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
+		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>CC:2</availability>
 		</model>
 		<model name='FS9-A'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>LA:1,SL:2,RWR:1</availability>
 		</model>
-		<model name='FS9-K'>
+		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>CC:2</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
@@ -1256,21 +1236,21 @@
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
@@ -1282,26 +1262,24 @@
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:2-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>SL:10,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1309,9 +1287,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1406,14 +1386,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:4,MOC:4,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,DC:3</availability>
-		<model name='GTHA-300'>
-			<availability>SL:6,FWL:6,SL.R:5</availability>
+		<model name='GTHA-500b'>
+			<availability>SL.R:5</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>SL:8,FWL:6,Periphery.Deep:6,SL.R:5,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>SL.R:5</availability>
+		<model name='GTHA-300'>
+			<availability>SL:6,FWL:6,SL.R:5</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:5</availability>
@@ -1424,11 +1404,11 @@
 		<model name='GRF-2N'>
 			<availability>CC:2+,LA:2+,SL:5+,FWL:2+,SL.R:8,FS:2+</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,SL:7-,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
-		</model>
 		<model name='GRF-1A'>
 			<availability>Periphery:3,TC:3</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>General:8,SL:7-,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1449,14 +1429,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:6,MOC:4,OA:4,TH:5,LA:6,SL:7,FWL:6,IS:6,RWR:4,FS:6,DC:6,TC:4</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,SL.R:7</availability>
+		<model name='HMR-HC'>
+			<availability>TH:4,IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>General:6,SL.R:4</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>TH:4,IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8,SL.R:7</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>SL.R:5</availability>
@@ -1471,6 +1451,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -1479,33 +1467,21 @@
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,RWR:5,FS:3,MERC:4,TC:5</availability>
+		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,RWR:5,FS:3,MERC:4,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1513,6 +1489,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -1521,6 +1501,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1528,14 +1516,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -1554,6 +1534,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:2,MOC:2+,OA:2+,LA:2,SL:5,FWL:2,IS:2,RWR:2,FS:2,DC:2,TC:2+</availability>
+		<model name='HCT-213C'>
+			<availability>SL.R:8</availability>
+		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>SL:8,IS:8,SL.R:5,DC:8,Periphery:8</availability>
@@ -1561,35 +1544,32 @@
 		<model name='HCT-214'>
 			<availability>IS:4,SL.R:3</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>SL.R:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:4-,OA:4-,LA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,FS:4-,MERC:6-,Periphery:4-,TC:4-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:5</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:5,CC:4,OA:5,SL:3,FWL:5,SL.R:6,RWR:4,DC:4</availability>
-		<model name='HER-1Sb'>
-			<roles>recon</roles>
-			<availability>FWL:3+,SL.R:8</availability>
-		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>General:8-</availability>
+		</model>
+		<model name='HER-1Sb'>
+			<roles>recon</roles>
+			<availability>FWL:3+,SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -1603,11 +1583,11 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:5,MOC:4,OA:4,LA:5,SL:4-,FWL:5,RWR:4,FS:5,DC:4,TC:6</availability>
-		<model name='HOP-4C'>
-			<availability>MOC:8,OA:8,SL:8,FS:8</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>CC:2,SL:2</availability>
+		</model>
+		<model name='HOP-4C'>
+			<availability>MOC:8,OA:8,SL:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -1637,12 +1617,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>LA:2,SL:10,RWR:4,FS:2,DC:1</availability>
-		<model name='HSR-200-Db'>
-			<availability>SL.R:5</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -1653,13 +1633,13 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>SL:3,RWR:4</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -1671,10 +1651,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:7,IS:7,Periphery.Deep:6,RWR:7,FS:9,Periphery:6,TC:7,OA:7,LA:9,PIR:4,SL:9,FWL:9</availability>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -1753,17 +1733,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>SL:8,IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1803,11 +1783,11 @@
 		<model name='KGC-000b'>
 			<availability>SL.R:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>SL.R:2</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>General:8,SL:8,SL.R:4</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>SL.R:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -1841,14 +1821,14 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:5,MOC:3,OA:3</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:5</availability>
-		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -1883,13 +1863,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CC:5,MOC:4,OA:4,LA:5,SL:7,IS:5,RWR:5,MERC:5,DC:5,TC:4</availability>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>SL:8,IS:8,DC:8</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>SL:8,IS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -1919,15 +1899,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:3</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,LA:4</availability>
@@ -1945,14 +1925,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:3,FS:3,DC:3,Periphery:2,TC:2</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:3</availability>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>SL.R:8</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -1964,13 +1944,13 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>TH:9,SL:5,IS:9,Periphery.Deep:5,Periphery:5</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -1994,9 +1974,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2622)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>SL:6</availability>
@@ -2007,12 +1984,12 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,IS:7,Periphery.Deep:7,RWR:7,FS:8,Periphery:7,TC:7,OA:7,LA:7,SL:4,FWL:9,SL.R:1,DC:6</availability>
+		<model name='LGB-0C'>
+			<availability>Periphery.Deep:4,Periphery:4</availability>
+		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='LGB-0C'>
-			<availability>Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
@@ -2030,22 +2007,19 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Luxor Heavy Cruiser' unitType='Warship'>
 		<availability>SL:3</availability>
 		<model name='(2727)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2727)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2074,11 +2048,11 @@
 		<model name='MSK-7A'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='MSK-8B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MSK-8B'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
@@ -2135,11 +2109,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:3,Periphery.CM:3,IS:3-,Periphery:3</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -2193,17 +2167,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2211,31 +2185,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -2244,11 +2218,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2291,21 +2265,21 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>SL:4,IS:2,MERC:2,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(ICE - LL)'>
+			<roles>support</roles>
+			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='(ICE - LL)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:2,MERC:2,DC:2</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -2321,13 +2295,13 @@
 	</chassis>
 	<chassis name='Model 96 &apos;Elephant&apos;' unitType='Dropship'>
 		<availability>SL:5</availability>
-		<model name='Mk I'>
-			<roles>tug</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>assault,tug</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk I'>
+			<roles>tug</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>
@@ -2339,13 +2313,13 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>SL:6,FWL:6+,RWR:4+,FS:6+,DC:6+</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>SL:8,IS:8,SL.R:8,RWR:8,Periphery:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>SL.R:7</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>SL:8,IS:8,SL.R:8,RWR:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
@@ -2353,16 +2327,9 @@
 		<model name='(2776)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Monsoon Battleship' unitType='Warship'>
 		<availability>RWR:5</availability>
-		<model name='(2574)'>
-			<roles>battleship</roles>
-			<availability>SL:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
 		<availability>SL:4</availability>
@@ -2384,6 +2351,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>SL:9,IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -2392,12 +2365,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2419,19 +2386,16 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2645)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:5</availability>
-		<model name='(Block I)'>
-			<roles>destroyer</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='(Block II)'>
 			<roles>destroyer</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Block I)'>
+			<roles>destroyer</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='New Syrtis Carrier' unitType='Warship'>
@@ -2489,9 +2453,6 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2447)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:5,FS:5,Periphery:4,TC:4,OA:4,TH:5,LA:5,Periphery.MW:4,SL:6,Periphery.ME:4,FWL:5,DC:5</availability>
@@ -2519,13 +2480,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:5,LA:5,SL:5,FWL:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,MERC:5,DC:5,Periphery:5</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,SL.R:4</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -2536,11 +2497,11 @@
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>SL.R:1-</availability>
-		<model name='OWR-2Mb'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='OWR-2M'>
 			<availability>General:8,SL:0</availability>
+		</model>
+		<model name='OWR-2Mb'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
@@ -2566,12 +2527,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:2,Periphery.DD:2,LA:2,SL:5-,FS.DMM:2,FWL:2,SL.R:0,MERC:2,Periphery.OS:2,FS:2,DC:2,Periphery:2</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,SL:2-,RWR:8,DC:2,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>SL:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,SL:2-,RWR:8,DC:2,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -2590,54 +2551,54 @@
 	</chassis>
 	<chassis name='Pentagon' unitType='Dropship'>
 		<availability>TH:6,SL:5</availability>
-		<model name='(2751)'>
-			<roles>assault</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>assault</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2751)'>
+			<roles>assault</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>SL:4,IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>SL:5,IS:4</availability>
-        </model>
-        <model name='PHX-HK1R'>
-            <availability>SL:3,IS:2+</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>SL:4,IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>SL:5,IS:4</availability>
+		</model>
+		<model name='PHX-HK1R'>
+			<availability>SL:3,IS:2+</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>TH:7,SL:4,IS:7,FWL:7,Periphery.Deep:5,Periphery:5</availability>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,SL:4-,Periphery:8</availability>
-		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>CC:4+,MOC:4+,OA:4+,SL:8,FWL:4+,SL.R:6</availability>
 		</model>
-		<model name='PXH-1K'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>DC:6</availability>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1Kk'>
+			<availability>DC:3+</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:3+</availability>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,SL:4-,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -2662,9 +2623,6 @@
 		<availability>MOC:8,OA:7,RWR:10,TC:8</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2702,13 +2660,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -2734,9 +2692,6 @@
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:6,SL:8,IS:2,RWR:3,MERC:2</availability>
-		<model name='RPR-100b'>
-			<availability>SL.R:5</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,SL.R:4</availability>
@@ -2747,16 +2702,19 @@
 		<model name='RPR-200'>
 			<availability>SL.R:4</availability>
 		</model>
+		<model name='RPR-100b'>
+			<availability>SL.R:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,OA:7,LA:7,SL:9,Periphery.Deep:8,IS:7,RWR:7,FS:7,MERC:7,Periphery:8,TC:7,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>fire_support</roles>
@@ -2772,10 +2730,6 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,TH:6,SL:5-,IS:6,FWL:6,Periphery.Deep:5,SL.R:2,FS:6,Periphery:5</availability>
-		<model name='RFL-1N'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,Periphery:3</availability>
-		</model>
 		<model name='RFL-2N'>
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery:5</availability>
@@ -2783,6 +2737,10 @@
 		<model name='RFL-3N'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='RFL-1N'>
+			<roles>fire_support</roles>
+			<availability>MOC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Riga Frigate' unitType='Warship'>
@@ -2796,9 +2754,6 @@
 		<availability>SL:3</availability>
 		<model name='(2747)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2747)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2815,28 +2770,28 @@
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
 		<availability>FS:6</availability>
-		<model name='Block I'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Block II'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Block I'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:5,MOC:3,OA:3,LA:5,SL:5,FWL:5,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
-		<model name='RGU-133L'>
-			<availability>General:4,SL.R:3</availability>
-		</model>
-		<model name='RGU-133F'>
-			<availability>General:6,SL.R:5</availability>
-		</model>
 		<model name='RGU-133Eb'>
 			<availability>SL.R:5</availability>
 		</model>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:7</availability>
+		</model>
+		<model name='RGU-133L'>
+			<availability>General:4,SL.R:3</availability>
+		</model>
+		<model name='RGU-133F'>
+			<availability>General:6,SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -2849,13 +2804,13 @@
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:8,SL.R:7</availability>
-		<model name='(Primitive)'>
-			<roles>sr_fire_support</roles>
-			<availability>Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Primitive)'>
+			<roles>sr_fire_support</roles>
+			<availability>Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -2875,11 +2830,11 @@
 		<model name='SB-27'>
 			<availability>General:8,SL:6,SL.R:4</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>SL:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samarkand Carrier' unitType='Warship'>
@@ -2895,13 +2850,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:6,CC:6,IS:6,RWR:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:6,FWL:6,DC:6</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CC:3+,MOC:1+,OA:4+,LA:3+,General:2+,SL:3,FWL:3+,RWR:1+,FS:3+,DC:3+,TC:1+</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,General:8,SL.R:4,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CC:3+,MOC:1+,OA:4+,LA:3+,General:2+,SL:3,FWL:3+,RWR:1+,FS:3+,DC:3+,TC:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Sand Devil Hover Tank' unitType='Tank'>
@@ -2943,25 +2898,25 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:3,Periphery.R:4,OA:4,LA:5,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>TH:7,LA:6,SL:6-,IS:7,Periphery.Deep:4,Periphery:4</availability>
-		<model name='SHD-2Hb'>
-			<availability>SL.R:5</availability>
+		<model name='SHD-1R'>
+			<availability>MOC:3,Periphery:3</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
 		</model>
-		<model name='SHD-1R'>
-			<availability>MOC:3,Periphery:3</availability>
+		<model name='SHD-2Hb'>
+			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
@@ -2974,6 +2929,12 @@
 		<availability>LA:4+,SL:4,SL.R:6,RWR:3+</availability>
 		<model name='ST-8A'>
 			<availability>General:8</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
@@ -2991,13 +2952,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>SL:2,RWR:2</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>SL:4,RWR:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>SL:4,RWR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3058,9 +3019,6 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:7,MOC:8,IS:7,Periphery.Deep:8,RWR:7,FS:7,Periphery:8,TC:8,OA:8,LA:7,SL:9-,FWL:8,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 		</model>
@@ -3069,6 +3027,9 @@
 		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:2+</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Dagger' unitType='Aero'>
@@ -3143,11 +3104,11 @@
 		<model name='STU-K5'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>SL.R:6</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -3164,11 +3125,11 @@
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>LA:6+,SL:9,FWL:6+,RWR:4+,FS:6+</availability>
-		<model name='TLN-5W'>
-			<availability>LA:8,SL:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>SL:5,FWL:8,RWR:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>LA:8,SL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
@@ -3194,11 +3155,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CC:3,MOC:4+,OA:4+,TH:4,SL:6,FWL:4,FS:4,MERC:4,DC:4,Periphery:3+,TC:4+</availability>
-		<model name='THE-F'>
-			<availability>TH:8,SL:1</availability>
-		</model>
 		<model name='THE-Nb'>
 			<availability>SL.R:5</availability>
+		</model>
+		<model name='THE-F'>
+			<availability>TH:8,SL:1</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>General:6+,SL:8</availability>
@@ -3212,11 +3173,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>LA:6+,SL:8,FWL:6+,IS:6+,RWR:4+,FS:6+,TC:4+</availability>
-		<model name='THG-11Eb'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>SL:8,FWL:8+,IS:8+,SL.R:6,RWR:8,FS:8+,DC:8+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -3238,28 +3199,28 @@
 			<roles>escort,ground_support</roles>
 			<availability>LA:6+,SL:6+,SL.R:6</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,SL.R:5</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>SL.R:8</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,SL.R:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,LA:8,SL:6-,IS:5,Periphery.Deep:5,FS:7,MERC:5,DC:8,Periphery:5,TC:5</availability>
-		<model name='TDR-5Sd'>
-			<availability>FS:3+</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>SL.R:5</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>MOC:2,TC:2,Periphery:2</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
+		</model>
+		<model name='TDR-5Sd'>
+			<availability>FS:3+</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
@@ -3271,20 +3232,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:5,MOC:3,OA:3,LA:6,SL:9,FWL:5,RWR:3,FS:3,MERC:3,DC:3,TC:3</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>SL:1,IS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>SL.R:5</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,SL.R:6</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Toro' unitType='Mek'>
@@ -3305,9 +3266,6 @@
 		<availability>CC:4,MOC:4,LA:4,SL:6,IS:4,FWL:4,Periphery.Deep:4,RWR:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
 		<model name='(2755) (LF)'>
 			<availability>SL:6</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,SL.R:6</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,SL.R:6</availability>
@@ -3351,10 +3309,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:3</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -3362,6 +3316,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -3427,23 +3385,23 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:5,LA:7,SL:7,IS:5,FWL:6,MERC:5,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>SL:2,IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>CC:2,LA:2,SL:8,FWL:2,FS:2,DC:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:5</availability>
 		</model>
-		<model name='VNL-K65N'>
-			<availability>SL:2,IS:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>MOC:5,OA:5,RWR:8,Periphery:2,TC:5</availability>
-		<model name='VLC-6N'>
-			<availability>RWR:5+</availability>
-		</model>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>RWR:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
@@ -3473,15 +3431,14 @@
 		<model name='(2570)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>TH:6,LA:9,SL:6,FWL:9,IS:8,RWR:5,TC:3,Periphery:3</availability>
 		<model name='WHM-6R'>
 			<availability>General:8,SL:7-,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
+		</model>
+		<model name='WHM-6Rk'>
+			<availability>DC:3+</availability>
 		</model>
 		<model name='WHM-7A'>
 			<availability>SL:3,SL.R:6</availability>
@@ -3489,20 +3446,17 @@
 		<model name='WHM-6Rb'>
 			<availability>CC:3+,LA:3+,FWL:3+,SL.R:7,FS:3+</availability>
 		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>SL:4,IS:3</availability>
-		<model name='WSP-100'>
-			<availability>SL:5,IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>SL:4,IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>SL:2+</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>SL:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -3517,13 +3471,13 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='WSP-1'>
-			<roles>recon</roles>
-			<availability>MOC:2,Periphery:2</availability>
-		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:8</availability>
+		</model>
+		<model name='WSP-1'>
+			<roles>recon</roles>
+			<availability>MOC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -3539,12 +3493,12 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>RWR:5</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>SL:3,DC:6</availability>
+		</model>
+		<model name='WTH-0'>
+			<availability>RWR:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine II' unitType='Mek'>
@@ -3566,16 +3520,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:6,SL:6,RWR:5,DC:6,TC:3</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>SL.R:8</availability>
+			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>SL:8</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CC:8,SL:8,SL.R:4,DC:8,TC:8</availability>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='XCT Marine' unitType='Infantry'>
@@ -3629,11 +3583,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>MOC:2,CC:3,OA:2,LA:3,SL:6,IS:3,FWL:3,RWR:2,FS:3,Periphery:2,TC:2,DC:5</availability>
-		<model name='ZRO-116b'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>General:8,SL.R:5</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2780.xml
+++ b/megamek/data/forcegenerator/2780.xml
@@ -302,13 +302,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CC:5,LA:3,SL:5,FWL:4,FS:5,DC:4</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,General:8</availability>
-		</model>
 		<model name='(2372)'>
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:6</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -322,13 +322,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:5+,MOC:3+,CS:7,OA:3+,LA:5+,SL:7,FWL:5+,NIOPS:7,FS:5+,MERC:5+,DC:5+,TC:3+</availability>
-		<model name='Mk III'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -361,13 +361,13 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,SL:2,IS:6,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>SLIE:4,LA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,DC:8,Periphery:8</availability>
-		</model>
 		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>SLIE:4,LA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,DC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -378,37 +378,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>PP:10,CC:10,MOC:10,SLIE:10,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PP:5-,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PP:6,PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PP:3,PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -418,17 +398,37 @@
 			<roles>apc</roles>
 			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PP:6,PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PP:6,PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:3,PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -443,26 +443,23 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>SL:3,SL.R:5</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>CC:2,MOC:1,CS:4-,OA:1,LA:3,SL:5,IS:2,FWL:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
-		<model name='AS7-D'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atreus Battleship' unitType='Warship'>
@@ -471,17 +468,11 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>SL:2</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -496,20 +487,17 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:4,OA:4,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
 		<availability>CC:3,LA:2,FWL:3,FS:3,DC:3</availability>
 		<model name='(2520)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2520)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -524,17 +512,17 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:7,CS:8-,MOC:4,LA:8,PIR:6,SL:4,FWL:8,IS:7,NIOPS:8-,FS:7,DC:7,TC:6</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:3+,LA:3+,SL:4,FWL:3+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>PP:4,CC:2+,SLIE:8,SL.R:8</availability>
+		</model>
 		<model name='BLR-1Gbc'>
 			<availability>PP:2,SLIE:2,SL:2</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:2,FS:8,Periphery:8</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>PP:4,CC:2+,SLIE:8,SL.R:8</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:3+,LA:3+,SL:4,FWL:3+,FS:2+,DC:2+</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:3+</availability>
@@ -563,11 +551,11 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CS:7,SL:10,FWL:6,NIOPS:7,FWL.OH:6,FS:6</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,SL:8,FWL:6+,NIOPS:8,FS:6+</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,NIOPS:4,FWL:2+,SL.R:6</availability>
+		</model>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,SL:8,FWL:6+,NIOPS:8,FS:6+</availability>
 		</model>
 		<model name='BL-7-KNT-L'>
 			<availability>FWL:6-</availability>
@@ -608,13 +596,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:4,SL:2,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -626,11 +614,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -673,32 +661,28 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:6,MOC:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,SL:3-,FWL:4,NIOPS:2,DC:6</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,SL:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,SL:4,FWL:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CC:1+,SL.R:8,DC:2+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,SL:4,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -735,15 +719,15 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:7,CS:5,LA:7,SL:5,IS:6,FWL:6,NIOPS:5,FS:6,MERC:6,DC:6</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:8+,CS:8,SL:8,NIOPS:8,SL.R:4</availability>
-		</model>
 		<model name='CHP-1Nb'>
 			<availability>SL.R:6</availability>
 		</model>
 		<model name='CHP-1N2'>
 			<availability>CC:4+,CS:4,LA:4+</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:8+,CS:8,SL:8,NIOPS:8,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -762,13 +746,13 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,SL:2-,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
+		</model>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -780,14 +764,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:3,PP:6,CC:5,MERC:5,FS:5,CIR:3,Periphery:2,TC:3,OA:3,SLIE:6,LA:8,SL:7,FWL:6,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>PP:6,SL:6</availability>
+		<model name='CHP-W5'>
+			<availability>PP:3,:0,SLIE:3,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>PP:4,SLIE:8,SL.R:8</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>PP:3,:0,SLIE:3,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>PP:6,SL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -799,29 +783,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:7,MOC:4,CS:3-,OA:4,LA:5,SL:3,IS:5,FWL:5,NIOPS:3-,FS:7,MERC:5,DC:5</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>PP:8,SL:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,SL:8</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>SL:2,IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>SL:2,IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
@@ -833,14 +817,14 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>LA:9,MERC:5,CIR:4</availability>
-		<model name='COM-1A'>
-			<roles>recon</roles>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1A'>
+			<roles>recon</roles>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
@@ -881,13 +865,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:6,MOC:3,IS:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:4,SL:7,FWL:4,NIOPS:6,DC:4</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -906,26 +890,26 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:3,PP:6,CC:3,MERC:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,SLIE:6,LA:4,SL:6,FWL:5,DC:3</availability>
-		<model name='CSR-V12'>
-			<availability>PP:8,SLIE:4,SL:8,IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
-		</model>
 		<model name='CSR-V12b'>
 			<availability>PP:4,SLIE:6,SL.R:6</availability>
+		</model>
+		<model name='CSR-V12'>
+			<availability>PP:8,SLIE:4,SL:8,IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -944,28 +928,28 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:7,CS:8,LA:7,SL:10,FWL:7,NIOPS:8,FS:7,DC:7</availability>
-		<model name='CRK-5003-1'>
-			<availability>CS:8,General:8+,NIOPS:8,SL.R:4</availability>
-		</model>
 		<model name='CRK-5003-1b'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='CRK-5003-1'>
+			<availability>CS:8,General:8+,NIOPS:8,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:1</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crosscut' unitType='Mek'>
 		<availability>PP:5</availability>
-		<model name='ED-X2M ForestryMech(Flamer)'>
+		<model name='ED-X2M2 ForestryMech(Rocket)'>
 			<availability>PP:8</availability>
 		</model>
-		<model name='ED-X2M2 ForestryMech(Rocket)'>
+		<model name='ED-X2M ForestryMech(Flamer)'>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -978,8 +962,9 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,SL:7,IS:8,NIOPS:6-,Periphery.Deep:6,SL.R:6,Periphery:6</availability>
-		<model name='CRD-2R'>
-			<availability>IS:2+,SL.R:8,Periphery:2+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,Periphery.Deep:8,SL.R:6,Periphery:8</availability>
@@ -987,9 +972,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>IS:2+,SL.R:8,Periphery:2+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -997,11 +981,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,LA:5,SL:4,IS:3,FWL:4,NIOPS:3,SL.R:5,FS:5,TC:2,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1009,13 +993,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:6,MOC:6,IS:4,FS:6,CIR:4,TC:6,Periphery:2,CS:6,OA:6,LA:6,SL:7,FWL:6,NIOPS:6,DC:6</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,CS:8,General:8,NIOPS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Czar Dropship' unitType='Dropship'>
@@ -1054,13 +1038,13 @@
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
 		<availability>FS:6</availability>
-		<model name='Block II'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='Block I'>
 			<roles>destroyer</roles>
 			<availability>FS:2</availability>
+		</model>
+		<model name='Block II'>
+			<roles>destroyer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Deathstalker' unitType='Aero'>
@@ -1078,11 +1062,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CS:6-,NIOPS:6-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -1098,14 +1082,14 @@
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
 		<availability>CC:6,CS:8,LA:6,SL:9,FWL:6,NIOPS:8,FS:6,MERC:6,DC:6</availability>
+		<model name='(Horned Demon)'>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CS:4,NIOPS:4,SL.R:6</availability>
-		</model>
-		<model name='(Horned Demon)'>
-			<availability>General:2</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:2</availability>
@@ -1122,22 +1106,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>SL:4,IS:4</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1156,14 +1140,11 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,PP:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,SLIE:4,LA:4,SL:4-,FWL:8,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
+		<model name='EGL-R6b'>
+			<availability>SLIE:6,SL.R:6</availability>
 		</model>
 		<model name='EGL-R4'>
 			<availability>LA:6,FS:6</availability>
-		</model>
-		<model name='EGL-R6b'>
-			<availability>SLIE:6,SL.R:6</availability>
 		</model>
 		<model name='EGL-R9'>
 			<availability>LA:4,General:4,FS:4</availability>
@@ -1171,6 +1152,9 @@
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1230,13 +1214,13 @@
 			<roles>fire_support</roles>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>LA:8,SL:2</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,NIOPS:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>LA:8,SL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1252,11 +1236,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CC:3,CS:4,LA:3,SL:8,FWL:3,NIOPS:4,FS:3,DC:3</availability>
-		<model name='EXT-4Db'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,NIOPS:8,SL.R:4</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>SL.R:8</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>SL:1+,SL.R:2</availability>
@@ -1284,6 +1268,10 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>SL:1,IS:1,Periphery:1</availability>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
@@ -1292,17 +1280,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -1320,48 +1304,48 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,SL:4-,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
+		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>CC:2</availability>
 		</model>
 		<model name='FS9-A'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>LA:1</availability>
 		</model>
-		<model name='FS9-K'>
+		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>CC:2</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CS:5,Periphery.R:4,LA:6,SL:8,FWL:5,NIOPS:5</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:8+,FWL:8+,NIOPS:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:4-</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:8+,FWL:8+,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
@@ -1373,26 +1357,24 @@
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:2-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>SL:10,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1400,9 +1382,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1497,14 +1481,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,LA:2,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
-		<model name='GTHA-300'>
-			<availability>SL:6,FWL:6,SL.R:4</availability>
+		<model name='GTHA-500b'>
+			<availability>SL.R:6</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,SL:8,FWL:6,NIOPS:6,Periphery.Deep:6,SL.R:3,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>SL.R:6</availability>
+		<model name='GTHA-300'>
+			<availability>SL:6,FWL:6,SL.R:4</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:4</availability>
@@ -1521,11 +1505,11 @@
 		<model name='GRF-2N'>
 			<availability>CC:4+,LA:4+,SL:6,FWL:4+,SL.R:8,FS:4+</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>General:8,SL:6-,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
-		</model>
 		<model name='GRF-1A'>
 			<availability>Periphery:2,TC:2</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>General:8,SL:6-,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
@@ -1546,14 +1530,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CC:6,MOC:4,IS:6,FS:6,CIR:4,TC:4,CS:7,OA:4,LA:6,SL:7,FWL:6,NIOPS:7,DC:6</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,SL.R:6</availability>
+		<model name='HMR-HC'>
+			<availability>IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:6,NIOPS:8,SL.R:2</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8,SL.R:6</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>SL.R:6</availability>
@@ -1561,12 +1545,12 @@
 	</chassis>
 	<chassis name='Harvester Ant' unitType='Mek'>
 		<availability>PP:5</availability>
-		<model name='KIC-3 Agromech(MG)'>
-			<roles>anti_infantry</roles>
-			<availability>PP:8</availability>
-		</model>
 		<model name='KIC-3 Agromech(LRM)'>
 			<roles>fire_support</roles>
+			<availability>PP:8</availability>
+		</model>
+		<model name='KIC-3 Agromech(MG)'>
+			<roles>anti_infantry</roles>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -1579,6 +1563,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -1587,33 +1579,21 @@
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
+		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1621,6 +1601,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -1629,6 +1613,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1636,14 +1628,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hector' unitType='Mek'>
@@ -1662,6 +1646,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:4,MOC:3+,IS:3,FS:4,TC:3+,CS:6,OA:3+,SLIE:6,LA:4,SL:6,FWL:4,NIOPS:6,DC:4</availability>
+		<model name='HCT-213C'>
+			<availability>PP:4,SLIE:6,SL.R:8</availability>
+		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,SLIE:8,SL:8,IS:8,SL.R:4,DC:8,Periphery:8</availability>
@@ -1669,24 +1656,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,PP:4,SLIE:4,IS:4,NIOPS:4,SL.R:2</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>PP:4,SLIE:6,SL.R:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,SL:4-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
@@ -1695,24 +1679,24 @@
 			<roles>recon</roles>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:5,CC:4,CS:3,OA:5,SL:3,FWL:5,NIOPS:3,SL.R:6,DC:4</availability>
-		<model name='HER-1Sb'>
-			<roles>recon</roles>
-			<availability>FWL:3+,SL.R:8</availability>
-		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>CS:8,General:8-,NIOPS:8</availability>
+		</model>
+		<model name='HER-1Sb'>
+			<roles>recon</roles>
+			<availability>FWL:3+,SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -1726,11 +1710,11 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:6,MOC:4,OA:4,LA:6,SL:3-,FWL:6,FS:6,DC:4,TC:6</availability>
-		<model name='HOP-4C'>
-			<availability>MOC:8,OA:8,SL:8,FS:8</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>CC:2,SL:2</availability>
+		</model>
+		<model name='HOP-4C'>
+			<availability>MOC:8,OA:8,SL:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -1766,12 +1750,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,LA:2,SL:10,NIOPS:4,FS:2,DC:1</availability>
-		<model name='HSR-200-Db'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,General:8,NIOPS:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -1782,13 +1766,13 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>SL:3</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
@@ -1806,10 +1790,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,IS:7,Periphery.Deep:8,FS:9,CIR:8,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,SL:9,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -1843,13 +1827,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -1885,13 +1869,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>DC:4</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:5</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -1903,17 +1887,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>SL:8,IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1930,11 +1914,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>PP:5,CC:3,CS:2,SLIE:5,LA:3,SL:5,FWL:4,NIOPS:2,FS:3,DC:3</availability>
-		<model name='(AC)'>
-			<availability>PP:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>PP:4,General:8</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>PP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -1956,11 +1940,11 @@
 		<model name='KGC-000b'>
 			<availability>SL.R:6</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>SL.R:2</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,General:7,SL:8,NIOPS:8,SL.R:4</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>SL.R:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -1968,11 +1952,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,General:4,NIOPS:8,SL.R:2,FS:4,MERC:4</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:2</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -1997,17 +1981,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:3,MOC:2,OA:2</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:4+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
+		<model name='KSC-4L'>
+			<availability>CC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -2039,13 +2023,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CC:6,MOC:4,CS:6,OA:4,LA:6,SL:6,IS:6,NIOPS:6,MERC:6,CIR:4,TC:4,DC:6</availability>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,SLIE:8,SL:8,IS:8,NIOPS:8,DC:8</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,SLIE:8,SL:8,IS:8,NIOPS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2075,15 +2059,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:3</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,LA:4</availability>
@@ -2104,14 +2088,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,SL:5,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:3</availability>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>PP:4,SLIE:8,SL.R:8</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -2123,13 +2107,13 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,SL:3,IS:9,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -2153,9 +2137,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2622)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
 		<availability>SL:6</availability>
@@ -2166,12 +2147,12 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,SL:3,FWL:9,NIOPS:4,DC:6</availability>
+		<model name='LGB-0C'>
+			<availability>Periphery:2</availability>
+		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='LGB-0C'>
-			<availability>Periphery:2</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
@@ -2189,10 +2170,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -2200,6 +2177,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
@@ -2231,11 +2212,11 @@
 		<model name='MSK-7A'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='MSK-8B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MSK-8B'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
@@ -2285,11 +2266,11 @@
 	</chassis>
 	<chassis name='Marco' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='MR-8D'>
-			<availability>PP:8</availability>
-		</model>
 		<model name='MR-8E'>
 			<availability>PP:7</availability>
+		</model>
+		<model name='MR-8D'>
+			<availability>PP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2301,11 +2282,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -2359,17 +2340,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2377,31 +2358,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>SL:7,IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -2410,11 +2391,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2451,21 +2432,21 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>SL:4,IS:2,MERC:2,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(ICE - LL)'>
+			<roles>support</roles>
+			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='(ICE - LL)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:2,MERC:2,DC:2</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -2481,13 +2462,13 @@
 	</chassis>
 	<chassis name='Model 96 &apos;Elephant&apos;' unitType='Dropship'>
 		<availability>CS:4,SL:5,NIOPS:4</availability>
-		<model name='Mk I'>
-			<roles>tug</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>assault,tug</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk I'>
+			<roles>tug</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>
@@ -2499,20 +2480,17 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>CS:6,MOC:3+,OA:3+,SL:6,FWL:6+,NIOPS:6,FS:6+,MERC:3+,DC:6+,TC:3+</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,SL:8,NIOPS:8,IS:8,SL.R:6,Periphery:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>SL.R:8</availability>
 		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,SL:8,NIOPS:8,IS:8,SL.R:6,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>SL:3,IS:3</availability>
-		<model name='(2776)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
 		</model>
@@ -2537,6 +2515,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>SL:9,IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -2545,12 +2529,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2568,13 +2546,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:5</availability>
-		<model name='(Block I)'>
-			<roles>destroyer</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='(Block II)'>
 			<roles>destroyer</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Block I)'>
+			<roles>destroyer</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -2664,13 +2642,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:5,CS:4,LA:5,SL:5,IS:5,FWL:5,NIOPS:4,Periphery.Deep:5,FS:5,MERC:5,Periphery:5,DC:5</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,SL.R:4</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -2681,11 +2659,11 @@
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>SL.R:1-</availability>
-		<model name='OWR-2Mb'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='OWR-2M'>
 			<availability>General:8,SL:0</availability>
+		</model>
+		<model name='OWR-2Mb'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
@@ -2715,12 +2693,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,SL:5-,FWL:3,NIOPS:2,SL.R:0,DC:8</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,DC:1,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>PP:8,SL:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,DC:1,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -2756,48 +2734,48 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>SL:4,IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>SL:5,IS:4</availability>
-        </model>
-        <model name='PHX-HK1R'>
-            <availability>SL:3,IS:2+</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:4</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>SL:4,IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>SL:5,IS:4</availability>
+		</model>
+		<model name='PHX-HK1R'>
+			<availability>SL:3,IS:2+</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:4</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,SL:3,IS:7,FWL:7,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>SL.R:4</availability>
+			<availability>CC:4+,MOC:4+,OA:4+,SL:8,FWL:4+,SL.R:6</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,SL:4-,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>CC:4+,MOC:4+,OA:4+,SL:8,FWL:4+,SL.R:6</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
+		<model name='PXH-1Kk'>
+			<availability>DC:3+</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>SL.R:7</availability>
 		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:3+</availability>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,SL:4-,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -2810,9 +2788,6 @@
 		<availability>MOC:6,OA:5,TC:6</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2843,10 +2818,10 @@
 	</chassis>
 	<chassis name='Powerman XI LoaderMech' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='(Laser)'>
+		<model name='(SRM)'>
 			<availability>PP:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(Laser)'>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -2859,13 +2834,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,General:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -2891,9 +2866,6 @@
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,OA:2,LA:6,SL:8,IS:3,NIOPS:8,MERC:3</availability>
-		<model name='RPR-100b'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,LA:4,General:4,SL.R:3</availability>
@@ -2904,16 +2876,19 @@
 		<model name='RPR-200'>
 			<availability>SL.R:4</availability>
 		</model>
+		<model name='RPR-100b'>
+			<availability>SL.R:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,SL:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>fire_support</roles>
@@ -2929,10 +2904,6 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,CS:6-,SL:4-,IS:6,FWL:6,NIOPS:6-,Periphery.Deep:5,FS:6,CIR:4,Periphery:5</availability>
-		<model name='RFL-1N'>
-			<roles>fire_support</roles>
-			<availability>MOC:2,Periphery:2</availability>
-		</model>
 		<model name='RFL-2N'>
 			<roles>fire_support</roles>
 			<availability>IS:2,Periphery:4</availability>
@@ -2941,14 +2912,15 @@
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
+		<model name='RFL-1N'>
+			<roles>fire_support</roles>
+			<availability>MOC:2,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riga II Destroyer/Carrier' unitType='Warship'>
 		<availability>SL:4</availability>
 		<model name='(2747)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2747)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2965,28 +2937,28 @@
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
 		<availability>FS:4</availability>
-		<model name='Block I'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Block II'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Block I'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:4,MOC:3,IS:4,FS:3,CIR:2,TC:3,CS:4,OA:3,LA:4,SL:5,FWL:4,NIOPS:4,DC:3</availability>
-		<model name='RGU-133L'>
-			<availability>CS:4,General:4,NIOPS:4,SL.R:2</availability>
-		</model>
-		<model name='RGU-133F'>
-			<availability>CS:6,General:6,NIOPS:6,SL.R:4</availability>
-		</model>
 		<model name='RGU-133Eb'>
 			<availability>SL.R:6</availability>
 		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8,SL.R:6</availability>
+		</model>
+		<model name='RGU-133L'>
+			<availability>CS:4,General:4,NIOPS:4,SL.R:2</availability>
+		</model>
+		<model name='RGU-133F'>
+			<availability>CS:6,General:6,NIOPS:6,SL.R:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -2994,16 +2966,16 @@
 		<model name='RND-J-1-11 (LRM)'>
 			<availability>PP:5</availability>
 		</model>
-		<model name='RND-J-1-11'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+		<model name='RND-J-1-11 (RL)'>
+			<availability>PP:5</availability>
 		</model>
 		<model name='RND-J-1-11 (SRM)'>
 			<availability>PP:5</availability>
 		</model>
-		<model name='RND-J-1-11 (RL)'>
-			<availability>PP:5</availability>
+		<model name='RND-J-1-11'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
@@ -3030,11 +3002,11 @@
 		<model name='SB-27'>
 			<availability>General:8,SL:4</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,SL:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samarkand Carrier' unitType='Warship'>
@@ -3050,13 +3022,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:6,PP:5,CC:6,IS:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,SLIE:5,LA:6,SL:5,FWL:6,DC:6</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>PP:4,CC:4+,MOC:1+,OA:4+,SLIE:8,LA:4+,General:3+,SL:4,FWL:4+,FS:4+,DC:4+,TC:1+</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,SLIE:4,General:8,SL.R:4,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>PP:4,CC:4+,MOC:1+,OA:4+,SLIE:8,LA:4+,General:3+,SL:4,FWL:4+,FS:4+,DC:4+,TC:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Sand Devil Hover Tank' unitType='Tank'>
@@ -3098,31 +3070,31 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,SL:4-,IS:7,NIOPS:6-,Periphery.Deep:4,Periphery:4</availability>
-		<model name='SHD-2Hb'>
-			<availability>SL.R:6,FS:2+</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SHD-2K'>
 			<availability>DC:7</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>MOC:2,Periphery:2</availability>
+		</model>
+		<model name='SHD-2D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>General:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>SL.R:6,FS:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3149,6 +3121,12 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,SL:3-,FWL:4,NIOPS:3,DC:8</availability>
 		<model name='(Standard)'>
@@ -3164,13 +3142,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>PP:3,SLIE:3,SL:3</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>SL:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>SL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3231,9 +3209,6 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:7,MOC:9,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,SL:9-,FWL:9,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 		</model>
@@ -3242,6 +3217,9 @@
 		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:2+</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Dagger' unitType='Aero'>
@@ -3309,11 +3287,11 @@
 		<model name='STU-K5'>
 			<availability>PP:8,SLIE:4,SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>PP:4,SLIE:8,SL.R:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -3324,11 +3302,11 @@
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>LA:7+,SL:9,FWL:7+,FS:7+</availability>
-		<model name='TLN-5W'>
-			<availability>PP:8,SLIE:8,LA:8,SL:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>SL:4,FWL:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>PP:8,SLIE:8,LA:8,SL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
@@ -3347,21 +3325,21 @@
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CC:4,MOC:2,FS:4,MERC:4,TC:2,CS:3,OA:2,LA:4,SL:6,FWL:4,NIOPS:3,SL.R:3,DC:4</availability>
+		<model name='(AC)'>
+			<availability>PP:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>PP:4,CS:8,General:8,NIOPS:8</availability>
 		</model>
-		<model name='(AC)'>
-			<availability>PP:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CC:4,CS:6,MOC:4+,OA:4+,SL:6,FWL:6,NIOPS:6,FS:4,MERC:4,Periphery:2+,TC:4+</availability>
-		<model name='THE-F'>
-			<availability>CC:2,FWL:2,FS:2</availability>
-		</model>
 		<model name='THE-Nb'>
 			<availability>SL.R:6</availability>
+		</model>
+		<model name='THE-F'>
+			<availability>CC:2,FWL:2,FS:2</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>CS:8,General:6+,SL:8,NIOPS:8</availability>
@@ -3379,11 +3357,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>PP:8,CS:7,SLIE:8,LA:6+,SL:8,FWL:6+,NIOPS:7,IS:6+,FS:6+,TC:4+</availability>
-		<model name='THG-11Eb'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,SL:8,FWL:8+,IS:8+,NIOPS:8,SL.R:4,FS:8+,DC:8+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -3405,28 +3383,28 @@
 			<roles>escort,ground_support</roles>
 			<availability>PP:4,SLIE:6,LA:6+,SL:6+,SL.R:6</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,SL.R:4</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>PP:4,SLIE:8,SL.R:8</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,SL.R:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,CS:5-,LA:8,SL:5-,IS:5,NIOPS:5-,Periphery.Deep:5,FS:7,MERC:5,Periphery:5,TC:5,DC:8</availability>
-		<model name='TDR-5Sd'>
-			<availability>FS:3+</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>SL.R:6</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>MOC:1,TC:1,Periphery:1</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,SLIE:5,LA:8,General:8,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
+		</model>
+		<model name='TDR-5Sd'>
+			<availability>FS:3+</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -3450,29 +3428,26 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:5,MOC:2,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,LA:6,SL:9,FWL:5,NIOPS:9,DC:2</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,SL:1,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>SL.R:6</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,SL.R:5</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
 		<availability>CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,CS:6,LA:5,SL:6,FWL:5,NIOPS:6,DC:5</availability>
 		<model name='(2755) (LF)'>
 			<availability>SL:6</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,SL.R:6</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,SL.R:6</availability>
@@ -3486,25 +3461,25 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:4,MOC:4,CS:5-,FWL:6,NIOPS:5-,MERC:4</availability>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CC:6+,CS:6,FWL:6+,NIOPS:6</availability>
-		</model>
 		<model name='TBT-5N'>
 			<roles>fire_support</roles>
 			<availability>CS:2,CC:2,MOC:2,NIOPS:2,FWL:2,MERC:2</availability>
 		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CC:6+,CS:6,FWL:6+,NIOPS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:6,MOC:5,FS:6,MERC:6,CIR:4,TC:5,CS:7,OA:5,LA:3,SL:7,FWL:4,NIOPS:7,DC:6</availability>
-		<model name='TRN-3U'>
-			<availability>IS:4-,Periphery:4-</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:7,SL:8,IS:7,NIOPS:8,Periphery.Deep:7,SL.R:4,Periphery:7</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>SL.R:8</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:4-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -3523,10 +3498,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:2</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -3534,6 +3505,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -3606,14 +3581,14 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:4,LA:7,SL:5,IS:4,FWL:6,FS:6,MERC:4,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>CC:2,LA:2,SL:8,FWL:2,FS:2,DC:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>SL.R:5</availability>
-		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -3649,18 +3624,17 @@
 		<model name='(2570)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,LA:9,SL:5,FWL:9,IS:8,NIOPS:6-,Periphery.Deep:4,TC:4,Periphery:4</availability>
+		<model name='WHM-6L'>
+			<availability>CC:3</availability>
+		</model>
 		<model name='WHM-6R'>
 			<availability>General:8,SL:6-,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 		</model>
-		<model name='WHM-6L'>
-			<availability>CC:3</availability>
+		<model name='WHM-6Rk'>
+			<availability>DC:3+</availability>
 		</model>
 		<model name='WHM-7A'>
 			<availability>SL:5,SL.R:8</availability>
@@ -3668,20 +3642,17 @@
 		<model name='WHM-6Rb'>
 			<availability>CC:4+,LA:4+,FWL:4+,SL.R:6,FS:4+</availability>
 		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>SL:4,IS:3</availability>
-		<model name='WSP-100'>
-			<availability>SL:5,IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>SL:4,IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>SL:2+,IS:1+</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>SL:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -3692,9 +3663,17 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,SL:4,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:5,Periphery:5</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:3</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='WSP-1L'>
+			<roles>recon</roles>
+			<availability>CC:3</availability>
 		</model>
 		<model name='WSP-1D'>
 			<roles>recon</roles>
@@ -3703,14 +3682,6 @@
 		<model name='WSP-1'>
 			<roles>recon</roles>
 			<availability>MOC:1,Periphery:1</availability>
-		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:3</availability>
-		</model>
-		<model name='WSP-1K'>
-			<roles>recon</roles>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -3739,6 +3710,10 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,SLIE:3,LA:7,SL:3,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:7,TC:4,DC:6</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>FWL:8</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3747,23 +3722,19 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>FWL:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,SL:6,NIOPS:6,FS:4,DC:6,TC:5</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>SL.R:8</availability>
+			<availability>CS:8,CC:8,SL:8,NIOPS:8,SL.R:4,FS:8,DC:8,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:3+,SL:8,FWL:3+</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CS:8,CC:8,SL:8,NIOPS:8,SL.R:4,FS:8,DC:8,TC:8</availability>
+			<availability>SL.R:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -3821,11 +3792,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CC:2,MOC:2,IS:2,FS:2,Periphery:2,TC:2,CS:5,OA:2,LA:2,SL:6,FWL:2,NIOPS:5,DC:4</availability>
-		<model name='ZRO-116b'>
-			<availability>SL.R:8</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,NIOPS:8,SL.R:4</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -312,13 +312,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>PP:5,CC:5,LA:3,FWL:4,FS:5,DC:4</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,General:8</availability>
-		</model>
 		<model name='(2372)'>
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:6</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -332,13 +332,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>PP:5,CC:5+,MOC:3+,CS:7,OA:3+,LA:5+,FWL:5+,NIOPS:7,FS:5+,MERC:5+,TC:3+,DC:5+</availability>
-		<model name='Mk III'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -358,13 +358,13 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>PP:3,CC:7,CS:5-,LA:9,IS:6,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>LA:8,IS:8,Periphery.Deep:8,DC:8,Periphery:8</availability>
-		</model>
 		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
 			<availability>PP:4</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>LA:8,IS:8,Periphery.Deep:8,DC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -375,37 +375,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>PP:10,CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PP:5-,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PP:6,PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PP:3,PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -415,17 +395,37 @@
 			<roles>apc</roles>
 			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PP:6,PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PP:6,PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:3,PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -440,35 +440,29 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>PP:3,CLAN:5</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>General:4,CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>PP:5,CC:2,MOC:1,CS:4-,OA:1,LA:3,IS:2,FWL:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
-		<model name='AS7-D'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atreus Battleship' unitType='Warship'>
 		<availability>FWL:5</availability>
 		<model name='(2552)'>
 			<roles>battleship</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2552)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -483,20 +477,17 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:4,OA:4,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
 		<availability>CC:3,LA:2,FWL:3,FS:3,DC:3</availability>
 		<model name='(2520)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2520)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -511,17 +502,17 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>PP:4,CC:7,CS:8-,MOC:5,LA:8,PIR:6,IS:7,FWL:8,NIOPS:8-,FS:7,DC:7,TC:6</availability>
+		<model name='BLR-1Gc'>
+			<availability>PP:4,CC:3+,LA:3+,FWL:3+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>PP:4,CC:2+</availability>
+		</model>
 		<model name='BLR-1Gbc'>
 			<availability>PP:2</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>PP:4,CC:2+</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>PP:4,CC:3+,LA:3+,FWL:3+,FS:2+,DC:2+</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:2+</availability>
@@ -550,17 +541,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>PP:10,CS:7,LA:4,FWL:6,NIOPS:7,FWL.OH:6,MERC:4,FS:6,DC:4</availability>
-		<model name='BL-6-KNT'>
-			<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>PP:4,CS:4,NIOPS:4,FWL:2+</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:6-</availability>
+		<model name='BL-6-KNT'>
+			<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:6-,FWL:3-,MERC:6-,FS:6-,DC:6-</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -598,13 +589,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:4,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -616,11 +607,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -666,32 +657,28 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>PP:2,CC:6,MOC:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,FWL:4,NIOPS:2,DC:6</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:4,DC:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>PP:4,CC:2+,CLAN:6,DC:3+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,FWL:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -725,18 +712,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>PP:5,CC:7,CS:5,LA:7,IS:6,FWL:6,NIOPS:5,FS:6,MERC:6,DC:6</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>PP:8,CC:7+,CS:8,NIOPS:8</availability>
+		<model name='CHP-1Nb'>
+			<availability>PP:4</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:4-,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CC:4+,CS:4,LA:4+</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>PP:8,CC:7+,CS:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -755,13 +742,13 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
+		</model>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -773,14 +760,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:3,PP:6,CC:5,OA:3,LA:8,FWL:6,MERC:5,FS:5,CIR:3,Periphery:2,TC:3,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>PP:6,LA:3,FS:3,MERC:3</availability>
+		<model name='CHP-W5'>
+			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>PP:4</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>PP:6,LA:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -792,29 +779,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,LA:5,FWL:5,NIOPS:3-,DC:5</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>PP:8,CS:8,IS:6</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
@@ -863,13 +850,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>PP:7,CC:6,MOC:3,IS:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:4,FWL:4,NIOPS:6,DC:4</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -888,26 +875,26 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:3,PP:6,CC:3,OA:3,LA:4,FWL:5,MERC:3,FS:6,CIR:2,Periphery:2,TC:3,DC:3</availability>
-		<model name='CSR-V12'>
-			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='CSR-V12b'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='CSR-V12'>
+			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -916,13 +903,13 @@
 			<roles>raider</roles>
 			<availability>PP:4,CC:3+,FWL:3+</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>PP:8,CS:8,CC:6+,LA:6+,NIOPS:8,FWL:6+,DC:6+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:4,Periphery.Deep:4,NIOPS:0,Periphery:4</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>PP:8,CS:8,CC:6+,LA:6+,NIOPS:8,FWL:6+,DC:6+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>PP:4,LA:4+,DC:4+</availability>
@@ -930,28 +917,28 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>PP:10,CC:7,CS:8,LA:7,FWL:7,NIOPS:8,FS:7,DC:7</availability>
-		<model name='CRK-5003-1'>
-			<availability>CS:8,General:8+,NIOPS:8</availability>
-		</model>
 		<model name='CRK-5003-1b'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='CRK-5003-1'>
+			<availability>CS:8,General:8+,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:1</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crosscut' unitType='Mek'>
 		<availability>PP:5</availability>
-		<model name='ED-X2M ForestryMech(Flamer)'>
+		<model name='ED-X2M2 ForestryMech(Rocket)'>
 			<availability>PP:8</availability>
 		</model>
-		<model name='ED-X2M2 ForestryMech(Rocket)'>
+		<model name='ED-X2M ForestryMech(Flamer)'>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -964,8 +951,9 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>PP:6,CS:6-,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='CRD-2R'>
-			<availability>PP:4,IS:3+,Periphery:3+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -973,9 +961,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>PP:4,IS:3+,Periphery:3+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -983,11 +970,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>PP:4,CC:5,CS:3,OA:3,LA:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -995,13 +982,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>PP:7,CC:5,MOC:5,IS:4,FS:5,CIR:4,TC:5,Periphery:3,CS:6,OA:5,LA:5,FWL:5,NIOPS:6,DC:5</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>PP:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,CS:8,General:8,NIOPS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daedalus' unitType='Mek'>
@@ -1033,13 +1020,13 @@
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
 		<availability>FS:6</availability>
-		<model name='Block II'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='Block I'>
 			<roles>destroyer</roles>
 			<availability>FS:2</availability>
+		</model>
+		<model name='Block II'>
+			<roles>destroyer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Deathstalker' unitType='Aero'>
@@ -1057,11 +1044,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1081,14 +1068,14 @@
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
 		<availability>PP:9,CC:6,CS:8,LA:6,FWL:6,NIOPS:8,FS:6,MERC:6,DC:6</availability>
+		<model name='(Horned Demon)'>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>PP:4,CS:4,NIOPS:4,IS:4</availability>
-		</model>
-		<model name='(Horned Demon)'>
-			<availability>General:2</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:2</availability>
@@ -1105,22 +1092,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:4</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1139,9 +1126,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,PP:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:6,FS:6</availability>
 		</model>
@@ -1151,6 +1135,9 @@
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:4,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1210,13 +1197,13 @@
 			<roles>fire_support</roles>
 			<availability>PP:4</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,NIOPS:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1232,11 +1219,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>PP:7,CC:2,CS:4,LA:2,FWL:2,NIOPS:4,FS:2,DC:2</availability>
-		<model name='EXT-4Db'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,NIOPS:8</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon' unitType='Mek'>
@@ -1247,10 +1234,10 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>PP:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
+		<model name='FLC-4Nb-PP2'>
 			<availability>PP:2</availability>
 		</model>
-		<model name='FLC-4Nb-PP2'>
+		<model name='FLC-4Nb'>
 			<availability>PP:2</availability>
 		</model>
 	</chassis>
@@ -1267,6 +1254,10 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
@@ -1275,17 +1266,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -1296,16 +1283,16 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>PP:8,CC:4,OA:2+,FS:4</availability>
-		<model name='FFL-3PP3'>
-			<availability>PP:2</availability>
-		</model>
 		<model name='FFL-3SLE'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='FFL-3PP'>
+			<availability>PP:2</availability>
 		</model>
 		<model name='FFL-3PP2'>
 			<availability>PP:2</availability>
 		</model>
-		<model name='FFL-3PP'>
+		<model name='FFL-3PP3'>
 			<availability>PP:2</availability>
 		</model>
 		<model name='FFL-3A'>
@@ -1315,52 +1302,44 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>PP:5,CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
+		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>CC:2</availability>
 		</model>
 		<model name='FS9-A'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>LA:1</availability>
 		</model>
-		<model name='FS9-K'>
+		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>CC:2</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>PP:8,CS:5,Periphery.R:4,LA:6,FWL:5,NIOPS:5</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:8+,FWL:8+,NIOPS:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:4-</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:8+,FWL:8+,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
@@ -1370,32 +1349,38 @@
 			<roles>cargo</roles>
 			<availability>PP:6</availability>
 		</model>
+		<model name='(Mortar)'>
+			<roles>cargo,support</roles>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:4,OA:4,Periphery.MW:2,Periphery.ME:2,FWL:6</availability>
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:2-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1403,9 +1388,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1460,12 +1447,12 @@
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>PP:7,CC:4,MOC:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,TC:6,Periphery:4,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,DC:8</availability>
-		<model name='GAL-200 (RL)'>
-			<availability>PP:5</availability>
-		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='GAL-200 (RL)'>
+			<availability>PP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -1503,14 +1490,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>PP:9,CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
-		<model name='GTHA-300'>
-			<availability>PP:6,FWL:6</availability>
+		<model name='GTHA-500b'>
+			<availability>PP:4</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>PP:6,CS:6,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>PP:4</availability>
+		<model name='GTHA-300'>
+			<availability>PP:6,FWL:6</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>PP:6,General:6</availability>
@@ -1549,14 +1536,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>PP:7,CC:6,MOC:4,IS:6,FS:6,CIR:4,TC:4,CS:7,OA:4,LA:6,FWL:6,NIOPS:7,DC:6</availability>
-		<model name='HMR-HD'>
-			<availability>General:8</availability>
+		<model name='HMR-HC'>
+			<availability>IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:6,NIOPS:8</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>PP:4</availability>
@@ -1564,23 +1551,23 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:4,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(Standard)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>FWL:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Harvester Ant' unitType='Mek'>
 		<availability>PP:5</availability>
-		<model name='KIC-3 Agromech(MG)'>
-			<roles>anti_infantry</roles>
-			<availability>PP:8</availability>
-		</model>
 		<model name='KIC-3 Agromech(LRM)'>
 			<roles>fire_support</roles>
+			<availability>PP:8</availability>
+		</model>
+		<model name='KIC-3 Agromech(MG)'>
+			<roles>anti_infantry</roles>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -1593,6 +1580,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -1601,33 +1596,21 @@
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
+		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1635,6 +1618,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -1643,6 +1630,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1650,14 +1645,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -1670,6 +1657,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>PP:6,CC:4,MOC:3+,CS:6,OA:3+,LA:4,IS:3,FWL:4,NIOPS:6,FS:4,TC:3+,DC:4</availability>
+		<model name='HCT-213C'>
+			<availability>PP:4,CLAN:8</availability>
+		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,IS:8,DC:8,Periphery:8</availability>
@@ -1677,24 +1667,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,PP:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>PP:4,CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
@@ -1703,24 +1690,24 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:5,PP:4,CC:4,CS:3,OA:5,FWL:5,NIOPS:3,DC:4</availability>
-		<model name='HER-1Sb'>
-			<roles>recon</roles>
-			<availability>PP:4,FWL:4+</availability>
-		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,General:8-,NIOPS:8</availability>
+		</model>
+		<model name='HER-1Sb'>
+			<roles>recon</roles>
+			<availability>PP:4,FWL:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -1737,11 +1724,11 @@
 		<model name='HOP-4Bb'>
 			<availability>PP:6</availability>
 		</model>
-		<model name='HOP-4C'>
-			<availability>MOC:8,OA:8,FS:8</availability>
-		</model>
 		<model name='HOP-4B'>
 			<availability>CC:2</availability>
+		</model>
+		<model name='HOP-4C'>
+			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -1777,12 +1764,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>PP:9,CS:4,LA:2,NIOPS:4,FS:2,DC:1</availability>
-		<model name='HSR-200-Db'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,General:8,NIOPS:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -1793,13 +1780,13 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>IS:2</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
@@ -1817,10 +1804,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>PP:9,CC:9,MOC:8,IS:7,Periphery.Deep:8,FS:9,CIR:8,TC:8,Periphery:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -1854,13 +1841,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -1896,13 +1883,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>FS.RR:2,FS.DMM:2,DC:4</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:5</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -1914,17 +1901,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -1941,11 +1928,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>PP:5,CC:3,CS:2,LA:3,FWL:4,NIOPS:2,FS:3,DC:3</availability>
-		<model name='(AC)'>
-			<availability>PP:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>PP:4,General:8</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>PP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -1976,11 +1963,11 @@
 		<model name='KTO-19'>
 			<availability>PP:8,CS:8,General:4,NIOPS:8,FS:4,MERC:4</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:2</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -2005,17 +1992,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:3,MOC:2,OA:2</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:4+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
+		<model name='KSC-4L'>
+			<availability>CC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -2047,13 +2034,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>PP:6,CC:6,MOC:4,CS:6,OA:4,LA:6,IS:6,NIOPS:6,MERC:6,CIR:4,TC:4,DC:6</availability>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>PP:6,CS:8,IS:8,NIOPS:8,DC:8</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>PP:6,CS:8,IS:8,NIOPS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2083,15 +2070,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:3</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,LA:4</availability>
@@ -2112,14 +2099,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>PP:5,CC:8,MOC:2,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:3</availability>
+		<model name='LTN-G15'>
+			<availability>General:8</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>PP:4</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -2131,13 +2118,13 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>PP:5,CS:6-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>PP:4</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -2163,9 +2150,6 @@
 		<availability>TC:2</availability>
 		<model name='(2622)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2622)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2198,10 +2182,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -2209,6 +2189,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
@@ -2283,30 +2267,30 @@
 	</chassis>
 	<chassis name='Marco' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='MR-8D'>
-			<availability>PP:8</availability>
-		</model>
 		<model name='MR-8E'>
 			<availability>PP:7</availability>
+		</model>
+		<model name='MR-8D'>
+			<availability>PP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
 		<availability>PP:5,MOC:4,OA:4,LA:5,IS:4,CIR:3,TC:4</availability>
-		<model name='(AC)'>
-			<availability>PP:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>PP:4,CHH:8,General:8</availability>
 		</model>
+		<model name='(AC)'>
+			<availability>PP:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden' unitType='Tank'>
@@ -2360,17 +2344,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2378,31 +2362,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -2411,11 +2395,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2456,21 +2440,21 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>PP:2,IS:2,MERC:2,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(ICE - LL)'>
+			<roles>support</roles>
+			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='(ICE - LL)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:2,MERC:2,DC:2</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -2500,20 +2484,17 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>PP:6,CS:6,MOC:4+,OA:4+,FWL:6+,NIOPS:6,FS:6+,MERC:4+,DC:6+,TC:4+</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>PP:8,CS:8,NIOPS:8,IS:8,Periphery:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>PP:4</availability>
 		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>PP:8,CS:8,NIOPS:8,IS:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>PP:2,IS:3</availability>
-		<model name='(2776)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
 		</model>
@@ -2532,6 +2513,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -2540,12 +2527,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2560,13 +2541,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:5</availability>
-		<model name='(Block I)'>
-			<roles>destroyer</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='(Block II)'>
 			<roles>destroyer</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Block I)'>
+			<roles>destroyer</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -2636,13 +2617,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>PP:5,CC:5,CS:4,LA:5,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>PP:4</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -2678,12 +2659,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>PP:6,CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:8</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,DC:1,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>PP:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,DC:1,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -2719,41 +2700,41 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:4</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:4</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>PP:5,CS:7,IS:7,FWL:7,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
-		<model name='PXH-1D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>PP:6,General:8,Periphery:8</availability>
-		</model>
 		<model name='PXH-2'>
 			<roles>recon</roles>
 			<availability>PP:4,CC:4+,MOC:4+,OA:4+,FWL:4+</availability>
 		</model>
-		<model name='PXH-1K'>
+		<model name='PXH-1D'>
 			<roles>recon</roles>
-			<availability>DC:6</availability>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-1Kk'>
+			<availability>DC:3+</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>PP:3</availability>
 		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:3+</availability>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>PP:6,General:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -2766,9 +2747,6 @@
 		<availability>MOC:6,OA:5,TC:6</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2799,10 +2777,10 @@
 	</chassis>
 	<chassis name='Powerman XI LoaderMech' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='(Laser)'>
+		<model name='(SRM)'>
 			<availability>PP:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(Laser)'>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -2815,13 +2793,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,General:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -2847,9 +2825,6 @@
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>PP:8,CS:8,OA:3,LA:6,IS:4,NIOPS:8,MERC:4</availability>
-		<model name='RPR-100b'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,LA:4,General:4</availability>
@@ -2860,16 +2835,19 @@
 		<model name='RPR-200'>
 			<availability>PP:2</availability>
 		</model>
+		<model name='RPR-100b'>
+			<availability>PP:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>PP:9,MOC:8,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>fire_support</roles>
@@ -2896,9 +2874,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>PP:5,CC:4+,CS:5,LA:4+,FWL:4+,NIOPS:5,FS:4+,DC:4+</availability>
@@ -2913,28 +2888,28 @@
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
 		<availability>FS:4</availability>
-		<model name='Block I'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Block II'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Block I'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>PP:5,CC:4,MOC:3,IS:4,FS:3,CIR:2,TC:3,CS:4,OA:3,LA:4,FWL:4,NIOPS:4,DC:3</availability>
-		<model name='RGU-133L'>
-			<availability>CS:4,General:4,NIOPS:4</availability>
-		</model>
-		<model name='RGU-133F'>
-			<availability>CS:6,General:6,NIOPS:6</availability>
-		</model>
 		<model name='RGU-133Eb'>
 			<availability>PP:4</availability>
 		</model>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
+		<model name='RGU-133L'>
+			<availability>CS:4,General:4,NIOPS:4</availability>
+		</model>
+		<model name='RGU-133F'>
+			<availability>CS:6,General:6,NIOPS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -2942,16 +2917,16 @@
 		<model name='RND-J-1-11 (LRM)'>
 			<availability>PP:5</availability>
 		</model>
-		<model name='RND-J-1-11'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>PP:2,General:8</availability>
+		<model name='RND-J-1-11 (RL)'>
+			<availability>PP:5</availability>
 		</model>
 		<model name='RND-J-1-11 (SRM)'>
 			<availability>PP:5</availability>
 		</model>
-		<model name='RND-J-1-11 (RL)'>
-			<availability>PP:5</availability>
+		<model name='RND-J-1-11'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>PP:2,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
@@ -2995,13 +2970,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:6,PP:5,CC:6,OA:6,LA:6,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>PP:4,CC:4+,MOC:1+,OA:4+,LA:4+,General:3+,FWL:4+,FS:4+,DC:4+,TC:1+</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,General:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>PP:4,CC:4+,MOC:1+,OA:4+,LA:4+,General:3+,FWL:4+,FS:4+,DC:4+,TC:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Sand Devil Hover Tank' unitType='Tank'>
@@ -3019,11 +2994,11 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,LA:6,FWL:6,IS:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -3059,28 +3034,28 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>PP:4,CS:6-,LA:6,IS:7,NIOPS:6-,Periphery.Deep:4,Periphery:4</availability>
-		<model name='SHD-2Hb'>
-			<availability>PP:4,FS:3+</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>PP:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>PP:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>PP:4,FS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3107,6 +3082,12 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>PP:4,CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 		<model name='(Standard)'>
@@ -3122,13 +3103,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>PP:3,CC:3+,LA:3+,CSJ:3</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>PP:4,LA:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>PP:4,LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3189,9 +3170,6 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>PP:9,CC:7,MOC:9,IS:8,Periphery.Deep:9,FS:7,CIR:9,TC:9,Periphery:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
@@ -3200,6 +3178,9 @@
 		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:2+</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -3261,11 +3242,11 @@
 		<model name='STU-K5'>
 			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -3276,11 +3257,11 @@
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>PP:9,LA:5+,FWL:5+,FS:5+</availability>
-		<model name='TLN-5W'>
-			<availability>PP:8,LA:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>FWL:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>PP:8,LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
@@ -3299,21 +3280,21 @@
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>PP:5,CC:4,MOC:2,CS:3,OA:2,LA:4,FWL:4,NIOPS:3,FS:4,MERC:4,TC:2,DC:4</availability>
+		<model name='(AC)'>
+			<availability>PP:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>PP:4,CS:8,General:8,NIOPS:8</availability>
 		</model>
-		<model name='(AC)'>
-			<availability>PP:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>PP:6,CC:4,CS:6,MOC:4+,OA:4+,FWL:6,NIOPS:6,FS:4,MERC:4,TC:4+</availability>
-		<model name='THE-F'>
-			<availability>CC:2,FWL:2,FS:2</availability>
-		</model>
 		<model name='THE-Nb'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='THE-F'>
+			<availability>CC:2,FWL:2,FS:2</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>PP:6,CS:8,General:6+,NIOPS:8</availability>
@@ -3331,11 +3312,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>PP:8,CS:7,LA:6+,FWL:6+,NIOPS:7,IS:6+,FS:6+,TC:4+</availability>
-		<model name='THG-11Eb'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>PP:8,CS:8,FWL:8+,IS:8+,NIOPS:8,FS:8+,DC:8+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -3357,25 +3338,25 @@
 			<roles>escort,ground_support</roles>
 			<availability>PP:4,LA:6+</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>PP:4</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>PP:5,CC:8,CS:5-,LA:8,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,TC:6,DC:8</availability>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:2+</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>PP:4</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -3399,27 +3380,24 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>PP:9,CC:5,MOC:2,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,LA:6,FWL:5,NIOPS:9,DC:2</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>PP:4</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='THK-63b'>
+			<availability>PP:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
 		<availability>PP:6,CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,CS:6,LA:5,FWL:5,NIOPS:6,DC:5</availability>
-		<model name='(2754)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2754)'>
 			<availability>General:8</availability>
 		</model>
@@ -3432,22 +3410,22 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:4,MOC:4,CS:5-,FWL:6,NIOPS:5-,MERC:4</availability>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CC:5+,CS:6,FWL:5+,NIOPS:6</availability>
-		</model>
 		<model name='TBT-5N'>
 			<roles>fire_support</roles>
 			<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
 		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CC:5+,CS:6,FWL:5+,NIOPS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>PP:7,CC:6,MOC:5,FS:6,MERC:6,CIR:4,TC:5,CS:7,OA:5,LA:3,FWL:4,NIOPS:7,DC:6</availability>
-		<model name='TRN-3U'>
-			<availability>IS:4-,Periphery:4-</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>PP:8,CS:8,OA:6,IS:6,NIOPS:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:4-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -3473,10 +3451,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:2</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -3484,6 +3458,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -3556,14 +3534,14 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>PP:5,CC:4,LA:7,IS:4,FWL:6,MERC:4,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>PP:8,CC:2,LA:2,FWL:2,FS:2,DC:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>PP:5</availability>
-		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -3599,18 +3577,17 @@
 		<model name='(2570)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>PP:6,CS:6-,LA:9,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,TC:5,Periphery:5</availability>
+		<model name='WHM-6L'>
+			<availability>CC:3</availability>
+		</model>
 		<model name='WHM-6R'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='WHM-6L'>
-			<availability>CC:3</availability>
+		<model name='WHM-6Rk'>
+			<availability>DC:2+</availability>
 		</model>
 		<model name='WHM-7A'>
 			<availability>PP:2</availability>
@@ -3618,20 +3595,17 @@
 		<model name='WHM-6Rb'>
 			<availability>PP:4,CC:4+,LA:4+,FWL:4+,FS:4+</availability>
 		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:2+</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -3642,21 +3616,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>PP:4,CS:4-,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:5,Periphery:5</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:3</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:3</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:3</availability>
+			<availability>FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -3672,16 +3646,20 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>PP:5,CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:7,TC:5,DC:6</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>FWL:8</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3690,23 +3668,19 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>FWL:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>PP:6,CS:6,CC:6,NIOPS:6,FS:6,DC:6,TC:5</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>PP:4</availability>
+			<availability>CS:8,CC:8,NIOPS:8,FS:8,DC:8,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:4+,FWL:4+</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CS:8,CC:8,NIOPS:8,FS:8,DC:8,TC:8</availability>
+			<availability>PP:4</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -3764,11 +3738,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>MOC:2,PP:6,CC:1,IS:1,FS:1,TC:2,Periphery:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:4</availability>
-		<model name='ZRO-116b'>
-			<availability>PP:4</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>PP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -486,13 +486,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>PP:5,CC:5,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:5,CGS:4,CSA:4,CDS:4,LA:3,CBS:4,CNC:5,FWL:4,CJF:5,DC:4,CB:4</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,General:8,CLAN:8</availability>
-		</model>
 		<model name='(2372)'>
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:6</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -506,13 +506,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>MOC:2+,PP:5,CC:4+,CLAN:7,MERC:4+,FS:4+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:4+,CNC:7,FWL:4+,NIOPS:7,CJF:7,DC:5+</availability>
-		<model name='Mk III'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -538,13 +538,13 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>PP:3,CC:7,CS:5-,LA:9,FWL:9,IS:6,NIOPS:5-,Periphery.Deep:6,FS:8,DC:8,Periphery:6</availability>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>LA:8,IS:8,Periphery.Deep:8,DC:8,Periphery:8</availability>
-		</model>
 		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
 			<availability>PP:2,CLAN:8</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>LA:8,IS:8,Periphery.Deep:8,DC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -555,37 +555,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>PP:10,CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PP:5-,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PP:4,PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PP:6,PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PP:3,PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -595,17 +575,37 @@
 			<roles>apc</roles>
 			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PP:6,PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PP:5,PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PP:6,PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PP:3,PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -620,26 +620,23 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>PP:3,CLAN:5</availability>
-		<model name='AS7-D-H'>
-			<availability>PP:6,General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>PP:2,CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>PP:6,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>PP:5,CC:2,MOC:1,CS:4-,OA:1,LA:3,IS:2,FWL:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
-		<model name='AS7-D'>
-			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atreus Battleship' unitType='Warship'>
@@ -648,17 +645,11 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -683,20 +674,17 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:4,OA:4,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
 		<availability>CC:3,LA:2,FWL:3,FS:3,DC:3</availability>
 		<model name='(2520)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2520)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -711,17 +699,17 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>PP:4,CC:7,MOC:6,CLAN:4,IS:7,FS:7,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4,DC:7</availability>
+		<model name='BLR-1Gc'>
+			<availability>PP:4,CC:3+,LA:3+,CLAN:4,FWL:3+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>PP:2,CC:2+,CLAN:8</availability>
+		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:2</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>PP:2,CC:2+,CLAN:8</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>PP:4,CC:3+,LA:3+,CLAN:4,FWL:3+,FS:2+,DC:2+</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:2+</availability>
@@ -750,17 +738,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>PP:10,CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:6,FS:5,MERC:4,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:4,CNC:10,FWL:6,NIOPS:7,CJF:8,CGB:10,DC:4</availability>
-		<model name='BL-6-KNT'>
-			<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>PP:2,CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:6-</availability>
+		<model name='BL-6-KNT'>
+			<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:6-,FWL:3-,MERC:6-,FS:6-,DC:6-</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -798,13 +786,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:4,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -816,11 +804,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -866,32 +854,28 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>PP:2,CC:6,MOC:2,CLAN:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,FWL:4,NIOPS:2,DC:6</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:4,DC:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>PP:2,CC:2+,CLAN:6,DC:3+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,FWL:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -925,18 +909,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>PP:5,CC:7,CHH:6,CLAN:5,IS:6,MERC:6,FS:6,CS:5,LA:7,FWL:6,NIOPS:5,CGB:6,DC:6</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>PP:8,CC:6+,CS:8,NIOPS:8</availability>
+		<model name='CHP-1Nb'>
+			<availability>PP:2,CLAN:8</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:5-,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CC:4+,CS:4,LA:4+</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>PP:8,CC:6+,CS:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -955,13 +939,13 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
+		</model>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -973,14 +957,14 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>PP:6,CC:5,MOC:3,CLAN:5,FS:5,MERC:5,CIR:3,Periphery:2,TC:3,OA:3,LA:8,FWL:6,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>PP:6,LA:4,CLAN:6,FS:4,MERC:4</availability>
+		<model name='CHP-W5'>
+			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>PP:2,CLAN:8,CGS:6</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>PP:6,LA:4,CLAN:6,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -992,20 +976,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1013,14 +997,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1028,35 +1009,41 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1064,18 +1051,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1084,27 +1077,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1112,35 +1096,35 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,LA:5,FWL:5,NIOPS:3-,DC:5</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>PP:8,CS:8,CLAN:8,IS:6</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
@@ -1189,13 +1173,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>PP:7,CC:6,MOC:3,CLAN:5,IS:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:4,FWL:4,NIOPS:6,DC:4</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,CLAN:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6,CLAN:6</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -1214,26 +1198,26 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>PP:6,CC:3,MOC:3,CLAN:5,FS:6,MERC:3,CIR:2,Periphery:2,TC:3,OA:3,LA:4,FWL:5,DC:3</availability>
-		<model name='CSR-V12'>
-			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='CSR-V12b'>
 			<availability>PP:2,CLAN:6</availability>
+		</model>
+		<model name='CSR-V12'>
+			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1242,13 +1226,13 @@
 			<roles>raider</roles>
 			<availability>PP:2,CC:3+,CLAN:8,FWL:3+,CGS:8</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>PP:8,CS:8,CC:5+,LA:5+,CLAN:4,NIOPS:8,FWL:5+,DC:5+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:5,Periphery.Deep:5,NIOPS:0,Periphery:5</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>PP:8,CS:8,CC:5+,LA:5+,CLAN:4,NIOPS:8,FWL:5+,DC:5+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>PP:4,LA:4+,CLAN:4,DC:4+</availability>
@@ -1256,28 +1240,28 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>PP:10,CC:7,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:7,CGS:8,CS:8,CDS:8,CW:10,LA:7,CBS:10,FWL:7,NIOPS:8,CJF:8,CGB:10,DC:7</availability>
-		<model name='CRK-5003-1'>
-			<availability>CS:8,General:7+,NIOPS:8</availability>
-		</model>
 		<model name='CRK-5003-1b'>
 			<availability>PP:2,CLAN:8,CGS:8</availability>
+		</model>
+		<model name='CRK-5003-1'>
+			<availability>CS:8,General:7+,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:1</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crosscut' unitType='Mek'>
 		<availability>PP:5</availability>
-		<model name='ED-X2M ForestryMech(Flamer)'>
+		<model name='ED-X2M2 ForestryMech(Rocket)'>
 			<availability>PP:8</availability>
 		</model>
-		<model name='ED-X2M2 ForestryMech(Rocket)'>
+		<model name='ED-X2M ForestryMech(Flamer)'>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -1290,8 +1274,9 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>PP:6,CS:6-,CLAN:6,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='CRD-2R'>
-			<availability>PP:4,CLAN:8,IS:3+,CGS:8,Periphery:3+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -1299,9 +1284,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>PP:4,CLAN:8,IS:3+,CGS:8,Periphery:3+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1309,11 +1293,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>PP:4,CC:5,CS:3,OA:3,LA:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1321,13 +1305,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>PP:7,CC:5,MOC:5,IS:4,FS:5,CIR:4,TC:5,Periphery:3,CS:6,OA:5,LA:5,FWL:5,NIOPS:6,DC:5</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>PP:4,CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,CS:8,General:8,NIOPS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>PP:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daedalus' unitType='Mek'>
@@ -1366,13 +1350,13 @@
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
 		<availability>FS:5</availability>
-		<model name='Block II'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='Block I'>
 			<roles>destroyer</roles>
 			<availability>FS:3</availability>
+		</model>
+		<model name='Block II'>
+			<roles>destroyer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Deathstalker' unitType='Aero'>
@@ -1390,11 +1374,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1414,14 +1398,14 @@
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
 		<availability>PP:9,CC:5,CS:8,LA:5,CLAN:9,FWL:5,NIOPS:8,FS:5,MERC:5,CJF:9,DC:5</availability>
+		<model name='(Horned Demon)'>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>PP:4,CS:4,CHH:8,CLAN:8,NIOPS:4,IS:4</availability>
-		</model>
-		<model name='(Horned Demon)'>
-			<availability>General:2</availability>
 		</model>
 		<model name='(PPC)'>
 			<availability>General:2</availability>
@@ -1438,22 +1422,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:4</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1472,9 +1456,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>PP:4,CC:4,MOC:4,CLAN:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:6,FS:6</availability>
 		</model>
@@ -1484,6 +1465,9 @@
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:3,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1543,13 +1527,13 @@
 			<roles>fire_support</roles>
 			<availability>PP:2,CLAN:8,CGS:8</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1565,11 +1549,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>PP:7,CC:1,CS:4,LA:1,CLAN:6,FWL:1,NIOPS:4,FS:1,DC:1</availability>
-		<model name='EXT-4Db'>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,CLAN:4,NIOPS:8</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>PP:2,CLAN:8</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>CLAN:2</availability>
@@ -1583,11 +1567,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>PP:4</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>PP:1,CLAN:8</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>PP:4</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>PP:1,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -1603,6 +1587,10 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
@@ -1611,17 +1599,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -1632,16 +1616,16 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>PP:8,CC:3,OA:2+,FS:3</availability>
-		<model name='FFL-3PP3'>
-			<availability>PP:3</availability>
-		</model>
 		<model name='FFL-3SLE'>
 			<availability>PP:4,CLAN:8</availability>
+		</model>
+		<model name='FFL-3PP'>
+			<availability>PP:3</availability>
 		</model>
 		<model name='FFL-3PP2'>
 			<availability>PP:3</availability>
 		</model>
-		<model name='FFL-3PP'>
+		<model name='FFL-3PP3'>
 			<availability>PP:3</availability>
 		</model>
 		<model name='FFL-3A'>
@@ -1651,52 +1635,44 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>PP:5,CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
+		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>CC:2</availability>
 		</model>
 		<model name='FS9-A'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>LA:1</availability>
 		</model>
-		<model name='FS9-K'>
+		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>CC:2</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>PP:8,CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:5,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:8+,CLAN:8,FWL:8+,NIOPS:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:5-</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:8+,CLAN:8,FWL:8+,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>PP:6,IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(Armor)'>
-			<roles>cargo,support</roles>
-			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>cargo,support</roles>
-			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>cargo,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC)'>
-			<roles>cargo</roles>
+		<model name='(Armor)'>
+			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>cargo,support</roles>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>cargo</roles>
@@ -1706,32 +1682,38 @@
 			<roles>cargo</roles>
 			<availability>PP:6</availability>
 		</model>
+		<model name='(Mortar)'>
+			<roles>cargo,support</roles>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='(AC)'>
+			<roles>cargo</roles>
+			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>MOC:4,OA:4,Periphery.MW:2,Periphery.ME:2,FWL:6</availability>
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:2-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1739,9 +1721,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1796,12 +1780,12 @@
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,PP:7,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
-		<model name='GAL-200 (RL)'>
-			<availability>PP:6</availability>
-		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='GAL-200 (RL)'>
+			<availability>PP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -1839,14 +1823,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>PP:9,CC:4,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:9,NIOPS:9,DC:2</availability>
-		<model name='GTHA-300'>
-			<availability>PP:6,FWL:6</availability>
+		<model name='GTHA-500b'>
+			<availability>PP:4,CLAN:8</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>PP:6,CS:6,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>PP:4,CLAN:8</availability>
+		<model name='GTHA-300'>
+			<availability>PP:6,FWL:6</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>PP:6,General:6</availability>
@@ -1885,14 +1869,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>MOC:4,PP:7,CC:5,CLAN:7,IS:5,FS:5,CIR:4,TC:4,CS:7,OA:4,LA:5,CNC:7,FWL:5,NIOPS:7,DC:5</availability>
-		<model name='HMR-HD'>
-			<availability>General:8</availability>
+		<model name='HMR-HC'>
+			<availability>IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:6,NIOPS:8</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>PP:2,CSR:8,CLAN:8</availability>
@@ -1900,23 +1884,23 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:5,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(Standard)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>FWL:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Harvester Ant' unitType='Mek'>
 		<availability>PP:5</availability>
-		<model name='KIC-3 Agromech(MG)'>
-			<roles>anti_infantry</roles>
-			<availability>PP:8</availability>
-		</model>
 		<model name='KIC-3 Agromech(LRM)'>
 			<roles>fire_support</roles>
+			<availability>PP:8</availability>
+		</model>
+		<model name='KIC-3 Agromech(MG)'>
+			<roles>anti_infantry</roles>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -1929,6 +1913,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -1937,33 +1929,21 @@
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
+		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1971,6 +1951,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -1979,6 +1963,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -1986,14 +1978,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2006,6 +1990,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>PP:6,CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
+		<model name='HCT-213C'>
+			<availability>PP:4,CLAN:8</availability>
+		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,IS:8,DC:8,Periphery:8</availability>
@@ -2013,24 +2000,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,PP:4,CLAN:2,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>PP:4,CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,DC:3-,Periphery:4-,TC:4-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
@@ -2039,24 +2023,24 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:5,PP:4,CC:4,CS:3,CHH:5,OA:5,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:4,CB:5</availability>
-		<model name='HER-1Sb'>
-			<roles>recon</roles>
-			<availability>PP:2,CLAN:8,FWL:4+</availability>
-		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,General:6-,CLAN:6,NIOPS:8</availability>
+		</model>
+		<model name='HER-1Sb'>
+			<roles>recon</roles>
+			<availability>PP:2,CLAN:8,FWL:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -2070,17 +2054,17 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>PP:3,CC:5,MOC:4,CHH:4,CSR:0,CLAN:3,FS:5,CGS:5,TC:5,OA:4,LA:5,FWL:5,DC:4</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>PP:4,CLAN:6</availability>
+		</model>
+		<model name='HOP-4B'>
+			<availability>CC:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4B'>
-			<availability>CC:2</availability>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2113,12 +2097,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>PP:9,CS:4,CIH:9,LA:2,CSV:9,CLAN:8,NIOPS:4,FS:2,DC:1</availability>
-		<model name='HSR-200-Db'>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>PP:8,CS:8,General:8,NIOPS:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>PP:2,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -2129,13 +2113,13 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>IS:2</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
@@ -2156,10 +2140,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>PP:9,CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -2193,13 +2177,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -2239,13 +2223,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:2,FS.RR:2,OA:2,FS.DMM:2,MERC:2,Periphery.OS:2,DC:4</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:5</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -2257,17 +2241,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2284,11 +2268,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>PP:5,CC:3,CS:2,CHH:6,LA:3,CLAN:5,FWL:4,NIOPS:2,FS:3,DC:3</availability>
-		<model name='(AC)'>
-			<availability>PP:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>PP:4,General:8</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>PP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -2313,11 +2297,11 @@
 		<model name='KGC-0000'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,General:5,NIOPS:8</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2325,11 +2309,11 @@
 		<model name='KTO-19'>
 			<availability>PP:8,CS:8,General:4,NIOPS:8,FS:4,MERC:4</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>PP:2,CLAN:8,CGS:8</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:2</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>PP:2,CLAN:8,CGS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -2354,17 +2338,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:3,MOC:2,OA:2</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:4+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
+		<model name='KSC-4L'>
+			<availability>CC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -2396,13 +2380,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:4,PP:6,CC:6,CIH:6,CLAN:6,IS:6,CFM:6,MERC:6,CIR:4,CGS:6,TC:4,CS:6,OA:4,LA:6,NIOPS:6,DC:6</availability>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>PP:6,CS:8,CLAN:8,IS:7,NIOPS:8,DC:7</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>PP:6,CS:8,CLAN:8,IS:7,NIOPS:8,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2432,15 +2416,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:3</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,LA:4</availability>
@@ -2461,14 +2445,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>PP:5,CC:8,MOC:2,CLAN:5,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:3</availability>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>PP:2,CLAN:8</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:4</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -2480,13 +2464,13 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>PP:5,CS:6-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>PP:2,CLAN:8</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -2512,9 +2496,6 @@
 		<availability>TC:2</availability>
 		<model name='(2622)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2622)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2547,10 +2528,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:4,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -2558,6 +2535,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
@@ -2635,30 +2616,30 @@
 	</chassis>
 	<chassis name='Marco' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='MR-8D'>
-			<availability>PP:8</availability>
-		</model>
 		<model name='MR-8E'>
 			<availability>PP:7</availability>
+		</model>
+		<model name='MR-8D'>
+			<availability>PP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
 		<availability>PP:5,MOC:4,CHH:3,OA:4,LA:5,CLAN:3,IS:4,CIR:3,TC:4</availability>
-		<model name='(AC)'>
-			<availability>PP:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>PP:4,CHH:8,General:8</availability>
 		</model>
+		<model name='(AC)'>
+			<availability>PP:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -2706,17 +2687,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2724,31 +2705,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -2757,11 +2738,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2802,21 +2783,21 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>PP:2,IS:2,MERC:2,DC:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:6,General:4,MERC:2,DC:6</availability>
+		</model>
+		<model name='(ICE - LL)'>
+			<roles>support</roles>
+			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='(ICE - LL)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>CC:2,MERC:2,DC:2</availability>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -2846,30 +2827,27 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>PP:6,MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:6+,NIOPS:6,CJF:7,CGB:5,DC:6+</availability>
-		<model name='MON-66'>
+		<model name='MON-70'>
 			<roles>recon</roles>
-			<availability>PP:8,CS:8,NIOPS:8,IS:6+,Periphery:6+</availability>
-		</model>
-		<model name='MON-69'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
+			<availability>IS:5</availability>
 		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>PP:2,CLAN:9,CGS:9</availability>
 		</model>
-		<model name='MON-70'>
+		<model name='MON-69'>
 			<roles>recon</roles>
-			<availability>IS:5</availability>
+			<availability>DC:6</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>PP:8,CS:8,NIOPS:8,IS:6+,Periphery:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>PP:2,CLAN:2,IS:3</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
@@ -2889,6 +2867,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -2897,12 +2881,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -2917,13 +2895,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:5</availability>
-		<model name='(Block I)'>
-			<roles>destroyer</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='(Block II)'>
 			<roles>destroyer</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Block I)'>
+			<roles>destroyer</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -2951,12 +2929,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>PP:4,CLAN:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>PP:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -3004,13 +2982,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>PP:5,CC:5,CLAN:4-,IS:5,Periphery.Deep:5,FS:5,MERC:5,Periphery:5,CS:4,LA:5,FWL:5,NIOPS:4,DC:5</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>PP:2,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -3053,12 +3031,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>PP:6,CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:8</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,DC:1,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>PP:8,CLAN:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,DC:1,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3094,45 +3072,45 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:4</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:4</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>PP:5,CS:7,IS:7,FWL:7,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:4,CGS:5</availability>
+			<availability>PP:4,CC:4+,MOC:4+,OA:4+,FWL:4+</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>PP:6,General:8,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>PP:4,CC:4+,MOC:4+,OA:4+,FWL:4+</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
+		<model name='PXH-1Kk'>
+			<availability>DC:2+</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>PP:2,CLAN:7</availability>
 		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:2+</availability>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>PP:6,General:8,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3145,9 +3123,6 @@
 		<availability>MOC:5,OA:4,TC:5</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -3178,10 +3153,10 @@
 	</chassis>
 	<chassis name='Powerman XI LoaderMech' unitType='Mek'>
 		<availability>PP:4</availability>
-		<model name='(Laser)'>
+		<model name='(SRM)'>
 			<availability>PP:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(Laser)'>
 			<availability>PP:8</availability>
 		</model>
 	</chassis>
@@ -3194,13 +3169,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,General:8,CLAN:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -3226,9 +3201,6 @@
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>PP:8,CS:8,OA:3,LA:6,CLAN:8,IS:4,NIOPS:8,MERC:4</availability>
-		<model name='RPR-100b'>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,LA:4,General:4</availability>
@@ -3239,16 +3211,19 @@
 		<model name='RPR-200'>
 			<availability>PP:2</availability>
 		</model>
+		<model name='RPR-100b'>
+			<availability>PP:2,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>PP:9,MOC:8,CLAN:9,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>fire_support</roles>
@@ -3284,9 +3259,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>PP:5,CC:3+,CS:5,CHH:5,LA:3+,FWL:3+,NIOPS:5,FS:4+,DC:3+</availability>
@@ -3301,31 +3273,31 @@
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
 		<availability>FS:3</availability>
-		<model name='Block I'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Block II'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Block I'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>PP:5,CC:3,MOC:2,CLAN:4,IS:3,FS:3,CIR:2,TC:2,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:2</availability>
+		<model name='RGU-133Eb'>
+			<availability>PP:2,CLAN:8</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -3333,16 +3305,16 @@
 		<model name='RND-J-1-11 (LRM)'>
 			<availability>PP:5</availability>
 		</model>
-		<model name='RND-J-1-11'>
-			<roles>recon</roles>
-			<deployedWith>solo</deployedWith>
-			<availability>PP:2,General:8</availability>
+		<model name='RND-J-1-11 (RL)'>
+			<availability>PP:5</availability>
 		</model>
 		<model name='RND-J-1-11 (SRM)'>
 			<availability>PP:5</availability>
 		</model>
-		<model name='RND-J-1-11 (RL)'>
-			<availability>PP:5</availability>
+		<model name='RND-J-1-11'>
+			<roles>recon</roles>
+			<deployedWith>solo</deployedWith>
+			<availability>PP:2,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
@@ -3369,11 +3341,11 @@
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samarkand Carrier' unitType='Warship'>
@@ -3389,13 +3361,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:6,PP:5,CC:6,OA:6,LA:6,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>PP:4,CC:4+,MOC:1+,OA:4+,LA:4+,General:3+,CLAN:8,FWL:4+,FS:4+,DC:4+,TC:1+</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,General:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>PP:4,CC:4+,MOC:1+,OA:4+,LA:4+,General:3+,CLAN:8,FWL:4+,FS:4+,DC:4+,TC:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Sand Devil Hover Tank' unitType='Tank'>
@@ -3413,11 +3385,11 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,LA:6,FWL:6,IS:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -3460,28 +3432,28 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>PP:4,CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,Periphery:5,CGB:4</availability>
-		<model name='SHD-2Hb'>
-			<availability>PP:2,CLAN:8,FS:3+</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>PP:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>PP:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>PP:2,CLAN:8,FS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3508,6 +3480,12 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>PP:4,CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 		<model name='(Standard)'>
@@ -3523,13 +3501,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>PP:3,CC:4+,LA:4+,CSJ:3</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>PP:4,LA:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>PP:4,LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3590,9 +3568,6 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>PP:9,CC:7,MOC:9,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,CLAN:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
@@ -3601,6 +3576,9 @@
 		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:2+</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,CLAN:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -3662,11 +3640,11 @@
 		<model name='STU-K5'>
 			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>PP:2,CLAN:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
@@ -3685,11 +3663,11 @@
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>PP:9,LA:3+,CLAN:9,FWL:3+,FS:3+</availability>
-		<model name='TLN-5W'>
-			<availability>LA:8,CLAN:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>FWL:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>LA:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
@@ -3708,21 +3686,21 @@
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>PP:5,CC:4,MOC:2,CLAN:5,FS:4,MERC:4,TC:2,CS:3,OA:2,LA:4,FWL:4,NIOPS:3,DC:4</availability>
+		<model name='(AC)'>
+			<availability>PP:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>PP:4,CS:8,General:8,NIOPS:8</availability>
 		</model>
-		<model name='(AC)'>
-			<availability>PP:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>PP:6,CC:4,CS:6,MOC:4+,OA:4+,FWL:6,NIOPS:6,FS:4,MERC:4,TC:4+</availability>
-		<model name='THE-F'>
-			<availability>CC:2,FWL:2,FS:2</availability>
-		</model>
 		<model name='THE-Nb'>
 			<availability>PP:2,CLAN:8,CGS:8</availability>
+		</model>
+		<model name='THE-F'>
+			<availability>CC:2,FWL:2,FS:2</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>PP:6,CS:8,General:6+,NIOPS:8</availability>
@@ -3740,11 +3718,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>PP:8,CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:4+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
-		<model name='THG-11Eb'>
-			<availability>PP:2,CLAN:8</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>PP:8,CS:8,FWL:8+,IS:8+,NIOPS:8,FS:8+,DC:8+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>PP:2,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -3766,25 +3744,25 @@
 			<roles>escort,ground_support</roles>
 			<availability>PP:4,LA:6+,CLAN:7</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>PP:2,CLAN:8</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>PP:5,CC:8,CLAN:5,IS:6,Periphery.Deep:6,FS:7,MERC:6,Periphery:6,TC:6,CS:5-,LA:8,NIOPS:5-,DC:8</availability>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:2+</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>PP:2,CHH:8,CSR:8,CDS:8,CW:8,CLAN:8,CNC:8,CJF:8,CGB:8</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -3808,29 +3786,26 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>PP:9,CC:5,MOC:2,CLAN:9,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:6,FWL:5,NIOPS:9,DC:2</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>PP:2,CLAN:8</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>PP:2,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
 		<availability>PP:6,CC:5,MOC:5,CLAN:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,CS:6,LA:5,FWL:5,NIOPS:6,DC:5</availability>
 		<model name='(2755) (LF)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,CLAN:4</availability>
@@ -3844,25 +3819,25 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:4,MOC:4,CS:5-,FWL:6,NIOPS:5-,MERC:4</availability>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CC:4+,CS:6,FWL:4+,NIOPS:6</availability>
-		</model>
 		<model name='TBT-5N'>
 			<roles>fire_support</roles>
 			<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
 		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CC:4+,CS:6,FWL:4+,NIOPS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>PP:7,CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:4,TC:4,CS:7,OA:5,LA:2,FWL:3,NIOPS:7,DC:5</availability>
-		<model name='TRN-3U'>
-			<availability>IS:4-,Periphery:4-</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>PP:8,CS:8,OA:5+,IS:5+,NIOPS:8,Periphery.Deep:5+,Periphery:5+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:8</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:4-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -3888,10 +3863,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:2</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -3899,6 +3870,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
@@ -3971,14 +3946,14 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>PP:5,CC:4,LA:7,CLAN:4,IS:4,FWL:6,MERC:4,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>PP:8,CC:2,LA:2,CLAN:8,FWL:2,FS:2,DC:2</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>PP:5,CLAN:5</availability>
-		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4014,18 +3989,17 @@
 		<model name='(2570)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>PP:6,CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
+		<model name='WHM-6L'>
+			<availability>CC:3</availability>
+		</model>
 		<model name='WHM-6R'>
 			<availability>General:8,CLAN:2,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='WHM-6L'>
-			<availability>CC:3</availability>
+		<model name='WHM-6Rk'>
+			<availability>DC:2+</availability>
 		</model>
 		<model name='WHM-7A'>
 			<availability>PP:2,CLAN:8</availability>
@@ -4033,20 +4007,17 @@
 		<model name='WHM-6Rb'>
 			<availability>PP:2,CC:4+,LA:4+,CLAN:4,FWL:4+,FS:4+</availability>
 		</model>
-		<model name='WHM-6Rk'>
-			<availability>DC:2+</availability>
-		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -4057,21 +4028,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>PP:4,CS:4-,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:5,Periphery:5</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:3</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:3</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:3</availability>
+			<availability>FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -4087,12 +4058,12 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine II' unitType='Mek'>
@@ -4103,6 +4074,10 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>PP:5,CC:7,CWOV:6,CLAN:3,IS:7,Periphery.Deep:6,FS:7,TC:5,CS:5-,LA:7,FWL:9,NIOPS:5-,DC:6</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>FWL:8</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4111,23 +4086,19 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>FWL:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>PP:6,CS:6,CC:6,CIH:5,CLAN:6,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:5</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>PP:2,CLAN:8,CFM:8,CGS:8</availability>
+			<availability>CS:8,CC:8,NIOPS:8,FS:8,DC:8,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:4+,FWL:4+</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CS:8,CC:8,NIOPS:8,FS:8,DC:8,TC:8</availability>
+			<availability>PP:2,CLAN:8,CFM:8,CGS:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4185,11 +4156,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>MOC:2,PP:6,CC:1,CLAN:6,IS:1,FS:1,Periphery:2,TC:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:3</availability>
-		<model name='ZRO-116b'>
-			<availability>PP:2,CSR:6</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>PP:2,CSR:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -556,13 +556,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CC:4,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:4,CGS:4,CSA:4,CDS:4,LA:3,CBS:4,CNC:5,FWL:4,CJF:5,DC:4,CB:4</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,General:5,CLAN:6</availability>
-		</model>
 		<model name='(2372)'>
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,General:5,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -576,29 +576,29 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>MOC:2+,CC:4+,CLAN:7,MERC:4+,FS:4+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:4+,CNC:7,FWL:4+,NIOPS:7,CJF:7,DC:4+</availability>
-		<model name='Mk III'>
-			<availability>General:2</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
 			<availability>General:2</availability>
 		</model>
+		<model name='Mk III'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CSR:3,CLAN:3,CCO:3,CGB:3</availability>
-		<model name='ANH-1G'>
-			<availability>CSA:6,CCO:6</availability>
+		<model name='C 2'>
+			<availability>CLAN:3</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CSA:2,CLAN:6,CCO:2</availability>
 		</model>
+		<model name='ANH-1G'>
+			<availability>CSA:6,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:6</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -617,61 +617,41 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:2</availability>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:8,CLAN:5,IS:8,Periphery.Deep:8,DC:7,Periphery:8</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8</availability>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:4</availability>
-		</model>
 		<model name='Mk.III'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -681,17 +661,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -706,26 +706,23 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:5</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>CC:3,MOC:1,CS:4-,OA:1,LA:4,CLAN:4-,IS:3,FWL:3,NIOPS:4-,FS:5,TC:1,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atreus Battleship' unitType='Warship'>
@@ -734,17 +731,11 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -769,20 +760,17 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:4,OA:4,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
 		<availability>CC:2,LA:2,FWL:2,FS:2,DC:2</availability>
 		<model name='(2520)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2520)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -797,17 +785,17 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:7,MOC:6,CLAN:4,IS:6,FS:6,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4,DC:7</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CC:2+,CLAN:8</availability>
+		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:2</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:2+,CLAN:8</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:2+,DC:2+</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:2+</availability>
@@ -836,17 +824,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:5,FS:5,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:5,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8-</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8-,FWL:4-,MERC:8-,FS:8-,DC:8-</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -870,13 +858,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,CDS:6,CLAN:5,NIOPS:5,FWL:3,DC:3</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>IS:6-,Periphery.Deep:6-,Periphery:6-</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,FWL:7+,DC:7+</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>IS:6-,Periphery.Deep:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -888,13 +876,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:4,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -906,11 +894,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -941,32 +929,28 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,TC:1,Periphery:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:4,DC:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CC:2+,CLAN:6,DC:3+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,FWL:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1003,18 +987,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:7,CS:5,CHH:6,LA:6,CLAN:5,IS:5,FWL:5,NIOPS:5,MERC:5,FS:5,CGB:6,DC:5</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:4+,CS:8,CHH:6,CLAN:6,NIOPS:8,CGB:6</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:6-,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CC:2+,CS:4,LA:2+,CLAN:2,CGB:2</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:4+,CS:8,CHH:6,CLAN:6,NIOPS:8,CGB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:4,CLAN:6,CGB:4</availability>
@@ -1036,16 +1020,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:5,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:5</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1057,25 +1041,25 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>CC:4,MOC:3,OA:3,LA:8,CLAN:5,FWL:5,FS:5,MERC:4,CIR:3,Periphery:2,TC:3,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:4,CLAN:6,FS:4,MERC:4</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:8,CGS:6</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:4,CLAN:6,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:5,CS:4-,OA:3,LA:5,IS:5,FWL:5,FS:5,MERC:5,Periphery:3,DC:5</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1097,20 +1081,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1118,14 +1102,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1133,35 +1114,41 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1169,18 +1156,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1189,27 +1182,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1217,35 +1201,35 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:4,CS:3-,OA:4,LA:5,CLAN:3-,IS:5,FWL:5,NIOPS:3-,FS:6,MERC:5,DC:5</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,CLAN:6,IS:6</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
@@ -1294,13 +1278,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:5,MOC:3,CLAN:4,IS:5,FS:4,CIR:2,TC:3,CS:6,OA:3,LA:3,FWL:3,NIOPS:6,DC:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,CLAN:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6,CLAN:6</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -1319,26 +1303,26 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12'>
-			<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='CSR-V12b'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='CSR-V12'>
+			<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1347,13 +1331,13 @@
 			<roles>raider</roles>
 			<availability>CC:3+,CLAN:8,FWL:3+,CGS:8</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:4+,LA:4+,CLAN:6,NIOPS:8,FWL:4+,DC:4+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:6,Periphery.Deep:6,NIOPS:0,Periphery:6</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CC:4+,LA:4+,CLAN:6,NIOPS:8,FWL:4+,DC:4+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:4+,CLAN:4,DC:4+</availability>
@@ -1361,20 +1345,20 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:6,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:6,CGS:8,CS:8,CDS:8,CW:10,LA:6,CBS:10,FWL:6,NIOPS:8,CJF:8,CGB:10,DC:6</availability>
-		<model name='CRK-5003-1'>
-			<availability>CS:8,General:6+,CLAN:6,NIOPS:8</availability>
-		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:8,CGS:8</availability>
+		</model>
+		<model name='CRK-5003-1'>
+			<availability>CS:8,General:6+,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:1</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -1386,8 +1370,9 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:6,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:8,IS:3+,CGS:8,Periphery:3+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:4,Periphery.Deep:8,Periphery:8</availability>
@@ -1395,9 +1380,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:8,IS:3+,CGS:8,Periphery:3+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1405,11 +1389,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:3,LA:5,CLAN:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1417,13 +1401,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:4,MOC:4,CHH:6,CSR:6,CLAN:6,IS:4,FS:4,CIR:3,TC:4,Periphery:2,CS:6,OA:4,LA:4,FWL:4,NIOPS:6,CJF:6,DC:4</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,CS:8,CLAN:6,General:8,NIOPS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1460,13 +1444,13 @@
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
 		<availability>FS:5</availability>
-		<model name='Block II'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='Block I'>
 			<roles>destroyer</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='Block II'>
+			<roles>destroyer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Defender Battlecruiser' unitType='Warship'>
@@ -1478,11 +1462,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1523,22 +1507,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:4</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1557,9 +1541,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:6,FS:6</availability>
 		</model>
@@ -1569,6 +1550,9 @@
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:3,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1628,13 +1612,13 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:8,CGS:8</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1650,11 +1634,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:6,NIOPS:4</availability>
-		<model name='EXT-4Db'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,CLAN:6,NIOPS:8</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>CLAN:1</availability>
@@ -1689,6 +1673,10 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:2</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
@@ -1697,17 +1685,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -1728,56 +1712,56 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
+		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>CC:2</availability>
 		</model>
 		<model name='FS9-A'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>LA:1</availability>
 		</model>
-		<model name='FS9-K'>
+		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>CC:2</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:6+,CLAN:8,FWL:5+,NIOPS:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:6-</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:6+,CLAN:8,FWL:5+,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -1785,26 +1769,24 @@
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:1-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1812,9 +1794,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1909,14 +1893,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
-		<model name='GTHA-300'>
-			<availability>CLAN:2,FWL:6</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:8</availability>
+		<model name='GTHA-300'>
+			<availability>CLAN:2,FWL:6</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:6,CLAN:4</availability>
@@ -1930,29 +1914,29 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:6,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CC:3+,LA:3+,CLAN:6,FWL:3+,FS:3+</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,CLAN:4-,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='GRF-1S'>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:7,CS:7,CHH:9,CSR:9,CLAN:9,IS:7,FWL:7,NIOPS:7,FS:6,MERC:7,DC:7</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,IS:6+,NIOPS:8,DC:6+</availability>
+			<availability>FWL:5-,NIOPS:0,MERC:5-</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2-,Periphery.ME:2-,FWL:2-,NIOPS:0,MERC:2-</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>FWL:5-,NIOPS:0,MERC:5-</availability>
+			<availability>CS:8,CLAN:8,IS:6+,NIOPS:8,DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
@@ -1966,14 +1950,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>MOC:3,CC:5,CLAN:7,IS:5,FS:5,CIR:3,TC:3,CS:7,OA:3,LA:5,CNC:7,FWL:5,NIOPS:7,DC:5</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CLAN:6,CNC:6</availability>
+		<model name='HMR-HC'>
+			<availability>IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:6,CLAN:2,NIOPS:8</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8,CLAN:6,CNC:6</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:8,CLAN:8</availability>
@@ -1981,13 +1965,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:5,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(Standard)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1999,6 +1983,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2007,33 +1999,21 @@
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
+		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2041,6 +2021,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2049,6 +2033,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2056,14 +2048,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2076,6 +2060,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
+		<model name='HCT-213C'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:6,DC:6,Periphery:6</availability>
@@ -2083,24 +2070,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,CLAN:2,IS:2,NIOPS:4</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2115,17 +2099,21 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:3,CB:5</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,General:5,CLAN:6,NIOPS:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:4</availability>
@@ -2137,10 +2125,6 @@
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:5,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -2154,17 +2138,17 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:5,MOC:3,CHH:4,OA:3,LA:5,CLAN:3,FWL:5,FS:5,CGS:5,DC:3,TC:5</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='HOP-4B'>
+			<availability>CC:1</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4B'>
-			<availability>CC:1</availability>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2197,12 +2181,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:9,LA:1+,CSV:9,CLAN:8,NIOPS:4,FS:1+</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -2213,22 +2197,22 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>IS:2</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:2,CW:2,CLAN:2</availability>
-		<model name='IMP-1C'>
-			<availability>CHH:8,CLAN:4</availability>
-		</model>
 		<model name='IMP-1A'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='IMP-1C'>
+			<availability>CHH:8,CLAN:4</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:4</availability>
@@ -2243,10 +2227,10 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
+		<model name='(2631)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
-		<model name='(2631)'>
+		<model name='(2631 PPC)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
@@ -2287,13 +2271,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -2333,13 +2317,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:2,FS.RR:3,OA:2,FS.DMM:3,MERC:2,Periphery.OS:2,DC:6</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -2351,17 +2335,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2404,11 +2388,11 @@
 		<model name='KGC-0000'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:5,CLAN:6,NIOPS:8,CB:5</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2416,11 +2400,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,FS:2+,MERC:2+</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:8,CGS:8</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:2</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:8,CGS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2452,17 +2436,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:2,MOC:2,OA:2</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:6+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
+		<model name='KSC-4L'>
+			<availability>CC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -2500,13 +2484,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:4,CC:5,CIH:6,CLAN:6,IS:5,CFM:6,MERC:5,CIR:4,CGS:6,TC:4,CS:6,OA:4,LA:5,NIOPS:6,DC:5</availability>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:7,NIOPS:8,DC:7</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:3,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:7,NIOPS:8,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2536,15 +2520,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,LA:5</availability>
@@ -2565,14 +2549,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:2</availability>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:6</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -2584,13 +2568,13 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -2616,9 +2600,6 @@
 		<availability>TC:2</availability>
 		<model name='(2622)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2622)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2651,10 +2632,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:3,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -2663,14 +2640,18 @@
 			<roles>support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:4+,CLAN:4,FWL:4+,DC:4+</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:6+</availability>
-		</model>
 		<model name='LNX-8Q'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2753,11 +2734,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -2805,17 +2786,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2823,31 +2804,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -2856,11 +2837,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2907,25 +2888,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:7,General:4,MERC:2,DC:7</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:4,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:4,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:4,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -2955,30 +2936,27 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:5+,NIOPS:6,CJF:7,CGB:5,DC:5+</availability>
-		<model name='MON-66'>
+		<model name='MON-70'>
 			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,IS:6+,Periphery:6+</availability>
-		</model>
-		<model name='MON-69'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>IS:3</availability>
 		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:9,CGS:9</availability>
 		</model>
-		<model name='MON-70'>
+		<model name='MON-69'>
 			<roles>recon</roles>
-			<availability>IS:3</availability>
+			<availability>DC:4</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,IS:6+,Periphery:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:3</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
@@ -2998,6 +2976,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -3006,12 +2990,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3026,11 +3004,11 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:3</availability>
-		<model name='(Block I)'>
+		<model name='(Block II)'>
 			<roles>destroyer</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='(Block II)'>
+		<model name='(Block I)'>
 			<roles>destroyer</roles>
 			<availability>DC:6</availability>
 		</model>
@@ -3060,12 +3038,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -3113,13 +3091,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:5,CS:4,LA:5,CLAN:4-,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6-</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -3144,13 +3122,13 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:4,CC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:6</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3166,12 +3144,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:4-,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3197,13 +3175,13 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -3211,45 +3189,45 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:4</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:4</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:8,FWL:8,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
+			<availability>CC:3+,MOC:3+,OA:3+,CLAN:4,FWL:3+</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>CC:3+,MOC:3+,OA:3+,CLAN:4,FWL:3+</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
+		<model name='PXH-1Kk'>
+			<availability>DC:2+</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:2+</availability>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3262,9 +3240,6 @@
 		<availability>MOC:5,OA:4,TC:5</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -3302,13 +3277,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,General:8,CLAN:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pulverizer' unitType='Mek'>
@@ -3334,21 +3309,15 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:7,NIOPS:3-,DC:6</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,OA:3,LA:5,CLAN:8,IS:4,NIOPS:8,MERC:4</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,LA:2,CLAN:3,General:2</availability>
@@ -3359,16 +3328,22 @@
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:4,CNC:4</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6,CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6,CLAN:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>fire_support</roles>
@@ -3377,11 +3352,11 @@
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
@@ -3407,9 +3382,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:3+,CS:5,CHH:5,CSR:4,LA:3+,CLAN:4,FWL:3+,NIOPS:5,FS:4+,CJF:4,DC:3+</availability>
@@ -3424,31 +3396,31 @@
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
 		<availability>FS:3</availability>
-		<model name='Block I'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Block II'>
 			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='Block I'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:3,MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:1</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,CLAN:2,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:6</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -3483,11 +3455,11 @@
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samarkand Carrier' unitType='Warship'>
@@ -3503,13 +3475,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:5,CC:5,OA:6,LA:5,CLAN:4,IS:5,FWL:5,MERC:5,FS:5,Periphery:5,TC:5,DC:5</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CC:3+,MOC:1+,OA:4+,LA:3+,General:2+,CLAN:8,FWL:3+,FS:3+,DC:3+,TC:1+</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,General:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CC:3+,MOC:1+,OA:4+,LA:3+,General:2+,CLAN:8,FWL:3+,FS:3+,DC:3+,TC:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Sand Devil Hover Tank' unitType='Tank'>
@@ -3531,14 +3503,14 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:7,LA:7,FWL:7,IS:7,Periphery.Deep:7,FS:7,DC:7,Periphery:7</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -3569,9 +3541,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:5,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
-		<model name='STN-3KB'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:4+,CLAN:6,NIOPS:8,FWL:4+,FS:4+,MERC:4+</availability>
 		</model>
@@ -3581,37 +3550,40 @@
 		<model name='STN-3Lb'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='STN-1S'>
-			<availability>LA:1,FWL:1,FS:1</availability>
-		</model>
 		<model name='STN-3KA'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='STN-3KB'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='STN-1S'>
+			<availability>LA:1,FWL:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,Periphery:5,CGB:4</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:8,FS:3+</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:8,CLAN:6-,Periphery.Deep:8,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>General:8,CLAN:6-,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:8,FS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3638,6 +3610,12 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 		<model name='(Standard)'>
@@ -3653,13 +3631,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:4+,LA:4+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3714,16 +3692,16 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>CC:5,CS:4,OA:2,LA:4,CLAN:2-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>DC:8</availability>
+		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stag II' unitType='Mek'>
@@ -3734,9 +3712,6 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>CC:7,MOC:9,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,CLAN:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
@@ -3745,6 +3720,9 @@
 		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,CLAN:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -3794,11 +3772,11 @@
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:8,MOC:7,CS:4,OA:7,LA:8,PIR:4,Periphery.Deep:4,NIOPS:4,FS:7,MERC:7,TC:7,DC:7</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -3809,19 +3787,19 @@
 		<model name='STU-K5'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -3833,10 +3811,10 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
@@ -3847,11 +3825,11 @@
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>CLAN:8</availability>
-		<model name='TLN-5W'>
-			<availability>LA:8,CLAN:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>FWL:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>LA:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
@@ -3877,11 +3855,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CC:2,MOC:2+,CLAN:4,MERC:2,FS:2,CCO:2,TC:2+,CSA:2,CS:6,OA:2+,CDS:5,FWL:4,NIOPS:6,CJF:5,CGB:5</availability>
-		<model name='THE-F'>
-			<availability>CC:2+,FWL:2+,FS:2+</availability>
-		</model>
 		<model name='THE-Nb'>
 			<availability>CLAN:8,CGS:8</availability>
+		</model>
+		<model name='THE-F'>
+			<availability>CC:2+,FWL:2+,FS:2+</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>CS:8,General:5+,CLAN:6,NIOPS:8</availability>
@@ -3899,11 +3877,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:4+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,FWL:6+,IS:6+,NIOPS:8,FS:6+,DC:6+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -3925,25 +3903,25 @@
 			<roles>escort,ground_support</roles>
 			<availability>LA:3+,CLAN:5</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:7</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,TC:6,DC:8</availability>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:2+</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:8,CSR:8,CDS:8,CW:8,CLAN:8,CNC:8,CJF:8,CGB:8</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -3967,29 +3945,26 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:5,FWL:4,NIOPS:9,DC:2</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:8</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
 		<availability>CC:5,MOC:6,CLAN:5,IS:5,Periphery.Deep:6,FS:5,MERC:5,CIR:5,Periphery:6,CS:6,LA:5,FWL:5,NIOPS:6,DC:5</availability>
 		<model name='(2755) (LF)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,CLAN:2</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,CLAN:2</availability>
@@ -4003,28 +3978,28 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:3+,CS:6,FWL:3+,NIOPS:6</availability>
 		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
+		<model name='TBT-5J'>
+			<availability>FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:2,TC:4,CS:7,OA:4,LA:2,FWL:3,NIOPS:7,DC:5</availability>
-		<model name='TRN-3U'>
-			<availability>IS:6-,Periphery:6-</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:5+,CLAN:6,IS:5+,NIOPS:8,Periphery.Deep:5+,Periphery:5+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:8</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4050,10 +4025,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:2</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -4061,6 +4032,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -4149,14 +4124,14 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:4,LA:7,CLAN:4,IS:4,FWL:6,MERC:4,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>CC:1,LA:1,CLAN:8,FWL:1,FS:1,DC:1</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
-		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4192,37 +4167,30 @@
 		<model name='(2570)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:3</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
+		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='2'>
+			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CC:4+,LA:4+,CLAN:4,FWL:4+,FS:4+</availability>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rk'>
 			<availability>DC:2+</availability>
+		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
@@ -4230,17 +4198,20 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CC:4+,LA:4+,CLAN:4,FWL:4+,FS:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -4251,21 +4222,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:5,Periphery:5</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -4281,12 +4252,12 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine II' unitType='Mek'>
@@ -4297,6 +4268,10 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,CWOV:6,LA:7,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,TC:5,DC:7</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4305,23 +4280,19 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:5,CLAN:6,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:5</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CLAN:8,CFM:8,CGS:8</availability>
+			<availability>CS:8,CC:5+,CLAN:6,NIOPS:8,CFM:6,FS:5+,DC:5+,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:3+,FWL:3+</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CS:8,CC:5+,CLAN:6,NIOPS:8,CFM:6,FS:5+,DC:5+,TC:8</availability>
+			<availability>CLAN:8,CFM:8,CGS:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4385,11 +4356,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>MOC:1,CS:5,OA:1,CLAN:6,NIOPS:5,DC:3,Periphery:1,TC:1</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:6</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -555,13 +555,13 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CC:3,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:3,CGS:4,CSA:4,CDS:4,LA:2,CBS:4,CNC:5,FWL:3,CJF:5,DC:3,CB:4</availability>
-		<model name='(2582)'>
-			<roles>cruiser</roles>
-			<availability>CS:8,General:5,CLAN:6</availability>
-		</model>
 		<model name='(2372)'>
 			<roles>cruiser</roles>
 			<availability>CC:8,IS:8</availability>
+		</model>
+		<model name='(2582)'>
+			<roles>cruiser</roles>
+			<availability>CS:8,General:5,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -575,29 +575,29 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>MOC:2+,CC:3+,CLAN:7,MERC:3+,FS:3+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:3+,CNC:7,FWL:3+,NIOPS:7,CJF:7,DC:3+</availability>
-		<model name='Mk III'>
-			<availability>General:1</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
 			<availability>General:1</availability>
 		</model>
+		<model name='Mk III'>
+			<availability>General:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CSR:3,CLAN:3,CCO:3,BAN:1,CGB:3</availability>
-		<model name='ANH-1G'>
-			<availability>CSA:6,CCO:6,BAN:1</availability>
+		<model name='C 2'>
+			<availability>CLAN:4,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CSA:2,CLAN:6,CCO:2,BAN:8</availability>
 		</model>
+		<model name='ANH-1G'>
+			<availability>CSA:6,CCO:6,BAN:1</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:6,BAN:1</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:4,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -616,61 +616,41 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:2</availability>
-		<model name='ARC-2K'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:8,CLAN:5,IS:8,Periphery.Deep:8,BAN:8,DC:7,Periphery:8</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Mk.III'>
 			<availability>General:5</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -680,17 +660,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -705,26 +705,23 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:5</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>CC:3,MOC:1,CS:4-,OA:1,LA:4,CLAN:4-,IS:3,FWL:3,NIOPS:4-,FS:5,TC:1,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atreus Battleship' unitType='Warship'>
@@ -733,17 +730,11 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -768,20 +759,17 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:4,OA:4,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
 		<availability>CC:2,LA:2,FWL:2,FS:2,DC:2</availability>
 		<model name='(2520)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2520)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -796,17 +784,17 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:7,MOC:6,CLAN:4,IS:6,FS:6,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4,DC:7</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CC:2+,CLAN:8,BAN:4</availability>
+		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:2</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>IS:8,Periphery.Deep:8,FS:8,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:2+,CLAN:8,BAN:4</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,DC:2+</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:2+</availability>
@@ -835,17 +823,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:5,FS:4,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:5,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8,BAN:4</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8-</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8-,FWL:4-,MERC:8-,FS:8-,DC:8-</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -869,13 +857,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,CDS:6,CLAN:5,NIOPS:5,FWL:3,DC:3</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>IS:6-,Periphery.Deep:6-,Periphery:6-</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,FWL:6+,BAN:8,DC:6+</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>IS:6-,Periphery.Deep:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -894,13 +882,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:4,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -912,11 +900,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -947,32 +935,28 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:3,DC:3</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CC:2+,CLAN:6,DC:2+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,FWL:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1009,18 +993,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:7,CS:5,CHH:6,LA:6,CLAN:5,IS:5,FWL:5,NIOPS:5,MERC:5,FS:5,CGB:6,DC:5</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:3+,CS:8,CHH:6,CLAN:6,NIOPS:8,BAN:8,CGB:6</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:7,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CC:2+,CS:4,LA:2+,CLAN:2,BAN:2,CGB:2</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:3+,CS:8,CHH:6,CLAN:6,NIOPS:8,BAN:8,CGB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:4,CLAN:6,CGB:4</availability>
@@ -1042,16 +1026,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:4,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:4</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1063,25 +1047,25 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:3,CC:4,OA:3,LA:8,CLAN:4,FWL:5,MERC:4,FS:5,CIR:3,TC:3,Periphery:2,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:4,CLAN:6,FS:4,MERC:4,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:8,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:4,CLAN:6,FS:4,MERC:4,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:5,CS:4-,OA:3,LA:5,IS:5,FWL:5,FS:5,MERC:5,Periphery:3,DC:5</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1103,20 +1087,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1124,14 +1108,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1139,35 +1120,41 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1175,18 +1162,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1195,27 +1188,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1223,8 +1207,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1235,29 +1219,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:4,CS:3-,OA:4,LA:5,CLAN:3-,IS:5,FWL:5,NIOPS:3-,FS:6,MERC:5,DC:5</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,CLAN:6,IS:5,BAN:5</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
@@ -1306,13 +1290,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:5,MOC:3,CLAN:4,IS:5,FS:4,CIR:1,BAN:4,TC:3,CS:6,OA:3,LA:3,FWL:3,NIOPS:6,DC:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,CLAN:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6,CLAN:6</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -1331,26 +1315,26 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12'>
-			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
-		</model>
 		<model name='CSR-V12b'>
 			<availability>CLAN:6,BAN:4</availability>
+		</model>
+		<model name='CSR-V12'>
+			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1359,13 +1343,13 @@
 			<roles>raider</roles>
 			<availability>CC:3+,CLAN:8,FWL:3+,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:3+,LA:3+,CLAN:6,NIOPS:8,FWL:3+,BAN:8,DC:3+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:7,Periphery.Deep:7,NIOPS:0,Periphery:7</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CC:3+,LA:3+,CLAN:6,NIOPS:8,FWL:3+,BAN:8,DC:3+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:3+,CLAN:4,DC:3+</availability>
@@ -1373,20 +1357,20 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:6,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:6,CGS:8,CS:8,CDS:8,CW:10,LA:6,CBS:10,FWL:6,NIOPS:8,CJF:8,CGB:10,DC:6</availability>
-		<model name='CRK-5003-1'>
-			<availability>CS:8,General:5+,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='CRK-5003-1b'>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
+		</model>
+		<model name='CRK-5003-1'>
+			<availability>CS:8,General:5+,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
 		<availability>LA:1</availability>
-		<model name='CRS-6C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CRS-6B'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRS-6C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -1398,8 +1382,9 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:6,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:8,IS:3+,CGS:8,BAN:4,Periphery:3+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:4,Periphery.Deep:8,BAN:8,Periphery:8</availability>
@@ -1407,9 +1392,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:8,IS:3+,CGS:8,BAN:4,Periphery:3+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1417,11 +1401,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:3,LA:5,CLAN:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1429,13 +1413,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:3,MOC:3,CHH:6,CSR:6,CLAN:6,IS:3,FS:3,CIR:2,TC:3,Periphery:2,CS:6,OA:3,LA:3,FWL:3,NIOPS:6,CJF:6,DC:3</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,CS:8,CLAN:6,General:8,NIOPS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1472,13 +1456,13 @@
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
 		<availability>FS:5</availability>
-		<model name='Block II'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='Block I'>
 			<roles>destroyer</roles>
 			<availability>FS:5</availability>
+		</model>
+		<model name='Block II'>
+			<roles>destroyer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Defender Battlecruiser' unitType='Warship'>
@@ -1490,11 +1474,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1535,22 +1519,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:4</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1569,9 +1553,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:6,FS:6</availability>
 		</model>
@@ -1581,6 +1562,9 @@
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:3,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1633,13 +1617,13 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1655,11 +1639,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:6,NIOPS:4</availability>
-		<model name='EXT-4Db'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>CLAN:1</availability>
@@ -1673,11 +1657,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1700,6 +1684,10 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:2</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
@@ -1708,17 +1696,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Firebee' unitType='Mek'>
@@ -1729,16 +1713,16 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CC:2+,OA:1+,CIH:7,CLAN:8,FS:2+,BAN:7,CB:7</availability>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3SLE'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='FFL-3PP'>
+			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FFL-3PP'>
+		<model name='FFL-3PP3'>
 			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3A'>
@@ -1748,56 +1732,56 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
+		<model name='FS9-K'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+			<availability>CC:2</availability>
 		</model>
 		<model name='FS9-A'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>LA:1</availability>
 		</model>
-		<model name='FS9-K'>
+		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
-			<availability>CC:2</availability>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:6+,CLAN:8,FWL:5+,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:6-</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:6+,CLAN:8,FWL:5+,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -1805,26 +1789,24 @@
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:1-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1832,9 +1814,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1935,14 +1919,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
-		<model name='GTHA-300'>
-			<availability>CLAN:2,FWL:6,BAN:6</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:8,BAN:4</availability>
+		<model name='GTHA-300'>
+			<availability>CLAN:2,FWL:6,BAN:6</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:5,CLAN:4</availability>
@@ -1956,14 +1940,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CC:3+,LA:3+,CLAN:6,FWL:3+,FS:3+,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -1975,17 +1959,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:7,CS:7,CHH:9,CSR:9,CLAN:9,IS:7,FWL:7,NIOPS:7,FS:6,MERC:7,DC:7</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,IS:6+,NIOPS:8,BAN:8,DC:6+</availability>
+			<availability>FWL:6-,NIOPS:0,MERC:6-</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2,Periphery.ME:2,FWL:2,NIOPS:0,MERC:2</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>FWL:6-,NIOPS:0,MERC:6-</availability>
+			<availability>CS:8,CLAN:8,IS:6+,NIOPS:8,BAN:8,DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
@@ -1999,14 +1983,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>MOC:3,CC:4,CLAN:7,IS:4,FS:4,CIR:3,TC:3,CS:7,OA:3,LA:4,CNC:7,FWL:4,NIOPS:7,DC:4</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CLAN:6,CNC:6</availability>
+		<model name='HMR-HC'>
+			<availability>IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:4,CLAN:2,NIOPS:8</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8,CLAN:6,CNC:6</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:8,CLAN:8,BAN:4</availability>
@@ -2014,13 +1998,13 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:6,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='(Standard)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2032,6 +2016,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2040,33 +2032,21 @@
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
+		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2074,6 +2054,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2082,6 +2066,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2089,14 +2081,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2109,6 +2093,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
+		<model name='HCT-213C'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,IS:6,DC:6,Periphery:5</availability>
@@ -2116,24 +2103,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,CLAN:2,IS:2,NIOPS:4,BAN:4</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2148,17 +2132,21 @@
 			<roles>recon</roles>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:3,CB:5</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,General:5,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:4</availability>
@@ -2170,10 +2158,6 @@
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:5,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -2187,17 +2171,17 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:4,MOC:3,CHH:4,OA:3,LA:4,CLAN:3,FWL:4,FS:4,CGS:5,DC:3,TC:4</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:6,BAN:2</availability>
+		</model>
+		<model name='HOP-4B'>
+			<availability>CC:1</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
 		</model>
-		<model name='HOP-4B'>
-			<availability>CC:1</availability>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2239,12 +2223,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:9,LA:1+,CSV:9,CLAN:8,NIOPS:4,FS:1+</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -2262,22 +2246,22 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>IS:2</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:2,CW:2,CLAN:2</availability>
-		<model name='IMP-1C'>
-			<availability>CHH:8,CLAN:4</availability>
-		</model>
 		<model name='IMP-1A'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='IMP-1C'>
+			<availability>CHH:8,CLAN:4</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:4</availability>
@@ -2292,16 +2276,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -2344,13 +2328,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -2390,13 +2374,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:3,FS.RR:4,OA:3,FS.DMM:4,MERC:3,Periphery.OS:3,FS:2,DC:6</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -2408,17 +2392,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2435,11 +2419,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CC:2,CS:2,CHH:6,LA:2,CLAN:5,FWL:3,NIOPS:2,FS:2,DC:2</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,BAN:4</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -2464,11 +2448,11 @@
 		<model name='KGC-0000'>
 			<availability>IS:6</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:4,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2476,11 +2460,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,FS:2+,MERC:2+,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:8,CGS:8,BAN:4</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:2</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:8,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2512,17 +2496,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:2,MOC:2,OA:2</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:6+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
+		<model name='KSC-4L'>
+			<availability>CC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -2560,13 +2544,13 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>MOC:4,CC:5,CIH:6,CLAN:6,IS:5,CFM:6,MERC:5,CIR:4,CGS:6,BAN:6,TC:4,CS:6,OA:4,LA:5,NIOPS:6,DC:5</availability>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:6,NIOPS:8,BAN:6,DC:6</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:2,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:6,NIOPS:8,BAN:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2596,15 +2580,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,LA:5</availability>
@@ -2625,14 +2609,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:2</availability>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:6</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -2650,13 +2634,13 @@
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -2682,9 +2666,6 @@
 		<availability>TC:1</availability>
 		<model name='(2622)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2622)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2717,10 +2698,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:3,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -2729,14 +2706,18 @@
 			<roles>support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:4+,CLAN:4,FWL:4+,DC:4+</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:5+</availability>
-		</model>
 		<model name='LNX-8Q'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2815,11 +2796,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -2867,17 +2848,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2885,31 +2866,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -2918,11 +2899,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
@@ -2963,25 +2944,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:7,General:4,MERC:2,DC:7</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:4,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:4,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:4,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -3011,34 +2992,31 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:3+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:3+,CS:6,OA:3+,CDS:5,CBS:7,FWL:5+,NIOPS:6,CJF:7,CGB:5,DC:5+</availability>
-		<model name='MON-66'>
+		<model name='MON-70'>
 			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,IS:5+,BAN:8,Periphery:5+</availability>
-		</model>
-		<model name='MON-69'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>IS:3</availability>
 		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:9,CGS:9,BAN:4</availability>
 		</model>
-		<model name='MON-70'>
-			<roles>recon</roles>
-			<availability>IS:3</availability>
-		</model>
 		<model name='MON-67'>
 			<roles>recon</roles>
 			<availability>MOC:4,OA:4,FWL:4,NIOPS:0,MERC:4,FS:4,DC:4,TC:4</availability>
+		</model>
+		<model name='MON-69'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,IS:5+,BAN:8,Periphery:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
@@ -3064,6 +3042,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -3072,12 +3056,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3092,13 +3070,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:3</availability>
-		<model name='(Block I)'>
-			<roles>destroyer</roles>
-			<availability>DC:7</availability>
-		</model>
 		<model name='(Block II)'>
 			<roles>destroyer</roles>
 			<availability>DC:5</availability>
+		</model>
+		<model name='(Block I)'>
+			<roles>destroyer</roles>
+			<availability>DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -3126,12 +3104,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -3185,13 +3163,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:5,CS:4,LA:5,CLAN:4-,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6-,BAN:8</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -3216,13 +3194,13 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:4,CC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:6</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3242,12 +3220,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:3-,MERC:5,Periphery.OS:5,FS:3,BAN:4,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3273,13 +3251,13 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -3287,45 +3265,45 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:4</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:4</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:8,FWL:8,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:3</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
+			<availability>CC:3+,MOC:3+,OA:3+,CLAN:4,FWL:3+,BAN:4</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>CC:3+,MOC:3+,OA:3+,CLAN:4,FWL:3+,BAN:4</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
+		<model name='PXH-1Kk'>
+			<availability>DC:1+</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:3</availability>
 		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:1+</availability>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3338,9 +3316,6 @@
 		<availability>MOC:4,OA:3,TC:4</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -3378,13 +3353,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,General:8,CLAN:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -3404,21 +3379,15 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:7,NIOPS:3-,DC:6</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,OA:3,LA:5,CLAN:8,IS:4,NIOPS:8,MERC:4</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,LA:2,CLAN:3,General:2</availability>
@@ -3429,16 +3398,22 @@
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:4,CNC:4</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6,CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6,CLAN:4</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>fire_support</roles>
@@ -3447,11 +3422,11 @@
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
@@ -3477,9 +3452,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:2+,CS:5,CHH:5,CSR:4,LA:2+,CLAN:4,FWL:2+,NIOPS:5,FS:3+,CJF:4,DC:2+</availability>
@@ -3494,31 +3466,31 @@
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
 		<availability>FS:2</availability>
-		<model name='Block I'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Block II'>
 			<roles>troop_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='Block I'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:3,MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:1</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,CLAN:2,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:6</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -3553,11 +3525,11 @@
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samarkand Carrier' unitType='Warship'>
@@ -3573,13 +3545,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:4,CC:4,OA:6,LA:4,CLAN:4,IS:4,FWL:4,MERC:4,FS:4,TC:4,Periphery:4,DC:5</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CC:3+,MOC:1+,OA:4+,LA:3+,General:2+,CLAN:8,FWL:3+,FS:3+,BAN:4,DC:3+,TC:1+</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,General:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CC:3+,MOC:1+,OA:4+,LA:3+,General:2+,CLAN:8,FWL:3+,FS:3+,BAN:4,DC:3+,TC:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Sand Devil Hover Tank' unitType='Tank'>
@@ -3601,14 +3573,14 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:7,LA:7,FWL:7,IS:7,Periphery.Deep:7,FS:7,DC:7,Periphery:7</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -3639,9 +3611,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:5,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
-		<model name='STN-3KB'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:4+,CLAN:6,NIOPS:8,FWL:4+,FS:4+,MERC:4+,BAN:8</availability>
 		</model>
@@ -3651,22 +3620,25 @@
 		<model name='STN-3Lb'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
-		<model name='STN-1S'>
-			<availability>LA:1,FWL:1,FS:1</availability>
-		</model>
 		<model name='STN-3KA'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='STN-3KB'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='STN-1S'>
+			<availability>LA:1,FWL:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
-		<model name='SYD-21'>
-			<roles>interceptor</roles>
-			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
 			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
@@ -3677,17 +3649,17 @@
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:4</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:8,FS:3+,BAN:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:8,CLAN:6-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>General:8,CLAN:6-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:8,FS:3+,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3714,6 +3686,12 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 		<model name='(Standard)'>
@@ -3729,13 +3707,13 @@
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:3+,LA:3+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3790,10 +3768,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>CC:5,CS:4,OA:2,LA:4,CLAN:2-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
@@ -3801,12 +3775,13 @@
 			<roles>anti_infantry</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:9,CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,TC:9,Periphery:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,CLAN:1,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
@@ -3815,6 +3790,9 @@
 		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,CLAN:1,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -3864,11 +3842,11 @@
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>MOC:6,CC:8,CS:4,OA:7,LA:8,PIR:4,Periphery.Deep:4,NIOPS:4,MERC:7,FS:6,TC:7,DC:6</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -3879,19 +3857,19 @@
 		<model name='STU-K5'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -3903,28 +3881,28 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>MOC:2+,CC:1+,CS:8,OA:3,LA:2+,CLAN:9,FWL:3+,NIOPS:8,MERC:3+,FS:3+,TC:2+,DC:3+</availability>
-		<model name='C'>
-			<availability>CCC:8,CSR:8,CLAN:6</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CCC:8,CSR:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>CLAN:8</availability>
-		<model name='TLN-5W'>
-			<availability>LA:8,CLAN:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>FWL:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>LA:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
@@ -3950,11 +3928,11 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>CC:2,MOC:2+,CLAN:4,MERC:2,FS:2,CCO:2,TC:2+,CSA:2,CS:6,OA:2+,CDS:5,FWL:4,NIOPS:6,CJF:5,CGB:5</availability>
-		<model name='THE-F'>
-			<availability>CC:2+,FWL:2+,FS:2+</availability>
-		</model>
 		<model name='THE-Nb'>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
+		</model>
+		<model name='THE-F'>
+			<availability>CC:2+,FWL:2+,FS:2+</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>CS:8,General:5+,CLAN:6,NIOPS:8,BAN:6</availability>
@@ -3972,11 +3950,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:3+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,FWL:6+,IS:6+,NIOPS:8,FS:6+,BAN:8,DC:6+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -3998,25 +3976,25 @@
 			<roles>escort,ground_support</roles>
 			<availability>LA:3+,CLAN:5</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:7</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:2+</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:7,CSR:7,CDS:7,CW:7,CLAN:7,CNC:7,CJF:7,BAN:4,CGB:7</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4040,29 +4018,26 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:5,FWL:4,NIOPS:9,DC:2</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:8,BAN:4</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
 		<availability>CC:5,MOC:6,CLAN:5,IS:5,Periphery.Deep:6,FS:5,MERC:5,CIR:5,Periphery:6,BAN:3,CS:6,LA:5,FWL:5,NIOPS:6,DC:5</availability>
 		<model name='(2755) (LF)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,CLAN:2,BAN:6</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,CLAN:2,BAN:6</availability>
@@ -4076,28 +4051,28 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:3+,CS:6,FWL:3+,NIOPS:6</availability>
 		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
+		<model name='TBT-5J'>
+			<availability>FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:4,MOC:3,CSR:7,CLAN:7,FS:4,MERC:4,CIR:2,TC:3,CS:7,OA:4,LA:1,FWL:2,NIOPS:7,DC:4</availability>
-		<model name='TRN-3U'>
-			<availability>IS:6-,Periphery:6-</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:4+,CLAN:6,IS:4+,NIOPS:8,Periphery.Deep:4+,BAN:8,Periphery:4+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:8,BAN:4</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4123,10 +4098,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:2</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -4134,6 +4105,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -4222,14 +4197,14 @@
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:3,LA:7,CLAN:3,IS:3,FWL:6,MERC:3,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>CC:1,LA:1,CLAN:8,FWL:1,FS:1,DC:1</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
-		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4265,10 +4240,6 @@
 		<model name='(2570)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Wakazashi' unitType='Mek'>
 		<availability>CJF:4</availability>
@@ -4278,30 +4249,27 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
+		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='2'>
+			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:3+,BAN:4</availability>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rk'>
 			<availability>DC:2+</availability>
+		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
@@ -4309,17 +4277,20 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:3+,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -4330,21 +4301,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:5,Periphery:6</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -4360,16 +4331,20 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4378,23 +4353,19 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:5,CLAN:6,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:5</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CLAN:8,CFM:8,CGS:8</availability>
+			<availability>CS:8,CC:5+,CLAN:6,NIOPS:8,CFM:6,FS:5+,BAN:8,DC:5+,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:3+,FWL:3+</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CS:8,CC:5+,CLAN:6,NIOPS:8,CFM:6,FS:5+,BAN:8,DC:5+,TC:8</availability>
+			<availability>CLAN:8,CFM:8,CGS:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4455,11 +4426,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>MOC:1,CS:5,OA:1,CLAN:6,NIOPS:5,DC:2,Periphery:1,TC:1</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:6</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -548,6 +548,10 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CC:2,CCC:3,CSR:5,CIH:3,CSV:3,CLAN:3,FS:2,CGS:3,CSA:3,CDS:3,LA:2,CBS:3,CNC:5,FWL:2,CJF:5,DC:2,CB:3</availability>
+		<model name='(2372)'>
+			<roles>cruiser</roles>
+			<availability>CC:8,IS:8</availability>
+		</model>
 		<model name='(2582)'>
 			<roles>cruiser</roles>
 			<availability>CS:8,CLAN:4</availability>
@@ -555,10 +559,6 @@
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:6</availability>
-		</model>
-		<model name='(2372)'>
-			<roles>cruiser</roles>
-			<availability>CC:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -572,13 +572,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>MOC:1+,CC:2+,CLAN:7,MERC:2+,FS:2+,TC:1+,CS:7,OA:1+,CDS:7,CW:7,LA:2+,CNC:7,FWL:2+,NIOPS:7,CJF:7,DC:2+</availability>
-		<model name='Mk III'>
-			<availability>General:1</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:1</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:1</availability>
 		</model>
 	</chassis>
@@ -591,17 +591,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:3,BAN:5</availability>
 		</model>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -620,30 +620,30 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
 			<availability>LA:6</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:7,CLAN:4,IS:8,Periphery.Deep:8,BAN:7,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Mk.III'>
 			<availability>General:4</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:7</availability>
 		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
@@ -657,37 +657,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -697,17 +677,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -729,26 +729,23 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>CC:3,MOC:1,CS:4-,OA:1,LA:4,CLAN:4-,IS:3,FWL:3,NIOPS:4-,FS:5,TC:1,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atreus Battleship' unitType='Warship'>
@@ -757,17 +754,11 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -792,11 +783,11 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:4,OA:4,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -805,26 +796,23 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2520)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,DC:2+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:2+,CLAN:8,BAN:4</availability>
 		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
+		</model>
 		<model name='BLR-1D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,DC:2+</availability>
+		<model name='BLR-1G'>
+			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:2+</availability>
@@ -846,14 +834,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
 		<model name='5'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -865,17 +853,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:3,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:7,NIOPS:4,FWL:2+,CGS:8,BAN:4</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -903,13 +891,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,CDS:6,CLAN:5,NIOPS:5,FWL:2,DC:2</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,FWL:6+,BAN:8,DC:6+</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -928,13 +916,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -946,11 +934,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -985,32 +973,28 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:3,DC:3</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CC:2+,CLAN:6,DC:2+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,FWL:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1053,18 +1037,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:7,CS:5,CHH:6,LA:6,CLAN:5,IS:4,FWL:4,NIOPS:5,MERC:4,FS:4,CGB:6,DC:4</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:3+,CS:8,CHH:6,CLAN:6,NIOPS:8,BAN:8,CGB:6</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:7,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:3+,CS:8,CHH:6,CLAN:6,NIOPS:8,BAN:8,CGB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1086,16 +1070,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:4,MOC:5,FS:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:4</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1107,25 +1091,25 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:4,FWL:4,MERC:3,FS:4,CIR:2,TC:2,Periphery:2,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:3,CLAN:6,FS:3,MERC:3,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:3,CLAN:6,FS:3,MERC:3,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,OA:3,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:3,DC:4</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1147,20 +1131,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1168,14 +1152,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1183,35 +1164,41 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1219,18 +1206,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1239,27 +1232,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1267,8 +1251,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1279,29 +1263,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:4,CS:3-,OA:4,LA:4,CLAN:3-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,CLAN:4,IS:4,BAN:5</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
@@ -1337,14 +1321,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -1356,13 +1340,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:3,MOC:2,CLAN:2,IS:3,FS:3,CIR:1,BAN:3,TC:2,CS:6,OA:2,LA:3,FWL:3,NIOPS:6,DC:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,CLAN:7</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6,CLAN:5</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -1381,29 +1365,29 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1418,13 +1402,13 @@
 			<roles>raider</roles>
 			<availability>CC:2+,CLAN:7,FWL:2+,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:2+,LA:2+,CLAN:6,NIOPS:8,FWL:2+,BAN:8,DC:2+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:7,Periphery.Deep:7,NIOPS:0,Periphery:7</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CC:2+,LA:2+,CLAN:6,NIOPS:8,FWL:2+,BAN:8,DC:2+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:3+,CLAN:4,DC:3+</availability>
@@ -1432,14 +1416,14 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:5,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:5,CGS:8,CS:8,CDS:8,CW:10,LA:5,CBS:10,FWL:5,NIOPS:8,CJF:8,CGB:10,DC:5</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:4+,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -1451,8 +1435,9 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:7,IS:3+,CGS:8,BAN:4,Periphery:3+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:3,Periphery.Deep:8,BAN:7,Periphery:8</availability>
@@ -1460,9 +1445,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:7,IS:3+,CGS:8,BAN:4,Periphery:3+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1470,11 +1454,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:2,LA:5,CLAN:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1482,13 +1466,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:2+,MOC:2+,CHH:6,CSR:6,CLAN:6,IS:2+,FS:2+,CIR:2+,TC:4+,Periphery:1+,CS:6,OA:2+,LA:2+,FWL:2+,NIOPS:6,CJF:6,DC:2+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,CS:8,CLAN:6,General:8,NIOPS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1514,9 +1498,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
@@ -1525,16 +1506,19 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
 		<availability>FS:4</availability>
-		<model name='Block II'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='Block I'>
 			<roles>destroyer</roles>
 			<availability>FS:5</availability>
+		</model>
+		<model name='Block II'>
+			<roles>destroyer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Defender Battlecruiser' unitType='Warship'>
@@ -1546,11 +1530,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1591,22 +1575,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:4</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1625,9 +1609,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:6,FS:6</availability>
 		</model>
@@ -1637,6 +1618,9 @@
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:3,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1689,13 +1673,13 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1711,11 +1695,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:6,NIOPS:4</availability>
-		<model name='EXT-4Db'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -1729,11 +1713,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1764,13 +1748,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -1788,19 +1772,19 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CC:2+,OA:1+,CIH:7,CLAN:8,FS:2+,BAN:7,CB:7</availability>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3SLE'>
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:5,BAN:2</availability>
+		<model name='FFL-3PP'>
+			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FFL-3PP'>
+		<model name='C'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='FFL-3PP3'>
 			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3A'>
@@ -1810,11 +1794,6 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
 			<availability>LA:1</availability>
@@ -1824,41 +1803,46 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:2</availability>
 		</model>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:3+,CLAN:8,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:6</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:3+,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -1866,26 +1850,24 @@
 		<model name='FLE-4'>
 			<availability>MOC:8,OA:8,FWL:8</availability>
 		</model>
-		<model name='FLE-15'>
-			<availability>MOC:3,OA:3,FWL:3</availability>
-		</model>
 		<model name='FLE-14'>
 			<availability>FWL:1-</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>MOC:3,OA:3,FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1893,9 +1875,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1996,14 +1980,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:2,MOC:3,CLAN:8,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:8,LA:2,Periphery.MW:2,Periphery.ME:2,CNC:8,FWL:5,NIOPS:9,DC:2</availability>
-		<model name='GTHA-300'>
-			<availability>CLAN:2,FWL:5,BAN:4</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
+		<model name='GTHA-300'>
+			<availability>CLAN:2,FWL:5,BAN:4</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:4,CLAN:3</availability>
@@ -2029,14 +2013,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CC:2+,LA:2+,CLAN:6,FWL:2+,FS:2+,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -2048,17 +2032,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:6,CS:7,CHH:9,CSR:9,CLAN:8,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:8,DC:4+</availability>
+			<availability>FWL:6-,NIOPS:0,MERC:6-</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:3,Periphery.ME:3,FWL:3,NIOPS:0,MERC:3</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>FWL:6-,NIOPS:0,MERC:6-</availability>
+			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:8,DC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -2079,14 +2063,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>MOC:3,CC:4,CLAN:7,IS:4,FS:4,CIR:2,TC:3,CS:7,OA:3,LA:4,CNC:7,FWL:4,NIOPS:7,DC:4</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CLAN:5,CNC:5</availability>
+		<model name='HMR-HC'>
+			<availability>IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:4,CLAN:2,NIOPS:8</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8,CLAN:5,CNC:5</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2094,16 +2078,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:6,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2115,6 +2099,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2122,14 +2114,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2140,25 +2124,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2166,6 +2146,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2174,6 +2158,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2181,14 +2173,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2201,6 +2185,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:2,MOC:3+,CLAN:5,IS:3,FS:3,TC:3+,CS:6,OA:3+,LA:3,CNC:5,FWL:2,NIOPS:6,DC:3</availability>
+		<model name='HCT-213C'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 		<model name='HCT-212'>
 			<availability>LA:6,IS:6,FS:6,Periphery:6</availability>
 		</model>
@@ -2211,24 +2198,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:4</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:3-,MOC:3-,OA:3-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2243,17 +2227,21 @@
 			<roles>recon</roles>
 			<availability>FWL:3</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:3,CB:5</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,General:4+,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2265,10 +2253,6 @@
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:4+,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
@@ -2282,14 +2266,14 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:3,MOC:1,CHH:4,OA:1,LA:3,CLAN:3,FWL:3,FS:3,CGS:5,DC:2,TC:3</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2338,12 +2322,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:9,LA:1+,CSV:9,CLAN:8,NIOPS:4,FS:1+</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -2367,22 +2351,22 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>IS:2</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:2,CW:2,CLAN:2</availability>
-		<model name='IMP-1C'>
-			<availability>CHH:5,CLAN:2</availability>
-		</model>
 		<model name='IMP-1A'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='IMP-1C'>
+			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
@@ -2403,16 +2387,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,TC:8,Periphery:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -2448,15 +2432,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2473,13 +2457,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -2519,13 +2503,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:3,FS.RR:5,OA:3,FS.DMM:5,MERC:4,Periphery.OS:3,FS:2,DC:8</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -2537,17 +2521,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2564,11 +2548,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CC:1,CS:2,CHH:5,LA:1,CLAN:4,FWL:3,NIOPS:2,FS:1,DC:1</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,BAN:3</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -2593,11 +2577,11 @@
 		<model name='KGC-0000'>
 			<availability>IS:6</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:4,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2605,11 +2589,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:2</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2641,17 +2625,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:1,MOC:2,OA:2</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:6+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
+		<model name='KSC-4L'>
+			<availability>CC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -2699,13 +2683,13 @@
 			<roles>fire_support</roles>
 			<availability>:0,DC:8-</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:5+,NIOPS:8,BAN:6,DC:5+</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:2,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:5+,NIOPS:8,BAN:6,DC:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2735,15 +2719,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,LA:5</availability>
@@ -2764,14 +2748,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:2</availability>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:6</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -2787,25 +2771,25 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:5,CW:5,CLAN:5,CJF:5,CGB:5</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -2824,9 +2808,6 @@
 		<availability>TC:1</availability>
 		<model name='(2622)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2622)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2863,10 +2844,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:3,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -2875,14 +2852,18 @@
 			<roles>support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:3,CLAN:4,FWL:3,DC:3</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:5+</availability>
-		</model>
 		<model name='LNX-8Q'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2939,9 +2920,6 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2+,CLAN:7,IS:4,FS:5,TC:3+,Periphery:2,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:7</availability>
-		<model name='MAD-3M'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='MAD-3D'>
 			<availability>FS:6</availability>
 		</model>
@@ -2956,6 +2934,9 @@
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:4,CLAN:4,IS:4+,NIOPS:8,MERC:0,BAN:4,TC:4+</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2973,11 +2954,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:2,Periphery.CM:2,IS:2-,Periphery:2</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -3007,13 +2988,13 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -3039,17 +3020,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -3057,31 +3038,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -3090,11 +3071,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3153,25 +3134,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -3201,14 +3182,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:3+,CHH:5,CLAN:6,MERC:4+,FS:5+,TC:3+,CS:6,OA:3+,CDS:5,CBS:7,FWL:4+,NIOPS:6,CJF:7,CGB:5,DC:4+</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,IS:4+,BAN:8,Periphery:4+</availability>
-		</model>
-		<model name='MON-69'>
-			<roles>recon</roles>
-			<availability>DC:1+</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
@@ -3217,14 +3190,19 @@
 			<roles>recon</roles>
 			<availability>MOC:6,OA:6,FWL:6,NIOPS:0,MERC:8,FS:6,DC:6,TC:6</availability>
 		</model>
+		<model name='MON-69'>
+			<roles>recon</roles>
+			<availability>DC:1+</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,IS:4+,BAN:8,Periphery:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:2,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
@@ -3250,6 +3228,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -3258,12 +3242,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3285,13 +3263,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:2</availability>
-		<model name='(Block I)'>
-			<roles>destroyer</roles>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Block II)'>
 			<roles>destroyer</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='(Block I)'>
+			<roles>destroyer</roles>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -3312,12 +3290,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -3357,11 +3335,11 @@
 		<model name='ON1-V'>
 			<availability>OA:3,IS:3,TC:3</availability>
 		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='ON1-K'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -3379,6 +3357,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:7,Periphery:8</availability>
@@ -3386,9 +3367,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -3399,13 +3377,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:5,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:5,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6-,BAN:8</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -3430,10 +3408,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3441,6 +3415,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3460,12 +3438,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:3-,MERC:5,Periphery.OS:5,FS:3,BAN:4,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3491,10 +3469,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -3502,6 +3476,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -3515,45 +3493,45 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:4</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:4</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
+			<availability>CC:2+,MOC:2+,OA:2+,CLAN:4,FWL:2+,BAN:4</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>CC:2+,MOC:2+,OA:2+,CLAN:4,FWL:2+,BAN:4</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
+		<model name='PXH-1Kk'>
+			<availability>DC:1+</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:3</availability>
 		</model>
-		<model name='PXH-1Kk'>
-			<availability>DC:1+</availability>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3566,9 +3544,6 @@
 		<availability>MOC:3,OA:2,TC:3</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -3606,13 +3581,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,General:8,CLAN:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -3632,21 +3607,15 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,OA:3,LA:4,CLAN:7,IS:3,NIOPS:8,MERC:3</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:3</availability>
@@ -3657,37 +3626,43 @@
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:4,CNC:4</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6,CLAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6,CLAN:4</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:3,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -3719,9 +3694,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:2+,CS:5,CHH:5,CSR:4,LA:2+,CLAN:4,FWL:2+,NIOPS:5,FS:2+,CJF:4,DC:2+</availability>
@@ -3736,31 +3708,31 @@
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
 		<availability>FS:1</availability>
-		<model name='Block I'>
+		<model name='Block II'>
 			<roles>troop_carrier</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='Block II'>
+		<model name='Block I'>
 			<roles>troop_carrier</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:3,CS:4,OA:3,LA:3,CLAN:3,FWL:3,IS:3,NIOPS:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,CLAN:2,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -3795,11 +3767,11 @@
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Samarkand Carrier' unitType='Warship'>
@@ -3815,13 +3787,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:4,CC:3,OA:5,LA:3,CLAN:2,IS:4,FWL:3,MERC:4,FS:4,TC:4,Periphery:4,DC:4</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,General:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sand Devil Hover Tank' unitType='Tank'>
@@ -3843,16 +3815,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:7,LA:7,FWL:7,IS:7,Periphery.Deep:7,FS:7,DC:7,Periphery:7</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -3884,9 +3856,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:1-,CSV:5,CLAN:6,CFM:7,FS:2-,CGS:5,CS:4,CDS:5,CW:5,LA:5-,CBS:5,FWL:2-,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
 		</model>
@@ -3899,9 +3868,16 @@
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3910,33 +3886,29 @@
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:8,FS:3+,BAN:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:8,CLAN:6-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>General:8,CLAN:6-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:8,FS:3+,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3973,41 +3945,47 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(MG)'>
-			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(MG)'>
+			<roles>recon</roles>
+			<availability>IS.pm:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15'>
-			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:3+,LA:3+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -4015,10 +3993,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8,CLAN:6</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -4070,10 +4044,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>CC:5,CS:4,OA:2,LA:4,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 		</model>
@@ -4081,12 +4051,13 @@
 			<roles>anti_infantry</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,CLAN:1,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
@@ -4095,6 +4066,9 @@
 		</model>
 		<model name='STK-3Fk'>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,CLAN:1,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4148,11 +4122,11 @@
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>MOC:6,CC:8,CS:4,OA:6,LA:8,PIR:4,Periphery.Deep:4,NIOPS:4,MERC:6,FS:6,TC:6,DC:6</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -4163,11 +4137,11 @@
 		<model name='STU-K5'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4185,10 +4159,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -4200,42 +4174,42 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>MOC:2+,CC:1+,CS:8,OA:3,LA:1+,CLAN:9,FWL:2+,NIOPS:8,MERC:2+,FS:2+,TC:2+,DC:3+</availability>
-		<model name='C'>
-			<availability>CCC:8,CSR:8,CLAN:7</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>CLAN:8</availability>
-		<model name='TLN-5W'>
-			<availability>LA:8,CLAN:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>FWL:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>LA:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tharkad Battlecruiser' unitType='Warship'>
@@ -4279,11 +4253,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:7,CSV:9,CLAN:8,IS:4,CFM:10,FS:4,TC:3+,CS:7,CDS:7,CW:9,CBS:7,LA:5,CNC:7,FWL:6,NIOPS:7,CJF:9,CGB:9</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,FWL:2+,IS:2+,NIOPS:8,FS:2+,BAN:8,DC:2+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:4,DC:4</availability>
@@ -4308,28 +4282,28 @@
 			<roles>escort,ground_support</roles>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,CLAN:5</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,CLAN:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:2+</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:7,CSR:7,CDS:7,CW:7,CLAN:7,CNC:7,CJF:7,BAN:4,CGB:7</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,CLAN:2-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4353,29 +4327,26 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:3,MOC:2,CLAN:8,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:8,LA:2,FWL:4,NIOPS:9,DC:1</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:8,BAN:4</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:5</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
 		<availability>CC:5,MOC:6,CLAN:5,IS:5,Periphery.Deep:6,FS:5,MERC:5,CIR:5,Periphery:6,BAN:3,CS:6,LA:5,FWL:5,NIOPS:6,DC:5</availability>
 		<model name='(2755) (LF)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,CLAN:2,BAN:6</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,CLAN:2,BAN:6</availability>
@@ -4392,28 +4363,28 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:2+,CS:6,FWL:2+,NIOPS:6</availability>
 		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
+		<model name='TBT-5J'>
+			<availability>FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:4,MOC:3,CSR:7,CLAN:7,FS:4,MERC:4,TC:3,CS:7,OA:4,LA:1,FWL:2,NIOPS:7,DC:4</availability>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:3+,CLAN:6,IS:3+,NIOPS:8,BAN:8,Periphery:3+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4439,10 +4410,6 @@
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
 		<availability>LA:1</availability>
-		<model name='TFN-3M'>
-			<roles>ground_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
 			<availability>General:8</availability>
@@ -4450,6 +4417,10 @@
 		<model name='TFN-3A'>
 			<roles>ground_support</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='TFN-3M'>
+			<roles>ground_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -4529,14 +4500,14 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>CC:3</availability>
+		</model>
 		<model name='VND-1X'>
 			<availability>CC:1</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
-		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>CC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4549,21 +4520,17 @@
 			<roles>cargo</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:4,LA:7,CLAN:3,IS:4,FWL:6,MERC:3,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
-		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4599,10 +4566,6 @@
 		<model name='(2570)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Wakazashi' unitType='Mek'>
 		<availability>CJF:5</availability>
@@ -4612,30 +4575,27 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:5</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
+		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='2'>
+			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:3+,BAN:4</availability>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rk'>
 			<availability>DC:2+</availability>
+		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
@@ -4643,17 +4603,20 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:3+,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -4664,21 +4627,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:5,Periphery:6</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -4694,16 +4657,20 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
 		</model>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4711,10 +4678,6 @@
 		<model name='WVR-6K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -4726,16 +4689,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CLAN:7,CFM:7,CGS:7</availability>
+			<availability>CS:8,CLAN:6,NIOPS:8,CFM:6,BAN:8,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:3+,FWL:3+</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,CFM:6,BAN:8,TC:8</availability>
+			<availability>CLAN:7,CFM:7,CGS:7</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4790,20 +4753,20 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:2</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:5</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,MERC:5</availability>
-		<model name='ZEU-6S'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='ZEU-5T'>
 			<availability>LA:3+</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='ZEU-5S'>
 			<availability>LA:3+</availability>
@@ -4811,11 +4774,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -548,6 +548,10 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CC:1,CCC:3,CSR:5,CIH:3,CSV:3,CLAN:3,FS:1,CGS:3,CSA:3,CDS:3,LA:1,CBS:3,CNC:5,FWL:1,CJF:5,DC:1,CB:3</availability>
+		<model name='(2372)'>
+			<roles>cruiser</roles>
+			<availability>CC:8,IS:8</availability>
+		</model>
 		<model name='(2582)'>
 			<roles>cruiser</roles>
 			<availability>CS:8,CLAN:2</availability>
@@ -555,10 +559,6 @@
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(2372)'>
-			<roles>cruiser</roles>
-			<availability>CC:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -572,13 +572,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>MOC:1+,CC:1+,CLAN:6,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:6,CW:6,LA:1+,CNC:6,FWL:1+,NIOPS:7,CJF:6,DC:1+</availability>
-		<model name='Mk III'>
-			<availability>General:1</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:1</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:1</availability>
 		</model>
 	</chassis>
@@ -591,17 +591,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:3,BAN:4</availability>
 		</model>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -620,30 +620,30 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
 			<availability>LA:6</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:6,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk.III'>
 			<availability>General:2</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
@@ -657,37 +657,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -697,17 +677,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -729,26 +729,23 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>CC:3,MOC:1,CS:4-,OA:1,LA:4,CLAN:3-,IS:3,FWL:3,NIOPS:4-,FS:5,TC:1,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atreus Battleship' unitType='Warship'>
@@ -757,17 +754,11 @@
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2552)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -792,11 +783,11 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:3,OA:3,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baron Destroyer' unitType='Warship'>
@@ -805,29 +796,26 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2520)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:1+,CLAN:8,BAN:4</availability>
 		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
+		</model>
 		<model name='BLR-1D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:1+</availability>
@@ -849,14 +837,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
 		<model name='5'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -868,17 +856,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:2,MERC:2,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:2</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -906,13 +894,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,CDS:6,CLAN:5,NIOPS:5,FWL:2,DC:2</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,FWL:5+,BAN:8,DC:5+</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -931,13 +919,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -949,11 +937,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -988,32 +976,28 @@
 		<model name='(2632)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2632)'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:2,DC:2</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CC:1+,CLAN:6,DC:1+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,FWL:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1056,18 +1040,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:6,CS:5,CHH:6,LA:5,CLAN:4,IS:4,FWL:4,NIOPS:5,MERC:4,FS:4,CGB:6,DC:4</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:2+,CS:8,CHH:6,CLAN:5,NIOPS:8,BAN:7,CGB:6</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:6,BAN:3</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:2+,CS:8,CHH:6,CLAN:5,NIOPS:8,BAN:7,CGB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1089,16 +1073,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1110,25 +1094,25 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,FS:3,CIR:2,TC:2,Periphery:2,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:3,CLAN:6,FS:3,MERC:3,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:3,CLAN:6,FS:3,MERC:3,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,OA:3,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:3,DC:4</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1150,20 +1134,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1171,14 +1155,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1186,35 +1167,41 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1222,18 +1209,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1242,27 +1235,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1270,8 +1254,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1282,29 +1266,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:3,CS:3-,OA:3,LA:4,CLAN:2-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,CLAN:4,IS:3,BAN:5</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando IIC' unitType='Mek'>
@@ -1347,14 +1331,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -1366,13 +1350,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:2,MOC:1,CLAN:2,IS:2,FS:2,BAN:3,TC:2,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:2</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6,CLAN:4</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress D Frigate' unitType='Warship'>
@@ -1391,29 +1375,29 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1424,11 +1408,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>CCO:6</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1437,13 +1421,13 @@
 			<roles>raider</roles>
 			<availability>CC:2+,CLAN:7,FWL:2+,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:2+,CLAN:3,DC:2+</availability>
@@ -1451,14 +1435,14 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:4,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:4,CGS:8,CS:8,CDS:8,CW:10,LA:4,CBS:10,FWL:4,NIOPS:8,CJF:8,CGB:10,DC:4</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:3+,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cruiser' unitType='Warship'>
@@ -1470,8 +1454,9 @@
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:7,IS:2+,CGS:8,BAN:4,Periphery:2+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
@@ -1479,9 +1464,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:7,IS:2+,CGS:8,BAN:4,Periphery:2+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1489,11 +1473,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:2,LA:5,CLAN:4,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1501,13 +1485,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:1+,MOC:1+,CHH:5,CSR:5,CLAN:5,IS:1+,FS:1+,CIR:1+,TC:2+,Periphery:1+,CS:6,OA:1+,LA:1+,FWL:1+,NIOPS:6,CJF:5,DC:1+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,CS:8,CLAN:5,General:8,NIOPS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1533,9 +1517,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
@@ -1544,16 +1525,19 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
 		<availability>FS:2</availability>
-		<model name='Block II'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='Block I'>
 			<roles>destroyer</roles>
 			<availability>FS:5</availability>
+		</model>
+		<model name='Block II'>
+			<roles>destroyer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Defender Battlecruiser' unitType='Warship'>
@@ -1565,11 +1549,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1610,22 +1594,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:3</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1644,9 +1628,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:5,FS:5</availability>
 		</model>
@@ -1656,6 +1637,9 @@
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:2,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1708,13 +1692,13 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1730,11 +1714,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:5,NIOPS:4</availability>
-		<model name='EXT-4Db'>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>CLAN:6,BAN:3</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -1748,11 +1732,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1783,13 +1767,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -1807,19 +1791,19 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CC:1+,CIH:7,CLAN:7,FS:1+,BAN:6,CB:7</availability>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3SLE'>
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:6,BAN:2</availability>
+		<model name='FFL-3PP'>
+			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FFL-3PP'>
+		<model name='C'>
+			<availability>CLAN:6,BAN:2</availability>
+		</model>
+		<model name='FFL-3PP3'>
 			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3A'>
@@ -1829,11 +1813,6 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
 			<availability>LA:1</availability>
@@ -1843,41 +1822,46 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:1</availability>
 		</model>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:7</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -1891,17 +1875,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1909,9 +1891,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2012,14 +1996,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
-		<model name='GTHA-300'>
-			<availability>CLAN:2,FWL:4,BAN:3</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
+		<model name='GTHA-300'>
+			<availability>CLAN:2,FWL:4,BAN:3</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:4,CLAN:2</availability>
@@ -2045,14 +2029,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CC:2+,LA:2+,CLAN:6,FWL:2+,FS:2+,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -2064,17 +2048,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:8,DC:3+</availability>
+			<availability>FWL:6,NIOPS:0,MERC:6</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:4,NIOPS:0,MERC:4</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>FWL:6,NIOPS:0,MERC:6</availability>
+			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:8,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -2095,14 +2079,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>MOC:2,CC:3,CLAN:6,IS:3,FS:3,CIR:2,TC:2,CS:7,OA:2,LA:3,CNC:6,FWL:3,NIOPS:7,DC:3</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CLAN:4,CNC:4</availability>
+		<model name='HMR-HC'>
+			<availability>IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:3,CLAN:2,NIOPS:8</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8,CLAN:4,CNC:4</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2110,16 +2094,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2131,6 +2115,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2138,14 +2130,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2156,25 +2140,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2182,6 +2162,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2190,6 +2174,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2197,14 +2189,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2217,6 +2201,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:3,TC:2+,CS:6,OA:2+,LA:2,CNC:4,FWL:2,NIOPS:6,DC:2</availability>
+		<model name='HCT-213C'>
+			<availability>CLAN:6,BAN:3</availability>
+		</model>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
@@ -2227,24 +2214,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2259,17 +2243,21 @@
 			<roles>recon</roles>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:3,CC:2,CS:3,CHH:5,OA:3,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:2,CB:5</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2281,10 +2269,6 @@
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
@@ -2304,14 +2288,14 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:2,MOC:1,CHH:4,OA:1,LA:2,CLAN:3,FWL:2,FS:2,CGS:5,DC:2,TC:2</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2348,11 +2332,11 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4J'>
-			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
 		<model name='HBK-4G'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='HBK-4J'>
+			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -2369,12 +2353,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:9,CSV:9,CLAN:8,NIOPS:4</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -2398,22 +2382,22 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>IS:1</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:2,CW:2,CLAN:2</availability>
-		<model name='IMP-1C'>
-			<availability>CHH:5,CLAN:2</availability>
-		</model>
 		<model name='IMP-1A'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='IMP-1C'>
+			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
@@ -2434,16 +2418,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,TC:8,Periphery:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:5</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:5</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -2479,15 +2463,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2504,13 +2488,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -2550,13 +2534,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:4,FS.RR:5,OA:3,FS.DMM:5,MERC:4,Periphery.OS:4,FS:2,DC:8</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -2568,17 +2552,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2595,11 +2579,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CC:1,CS:2,CHH:4,LA:1,CLAN:3,FWL:2,NIOPS:2,FS:1,DC:1</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,BAN:3</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -2624,11 +2608,11 @@
 		<model name='KGC-0000'>
 			<availability>IS:7</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2636,11 +2620,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:4</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2672,17 +2656,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:1,MOC:1,OA:1</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:6+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
+		<model name='KSC-4L'>
+			<availability>CC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -2723,13 +2707,13 @@
 			<roles>fire_support</roles>
 			<availability>:0,DC:8-</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:1,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='League Destroyer' unitType='Warship'>
@@ -2759,15 +2743,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,LA:5</availability>
@@ -2788,14 +2772,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:4,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:1</availability>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:5</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -2811,25 +2795,25 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:3</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:3</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -2848,9 +2832,6 @@
 		<availability>TC:1</availability>
 		<model name='(2622)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2622)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2887,10 +2868,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:3,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -2898,6 +2875,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
@@ -2915,11 +2896,11 @@
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:2,CLAN:4,FWL:2,DC:2</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:4+</availability>
-		</model>
 		<model name='LNX-8Q'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2976,9 +2957,6 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5,CGB:6</availability>
-		<model name='MAD-3M'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='MAD-3D'>
 			<availability>FS:6</availability>
 		</model>
@@ -2993,6 +2971,9 @@
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:3,CLAN:4,IS:3+,NIOPS:8,MERC:0,BAN:4,TC:3+</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -3010,11 +2991,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -3044,13 +3025,13 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -3076,17 +3057,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -3094,31 +3075,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -3127,11 +3108,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3183,25 +3164,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -3231,14 +3212,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:2+,CHH:5,CLAN:6,MERC:4+,FS:4+,TC:2+,CS:6,OA:2+,CDS:5,CBS:7,FWL:3+,NIOPS:6,CJF:7,CGB:5,DC:3+</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,IS:3+,BAN:8,Periphery:3+</availability>
-		</model>
-		<model name='MON-69'>
-			<roles>recon</roles>
-			<availability>DC:1+</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
@@ -3247,14 +3220,19 @@
 			<roles>recon</roles>
 			<availability>MOC:6,OA:6,FWL:6,NIOPS:0,MERC:8,FS:6,DC:6,TC:6</availability>
 		</model>
+		<model name='MON-69'>
+			<roles>recon</roles>
+			<availability>DC:1+</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,IS:3+,BAN:8,Periphery:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
@@ -3274,6 +3252,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -3282,12 +3266,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3309,13 +3287,13 @@
 	</chassis>
 	<chassis name='Narukami Destroyer' unitType='Warship'>
 		<availability>DC:1</availability>
-		<model name='(Block I)'>
-			<roles>destroyer</roles>
-			<availability>DC:8</availability>
-		</model>
 		<model name='(Block II)'>
 			<roles>destroyer</roles>
 			<availability>DC:3</availability>
+		</model>
+		<model name='(Block I)'>
+			<roles>destroyer</roles>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -3336,12 +3314,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:4</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -3381,11 +3359,11 @@
 		<model name='ON1-V'>
 			<availability>OA:2,IS:3,TC:3</availability>
 		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='ON1-K'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -3403,6 +3381,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
@@ -3410,9 +3391,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -3423,13 +3401,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:5-,BAN:8</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -3454,10 +3432,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
@@ -3465,6 +3439,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3484,12 +3462,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:2-,MERC:5,Periphery.OS:5,FS:3,BAN:3,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3515,10 +3493,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -3526,6 +3500,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -3553,42 +3531,42 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:4</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:4</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
+			<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
+			<availability>CLAN:7,BAN:3</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
+		<model name='PXH-1'>
 			<roles>recon</roles>
-			<availability>CLAN:7,BAN:3</availability>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3601,9 +3579,6 @@
 		<availability>MOC:2,OA:1,TC:2</availability>
 		<model name='(2502)'>
 			<roles>corvette</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2502)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -3641,13 +3616,13 @@
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,General:8,CLAN:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -3667,21 +3642,15 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,OA:2,LA:4,CLAN:6,IS:2,NIOPS:8,MERC:2</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:2</availability>
@@ -3692,37 +3661,43 @@
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:3,CNC:3</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6,CLAN:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6,CLAN:3</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -3754,9 +3729,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:1+,CS:5,CHH:5,CSR:4,LA:1+,CLAN:4,FWL:1+,NIOPS:5,FS:1+,CJF:3,DC:1+</availability>
@@ -3771,31 +3743,31 @@
 	</chassis>
 	<chassis name='Robinson Transport' unitType='Warship'>
 		<availability>FS:1</availability>
-		<model name='Block I'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='Block II'>
 			<roles>troop_carrier</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='Block I'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,CLAN:2,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -3830,11 +3802,11 @@
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:7</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Samarkand Carrier' unitType='Warship'>
@@ -3850,13 +3822,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:3,CC:3,OA:5,LA:2,CLAN:1,IS:3,FWL:2,MERC:3,FS:4,TC:4,Periphery:4,DC:4</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,General:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
@@ -3872,16 +3844,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:8,LA:8,FWL:8,IS:8,Periphery.Deep:8,FS:8,DC:8,Periphery:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -3913,9 +3885,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CC:1-,CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
 		</model>
@@ -3928,9 +3897,16 @@
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3939,33 +3915,29 @@
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:6,FS:2+,BAN:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:8,CLAN:5-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>General:8,CLAN:5-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:6,FS:2+,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -4002,41 +3974,47 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(MG)'>
-			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(MG)'>
+			<roles>recon</roles>
+			<availability>IS.pm:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15'>
-			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:2+,LA:2+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -4044,10 +4022,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8,CLAN:4</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -4099,10 +4073,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>CC:5,CS:4,OA:2,LA:4,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:6,Periphery:8</availability>
 		</model>
@@ -4110,17 +4080,21 @@
 			<roles>anti_infantry</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4170,11 +4144,11 @@
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>MOC:6,CC:8,CS:4,OA:6,LA:8,PIR:3,NIOPS:4,MERC:6,FS:6,TC:6,DC:6</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -4185,11 +4159,11 @@
 		<model name='STU-K5'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4207,10 +4181,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -4222,42 +4196,42 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>MOC:1+,CC:1+,CS:8,OA:2,LA:1+,CLAN:8,FWL:1+,NIOPS:8,MERC:1+,FS:1+,TC:1+,DC:2+</availability>
-		<model name='C'>
-			<availability>CCC:8,CSR:8,CLAN:7</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>CLAN:8</availability>
-		<model name='TLN-5W'>
-			<availability>LA:8,CLAN:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>FWL:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>LA:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8,CLAN:4</availability>
+		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tharkad Battlecruiser' unitType='Warship'>
@@ -4285,12 +4259,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4302,11 +4276,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:2+,CS:7,CDS:7,CW:9,CBS:7,LA:4,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,FWL:2+,IS:2+,NIOPS:8,FS:2+,BAN:8,DC:2+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:5,DC:5</availability>
@@ -4340,28 +4314,28 @@
 			<roles>escort,ground_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,CLAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
+		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:1+</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:6,CSR:6,CDS:6,CW:6,CLAN:6,CNC:6,CJF:6,BAN:4,CGB:6</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
-		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4385,29 +4359,26 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:7,LA:2,FWL:4,NIOPS:9,DC:1</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:8,BAN:4</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:4</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
 		<availability>CC:5,MOC:6,CLAN:5,IS:5,Periphery.Deep:6,FS:5,MERC:5,CIR:5,Periphery:6,BAN:3,CS:6,LA:5,FWL:5,NIOPS:6,DC:5</availability>
 		<model name='(2755) (LF)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,CLAN:2,BAN:6</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,CLAN:2,BAN:6</availability>
@@ -4424,28 +4395,28 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CC:1+,CS:6,FWL:1+,NIOPS:6</availability>
 		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
+		<model name='TBT-5J'>
+			<availability>FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:6,CLAN:6,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:2+,CLAN:6,IS:2+,NIOPS:8,BAN:8,Periphery:2+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4546,14 +4517,14 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>CC:3</availability>
+		</model>
 		<model name='VND-1X'>
 			<availability>CC:1</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
-		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>CC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4566,21 +4537,17 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:4,LA:7,CLAN:2,IS:4,FWL:6,MERC:2,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
-		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4616,10 +4583,6 @@
 		<model name='(2570)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2570)'>
-			<roles>frigate</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Wakazashi' unitType='Mek'>
 		<availability>CJF:6</availability>
@@ -4629,30 +4592,27 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
+		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='2'>
+			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,BAN:4</availability>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rk'>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
@@ -4660,14 +4620,17 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -4678,21 +4641,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -4708,16 +4671,20 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:6</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
 		</model>
+		<model name='WTH-0'>
+			<availability>TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4725,10 +4692,6 @@
 		<model name='WVR-6K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -4740,16 +4703,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CLAN:6,CFM:6,CGS:6</availability>
+			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:2+,FWL:2+</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
+			<availability>CLAN:6,CFM:6,CGS:6</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4804,20 +4767,20 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:4</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,MERC:5</availability>
-		<model name='ZEU-6S'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='ZEU-5T'>
 			<availability>LA:2+</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='ZEU-5S'>
 			<availability>LA:2+</availability>
@@ -4825,11 +4788,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -542,6 +542,10 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:3,CCC:3,CIH:3,CSR:5,CDS:3,CBS:3,CSV:3,CNC:5,CLAN:3,CGS:3,CJF:5,CB:3</availability>
+		<model name='(2372)'>
+			<roles>cruiser</roles>
+			<availability>CC:8,IS:8</availability>
+		</model>
 		<model name='(2582)'>
 			<roles>cruiser</roles>
 			<availability>CS:8,CLAN:1</availability>
@@ -549,10 +553,6 @@
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(2372)'>
-			<roles>cruiser</roles>
-			<availability>CC:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -566,13 +566,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>MOC:1+,CC:1+,CLAN:6,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:6,CW:6,LA:1+,CNC:6,FWL:1+,NIOPS:7,CJF:6,DC:1+</availability>
-		<model name='Mk III'>
-			<availability>General:1</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:1</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:1</availability>
 		</model>
 	</chassis>
@@ -585,17 +585,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:3,BAN:4</availability>
 		</model>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -614,30 +614,30 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
 			<availability>LA:6</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:6,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk.III'>
 			<availability>General:2</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
@@ -651,37 +651,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -691,17 +671,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -723,35 +723,29 @@
 			<roles>cruiser</roles>
 			<availability>MOC:8</availability>
 		</model>
-		<model name='(2569)'>
-			<availability>MOC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>CC:3,MOC:1,CS:4-,OA:1,LA:4,CLAN:3-,IS:3,FWL:3,NIOPS:4-,FS:5,TC:1,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -776,32 +770,32 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:3,OA:3,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:1+,CLAN:8,BAN:4</availability>
 		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
+		</model>
 		<model name='BLR-1D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:1+</availability>
@@ -823,14 +817,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
 		<model name='5'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -842,17 +836,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:2,MERC:2,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:2</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -874,13 +868,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,CDS:6,CLAN:5,IS:2,NIOPS:5,FWL:2,DC:2</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,FWL:4+,BAN:8,DC:4+</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -899,13 +893,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -917,11 +911,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -953,25 +947,25 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:2,DC:2</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CC:1+,CLAN:6,DC:1+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,FWL:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1014,18 +1008,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:6,CS:5,CHH:6,LA:5,CLAN:4,IS:4,FWL:4,NIOPS:5,MERC:4,FS:4,CGB:6,DC:4</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:2+,CS:8,CHH:6,CLAN:5,NIOPS:8,BAN:7,CGB:6</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:6,BAN:3</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:2+,CS:8,CHH:6,CLAN:5,NIOPS:8,BAN:7,CGB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1047,16 +1041,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1068,25 +1062,25 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:3,TC:2,Periphery:2,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:2,CLAN:6,FS:2,MERC:2,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:2,CLAN:6,FS:2,MERC:2,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,OA:3,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:3,DC:4</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1108,20 +1102,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1129,14 +1123,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1144,35 +1135,41 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1180,18 +1177,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1200,27 +1203,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1228,8 +1222,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1240,29 +1234,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:3,CS:3-,OA:3,LA:4,CLAN:2-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,CLAN:4,IS:2,BAN:5</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando IIC' unitType='Mek'>
@@ -1287,14 +1281,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -1306,13 +1300,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:2,MOC:1,CLAN:2,IS:2,FS:2,BAN:3,TC:2,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:2</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,CLAN:5</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6,CLAN:3</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -1324,29 +1318,29 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1357,11 +1351,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,CCO:6</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1370,13 +1364,13 @@
 			<roles>raider</roles>
 			<availability>CC:1+,CLAN:7,FWL:1+,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:2+,CLAN:3,DC:2+</availability>
@@ -1384,20 +1378,21 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:3,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:3,CGS:8,CS:8,CDS:8,CW:10,LA:3,CBS:10,FWL:3,NIOPS:8,CJF:8,CGB:10,DC:3</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:3+,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:7,IS:2+,CGS:8,BAN:4,Periphery:2+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
@@ -1405,9 +1400,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:7,IS:2+,CGS:8,BAN:4,Periphery:2+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1415,11 +1409,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:2,LA:5,CLAN:4,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1427,13 +1421,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:1+,MOC:1+,CHH:5,CSR:5,CLAN:5,IS:1+,FS:1+,CIR:1+,TC:2+,Periphery:1+,CS:6,OA:1+,LA:1+,FWL:1+,NIOPS:6,CJF:5,DC:1+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,CS:8,CLAN:5,General:8,NIOPS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1452,9 +1446,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
@@ -1463,14 +1454,17 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1511,22 +1505,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:3</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1538,9 +1532,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:5,FS:5</availability>
 		</model>
@@ -1550,6 +1541,9 @@
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
 			<availability>LA:4,General:2,FS:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1584,13 +1578,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:6,IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:6,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -1606,13 +1600,13 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1628,11 +1622,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:5,NIOPS:4</availability>
-		<model name='EXT-4Db'>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>CLAN:6,BAN:3</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -1646,11 +1640,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1681,13 +1675,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -1705,19 +1699,19 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CC:1+,CIH:7,CLAN:7,FS:1+,BAN:6,CB:7</availability>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3SLE'>
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:6,BAN:2</availability>
+		<model name='FFL-3PP'>
+			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FFL-3PP'>
+		<model name='C'>
+			<availability>CLAN:6,BAN:2</availability>
+		</model>
+		<model name='FFL-3PP3'>
 			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3A'>
@@ -1727,11 +1721,6 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
 			<availability>LA:1</availability>
@@ -1741,41 +1730,46 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:1</availability>
 		</model>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:7</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -1789,17 +1783,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1807,9 +1799,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1916,14 +1910,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
-		<model name='GTHA-300'>
-			<availability>CLAN:2,FWL:4,BAN:3</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
+		<model name='GTHA-300'>
+			<availability>CLAN:2,FWL:4,BAN:3</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:3,CLAN:2</availability>
@@ -1949,14 +1943,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CC:1+,LA:1+,CLAN:6,FWL:1+,FS:1+,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -1968,17 +1962,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:8,DC:3+</availability>
+			<availability>FWL:7,NIOPS:0,MERC:7</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:4,NIOPS:0,MERC:4</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>FWL:7,NIOPS:0,MERC:7</availability>
+			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:8,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -1999,14 +1993,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>MOC:2,CC:3,CLAN:6,IS:3,FS:3,CIR:2,TC:2,CS:7,OA:2,LA:3,CNC:6,FWL:3,NIOPS:7,DC:3</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CLAN:4,CNC:4</availability>
+		<model name='HMR-HC'>
+			<availability>IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:3,CLAN:2,NIOPS:8</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8,CLAN:4,CNC:4</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2014,16 +2008,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2035,6 +2029,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2042,14 +2044,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2060,25 +2054,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2086,6 +2076,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2094,6 +2088,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2101,14 +2103,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2121,6 +2115,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:2,TC:2+,CS:6,OA:2+,LA:2,CNC:4,FWL:2,NIOPS:6,DC:2</availability>
+		<model name='HCT-213C'>
+			<availability>CLAN:6,BAN:3</availability>
+		</model>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
@@ -2131,24 +2128,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2163,17 +2157,21 @@
 			<roles>recon</roles>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:3,CC:2,CS:3,CHH:5,OA:3,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:2,CB:5</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2185,10 +2183,6 @@
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
@@ -2208,14 +2202,14 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:2,MOC:1,CHH:4,OA:1,LA:2,CLAN:3,FWL:2,FS:2,CGS:5,DC:2,TC:2</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2252,11 +2246,11 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4J'>
-			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
 		<model name='HBK-4G'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='HBK-4J'>
+			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -2273,12 +2267,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:9,CSV:9,CLAN:8,NIOPS:4</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -2302,25 +2296,25 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>IS:1</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:2,CW:2,CLAN:2</availability>
-		<model name='IMP-1C'>
-			<availability>CHH:5,CLAN:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:5</availability>
 		</model>
 		<model name='IMP-1A'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='IMP-1C'>
+			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
@@ -2341,16 +2335,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,TC:8,Periphery:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:5</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:5</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -2386,15 +2380,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2411,13 +2405,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -2457,13 +2451,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:4,FS.RR:5,OA:3,FS.DMM:5,MERC:4,Periphery.OS:4,FS:2,DC:8</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -2475,17 +2469,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2502,11 +2496,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CC:1,CS:2,CHH:4,LA:1,CLAN:3,FWL:2,NIOPS:2,FS:1,DC:1</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,BAN:3</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -2531,11 +2525,11 @@
 		<model name='KGC-0000'>
 			<availability>IS:7</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2543,11 +2537,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:5</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2579,17 +2573,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:1,MOC:1,OA:1</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:6+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
+		<model name='KSC-4L'>
+			<availability>CC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -2630,13 +2624,13 @@
 			<roles>fire_support</roles>
 			<availability>:0,DC:8-</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:1,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
@@ -2655,15 +2649,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,LA:5</availability>
@@ -2684,14 +2678,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:4,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:1</availability>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:5</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -2707,25 +2701,25 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:3</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:3</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -2744,9 +2738,6 @@
 		<availability>TC:1</availability>
 		<model name='(2622)'>
 			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2622)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -2783,10 +2774,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:3,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -2794,6 +2781,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
@@ -2811,11 +2802,11 @@
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:2,CLAN:4,FWL:2,DC:2</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:4+</availability>
-		</model>
 		<model name='LNX-8Q'>
 			<availability>LA:3</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2865,9 +2856,6 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5,CGB:6</availability>
-		<model name='MAD-3M'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='MAD-3D'>
 			<availability>FS:6</availability>
 		</model>
@@ -2882,6 +2870,9 @@
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:3,CLAN:4,IS:2+,NIOPS:8,MERC:0,BAN:4,TC:3+</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2899,11 +2890,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -2933,13 +2924,13 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -2965,17 +2956,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2983,31 +2974,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -3016,11 +3007,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3072,25 +3063,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -3120,14 +3111,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:2+,CHH:5,CLAN:6,MERC:4+,FS:3+,TC:2+,CS:6,OA:2+,CDS:5,CBS:7,FWL:2+,NIOPS:6,CJF:7,CGB:5,DC:2+</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,IS:2+,BAN:8,Periphery:2+</availability>
-		</model>
-		<model name='MON-69'>
-			<roles>recon</roles>
-			<availability>DC:1+</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
@@ -3136,14 +3119,19 @@
 			<roles>recon</roles>
 			<availability>MOC:5,OA:5,FWL:5,NIOPS:0,MERC:8,FS:5,DC:5,TC:5</availability>
 		</model>
+		<model name='MON-69'>
+			<roles>recon</roles>
+			<availability>DC:1+</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,IS:2+,BAN:8,Periphery:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
@@ -3163,6 +3151,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -3171,12 +3165,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3214,12 +3202,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:4</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -3262,11 +3250,11 @@
 		<model name='ON1-V'>
 			<availability>OA:2,IS:3,TC:3</availability>
 		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='ON1-K'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -3284,6 +3272,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
@@ -3291,9 +3282,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -3304,13 +3292,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:5-,BAN:6</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -3335,10 +3323,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
@@ -3346,6 +3330,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3365,12 +3353,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:2-,MERC:5,Periphery.OS:5,FS:3,BAN:3,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3396,10 +3384,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -3407,6 +3391,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -3434,42 +3422,42 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:4</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:4</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
+			<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
+			<availability>CLAN:7,BAN:3</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
+		<model name='PXH-1'>
 			<roles>recon</roles>
-			<availability>CLAN:7,BAN:3</availability>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3516,13 +3504,13 @@
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,General:6,CLAN:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,General:6,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -3542,21 +3530,15 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,OA:2,LA:4,CLAN:6,IS:2,NIOPS:8,MERC:2</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:2</availability>
@@ -3567,37 +3549,43 @@
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:3,CNC:3</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6,CLAN:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6,CLAN:3</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -3629,9 +3617,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:1+,CS:5,CHH:5,CSR:4,LA:1+,CLAN:4,FWL:1+,NIOPS:5,FS:1+,CJF:3,DC:1+</availability>
@@ -3646,20 +3631,20 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,CLAN:2,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -3694,22 +3679,22 @@
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:7</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:3,CC:2,OA:5,LA:2,CLAN:1,IS:3,FWL:2,MERC:3,FS:3,TC:3,Periphery:3,DC:4</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,General:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
@@ -3725,16 +3710,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:8,LA:8,FWL:8,IS:8,Periphery.Deep:8,FS:8,DC:8,Periphery:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -3766,9 +3751,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
 		</model>
@@ -3781,9 +3763,16 @@
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3792,33 +3781,29 @@
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:6,FS:2+,BAN:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:8,CLAN:5-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>General:8,CLAN:5-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:6,FS:2+,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3855,41 +3840,47 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(MG)'>
-			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(MG)'>
+			<roles>recon</roles>
+			<availability>IS.pm:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15'>
-			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:2+,LA:2+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3897,10 +3888,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8,CLAN:3</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -3945,10 +3932,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>CC:5,CS:4,OA:2,LA:4,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:5,Periphery:8</availability>
 		</model>
@@ -3956,17 +3939,21 @@
 			<roles>anti_infantry</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4016,11 +4003,11 @@
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>MOC:5,CC:8,CS:4,OA:5,LA:8,PIR:3,NIOPS:4,MERC:5,FS:5,TC:5,DC:5</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -4031,11 +4018,11 @@
 		<model name='STU-K5'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4053,10 +4040,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -4068,42 +4055,42 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CC:1+,MOC:1+,CS:8,OA:2,CLAN:8,FWL:1+,NIOPS:8,FS:1+,MERC:1+,TC:1+,DC:1+</availability>
-		<model name='C'>
-			<availability>CCC:8,CSR:8,CLAN:7</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>CLAN:8</availability>
-		<model name='TLN-5W'>
-			<availability>LA:8,CLAN:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>FWL:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>LA:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:7</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8,CLAN:3</availability>
+		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -4124,12 +4111,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4141,11 +4128,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:2+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,FWL:2+,IS:2+,NIOPS:8,FS:2+,BAN:8,DC:2+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:6,DC:6</availability>
@@ -4179,28 +4166,28 @@
 			<roles>escort,ground_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,CLAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
+		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:1+</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:6,CSR:6,CDS:6,CW:6,CLAN:6,CNC:6,CJF:6,BAN:4,CGB:6</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
-		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4224,29 +4211,26 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:7,LA:2,FWL:4,NIOPS:9,DC:1</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:8,BAN:4</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:4</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
 		<availability>CC:5,MOC:6,CLAN:5,IS:5,Periphery.Deep:6,FS:5,MERC:5,CIR:5,Periphery:6,BAN:3,CS:6,LA:5,FWL:5,NIOPS:6,DC:5</availability>
 		<model name='(2755) (LF)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,CLAN:2,BAN:6</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,CLAN:2,BAN:6</availability>
@@ -4263,31 +4247,31 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CC:1+,CS:6,FWL:1+,NIOPS:6</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
 		<model name='TBT-5S'>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CC:1+,CS:6,FWL:1+,NIOPS:6</availability>
-		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:6,CLAN:6,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:2+,CLAN:6,IS:2+,NIOPS:8,BAN:8,Periphery:2+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4381,14 +4365,14 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>CC:3</availability>
+		</model>
 		<model name='VND-1X'>
 			<availability>CC:1</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
-		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>CC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4401,21 +4385,17 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:4,LA:7,CLAN:2,IS:4,FWL:6,MERC:2,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
-		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4454,30 +4434,27 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='2'>
-			<roles>fire_support</roles>
+		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='2'>
+			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,BAN:4</availability>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rk'>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
@@ -4485,14 +4462,17 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -4503,21 +4483,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -4533,16 +4513,20 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:5</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
 		</model>
+		<model name='WTH-0'>
+			<availability>TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4550,10 +4534,6 @@
 		<model name='WVR-6K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -4565,16 +4545,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CLAN:6,CFM:6,CGS:6</availability>
+			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:2+,FWL:2+</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
+			<availability>CLAN:6,CFM:6,CGS:6</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4629,20 +4609,20 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:4</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,MERC:5</availability>
-		<model name='ZEU-6S'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='ZEU-5T'>
 			<availability>LA:2+</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='ZEU-5S'>
 			<availability>LA:2+</availability>
@@ -4650,11 +4630,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -546,6 +546,10 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:3,CCC:3,CIH:3,CSR:5,CDS:3,CBS:3,CSV:3,CNC:5,CLAN:3,CGS:3,CJF:5,CB:3</availability>
+		<model name='(2372)'>
+			<roles>cruiser</roles>
+			<availability>CC:8,IS:8</availability>
+		</model>
 		<model name='(2582)'>
 			<roles>cruiser</roles>
 			<availability>CS:8,CLAN:1</availability>
@@ -553,10 +557,6 @@
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2372)'>
-			<roles>cruiser</roles>
-			<availability>CC:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -570,13 +570,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>MOC:1+,CC:1+,CLAN:5,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:5,CW:5,LA:1+,CNC:5,FWL:1+,NIOPS:7,CJF:5,DC:1+</availability>
-		<model name='Mk III'>
-			<availability>General:1</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:1</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:1</availability>
 		</model>
 	</chassis>
@@ -589,17 +589,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:3,BAN:4</availability>
 		</model>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -618,30 +618,30 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,IS:7,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
 			<availability>LA:6</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:5,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk.III'>
 			<availability>General:1</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
@@ -655,37 +655,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -695,17 +675,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -723,29 +723,26 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>CC:3,MOC:1,CS:4-,OA:1,LA:4,CLAN:3-,IS:3,FWL:3,NIOPS:4-,FS:5,TC:1,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -770,32 +767,32 @@
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:2,OA:2,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CC:1+,CLAN:8,BAN:4</availability>
 		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
+		</model>
 		<model name='BLR-1D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:1+</availability>
@@ -817,14 +814,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
 		<model name='5'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -836,17 +833,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -868,13 +865,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,OA:2,CDS:6,CLAN:5,IS:2,NIOPS:5,FWL:2,DC:2,Periphery:2</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,FWL:3+,BAN:8,DC:3+</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -893,13 +890,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -911,11 +908,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -947,25 +944,25 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:2,DC:1</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CC:1+,CLAN:6,DC:1+</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,FWL:2,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1014,18 +1011,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:5,CS:5,CHH:6,LA:5,CLAN:4,IS:4,FWL:4,NIOPS:5,MERC:4,FS:4,CGB:6,DC:4</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:2+,CS:8,CHH:6,CLAN:4,NIOPS:8,BAN:7,CGB:6</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:5,BAN:3</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:5,BAN:3</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:2+,CS:8,CHH:6,CLAN:4,NIOPS:8,BAN:7,CGB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1047,16 +1044,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1068,25 +1065,25 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:2,CLAN:6,FS:2,MERC:2,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:2,CLAN:6,FS:2,MERC:2,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,OA:3,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:3,DC:4</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1108,20 +1105,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1129,14 +1126,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1144,35 +1138,41 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1180,18 +1180,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1200,27 +1206,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1228,8 +1225,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1240,29 +1237,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:3,CS:3-,OA:3,LA:4,CLAN:2-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,CLAN:4,IS:2,BAN:5</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando IIC' unitType='Mek'>
@@ -1287,14 +1284,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -1306,13 +1303,13 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:2,MOC:1,CLAN:2,IS:2,FS:2,BAN:3,TC:2,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:2</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,CLAN:4</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6,CLAN:2</availability>
+		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
@@ -1324,29 +1321,29 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1357,11 +1354,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>CLAN:5,CCO:8</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1370,13 +1367,13 @@
 			<roles>raider</roles>
 			<availability>CC:1+,CLAN:7,FWL:1+,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:1+,CLAN:3,DC:1+</availability>
@@ -1384,20 +1381,21 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:2,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:2,CGS:8,CS:8,CDS:8,CW:10,LA:2,CBS:10,FWL:2,NIOPS:8,CJF:8,CGB:10,DC:2</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:7,IS:1+,CGS:8,BAN:4,Periphery:1+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
@@ -1405,9 +1403,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:7,IS:1+,CGS:8,BAN:4,Periphery:1+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1415,11 +1412,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,CS:3,OA:2,LA:5,CLAN:3,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1427,13 +1424,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:1+,MOC:1+,CHH:5,CSR:5,CLAN:5,IS:1+,FS:1+,CIR:1+,TC:1+,Periphery:1+,CS:6,OA:1+,LA:1+,FWL:1+,NIOPS:6,CJF:5,DC:1+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,CS:8,CLAN:4,General:8,NIOPS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1452,9 +1449,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
@@ -1463,14 +1457,17 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1511,22 +1508,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:3</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1538,9 +1535,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:5,FS:5</availability>
 		</model>
@@ -1551,17 +1545,20 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,General:2,FS:4</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CW:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1596,13 +1593,13 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>CLAN:4,IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>CLAN:4,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -1618,13 +1615,13 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1640,11 +1637,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:5,NIOPS:4</availability>
-		<model name='EXT-4Db'>
-			<availability>CLAN:5,BAN:3</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>CLAN:5,BAN:3</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -1658,11 +1655,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1693,13 +1690,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -1717,19 +1714,19 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CC:1+,CIH:7,CLAN:7,FS:1+,BAN:6,CB:7</availability>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3SLE'>
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:7,BAN:2</availability>
+		<model name='FFL-3PP'>
+			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FFL-3PP'>
+		<model name='C'>
+			<availability>CLAN:7,BAN:2</availability>
+		</model>
+		<model name='FFL-3PP3'>
 			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3A'>
@@ -1739,11 +1736,6 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
 			<availability>LA:1</availability>
@@ -1753,41 +1745,46 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:1</availability>
 		</model>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:7</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -1801,17 +1798,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -1819,9 +1814,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -1928,14 +1925,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9,DC:1</availability>
-		<model name='GTHA-300'>
-			<availability>CLAN:2,FWL:3,BAN:3</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
+		<model name='GTHA-300'>
+			<availability>CLAN:2,FWL:3,BAN:3</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:3,CLAN:2</availability>
@@ -1961,14 +1958,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CC:1+,LA:1+,CLAN:6,FWL:1+,FS:1+,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -1980,17 +1977,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,IS:2+,NIOPS:8,BAN:8,DC:2+</availability>
+			<availability>FWL:7,NIOPS:0,MERC:7</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:4,NIOPS:0,MERC:4</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>FWL:7,NIOPS:0,MERC:7</availability>
+			<availability>CS:8,CLAN:8,IS:2+,NIOPS:8,BAN:8,DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -2011,14 +2008,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>MOC:1,CC:2,CLAN:6,IS:2,FS:2,CIR:1,TC:1,CS:7,OA:1,LA:2,CNC:6,FWL:2,NIOPS:7,DC:2</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CLAN:4,CNC:4</availability>
+		<model name='HMR-HC'>
+			<availability>IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:2,CLAN:2,NIOPS:8</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8,CLAN:4,CNC:4</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2026,16 +2023,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2047,6 +2044,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2054,14 +2059,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2072,25 +2069,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2098,6 +2091,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2106,6 +2103,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2113,14 +2118,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2133,6 +2130,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:1,MOC:1+,CLAN:3,IS:1,FS:1,TC:1+,CS:6,OA:1+,LA:1,CNC:3,FWL:1,NIOPS:6,DC:1</availability>
+		<model name='HCT-213C'>
+			<availability>CLAN:5,BAN:3</availability>
+		</model>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
@@ -2143,24 +2143,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>CLAN:5,BAN:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2175,17 +2172,21 @@
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:2,CC:1,CS:3,CHH:5,OA:2,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:1,CB:5</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,General:1+,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2198,10 +2199,6 @@
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
 		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,General:1+,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CW:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
@@ -2211,32 +2208,32 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:2,CS:9,LA:2,CLAN:9,FWL:2,NIOPS:9,IS:1,CFM:10,MERC:1,FS:1,CJF:10,DC:2</availability>
+		<model name='HGN-733C'>
+			<availability>CC:3,:0,LA:3</availability>
+		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:7,FWL:1+,BAN:4</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:3-,:0,LA:3-</availability>
 		</model>
-		<model name='HGN-733C'>
-			<availability>CC:3,:0,LA:3</availability>
+		<model name='HGN-733'>
+			<availability>CC:6-,:0,LA:6-</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>CC:2+,MOC:1+,CS:8,LA:2+,CLAN:6,FWL:2+,IS:1+,NIOPS:8,FS:2+,MERC:1+,BAN:8,DC:2+</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:6-,:0,LA:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:2,MOC:1,CHH:4,OA:1,LA:2,CLAN:3,FWL:2,FS:2,CGS:5,DC:2,TC:2</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2273,11 +2270,11 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4J'>
-			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
 		<model name='HBK-4G'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='HBK-4J'>
+			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -2294,12 +2291,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:9,CSV:9,CLAN:8,NIOPS:4</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -2323,25 +2320,25 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>IS:1</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:4,CW:4,CLAN:3</availability>
-		<model name='IMP-1C'>
-			<availability>CHH:5,CLAN:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='IMP-1A'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='IMP-1C'>
+			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
@@ -2362,16 +2359,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:5</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:5</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -2407,15 +2404,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2432,13 +2429,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -2482,13 +2479,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:4,FS.RR:5,OA:3,FS.DMM:5,MERC:4,Periphery.OS:4,FS:2,DC:8</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -2500,17 +2497,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2527,11 +2524,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CC:1,CS:2,CHH:4,LA:1,CLAN:3,FWL:2,NIOPS:2,FS:1,DC:1</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,BAN:3</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -2556,11 +2553,11 @@
 		<model name='KGC-0000'>
 			<availability>IS:7</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
@@ -2568,11 +2565,11 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:6</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2604,17 +2601,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:1,MOC:1,OA:1</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:6+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
+		<model name='KSC-4L'>
+			<availability>CC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -2655,13 +2652,13 @@
 			<roles>fire_support</roles>
 			<availability>:0,DC:8-</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,IS:1,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
@@ -2680,15 +2677,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,LA:5</availability>
@@ -2709,14 +2706,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>CC:8,MOC:2,CLAN:3,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:1</availability>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:4</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -2732,25 +2729,25 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:2</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -2798,10 +2795,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:3,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -2809,6 +2802,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
@@ -2826,11 +2823,11 @@
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:1,CLAN:4,FWL:1,DC:1</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:3+</availability>
-		</model>
 		<model name='LNX-8Q'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -2880,9 +2877,6 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5,CGB:6</availability>
-		<model name='MAD-3M'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='MAD-3D'>
 			<availability>FS:6</availability>
 		</model>
@@ -2897,6 +2891,9 @@
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:2,CLAN:4,IS:1+,NIOPS:8,MERC:0,BAN:4,TC:2+</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -2914,11 +2911,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -2948,13 +2945,13 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:6,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -2980,17 +2977,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2998,31 +2995,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -3031,11 +3028,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3087,25 +3084,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -3135,14 +3132,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:1,CHH:5,CLAN:6,MERC:4,FS:2,TC:1,CS:6,OA:1,CDS:5,CBS:7,FWL:2,NIOPS:6,CJF:7,CGB:5,DC:2</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,IS:1+,BAN:8,Periphery:1+</availability>
-		</model>
-		<model name='MON-69'>
-			<roles>recon</roles>
-			<availability>DC:1+</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
@@ -3151,14 +3140,19 @@
 			<roles>recon</roles>
 			<availability>MOC:4,OA:4,FWL:4,NIOPS:0,MERC:8,FS:4,DC:4,TC:4</availability>
 		</model>
+		<model name='MON-69'>
+			<roles>recon</roles>
+			<availability>DC:1+</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,IS:1+,BAN:8,Periphery:1+</availability>
+		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
@@ -3178,6 +3172,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -3186,12 +3186,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3229,12 +3223,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -3259,12 +3253,12 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,CIR:4</availability>
+		<model name='(Fusion)'>
+			<availability>FWL:2</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
-		</model>
-		<model name='(Fusion)'>
-			<availability>FWL:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3281,11 +3275,11 @@
 		<model name='ON1-V'>
 			<availability>OA:2,IS:3,TC:3</availability>
 		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='ON1-K'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -3303,6 +3297,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:5,Periphery:8</availability>
@@ -3310,9 +3307,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -3323,13 +3317,13 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:5-,BAN:6</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -3354,10 +3348,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
@@ -3365,6 +3355,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6,DC:4</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3384,12 +3378,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:1-,MERC:5,Periphery.OS:5,FS:3,BAN:2,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3415,10 +3409,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -3426,6 +3416,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -3453,39 +3447,39 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:4</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:4</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
+			<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
+			<availability>CLAN:7,BAN:3</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
+		<model name='PXH-1'>
 			<roles>recon</roles>
-			<availability>CLAN:7,BAN:3</availability>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3532,13 +3526,13 @@
 			<roles>support</roles>
 			<availability>IS:6,Periphery:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,General:4,CLAN:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,General:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -3558,21 +3552,15 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,OA:2,LA:3,CLAN:6,IS:2,NIOPS:8,MERC:2</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:2</availability>
@@ -3583,37 +3571,43 @@
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:3,CNC:3</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6,CLAN:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6,CLAN:3</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -3645,9 +3639,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:1+,CS:5,CHH:5,CSR:4,LA:1+,CLAN:4,FWL:1+,NIOPS:5,FS:1+,CJF:3,DC:1+</availability>
@@ -3662,20 +3653,20 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,CLAN:2,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -3710,22 +3701,22 @@
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:7</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:5,LA:1,CLAN:1,IS:2,FWL:1,MERC:2,FS:2,Periphery:2,TC:2,DC:4</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,General:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
@@ -3741,16 +3732,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:8,LA:8,FWL:8,IS:8,Periphery.Deep:8,FS:8,DC:8,Periphery:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -3782,9 +3773,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
 		</model>
@@ -3797,9 +3785,16 @@
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3808,33 +3803,29 @@
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:6,FS:1+,BAN:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:6,FS:1+,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
@@ -3871,41 +3862,47 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(MG)'>
-			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(MG)'>
+			<roles>recon</roles>
+			<availability>IS.pm:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15'>
-			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:1+,LA:1+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -3913,10 +3910,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8,CLAN:2</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -3961,10 +3954,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>CC:5,CS:4,OA:2,LA:4,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:4,Periphery:8</availability>
 		</model>
@@ -3972,17 +3961,21 @@
 			<roles>anti_infantry</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4032,11 +4025,11 @@
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>MOC:4,CC:8,CS:4,OA:5,LA:8,PIR:2,NIOPS:4,MERC:5,FS:5,TC:5,DC:5</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -4047,11 +4040,11 @@
 		<model name='STU-K5'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:4,FS.DMM:8</availability>
-		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4069,10 +4062,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -4084,42 +4077,42 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CC:1+,MOC:1+,CS:8,OA:1,CLAN:8,FWL:1+,NIOPS:8,FS:1+,MERC:1+,TC:1+,DC:1+</availability>
-		<model name='C'>
-			<availability>CCC:8,CSR:8,CLAN:7</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>CLAN:8</availability>
-		<model name='TLN-5W'>
-			<availability>LA:8,CLAN:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>FWL:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>LA:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:7</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8,CLAN:2</availability>
+		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -4140,12 +4133,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4157,11 +4150,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:1+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,FWL:2+,IS:2+,NIOPS:8,FS:2+,BAN:8,DC:2+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:6,DC:6</availability>
@@ -4195,28 +4188,28 @@
 			<roles>escort,ground_support</roles>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,CLAN:3</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,CLAN:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:4,Periphery:8</availability>
+		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:1+</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:6,CSR:6,CDS:6,CW:6,CLAN:6,CNC:6,CJF:6,BAN:4,CGB:6</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:4,Periphery:8</availability>
-		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4240,29 +4233,26 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:2,MOC:1,CS:9,OA:1,CW:6,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:8,BAN:4</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:4</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
 		<availability>MOC:6,CC:5,CLAN:5,IS:5,Periphery.Deep:6,MERC:5,FS:5,CIR:5,Periphery:6,BAN:3,CS:6,LA:5,FWL:5,NIOPS:6,DC:5</availability>
 		<model name='(2755) (LF)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,CLAN:2,BAN:6</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,CLAN:2,BAN:6</availability>
@@ -4279,31 +4269,31 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CC:1+,CS:6,FWL:1+,NIOPS:6</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
 		<model name='TBT-5S'>
 			<availability>MOC:4,FWL:4,MERC:4</availability>
 		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CC:1+,CS:6,FWL:1+,NIOPS:6</availability>
-		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:5,CLAN:5,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:1+,CLAN:6,IS:1+,NIOPS:8,BAN:8,Periphery:1+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4397,14 +4387,14 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>CC:3</availability>
+		</model>
 		<model name='VND-1X'>
 			<availability>CC:1</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
-		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>CC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4417,21 +4407,17 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:4,LA:7,CLAN:1,IS:4,FWL:6,MERC:2,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
-		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4470,30 +4456,27 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,BAN:4</availability>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rk'>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
@@ -4501,14 +4484,17 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -4519,21 +4505,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -4549,16 +4535,20 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:4</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
 		</model>
+		<model name='WTH-0'>
+			<availability>TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4567,18 +4557,14 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:8,CLAN:4-</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -4590,16 +4576,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CLAN:5,CFM:6,CGS:6</availability>
+			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:1+,FWL:1+</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
+			<availability>CLAN:5,CFM:6,CGS:6</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -4654,20 +4640,20 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:4</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,MERC:5</availability>
-		<model name='ZEU-6S'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='ZEU-5T'>
 			<availability>LA:1+</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='ZEU-5S'>
 			<availability>LA:1+</availability>
@@ -4675,11 +4661,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -537,6 +537,10 @@
 	</chassis>
 	<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
 		<availability>CSA:3,CCC:3,CIH:3,CSR:5,CDS:3,CBS:3,CSV:3,CNC:5,CLAN:3,CGS:3,CJF:5,CB:3</availability>
+		<model name='(2372)'>
+			<roles>cruiser</roles>
+			<availability>CC:8,IS:8</availability>
+		</model>
 		<model name='(2582)'>
 			<roles>cruiser</roles>
 			<availability>CS:8</availability>
@@ -544,10 +548,6 @@
 		<model name='(2843)'>
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2372)'>
-			<roles>cruiser</roles>
-			<availability>CC:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
@@ -561,13 +561,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>MOC:1+,CC:1+,CLAN:5,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:5,CW:5,LA:1+,CNC:5,FWL:1+,NIOPS:7,CJF:5,DC:1+</availability>
-		<model name='Mk III'>
-			<availability>General:1</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:1</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:1</availability>
 		</model>
 	</chassis>
@@ -580,17 +580,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:3,BAN:4</availability>
 		</model>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -609,30 +609,30 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
 			<availability>LA:6</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:5,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk.III'>
 			<availability>General:1</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
@@ -646,37 +646,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -686,17 +666,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -721,35 +721,35 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,CS:4-,OA:1,LA:4,CLAN:3-,IS:3,FWL:3,NIOPS:4-,FS:5,TC:1,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+		<model name='AS7-D-DC'>
+			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='AS7-RS'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1,MERC:0,DC:2</availability>
+		<model name='AS7-D'>
+			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:6,CCC:6,CSR:6,CW:5,CLAN:5,CNC:5,BAN:4</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
@@ -759,9 +759,6 @@
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -797,6 +794,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -804,23 +809,19 @@
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:3,CLAN:3</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -828,55 +829,51 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3E'>
-			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>MOC:2,OA:2,FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CBS:5,CSV:6,CGS:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
+		</model>
 		<model name='BLR-1D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:4</availability>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='BLR-1Gd'>
 			<availability>FS:1+</availability>
@@ -898,14 +895,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
 		<model name='5'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -923,29 +920,29 @@
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:7,NIOPS:4,CGS:8,BAN:4</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -967,13 +964,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,OA:2,CDS:6,CLAN:5,IS:2,NIOPS:5,FWL:2,DC:2,Periphery:2</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,FWL:2+,BAN:8,DC:2+</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -999,13 +996,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -1017,11 +1014,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -1060,25 +1057,25 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:1,CC:5,CLAN:2,IS:3,MERC:2,FS:3,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:2,DC:1</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4,FWL:2,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1095,17 +1092,17 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>IS:2,FS:2,MERC:2,Periphery:2</availability>
+			<availability>LA:2,IS:2,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:2,IS:2,FS:4,MERC:4,Periphery:2</availability>
+			<availability>IS:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cestus' unitType='Mek'>
@@ -1135,18 +1132,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:5,CS:5,CHH:6,LA:5,CLAN:4,IS:4,FWL:4,NIOPS:5,MERC:4,FS:4,CGB:6,DC:4</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:2+,CS:8,CHH:6,CLAN:4,NIOPS:8,BAN:7,CGB:6</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:5,BAN:3</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:5,BAN:3</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:2+,CS:8,CHH:6,CLAN:4,NIOPS:8,BAN:7,CGB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1168,16 +1165,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1189,25 +1186,25 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:1,CLAN:6,FS:1,MERC:1,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1,CLAN:6,FS:1,MERC:1,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,OA:2,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:2,DC:4</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1229,20 +1226,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1256,14 +1253,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1271,35 +1265,41 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1307,18 +1307,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1327,27 +1333,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1355,8 +1352,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1367,29 +1364,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:2,CS:3-,OA:2,LA:4,CLAN:1-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:4,FS:4</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:4,FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,CLAN:4,IS:1,BAN:5</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando IIC' unitType='Mek'>
@@ -1414,14 +1411,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -1433,51 +1430,51 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CC:1,CS:6,LA:1,CLAN:2,FWL:1,IS:1,NIOPS:6,FS:1,BAN:3,DC:1,TC:1</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,CSR:1,CW:2,CSV:1,CLAN:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8,CLAN:6</availability>
 		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,TC:2,Periphery:2,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1488,11 +1485,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>CLAN:5,CCO:8</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1501,13 +1498,13 @@
 			<roles>raider</roles>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>LA:1+,CLAN:3,DC:1+</availability>
@@ -1515,14 +1512,14 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:1,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:1,CGS:8,CS:8,CDS:8,CW:10,LA:1,CBS:10,FWL:1,NIOPS:8,CJF:8,CGB:10,DC:1</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
@@ -1530,17 +1527,18 @@
 		<model name='A'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:7,IS:1+,CGS:8,BAN:4,Periphery:1+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
@@ -1548,9 +1546,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:7,IS:1+,CGS:8,BAN:4,Periphery:1+</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1558,11 +1555,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,CLAN:3,IS:3,FS:5,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1570,13 +1567,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CC:1+,MOC:1+,CHH:5,CSR:5,CLAN:5,IS:1+,FS:1+,TC:1+,CS:6,OA:1+,LA:1+,FWL:1+,NIOPS:6,CJF:5,DC:1+</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CC:8,CS:8,CLAN:4,General:8,NIOPS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1595,9 +1592,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
@@ -1605,6 +1599,9 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
@@ -1629,11 +1626,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1671,22 +1668,22 @@
 	</chassis>
 	<chassis name='Dictator' unitType='Dropship'>
 		<availability>IS:2</availability>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Command)'>
 			<roles>troop_carrier</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1698,9 +1695,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:5,FS:5</availability>
 		</model>
@@ -1711,15 +1705,18 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,General:2,FS:4</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Space) [Flamer]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:3,CLAN:2</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:8</availability>
@@ -1728,8 +1725,8 @@
 			<roles>marine</roles>
 			<availability>CSR:3,CLAN:2</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1764,32 +1761,32 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CIH:3+,CGS:3+</availability>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='A'>
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -1805,13 +1802,13 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='EXC-B1'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
 			<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
+		<model name='EXC-B1'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1827,11 +1824,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:5,NIOPS:4</availability>
-		<model name='EXT-4Db'>
-			<availability>CLAN:4,BAN:3</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>CLAN:4,BAN:3</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -1845,11 +1842,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1880,13 +1877,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -1904,19 +1901,19 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CC:1+,CIH:7,CLAN:7,FS:1+,BAN:6,CB:7</availability>
-		<model name='FFL-3PP3'>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='FFL-3SLE'>
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,BAN:2</availability>
+		<model name='FFL-3PP'>
+			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3PP2'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FFL-3PP'>
+		<model name='C'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='FFL-3PP3'>
 			<availability>BAN:2</availability>
 		</model>
 		<model name='FFL-3A'>
@@ -1926,11 +1923,6 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
 			<availability>LA:1</availability>
@@ -1940,41 +1932,46 @@
 			<deployedWith>Vulcan</deployedWith>
 			<availability>CC:1</availability>
 		</model>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:1,NIOPS:5,CJF:7,CGB:5</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:8</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:10,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -1988,17 +1985,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:10,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2006,9 +2001,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2112,23 +2109,23 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:7,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CSV:8,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:4,General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>MOC:1,CS:9,CDS:7,Periphery.MW:1,CLAN:7,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9</availability>
-		<model name='GTHA-300'>
-			<availability>CLAN:2,FWL:3,BAN:3</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
+		<model name='GTHA-300'>
+			<availability>CLAN:2,FWL:3,BAN:3</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:2,CLAN:2</availability>
@@ -2154,14 +2151,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:5,CLAN:3,IS:9,Periphery.Deep:6,MERC:8,TC:7,Periphery:6,CS:4,OA:4,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
@@ -2179,17 +2176,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,IS:2+,NIOPS:8,BAN:8,DC:2+</availability>
+			<availability>FWL:8,NIOPS:0,MERC:8</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:4,NIOPS:0,MERC:4,Periphery:2</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>FWL:8,NIOPS:0,MERC:8</availability>
+			<availability>CS:8,CLAN:8,IS:2+,NIOPS:8,BAN:8,DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -2210,14 +2207,14 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>MOC:1,CC:1,CLAN:6,IS:1,FS:1,CIR:1,TC:1,CS:7,OA:1,LA:1,CNC:6,FWL:1,NIOPS:7,DC:1</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CLAN:4,CNC:4</availability>
+		<model name='HMR-HC'>
+			<availability>IS:8</availability>
 		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:1,CLAN:2,NIOPS:8</availability>
 		</model>
-		<model name='HMR-HC'>
-			<availability>IS:8</availability>
+		<model name='HMR-HD'>
+			<availability>General:8,CLAN:4,CNC:4</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2225,16 +2222,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2246,6 +2243,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2253,14 +2258,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2271,25 +2268,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:6,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2297,6 +2290,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2305,6 +2302,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:6,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2312,14 +2317,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2332,6 +2329,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CC:1,MOC:1+,CLAN:3,IS:1,FS:1,TC:1+,CS:6,OA:1+,LA:1,CNC:3,FWL:1,NIOPS:6,DC:1</availability>
+		<model name='HCT-213C'>
+			<availability>CLAN:5,BAN:3</availability>
+		</model>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 		</model>
@@ -2342,24 +2342,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>CLAN:5,BAN:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2374,17 +2371,21 @@
 			<roles>recon</roles>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>MOC:1,CC:1,CS:3,CHH:5,OA:1,CLAN:4,FWL:3,NIOPS:3,CGB:5,DC:1,CB:5</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2396,10 +2397,6 @@
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
@@ -2422,32 +2419,32 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:2,CS:9,LA:2,CLAN:9,FWL:1,NIOPS:9,IS:1,CFM:10,FS:1,CJF:10,DC:2</availability>
+		<model name='HGN-733C'>
+			<availability>CC:4,:0,LA:4</availability>
+		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:7,FWL:1+,BAN:4</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:4,:0,LA:4</availability>
 		</model>
-		<model name='HGN-733C'>
-			<availability>CC:4,:0,LA:4</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>CS:8,CLAN:6,NIOPS:8,FWL:1+,FS:1+,BAN:8</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:1,MOC:1,CHH:4,OA:1,LA:1,CLAN:3,FWL:1,FS:1,CGS:5,DC:1,TC:2</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2484,17 +2481,17 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4J'>
-			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
 		<model name='HBK-4G'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
-		<model name='HBK-4P'>
-			<availability>IS:3,Periphery:3</availability>
+		<model name='HBK-4J'>
+			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -2508,12 +2505,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:9,CSV:9,CLAN:8,NIOPS:4</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:6,BAN:4</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -2537,25 +2534,25 @@
 	</chassis>
 	<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 		<availability>IS:1</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:4,CW:4,CLAN:3</availability>
-		<model name='IMP-1C'>
-			<availability>CHH:5,CLAN:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='IMP-1A'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='IMP-1C'>
+			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
@@ -2576,16 +2573,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,CLAN:9,IS:7,Periphery.Deep:8,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:5</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:5</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:5</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -2603,13 +2600,13 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CIH:3,CLAN:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
@@ -2625,15 +2622,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2650,13 +2647,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -2700,13 +2697,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:4,FS.RR:5,OA:3,FS.DMM:5,MERC:4,Periphery.OS:4,FS:2,DC:8</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -2718,17 +2715,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2745,11 +2742,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CS:2,CHH:4,CLAN:3,FWL:1,NIOPS:2</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,BAN:3</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -2780,11 +2777,11 @@
 		<model name='KGC-0000'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
@@ -2810,26 +2807,26 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:6</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,CGB:9</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso Command Mech' unitType='Mek'>
@@ -2861,17 +2858,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:1,MOC:1,OA:1</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4,MOC:8,OA:8</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:6+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4,MOC:8,OA:8</availability>
+		<model name='KSC-4L'>
+			<availability>CC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -2915,13 +2912,13 @@
 		<model name='LNC25-03'>
 			<availability>IS:4-,DC:6-</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:6,DC:3+</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:6,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -2947,15 +2944,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,LA:5</availability>
@@ -2976,14 +2973,14 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:2,CC:8,CLAN:3,IS:2,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
-		<model name='LTN-G14'>
-			<availability>Periphery:1</availability>
+		<model name='LTN-G15'>
+			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='LTN-G15b'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='LTN-G15'>
-			<availability>General:8,CLAN:4</availability>
+		<model name='LTN-G14'>
+			<availability>Periphery:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -2999,25 +2996,25 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,CLAN:2-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
-		<model name='LCT-1M'>
-			<roles>recon</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='LCT-1M'>
+			<roles>recon</roles>
+			<availability>FS:2</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
@@ -3065,10 +3062,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:3,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -3076,6 +3069,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
@@ -3093,11 +3090,11 @@
 	</chassis>
 	<chassis name='Lynx' unitType='Mek'>
 		<availability>LA:1,CLAN:4,FWL:1,DC:1</availability>
-		<model name='LNX-9Q'>
-			<availability>CLAN:8,IS:2+</availability>
-		</model>
 		<model name='LNX-8Q'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='LNX-9Q'>
+			<availability>CLAN:8,IS:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -3147,9 +3144,6 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5,CGB:6</availability>
-		<model name='MAD-3M'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='MAD-3D'>
 			<availability>FS:6</availability>
 		</model>
@@ -3164,6 +3158,9 @@
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,MOC:1,CLAN:4,NIOPS:8,MERC:0,BAN:4,TC:1+</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -3181,11 +3178,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -3215,13 +3212,13 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:6,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -3247,17 +3244,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -3265,31 +3262,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -3298,11 +3295,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3354,25 +3351,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -3402,14 +3399,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:1,CHH:5,CLAN:6,MERC:4,FS:1,TC:1,CS:6,OA:1,CDS:5,CBS:7,FWL:1,NIOPS:6,CJF:7,CGB:5,DC:1</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='MON-69'>
-			<roles>recon</roles>
-			<availability>DC:1+</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
@@ -3418,14 +3407,19 @@
 			<roles>recon</roles>
 			<availability>MOC:2,OA:2,FWL:2,NIOPS:0,MERC:8,FS:2,DC:2,TC:2</availability>
 		</model>
+		<model name='MON-69'>
+			<roles>recon</roles>
+			<availability>DC:1+</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Monolith Jumpship' unitType='Jumpship'>
 		<availability>CLAN:1,IS:1</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
@@ -3445,6 +3439,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:9,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -3453,12 +3453,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3496,12 +3490,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -3532,12 +3526,12 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,CIR:4</availability>
+		<model name='(Fusion)'>
+			<availability>FWL:2</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
-		</model>
-		<model name='(Fusion)'>
-			<availability>FWL:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3554,11 +3548,11 @@
 		<model name='ON1-V'>
 			<availability>OA:2,IS:3,TC:3</availability>
 		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='ON1-K'>
 			<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -3576,6 +3570,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:3-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:5,Periphery:8</availability>
@@ -3583,9 +3580,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -3596,22 +3590,22 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:5,BAN:4</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:5-,BAN:6</availability>
 		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:5,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,FWL:7,NIOPS:6,Periphery.Deep:4,FS:7,MERC:7,Periphery:4</availability>
-		<model name='OTL-4F'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='OTL-4D'>
 			<availability>CLAN:8,IS:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='OTL-4F'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -3630,10 +3624,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery.Deep:6,Periphery:6</availability>
@@ -3641,6 +3631,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6,DC:4</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3660,12 +3654,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:1-,MERC:5,Periphery.OS:5,FS:3,BAN:2,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:8,LA:8,TC:8</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:8,LA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3691,10 +3685,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -3702,6 +3692,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -3729,36 +3723,36 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:4</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:4</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,CLAN:2,IS:9,FWL:9,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
+			<availability>CLAN:3,BAN:4</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>CLAN:3,BAN:4</availability>
+			<availability>CLAN:7,BAN:3</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
+		<model name='PXH-1'>
 			<roles>recon</roles>
-			<availability>CLAN:7,BAN:3</availability>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3787,13 +3781,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -3813,13 +3807,13 @@
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,General:2,CLAN:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,General:2,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -3839,21 +3833,15 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,OA:2,LA:3,CLAN:6,IS:1,NIOPS:8,MERC:1</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:2</availability>
@@ -3864,37 +3852,43 @@
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:3,CNC:3</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6,CLAN:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6,CLAN:3</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -3926,9 +3920,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CS:5,CHH:5,CSR:4,CLAN:4,NIOPS:5,CJF:3</availability>
@@ -3943,20 +3934,20 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CC:1,CS:4,OA:2,LA:1,CLAN:3,FWL:1,IS:1,NIOPS:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,CLAN:2,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:2,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -3991,22 +3982,22 @@
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:7</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>MOC:1,CC:1,OA:5,LA:1,CLAN:1,IS:1,FWL:1,MERC:1,FS:1,Periphery:1,TC:1,DC:4</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,General:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sassanid' unitType='Dropship'>
@@ -4029,16 +4020,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,LA:9,FWL:9,IS:9,Periphery.Deep:9,FS:9,DC:9,Periphery:9</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4070,9 +4061,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
 		</model>
@@ -4085,9 +4073,16 @@
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4096,33 +4091,29 @@
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>LA:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:5,FS:1+,BAN:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:5,FS:1+,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -4165,41 +4156,47 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(MG)'>
-			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(MG)'>
+			<roles>recon</roles>
+			<availability>IS.pm:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15'>
-			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
 		<availability>CC:1+,LA:1+,CLAN:1,CSJ:2</availability>
-		<model name='SL-1H'>
-			<roles>spotter</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='SL-1G'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SL-1H'>
+			<roles>spotter</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Soarece Superheavy MBT' unitType='Tank'>
@@ -4218,10 +4215,6 @@
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Spad' unitType='Aero'>
 		<availability>CS:6,OA:3,CSR:3,CLAN:3,NIOPS:6</availability>
@@ -4234,13 +4227,13 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>FS.CMM:3</availability>
-		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>FS.CMM:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -4265,10 +4258,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>CC:5,CS:4,OA:2,LA:3,CLAN:1-,IS:3,FWL:7,NIOPS:4,MERC:4,FS:5,TC:2,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:3,Periphery:8</availability>
 		</model>
@@ -4276,20 +4265,24 @@
 			<roles>anti_infantry</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
-		</model>
-		<model name='STK-4N'>
-			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4339,11 +4332,11 @@
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>MOC:3,CC:8,CS:4,OA:4,LA:6,PIR:2,NIOPS:4,MERC:4,FS:4,TC:4,DC:4</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -4354,14 +4347,14 @@
 		<model name='STU-K5'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>FS:3</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4383,10 +4376,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -4398,46 +4391,49 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:8,NIOPS:8</availability>
-		<model name='C'>
-			<availability>CCC:8,CSR:8,CLAN:7</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CCC:8,CSR:8,CLAN:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
 		<availability>CLAN:8</availability>
-		<model name='TLN-5W'>
-			<availability>LA:8,CLAN:8</availability>
-		</model>
 		<model name='TLN-5V'>
 			<availability>FWL:8,FS:8</availability>
+		</model>
+		<model name='TLN-5W'>
+			<availability>LA:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:5,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
@@ -4445,9 +4441,6 @@
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:8,General:8,CJF:9,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
@@ -4475,12 +4468,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4492,11 +4485,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:2,TC:1+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,FWL:1+,IS:1+,NIOPS:8,FS:1+,BAN:8,DC:1+,TC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:8,DC:8</availability>
@@ -4530,31 +4523,31 @@
 			<roles>escort,ground_support</roles>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,CLAN:3</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,CLAN:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:8,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:8,Periphery:6,TC:6,DC:8</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
+		</model>
+		<model name='TDR-5S'>
+			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:4,Periphery:8</availability>
+		</model>
+		<model name='TDR-5SS'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='TDR-5Sd'>
 			<availability>FS:1+</availability>
 		</model>
 		<model name='TDR-5Sb'>
 			<availability>CHH:5,CSR:5,CDS:5,CW:5,CLAN:5,CNC:5,CJF:5,BAN:4,CGB:5</availability>
-		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:4,Periphery:8</availability>
-		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4565,13 +4558,13 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:4,CLAN:3,NIOPS:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
@@ -4582,29 +4575,26 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CC:2,MOC:1,CS:9,OA:1,CW:6,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:8,BAN:4</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:4</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
 		<availability>MOC:6,CC:5,CLAN:5,IS:5,Periphery.Deep:6,MERC:5,FS:5,CIR:5,Periphery:6,BAN:3,CS:6,LA:5,FWL:5,NIOPS:6,DC:5</availability>
 		<model name='(2755) (LF)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2754)'>
-			<availability>General:8,CLAN:2,BAN:6</availability>
 		</model>
 		<model name='(2754)'>
 			<availability>General:8,CLAN:2,BAN:6</availability>
@@ -4630,31 +4620,31 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,NIOPS:6</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
 		<model name='TBT-5S'>
 			<availability>MOC:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,NIOPS:6</availability>
-		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:2,MOC:2,CS:7,OA:4,CSR:5,CLAN:5,NIOPS:7,FS:2,MERC:2,DC:2,TC:2</availability>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:1+,CLAN:6,IS:1+,NIOPS:8,BAN:8,Periphery:1+</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4680,8 +4670,9 @@
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:8,CSR:6,CJF:6</availability>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
@@ -4694,12 +4685,11 @@
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -4772,14 +4762,14 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>CC:3</availability>
+		</model>
 		<model name='VND-1X'>
 			<availability>CC:1</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
-		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>CC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -4792,21 +4782,17 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:4,LA:7,CLAN:1,IS:4,FWL:6,MERC:2,FS:6,DC:7</availability>
+		<model name='VNL-K65N'>
+			<availability>IS:8</availability>
+		</model>
 		<model name='(Star League)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5</availability>
-		</model>
-		<model name='VNL-K65N'>
-			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -4845,30 +4831,27 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>General:8,CLAN:1,Periphery.Deep:8,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WHM-7A'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,BAN:4</availability>
+		<model name='WHM-6R'>
+			<availability>General:8,CLAN:1,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 		<model name='WHM-6Rk'>
 			<availability>DC:1+</availability>
+		</model>
+		<model name='WHM-7A'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
@@ -4876,14 +4859,17 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -4894,21 +4880,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:3,Periphery:6</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -4928,16 +4914,20 @@
 			<roles>fire_support</roles>
 			<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-0'>
-			<availability>TC:2</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
 		</model>
+		<model name='WTH-0'>
+			<availability>TC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4946,18 +4936,14 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:8,CLAN:4-</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -4969,16 +4955,16 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:6,FS:6,MERC:5,DC:6,TC:4</availability>
-		<model name='WVE-5Nb'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CLAN:5,CFM:6,CGS:6</availability>
+			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
 		</model>
 		<model name='WVE-5Nsl'>
 			<availability>LA:1+,FWL:1+</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-5Nb'>
 			<roles>urban</roles>
-			<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
+			<availability>CLAN:5,CFM:6,CGS:6</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -5033,20 +5019,20 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:4</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,MERC:5</availability>
-		<model name='ZEU-6S'>
-			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
-		</model>
 		<model name='ZEU-5T'>
 			<availability>LA:1+</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 		<model name='ZEU-5S'>
 			<availability>LA:1+</availability>
@@ -5054,11 +5040,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -559,13 +559,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>MOC:1+,CC:1+,CLAN:4,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:4,CW:4,LA:1+,CNC:4,FWL:1+,NIOPS:7,CJF:3,DC:1+</availability>
-		<model name='Mk III'>
-			<availability>General:1</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:1</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:1</availability>
 		</model>
 	</chassis>
@@ -578,17 +578,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
-		<model name='ANH-1G'>
-			<availability>CSA:4,CCO:4,BAN:1</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>CLAN:2,BAN:3</availability>
 		</model>
+		<model name='ANH-1G'>
+			<availability>CSA:4,CCO:4,BAN:1</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -607,30 +607,30 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,FS:8,Periphery:5,DC:8</availability>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
 			<availability>LA:6</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,LA:7,CLAN:2,IS:8,Periphery.Deep:7,BAN:4,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
 		<availability>CLAN:4,IS:8,Periphery:6</availability>
-		<model name='Mark VII'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk.III'>
 			<availability>General:1</availability>
+		</model>
+		<model name='Mark VII'>
+			<availability>General:8</availability>
 		</model>
 		<model name='Mark VII-C'>
 			<availability>CLAN:8</availability>
@@ -644,37 +644,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -684,17 +664,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -719,35 +719,35 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:4</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,CLAN:2-,IS:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,LA:4,FWL:3,NIOPS:4-,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
+		<model name='AS7-D-DC'>
+			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='AS7-RS'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1,MERC:0,DC:2</availability>
+		<model name='AS7-D'>
+			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:6,CCC:6,CSR:6,CW:5,CLAN:5,CNC:5,BAN:4</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
@@ -757,9 +757,6 @@
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -795,6 +792,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -802,23 +807,19 @@
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CLAN:4</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -826,74 +827,70 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:10-,CC:4-,HL:8-,IS:7-,Periphery.Deep:9-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
-		<model name='BNC-3E'>
-			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='BNC-3M'>
 			<availability>FWL:4</availability>
+		</model>
+		<model name='BNC-3E'>
+			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8</availability>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CBS:5,CSV:6,CGS:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,HL:4,CLAN:3,IS:5,FS:5,Periphery:4,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-2C'>
-			<availability>CS:1</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:6,BAN:8,Periphery:8</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:3</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
+		</model>
 		<model name='BLR-1D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:3</availability>
+		<model name='BLR-2C'>
+			<availability>CS:1</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:6,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -912,14 +909,14 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
 		<model name='5'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -937,29 +934,29 @@
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:4,FS:1,MERC:1,CGS:9,CS:7,CDS:7,CW:9,CBS:9,LA:2,CNC:9,FWL:4,NIOPS:7,CJF:7,CGB:9,DC:1</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:7,NIOPS:4,CGS:8,BAN:4</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -987,13 +984,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,OA:2,CDS:6,CLAN:5,IS:2,NIOPS:5,FWL:2,Periphery:2,DC:2</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -1026,13 +1023,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -1044,11 +1041,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -1087,25 +1084,25 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:1,CC:5,CLAN:1,IS:3,MERC:2,FS:3,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,HL:6,CLAN:4,IS:8,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:4</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1122,17 +1119,17 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>IS:2,FS:2,MERC:2,Periphery:2</availability>
+			<availability>LA:2,IS:2,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:2,IS:2,FS:4,MERC:4,Periphery:2</availability>
+			<availability>IS:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cestus' unitType='Mek'>
@@ -1162,18 +1159,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:4,CS:5,CHH:5,LA:4,CLAN:3,IS:3,FWL:3,NIOPS:5,MERC:3,FS:3,CGB:5,DC:3</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CC:1+,CS:8,CHH:5,CLAN:3,NIOPS:8,BAN:6,CGB:5</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CS:4,CLAN:1,BAN:2,CGB:1</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CC:1+,CS:8,CHH:5,CLAN:3,NIOPS:8,BAN:6,CGB:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1195,16 +1192,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1216,25 +1213,25 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:2,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:7,CGS:6,BAN:4</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,OA:2,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:2,DC:4</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1256,20 +1253,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1283,14 +1280,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1298,29 +1292,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -1331,8 +1328,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1340,18 +1340,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1360,27 +1366,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1388,8 +1385,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1400,29 +1397,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:6,MOC:2,IS:4,FS:6,MERC:4,TC:2,Periphery:2,CS:3-,OA:2,LA:4,FWL:4,NIOPS:3-,DC:4</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,FS:3</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,CLAN:3,BAN:4</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando IIC' unitType='Mek'>
@@ -1447,14 +1444,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,HL:1,IS:3,FS:3,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -1466,51 +1463,51 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:2,NIOPS:6,BAN:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,CSR:1,CW:2,CSV:1,CLAN:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8,CLAN:6</availability>
 		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,TC:2,Periphery:2,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='CSR-V12'>
 			<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:4</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1521,11 +1518,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>CLAN:5,CCO:8</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1534,13 +1531,13 @@
 			<roles>raider</roles>
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
 		</model>
 		<model name='CRB-27sl'>
 			<availability>CLAN:2</availability>
@@ -1548,14 +1545,14 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CC:1,CHH:9,CSR:7,CSV:7,CLAN:8,CFM:7,FS:1,CGS:7,CS:8,CDS:7,CW:9,LA:1,CBS:9,FWL:1,NIOPS:8,CJF:7,CGB:9,DC:1</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
@@ -1563,17 +1560,18 @@
 		<model name='A'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>HL:6,General:8,CLAN:1,Periphery.Deep:7,BAN:5,Periphery:8</availability>
@@ -1581,9 +1579,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1591,11 +1588,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,CLAN:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1603,13 +1600,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CS:6,CHH:4,CSR:4,CLAN:4,NIOPS:6,CJF:4</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CS:8,CLAN:3,General:8,NIOPS:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1635,9 +1632,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
@@ -1645,6 +1639,9 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
@@ -1669,11 +1666,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7-,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7-,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1715,29 +1712,29 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CFM:7</availability>
-		<model name='D'>
-			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1749,9 +1746,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:4,General:8,FS:4</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:4,FS:4</availability>
 		</model>
@@ -1762,15 +1756,18 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,General:1,FS:4</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:4,General:8,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Space) [Flamer]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:3,CLAN:2</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:8</availability>
@@ -1779,8 +1776,8 @@
 			<roles>marine</roles>
 			<availability>CSR:3,CLAN:2</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1815,32 +1812,32 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CIH:3+,CGS:3+</availability>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='A'>
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -1874,11 +1871,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:4,NIOPS:4</availability>
-		<model name='EXT-4Db'>
-			<availability>CLAN:3,BAN:2</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,General:8+,CLAN:6,NIOPS:8,BAN:4</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>CLAN:3,BAN:2</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -1892,11 +1889,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1908,19 +1905,19 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CW:6</availability>
-		<model name='B'>
-			<availability>General:5</availability>
-		</model>
-		<model name='C'>
+		<model name='D'>
 			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
+		<model name='B'>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -1952,13 +1949,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -1976,68 +1973,68 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CIH:7,CLAN:6,BAN:5,CB:6</availability>
-		<model name='FFL-3PP3'>
-			<availability>BAN:1</availability>
-		</model>
 		<model name='FFL-3SLE'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,BAN:2</availability>
+		<model name='FFL-3PP'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='FFL-3PP2'>
 			<availability>BAN:1</availability>
 		</model>
-		<model name='FFL-3PP'>
+		<model name='C'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='FFL-3PP3'>
 			<availability>BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,LA:1+,CLAN:8,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:8</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,LA:1+,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -2051,17 +2048,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2069,9 +2064,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2172,23 +2169,23 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:7,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CSV:8,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:4,General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>MOC:1,CS:9,CDS:6,Periphery.MW:1,CLAN:6,Periphery.ME:1,CNC:6,FWL:1,NIOPS:9</availability>
-		<model name='GTHA-300'>
-			<availability>CLAN:1,FWL:2,BAN:2</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:3,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:7,BAN:4</availability>
+		<model name='GTHA-300'>
+			<availability>CLAN:1,FWL:2,BAN:2</availability>
 		</model>
 		<model name='GTHA-100'>
 			<availability>General:1,CLAN:1</availability>
@@ -2214,14 +2211,14 @@
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:5,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:8,TC:7,Periphery:6,CS:4,OA:4,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>HL:6,General:8,CLAN:3-,Periphery.Deep:7,BAN:5,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -2245,17 +2242,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CS:7,CHH:7,CSR:7,CLAN:5,IS:5,FWL:5,NIOPS:7,FS:4,MERC:5,DC:5,Periphery:3</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,IS:1+,NIOPS:8,BAN:8,DC:1+</availability>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:4,NIOPS:0,MERC:4,Periphery:2</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
+			<availability>CS:8,CLAN:8,IS:1+,NIOPS:8,BAN:8,DC:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -2267,11 +2264,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:5,CNC:5,NIOPS:7</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CLAN:2,CNC:2</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:1,CLAN:1,NIOPS:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CLAN:2,CNC:2</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
@@ -2279,16 +2276,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,HL:2,Periphery.Deep:4,MERC:4,Periphery:4,FWL.pm:8,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,FWL:4,MH:5,DC:4</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2300,6 +2297,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2307,14 +2312,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2325,25 +2322,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2351,6 +2344,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2359,6 +2356,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2366,14 +2371,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -2386,6 +2383,9 @@
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6</availability>
+		<model name='HCT-213C'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
 		</model>
@@ -2396,24 +2396,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,CLAN:1,NIOPS:4,BAN:2</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>CC:1-,MOC:3-,OA:3-,HL:1,LA:6-,FWL:1-,Periphery.Deep:3-,FS:5-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2424,17 +2421,21 @@
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>CC:4,MOC:4,FWL:10,MH:4,MERC:4,DC:4</availability>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,CHH:5,CLAN:3,FWL:3,NIOPS:3,CGB:5,CB:5</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2446,10 +2447,6 @@
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
-		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
@@ -2472,32 +2469,32 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:2,CS:9,LA:2,CLAN:8,NIOPS:9,CFM:9,CJF:9,DC:1</availability>
+		<model name='HGN-733C'>
+			<availability>CC:4,:0,LA:4</availability>
+		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:4,:0,LA:4</availability>
 		</model>
-		<model name='HGN-733C'>
-			<availability>CC:4,:0,LA:4</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8,DC:8</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CC:1,MOC:1,CHH:4,OA:1,LA:1,CLAN:3,FWL:1,FS:1,CGS:4,DC:1,TC:2</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='HOP-4C'>
 			<availability>MOC:8,OA:8,FS:8</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -2534,19 +2531,19 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,CLAN:1-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4N'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		<model name='HBK-4G'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4G'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		<model name='HBK-4H'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
@@ -2568,12 +2565,12 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:8,CSV:8,CLAN:7,NIOPS:4</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:5,BAN:3</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:5,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -2597,14 +2594,14 @@
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:4,CW:4,CLAN:3</availability>
-		<model name='IMP-1C'>
-			<availability>CHH:5,CLAN:2</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='IMP-1A'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='IMP-1C'>
+			<availability>CHH:5,CLAN:2</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:2</availability>
@@ -2625,16 +2622,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,HL:6,CLAN:9,IS:7,Periphery.Deep:7,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:4</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:4</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:4</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -2652,13 +2649,13 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CIH:3,CLAN:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
@@ -2674,15 +2671,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2699,13 +2696,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:4,MOC:5,HL:3,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4,TC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>HL:4,General:8,Periphery.Deep:5,Periphery:6</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4,TC:3</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -2749,13 +2746,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,OA:3,HL:1,FS.DMM:5,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,DC:8</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -2767,17 +2764,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2794,11 +2791,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CS:2,CHH:2,CLAN:2,FWL:1,NIOPS:2</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,BAN:3</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -2829,11 +2826,11 @@
 		<model name='KGC-0000'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
@@ -2859,26 +2856,26 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:7,CGS:8,BAN:4</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:6</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,CGB:9</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -2903,17 +2900,17 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>CC:1</availability>
+		<model name='KSC-3L'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='KSC-4I'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='KSC-4L'>
-			<availability>CC:6+</availability>
 		</model>
 		<model name='KSC-3I'>
 			<availability>CC:2</availability>
 		</model>
-		<model name='KSC-3L'>
-			<availability>CC:4</availability>
+		<model name='KSC-4L'>
+			<availability>CC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
@@ -2922,9 +2919,9 @@
 			<roles>recon</roles>
 			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
 		</model>
-		<model name='D'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
@@ -2934,9 +2931,9 @@
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,CDS:6,CW:5,General:5,CSJ:4,CGS:6,CCO:4,CGB:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
+			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -2973,13 +2970,13 @@
 		<model name='LNC25-03'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:6,DC:3+</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:6,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -3005,15 +3002,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,HL:4,LA:5</availability>
@@ -3034,11 +3031,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:2,CC:8,CS:5-,OA:2,LA:3,CLAN:3,IS:1,NIOPS:5-,FS:3,TC:2,Periphery:2,DC:3</availability>
-		<model name='LTN-G15b'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8,CLAN:3</availability>
+		</model>
+		<model name='LTN-G15b'>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -3054,14 +3051,14 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
-		</model>
-		<model name='3'>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
@@ -3085,14 +3082,14 @@
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CDS:5,CW:5,CBS:5,CSV:5,CLAN:5,CFM:5,CSJ:5,CJF:5,CGB:5,CB:5</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -3128,10 +3125,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:3,General:2</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -3139,6 +3132,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
@@ -3176,20 +3173,20 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CW:8</availability>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
@@ -3210,14 +3207,14 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
@@ -3243,9 +3240,6 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,CLAN:5,IS:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:5</availability>
-		<model name='MAD-3M'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='MAD-3D'>
 			<availability>FS:6</availability>
 		</model>
@@ -3260,6 +3254,9 @@
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,CLAN:3,NIOPS:8,MERC:0,BAN:4</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -3277,11 +3274,11 @@
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
 		<availability>Periphery.R:1,LA:1-,Periphery.MW:1,IS:1-</availability>
-		<model name='II-A'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='II-A'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -3311,13 +3308,13 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -3343,17 +3340,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -3361,31 +3358,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -3394,11 +3391,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3450,25 +3447,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -3498,10 +3495,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:1,CS:6,CHH:5,OA:1,CDS:5,CBS:6,CLAN:6,NIOPS:6,MERC:4,CJF:6,TC:1,CGB:5</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
@@ -3509,6 +3502,10 @@
 		<model name='MON-67'>
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:8,Periphery:4</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -3521,9 +3518,6 @@
 		<availability>CLAN:1,IS:1</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
@@ -3543,6 +3537,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -3551,12 +3551,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3582,21 +3576,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -3624,12 +3618,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:2</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -3653,12 +3647,12 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,PIR:3,FWL:5,CIR:4</availability>
+		<model name='(Fusion)'>
+			<availability>FWL:2</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
-		</model>
-		<model name='(Fusion)'>
-			<availability>FWL:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3672,17 +3666,17 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:5,CC:5,HL:2,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='ON1-V'>
 			<availability>IS:3,MH:3,TC:3</availability>
 		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1</availability>
 		</model>
 		<model name='ON1-K'>
 			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -3693,6 +3687,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:4,CS:4,HL:2,LA:5,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:4,TC:4,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,CLAN:2,IS:8,Periphery.Deep:7,MERC:8,BAN:4,Periphery:8</availability>
@@ -3700,9 +3697,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -3713,22 +3707,22 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:4,CS:4,HL:1,LA:4,CLAN:4-,IS:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:3,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:5,BAN:4</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:4-,BAN:5</availability>
 		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:5,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:5,FWL:7,NIOPS:6,FS:7,MERC:7,Periphery:3</availability>
-		<model name='OTL-4F'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='OTL-4D'>
 			<availability>HL:6,CLAN:8,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='OTL-4F'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -3747,10 +3741,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:4,General:8,Periphery.Deep:5,Periphery:6</availability>
@@ -3758,6 +3748,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3777,12 +3771,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,BAN:1,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:6,LA:6,TC:6</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,CLAN:8,IS:8,Periphery.Deep:7,MERC:8,Periphery:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:6,LA:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3808,10 +3802,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,HL:6,IS:8,Periphery.Deep:7,FS:8,CIR:8,Periphery:8,TC:8,OA:8,LA:9,FWL:10,DC:8</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -3819,6 +3809,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -3846,36 +3840,36 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:9,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6</availability>
+			<availability>CLAN:2,BAN:3</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>CLAN:2,BAN:3</availability>
+			<availability>CLAN:7,BAN:3</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
+		<model name='PXH-1'>
 			<roles>recon</roles>
-			<availability>CLAN:7,BAN:3</availability>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -3904,13 +3898,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -3958,21 +3952,15 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,HL:4,Periphery.Deep:5,FWL:8,IS:6,Periphery:6,DC:8,TC:8</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,OA:1,LA:2,CLAN:5,IS:1,NIOPS:8,MERC:1</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4,CLAN:1</availability>
@@ -3983,37 +3971,43 @@
 		<model name='RPR-200'>
 			<availability>CCC:4,CSR:4,CBS:4,CLAN:2,CNC:2</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6,CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:4,CW:4,General:8,CLAN:4,CNC:4</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6,CLAN:2</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
@@ -4045,9 +4039,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CS:5,CHH:5,CSR:4,CLAN:4,NIOPS:5,CJF:2</availability>
@@ -4062,20 +4053,20 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,OA:1,CLAN:3,NIOPS:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:4</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,CLAN:2,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,CLAN:1,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:1,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,CLAN:2,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -4088,17 +4079,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:8,CDS:8,CBS:7,CSV:5,CLAN:6,CNC:6,CSJ:7,CJF:8</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -4128,11 +4119,11 @@
 		<model name='SB-27'>
 			<availability>General:8,CLAN:2</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:4,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
@@ -4143,13 +4134,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>OA:5,DC:4</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -4190,16 +4181,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,HL:7,LA:9,FWL:9,IS:9,Periphery.Deep:8,FS:9,DC:9,Periphery:9</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4243,9 +4234,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:4,CLAN:5,CFM:6,CGS:4,CS:4,CDS:4,CW:4,LA:3-,CBS:4,NIOPS:4,CJF:6,CGB:6,DC:1</availability>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
@@ -4258,9 +4246,16 @@
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:5,OA:2,HL:4,LA:8,Periphery.Deep:4,CIR:3,FS:1,Periphery:4,TC:2</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>HL:6,LA:8,IS:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4269,33 +4264,29 @@
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>HL:6,LA:8,IS:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:6,CLAN:2,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:3,Periphery:5,CGB:2</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:5,BAN:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:6,General:8,CLAN:3-,Periphery.Deep:7,BAN:4,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>HL:6,General:8,CLAN:3-,Periphery.Deep:7,BAN:4,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:5,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -4338,34 +4329,40 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
@@ -4391,10 +4388,6 @@
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Space Marine' unitType='Infantry'>
 		<availability>CS:5</availability>
@@ -4414,13 +4407,13 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:2</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>FS.CMM:3</availability>
-		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>FS.CMM:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -4445,10 +4438,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:5,CLAN:1-,IS:3,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>HL:6,CLAN:8,IS:8,Periphery.Deep:7,FS:3,Periphery:8</availability>
 		</model>
@@ -4456,20 +4445,24 @@
 			<roles>anti_infantry</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
-		</model>
-		<model name='STK-4N'>
-			<availability>MOC:2,OA:2,IS:2,Periphery:1,TC:2</availability>
-		</model>
 		<model name='STK-3F'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:4</availability>
+		</model>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:2,OA:2,IS:2,Periphery:1,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4487,11 +4480,11 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
@@ -4528,11 +4521,11 @@
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>MOC:3,CC:8,CS:4,OA:3,LA:5,NIOPS:4,MERC:3,FS:3,TC:3,DC:3</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -4543,14 +4536,14 @@
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>FS:3</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
@@ -4572,10 +4565,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -4587,22 +4580,22 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:7,NIOPS:8</availability>
-		<model name='C'>
-			<availability>CCC:8,CSR:8,CLAN:7</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:5</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CCC:8,CSR:8,CLAN:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -4613,17 +4606,20 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:5,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
@@ -4631,9 +4627,6 @@
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:8,General:8,CJF:9,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
@@ -4661,12 +4654,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4678,11 +4671,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:6,CSV:8,CLAN:7,IS:2,CFM:9,FS:1,CS:7,CDS:6,CW:8,CBS:6,LA:2,CNC:6,FWL:4,NIOPS:7,CJF:8,CGB:8</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:7,BAN:4</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,FWL:1+,IS:1+,NIOPS:8,FS:1+,BAN:8,DC:1+</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:7,BAN:4</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:8,DC:8</availability>
@@ -4716,28 +4709,28 @@
 			<roles>escort,ground_support</roles>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,CLAN:2</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,CLAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:9,HL:4,CLAN:4,IS:8,Periphery.Deep:5,FS:7,MERC:8,Periphery:6,TC:6,CS:5-,LA:8,NIOPS:5-,MH:6,DC:8</availability>
-		<model name='TDR-5Sb'>
-			<availability>CHH:4,CSR:4,CDS:4,CW:4,CLAN:4,CNC:4,CJF:4,BAN:3,CGB:4</availability>
-		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:6</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,HL:6,LA:8,General:8,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
+		<model name='TDR-5SS'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>CHH:4,CSR:4,CDS:4,CW:4,CLAN:4,CNC:4,CJF:4,BAN:3,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4748,13 +4741,13 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:4,CLAN:3,NIOPS:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
@@ -4765,20 +4758,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:6,CLAN:5,FWL:1,NIOPS:9</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,IS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:6,BAN:4</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:2</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -4796,9 +4789,6 @@
 		<model name='(2754)'>
 			<availability>General:8,CLAN:1,BAN:5</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,CLAN:1,BAN:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
@@ -4811,41 +4801,41 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,NIOPS:6</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
 		<model name='TBT-5S'>
 			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,NIOPS:6</availability>
-		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:2,MOC:2,CS:7,OA:4,CSR:4,CLAN:4,NIOPS:7,FS:2,MERC:2,DC:2,TC:2</availability>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:8,CLAN:7,BAN:4</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -4864,17 +4854,18 @@
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:7,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:8,CSR:6,CJF:6</availability>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
@@ -4887,12 +4878,11 @@
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -4943,6 +4933,13 @@
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
@@ -4950,13 +4947,6 @@
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
@@ -4996,21 +4986,18 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>CC:2</availability>
+		</model>
 		<model name='VND-1X'>
 			<availability>CC:1</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>CC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CJF:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
@@ -5020,16 +5007,15 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
 		<availability>CSA:2,CS:1,CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,NIOPS:1,CGS:2,CGB:2,CB:2</availability>
 		<model name='(2709)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2836)'>
 			<roles>cargo</roles>
@@ -5078,6 +5064,12 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='10'>
+			<availability>CSJ:3</availability>
+		</model>
 		<model name='12'>
 			<availability>CSJ:3</availability>
 		</model>
@@ -5088,26 +5080,17 @@
 		<model name='11'>
 			<availability>CSJ:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='10'>
-			<availability>CSJ:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,HL:4,LA:9,CLAN:4,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:6,General:8,CLAN:1,Periphery.Deep:7,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
+		<model name='WHM-6R'>
+			<availability>HL:6,General:8,CLAN:1,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-7A'>
 			<availability>CLAN:3</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:4</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
@@ -5115,14 +5098,17 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -5133,21 +5119,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,HL:4,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:3,Periphery:6</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -5174,6 +5160,10 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,CS:5-,HL:3,LA:7,IS:7,Periphery.Deep:5,FWL:10,NIOPS:5-,FS:8,Periphery:4,TC:5,DC:7</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5182,18 +5172,14 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:8,CLAN:4-</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -5205,13 +5191,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:5,CIH:3,CLAN:4,IS:5,NIOPS:6,CFM:5,FS:6,MERC:5,Periphery:3,DC:5,TC:3</availability>
-		<model name='WVE-5Nb'>
-			<roles>urban</roles>
-			<availability>CLAN:4,CFM:5,CGS:5</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>CS:8,CLAN:4,NIOPS:8,CFM:5,BAN:6</availability>
+		</model>
+		<model name='WVE-5Nb'>
+			<roles>urban</roles>
+			<availability>CLAN:4,CFM:5,CGS:5</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -5257,29 +5243,29 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:4,NIOPS:5,DC:1</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:3</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:4,LA:10,MERC:5,FS:2</availability>
-		<model name='ZEU-6S'>
-			<availability>HL:6,General:8,Periphery.Deep:6,Periphery:8</availability>
-		</model>
 		<model name='ZEU-6Y'>
 			<availability>LA:3</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:6,General:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:4</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -573,13 +573,13 @@
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CS:7,CDS:2,CW:2,CNC:2,CLAN:2,NIOPS:7,CJF:1</availability>
-		<model name='Mk III'>
-			<availability>General:1</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Mk IV'>
+			<availability>General:1</availability>
+		</model>
+		<model name='Mk III'>
 			<availability>General:1</availability>
 		</model>
 	</chassis>
@@ -592,17 +592,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,CHH:2,CSR:2,CLAN:1,CCO:2,BAN:2,CGB:2</availability>
-		<model name='ANH-1G'>
-			<availability>BAN:1</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1X'>
 			<availability>BAN:2</availability>
 		</model>
+		<model name='ANH-1G'>
+			<availability>BAN:1</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -621,21 +621,21 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,FS:8,Periphery:5,DC:8</availability>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,BAN:3</availability>
+		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,LA:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:3,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:3</availability>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -655,37 +655,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -695,17 +675,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -730,35 +730,35 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:3</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,CLAN:1-,IS:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,LA:4,FWL:3,NIOPS:4-,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
+		<model name='AS7-D-DC'>
+			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='AS7-RS'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1,MERC:0,DC:2</availability>
+		<model name='AS7-D'>
+			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:6,CCC:6,CSR:6,CW:5,CLAN:5,CNC:5,BAN:5</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
@@ -768,9 +768,6 @@
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -786,11 +783,11 @@
 		<model name='AWS-8R'>
 			<availability>CS:2,IS:2,FWL:4</availability>
 		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:3</availability>
-		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:3</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -809,6 +806,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -816,23 +821,19 @@
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CLAN:4</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -840,77 +841,73 @@
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:9-,CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:6-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
+		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:3</availability>
 		</model>
 		<model name='BNC-3E'>
 			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:4</availability>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:6,CSR:2,CDS:2,CBS:6,CSV:8,CNC:2,CGS:6,CCO:2,CB:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,HL:3,CLAN:2,IS:5,FS:5,Periphery:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:5</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='BLR-2C'>
-			<availability>CS:1</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:3</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CLAN:8,BAN:3</availability>
 		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:2</availability>
+		</model>
 		<model name='BLR-1D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:3</availability>
+		<model name='BLR-2C'>
+			<availability>CS:1</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -926,15 +923,15 @@
 			<roles>interceptor</roles>
 			<availability>CHH:7,CIH:7,CNC:9,General:8,CGS:7</availability>
 		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CFM:6,CGS:8,CJF:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -946,17 +943,17 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
+		<model name='6'>
+			<availability>General:2</availability>
 		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='6'>
-			<availability>General:2</availability>
-		</model>
 		<model name='5'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
@@ -983,29 +980,29 @@
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:4,CGS:9,CS:7,CDS:7,CW:9,CBS:9,LA:1,CNC:9,FWL:2,NIOPS:7,CJF:7,CGB:9</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:6,NIOPS:4,CGS:7,BAN:3</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1033,13 +1030,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,OA:2-,CDS:6,CLAN:5,IS:2-,NIOPS:5,FWL:2-,Periphery:1,DC:2-</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -1055,13 +1052,13 @@
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:6,CLAN:4</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -1092,13 +1089,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -1110,11 +1107,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -1146,13 +1143,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CHH:1,CCC:1,CIH:1,CSR:1,CDS:5,CW:1,CSV:1,CNC:6,CFM:1,CGS:1,CCO:1,CGB:1</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CDS:6,CNC:6</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1164,25 +1161,25 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:1,CC:4,IS:2,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:5</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,HL:6,CLAN:4,IS:8,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+			<availability>CC:4,MOC:4,OA:4</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4,OA:4</availability>
+			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1199,17 +1196,17 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>IS:3,FS:3,MERC:3,Periphery:3</availability>
+			<availability>LA:3,IS:3,FS:4,MERC:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:3,IS:3,FS:4,MERC:4,Periphery:3</availability>
+			<availability>IS:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cestus' unitType='Mek'>
@@ -1239,18 +1236,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:3,CS:5,CHH:5,LA:3,CLAN:2,IS:2,FWL:2,NIOPS:5,MERC:2,FS:2,CGB:5,DC:2</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CS:8,CHH:5,CLAN:2,NIOPS:8,BAN:5,CGB:5</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:3,BAN:1</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:3,BAN:1</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CS:4,CLAN:1,BAN:1,CGB:1</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CS:8,CHH:5,CLAN:2,NIOPS:8,BAN:5,CGB:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1272,16 +1269,16 @@
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1297,8 +1294,8 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:1,FWL:4,MERC:3,FS:3,CIR:2,Periphery:2,TC:2,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
@@ -1306,19 +1303,19 @@
 		<model name='CHP-W5b'>
 			<availability>CLAN:6,CGS:6,BAN:3</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,OA:2,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:2,DC:4</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1340,20 +1337,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1367,14 +1364,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1382,29 +1376,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -1415,8 +1412,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1424,18 +1424,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1444,27 +1450,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1472,8 +1469,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clint IIC' unitType='Mek'>
@@ -1484,29 +1481,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:5,MOC:1,IS:4,FS:5,MERC:4,TC:1,Periphery:1,CS:3-,OA:1,LA:4,FWL:4,NIOPS:3-,MH:1,DC:4</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,FS:3</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:8,Periphery:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,CLAN:2,BAN:3</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,General:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando IIC' unitType='Mek'>
@@ -1531,14 +1528,14 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,HL:1,IS:3,FS:3,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -1550,51 +1547,51 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:2,NIOPS:6,BAN:2</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,CSR:1,CW:2,CSV:1,CLAN:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8,CLAN:4</availability>
 		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,DC:2,TC:2,Periphery:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:3</availability>
 		</model>
 		<model name='CSR-V12'>
 			<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:3</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1605,11 +1602,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>CLAN:3-,CCO:5-,BAN:3</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1618,25 +1615,25 @@
 			<roles>raider</roles>
 			<availability>CLAN:6,CGS:7,BAN:3</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
 		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:9,CSR:7,CSV:7,CLAN:8,CFM:7,CGS:7,CS:8,CDS:7,CW:9,CBS:9,NIOPS:8,CJF:7,CGB:9</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:6,CGS:7,BAN:3</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:6,CGS:7,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
@@ -1644,17 +1641,18 @@
 		<model name='A'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:6,CGS:7,BAN:3</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>HL:6,General:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -1662,9 +1660,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:6,CGS:7,BAN:3</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1672,11 +1669,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1684,13 +1681,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CS:6,CHH:4,CSR:4,CLAN:3,NIOPS:6,CJF:4</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CS:8,CLAN:2,General:8,NIOPS:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1716,9 +1713,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
@@ -1726,6 +1720,9 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
@@ -1750,11 +1747,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1789,29 +1786,29 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:4,CIH:4,CDS:4,CSV:3,CLAN:4,CFM:5,CSJ:3,CJF:4,CGB:3,CB:4</availability>
-		<model name='D'>
-			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -1823,9 +1820,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:7,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:3,General:8,FS:3</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:4,FS:4</availability>
 		</model>
@@ -1836,15 +1830,18 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:3,General:8,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Space) [Flamer]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:8</availability>
@@ -1853,8 +1850,8 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -1889,32 +1886,32 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CIH:3+,CGS:3+</availability>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='A'>
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CIH:1,CSR:1,CDS:3,CSV:1,CLAN:1,CSJ:3,CGS:1,CCO:1,CGB:3,CB:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -1948,11 +1945,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:4,NIOPS:4</availability>
-		<model name='EXT-4Db'>
-			<availability>CLAN:2,BAN:1</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:3</availability>
+		</model>
+		<model name='EXT-4Db'>
+			<availability>CLAN:2,BAN:1</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -1966,11 +1963,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -1982,28 +1979,24 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CIH:7,CDS:5,CW:8,CSV:2,CNC:4,CLAN:2,CSJ:4,CJF:6,CGB:2</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:4,LA:3,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:3,FS:9</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
 			<availability>LA:2,FWL:2,FS:5</availability>
@@ -2011,6 +2004,10 @@
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -2034,13 +2031,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -2052,68 +2049,68 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CIH:7,CLAN:5,BAN:4,CB:6</availability>
-		<model name='FFL-3PP3'>
-			<availability>BAN:1</availability>
-		</model>
 		<model name='FFL-3SLE'>
 			<availability>CLAN:2,BAN:1</availability>
 		</model>
-		<model name='C'>
-			<availability>CLAN:8,BAN:2</availability>
+		<model name='FFL-3PP'>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='FFL-3PP2'>
 			<availability>BAN:1</availability>
 		</model>
-		<model name='FFL-3PP'>
+		<model name='C'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='FFL-3PP3'>
 			<availability>BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,LA:8</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -2127,17 +2124,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2145,9 +2140,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2197,11 +2194,11 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:7,CW:7,CLAN:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:6,CCO:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -2255,23 +2252,23 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:6,CLAN:4</availability>
-		<model name='(Standard)'>
-			<availability>CSV:8,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:6,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:9,CDS:6,CLAN:6,CNC:6,NIOPS:9</availability>
-		<model name='GTHA-300'>
-			<availability>CLAN:1,BAN:1</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:6,BAN:3</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:2,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:6,BAN:3</availability>
+		<model name='GTHA-300'>
+			<availability>CLAN:1,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -2288,23 +2285,23 @@
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:4,CIH:5,CDS:4,CW:5,CNC:5,CLAN:4,CCO:4,CJF:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CNC:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CIH:6,CNC:6,CLAN:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:4,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:3,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>HL:6,General:8,CLAN:2-,Periphery.Deep:7,BAN:4,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -2328,17 +2325,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:4,CS:7,CHH:6,CSR:6,CLAN:4,IS:4,FWL:4,NIOPS:7,FS:3,MERC:4,DC:4,Periphery:3</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:3,Periphery.ME:3,FWL:3,NIOPS:0,MERC:3,Periphery:1</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -2350,11 +2347,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:5,CNC:5,NIOPS:7</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CLAN:1,CNC:1</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,General:1,CLAN:1,NIOPS:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CLAN:1,CNC:1</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:7,CLAN:6,BAN:3</availability>
@@ -2369,16 +2366,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:2,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:6,MH:6,DC:5</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2390,6 +2387,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2397,14 +2402,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2415,25 +2412,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2441,6 +2434,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2449,6 +2446,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2457,17 +2462,12 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,CLAN:1,CNC:1,NIOPS:6</availability>
+		<model name='HCT-213C'>
+			<availability>CLAN:2,BAN:1</availability>
+		</model>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
 		</model>
@@ -2478,24 +2478,21 @@
 		<model name='HCT-214'>
 			<availability>CS:4,CLAN:1,NIOPS:4,BAN:1</availability>
 		</model>
-		<model name='HCT-213C'>
-			<availability>CLAN:2,BAN:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:3-,FS:4-,MERC:5-,Periphery:3-,TC:3-,DC:1-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:6</availability>
+		<model name='HCT-213S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:7</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2506,17 +2503,21 @@
 	</chassis>
 	<chassis name='Hermes II' unitType='Mek'>
 		<availability>CC:4,MOC:4,FWL:10,MH:4,MERC:4,DC:4</availability>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,CHH:4,CLAN:2,FWL:2,NIOPS:3,CGB:4,CB:4</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2529,18 +2530,14 @@
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
 		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,Periphery.CM:7,IS:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(AC10)'>
 			<availability>IS:2,Periphery:2</availability>
@@ -2557,40 +2554,40 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:2,CS:9,LA:2,CLAN:8,NIOPS:9,CFM:9,CJF:9,DC:1</availability>
+		<model name='HGN-733C'>
+			<availability>CC:3,:0,LA:3</availability>
+		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:6,BAN:3</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:3,:0,LA:3</availability>
 		</model>
-		<model name='HGN-733C'>
-			<availability>CC:3,:0,LA:3</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8,DC:8</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:3,CLAN:3,CGS:4,TC:1</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:2</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:3,BAN:1</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:1,MERC:3,Periphery.OS:2,FS.CrMM:2,Periphery:2,TC:2</availability>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -2620,19 +2617,19 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4N'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		<model name='HBK-4G'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4G'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		<model name='HBK-4H'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
@@ -2647,14 +2644,6 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>CC:6,MOC:4,HL:3,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:5,OA:5,LA:7,FWL:4,DC:5</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -2663,15 +2652,23 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(LRM15)'>
+			<roles>fire_support</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:8,CSV:8,CLAN:7,NIOPS:4</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -2695,14 +2692,14 @@
 	</chassis>
 	<chassis name='Imp' unitType='Mek'>
 		<availability>CSA:4,CW:4,CLAN:3</availability>
-		<model name='IMP-1C'>
-			<availability>CHH:3,CLAN:1</availability>
-		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='IMP-1A'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='IMP-1C'>
+			<availability>CHH:3,CLAN:1</availability>
 		</model>
 		<model name='IMP-1B'>
 			<availability>CLAN:1</availability>
@@ -2723,16 +2720,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,HL:6,CLAN:9,IS:7,Periphery.Deep:7,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:3</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:3</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:3</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -2750,13 +2747,13 @@
 	</chassis>
 	<chassis name='Ishtar Heavy Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CIH:3,CLAN:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Issus' unitType='Aero'>
@@ -2772,15 +2769,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2797,16 +2794,16 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:5,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,OA:5,LA:4,FWL:3,NIOPS:4-,DC:6</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4,TC:3</availability>
-		</model>
 		<model name='(Cell)'>
 			<availability>DC:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4,TC:3</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -2850,13 +2847,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -2868,17 +2865,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -2895,11 +2892,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CS:2,CHH:1,CLAN:1,NIOPS:2</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,BAN:2</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -2930,11 +2927,11 @@
 		<model name='KGC-0000'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='KGC-010'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='KGC-000'>
 			<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+		</model>
+		<model name='KGC-010'>
+			<availability>CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
@@ -2960,26 +2957,26 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:6,CGS:7,BAN:3</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:6</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:6,CGS:7,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:5,CGB:9</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -2999,9 +2996,9 @@
 			<roles>recon</roles>
 			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
 		</model>
-		<model name='D'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
@@ -3011,9 +3008,9 @@
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,CDS:6,CW:5,General:5,CSJ:4,CGS:6,CCO:4,CGB:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
+			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -3047,13 +3044,13 @@
 			<roles>fire_support</roles>
 			<availability>:0,DC:8</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -3079,15 +3076,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,HL:4,LA:5</availability>
@@ -3108,11 +3105,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:6,CC:7,CS:5-,OA:6,LA:4,CLAN:2,NIOPS:5-,FS:4,TC:3,Periphery:2,DC:5</availability>
-		<model name='LTN-G15b'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8,CLAN:2</availability>
+		</model>
+		<model name='LTN-G15b'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -3128,14 +3125,14 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:5,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
-		</model>
-		<model name='3'>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
@@ -3159,14 +3156,14 @@
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CDS:7,CW:6,CBS:7,CSV:6,CLAN:7,CFM:7,CSJ:6,CJF:7,BAN:6,CGB:6,CB:7</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -3208,10 +3205,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:3,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -3219,6 +3212,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
@@ -3256,20 +3253,20 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:4,CIH:2,CDS:4,CW:9,CBS:2,CLAN:2,CSJ:4,CCO:4,CJF:4,CB:2</availability>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Magellan Jumpship' unitType='Jumpship'>
@@ -3296,14 +3293,14 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
@@ -3329,9 +3326,6 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,CLAN:4,IS:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:4</availability>
-		<model name='MAD-3M'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='MAD-3D'>
 			<availability>FS:6</availability>
 		</model>
@@ -3346,6 +3340,9 @@
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,CLAN:2,NIOPS:8,MERC:0,BAN:3</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -3363,17 +3360,17 @@
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSJ:7</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:9</availability>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:9</availability>
+		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -3407,13 +3404,13 @@
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -3439,17 +3436,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -3457,31 +3454,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -3490,11 +3487,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3546,25 +3543,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -3594,10 +3591,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>CS:6,CHH:5,CDS:5,CBS:6,CLAN:6,NIOPS:6,MERC:3,CJF:6,CGB:5</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:6,CGS:8,BAN:3</availability>
@@ -3605,6 +3598,10 @@
 		<model name='MON-67'>
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -3617,9 +3614,6 @@
 		<availability>CLAN:1,IS:1</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8,CLAN:8</availability>
@@ -3639,6 +3633,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -3647,12 +3647,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3678,21 +3672,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -3700,11 +3694,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:3</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -3726,12 +3720,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:1</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -3755,12 +3749,12 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,LA:3,PIR:4,Periphery.ME:4,FWL:8,MH:4,CIR:4,FS:3</availability>
+		<model name='(Fusion)'>
+			<availability>FWL:1</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
-		</model>
-		<model name='(Fusion)'>
-			<availability>FWL:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3774,17 +3768,17 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:5,CC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='ON1-V'>
 			<availability>IS:3,MH:3,TC:3</availability>
 		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1</availability>
 		</model>
 		<model name='ON1-K'>
 			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -3795,6 +3789,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:5,MOC:3,CS:4,HL:1,LA:5,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,TC:3,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
@@ -3802,9 +3799,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:6,BAN:3</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -3815,22 +3809,22 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:4,CS:4,LA:4,CLAN:3-,FWL:4,IS:4,NIOPS:4,FS:4,MERC:4,DC:4,Periphery:2</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:5,BAN:3</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:2-,BAN:4</availability>
 		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:5,BAN:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:5,FWL:7,NIOPS:6,FS:7,MERC:7,Periphery:3</availability>
-		<model name='OTL-4F'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='OTL-4D'>
 			<availability>HL:6,CLAN:8,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='OTL-4F'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -3849,10 +3843,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -3860,6 +3850,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -3879,12 +3873,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,BAN:1,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:4,LA:4,TC:4</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,CLAN:8,IS:8,Periphery.Deep:7,MERC:8,Periphery:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:4,LA:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -3910,10 +3904,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:8,HL:6,IS:9,Periphery.Deep:7,FS:9,CIR:8,Periphery:8,TC:8,OA:8,LA:9,FWL:10,DC:8</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -3921,6 +3911,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -3948,48 +3942,48 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:1,FWL:3</availability>
-        </model>
-    </chassis>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:1,FWL:3</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:3,CGS:6</availability>
+			<availability>CLAN:1,BAN:2</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>CLAN:1,BAN:2</availability>
+			<availability>CLAN:7,BAN:2</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
+		<model name='PXH-1'>
 			<roles>recon</roles>
-			<availability>CLAN:7,BAN:2</availability>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>CC:4,MOC:7,HL:2,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:4,CS:6-,OA:5,LA:5,FWL:4,MH:4,DC:5</availability>
-		<model name='(Standard)'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
-		</model>
 		<model name='(Missile)'>
 			<availability>MOC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
@@ -4018,13 +4012,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:2,CCC:3,CIH:2,CSR:5,CSV:3,CLAN:1,CFM:2,CGS:4,CCO:3,CSA:2,CS:1,CDS:5,CW:2,NIOPS:1,CSJ:2</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -4050,13 +4044,13 @@
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4076,21 +4070,15 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,LA:1,CLAN:5,NIOPS:8</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
@@ -4101,37 +4089,43 @@
 		<model name='RPR-200'>
 			<availability>CCC:3,CSR:3,CBS:3,CLAN:1,CNC:1</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:6,BAN:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6,CLAN:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:4,CW:4,General:8,CLAN:2,CNC:4</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6,CLAN:1</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:6,BAN:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
@@ -4139,11 +4133,11 @@
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:5,CNC:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:4,CNC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:8,CLAN:8,CNC:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -4173,20 +4167,20 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:3,NIOPS:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:7,BAN:3</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,CLAN:1,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,CLAN:1,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,CLAN:1,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:7,BAN:3</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2,LA:8</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,CLAN:1,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -4199,17 +4193,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CDS:8,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:6</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -4239,31 +4233,31 @@
 		<model name='SB-27'>
 			<availability>General:8,CLAN:1</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,CLAN:2,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:8,LA:6,DC.AL:10,IS:7,FWL:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,DC:9</availability>
-		<model name='(Armor)'>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>OA:4,DC:4</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:3</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -4307,16 +4301,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,HL:8,LA:9,FWL:9,IS:10,Periphery.Deep:9,FS:9,DC:9,Periphery:10</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4344,11 +4338,11 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4375,9 +4369,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:4,CLAN:5,CFM:6,CGS:4,CS:4,CDS:4,CW:4,CBS:4,LA:2-,NIOPS:4,CJF:6,CGB:6,DC:1</availability>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
@@ -4390,9 +4381,16 @@
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:6,OA:2,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:4,TC:2</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>HL:6,LA:8,IS:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4401,33 +4399,29 @@
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>HL:6,LA:8,IS:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:7,CGB:7</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:6,CLAN:2,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:3,Periphery:5,CGB:2</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:5,BAN:3</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:6,General:8,CLAN:2-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>HL:6,General:8,CLAN:2-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:5,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -4470,34 +4464,40 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sling' unitType='Mek'>
@@ -4512,10 +4512,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -4540,13 +4536,13 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:4</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>FS.CMM:3</availability>
-		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		</model>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>FS.CMM:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -4571,10 +4567,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>CC:5,MOC:2,IS:2,FS:5,MERC:4,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:2,Periphery:8</availability>
 		</model>
@@ -4582,14 +4574,15 @@
 			<roles>anti_infantry</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
-		</model>
-		<model name='STK-4N'>
-			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4597,8 +4590,11 @@
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:3</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4609,11 +4605,11 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
@@ -4643,16 +4639,16 @@
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5</availability>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -4665,11 +4661,11 @@
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>MOC:2,CC:7,CS:4,OA:2,LA:4,NIOPS:4,MERC:2,FS:2,TC:2,DC:2</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -4680,23 +4676,23 @@
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:3</availability>
+		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,FS:3,TC:2,Periphery:1</availability>
 		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:6</availability>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
@@ -4724,10 +4720,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -4739,22 +4735,22 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:7,NIOPS:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:9,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:4</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:9,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -4765,30 +4761,30 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:8,General:8,CJF:9,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
@@ -4816,12 +4812,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -4833,11 +4829,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:6,CSV:8,CLAN:7,IS:2,CFM:9,CS:7,CDS:6,CW:8,CBS:6,CNC:6,FWL:4,NIOPS:7,CJF:8,CGB:8</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:6,BAN:3</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:6,BAN:3</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:8,DC:8</availability>
@@ -4871,28 +4867,28 @@
 			<roles>escort,ground_support</roles>
 			<availability>CLAN:1</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8,CLAN:1</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8,CLAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,HL:3,CLAN:4,IS:8,Periphery.Deep:6,FS:7,MERC:8,Periphery:5,TC:5,CS:5-,LA:8,NIOPS:5-,MH:5,DC:8</availability>
-		<model name='TDR-5Sb'>
-			<availability>CHH:4,CSR:4,CDS:4,CW:4,CLAN:4,CNC:4,CJF:4,BAN:2,CGB:4</availability>
-		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:8</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,HL:6,LA:6,General:8,Periphery.Deep:7,BAN:2,Periphery:8</availability>
 		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
+		<model name='TDR-5SS'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>CHH:4,CSR:4,CDS:4,CW:4,CLAN:4,CNC:4,CJF:4,BAN:2,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -4903,13 +4899,13 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:4,CLAN:3,NIOPS:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8,CLAN:4</availability>
+		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
@@ -4920,20 +4916,20 @@
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:5,CLAN:5,NIOPS:9</availability>
-		<model name='THK-43'>
-			<roles>escort</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:5,BAN:3</availability>
+		<model name='THK-43'>
+			<roles>escort</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8,CLAN:1</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:5,BAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -4951,9 +4947,6 @@
 		<model name='(2754)'>
 			<availability>General:8,CLAN:1,BAN:5</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,CLAN:1,BAN:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
@@ -4966,41 +4959,41 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,NIOPS:6</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
 		<model name='TBT-5S'>
 			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,NIOPS:6</availability>
-		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CC:1,MOC:1,CS:7,OA:3,CSR:2,CLAN:2,NIOPS:7,FS:1,MERC:1,DC:1,TC:1</availability>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:7,CLAN:6,BAN:3</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -5019,17 +5012,18 @@
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:8,CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:3,CIH:3,CSR:7,CSV:2,CLAN:4,CCO:3,CDS:2,CW:3,CBS:5,CNC:2,CSJ:3,CJF:7,CGB:3</availability>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
@@ -5042,12 +5036,11 @@
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -5084,17 +5077,24 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:2,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:8,FS:8,MERC:8,TC:8</availability>
-		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:8,FS:8,MERC:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:3</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
@@ -5102,13 +5102,6 @@
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
@@ -5155,21 +5148,18 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>CC:1</availability>
+		</model>
 		<model name='VND-1X'>
 			<availability>CC:1</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>General:6</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>CC:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
@@ -5179,14 +5169,17 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:5,CGS:6,CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -5194,10 +5187,6 @@
 		<model name='(2709)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2836)'>
 			<roles>cargo</roles>
@@ -5229,14 +5218,14 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CIH:7,CW:7,CSV:7,CLAN:8,CNC:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:9</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:5</availability>
@@ -5244,10 +5233,6 @@
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
 		<availability>MOC:1,OA:1,MERC:2,DC:1,Periphery:2,TC:1</availability>
-		<model name='(2312)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2312)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
@@ -5261,6 +5246,12 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='10'>
+			<availability>CSJ:4</availability>
+		</model>
 		<model name='12'>
 			<availability>CSJ:4</availability>
 		</model>
@@ -5271,26 +5262,17 @@
 		<model name='11'>
 			<availability>CSJ:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='10'>
-			<availability>CSJ:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,HL:4,LA:9,CLAN:4,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
+		<model name='WHM-6R'>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-7A'>
 			<availability>CLAN:2</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:3</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
@@ -5298,26 +5280,29 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:4,FS.CH:7,IS:6,Periphery.Deep:4,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
 		<model name='H-7'>
 			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 		</model>
-		<model name='H-7C'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='H-7C'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
@@ -5328,21 +5313,21 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,HL:4,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:2,Periphery:6</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -5369,6 +5354,10 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10,MH:6</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5377,18 +5366,14 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10,MH:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:6,CLAN:4-,BAN:3</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -5400,13 +5385,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:5,CIH:3,CLAN:4,IS:5,NIOPS:6,CFM:5,FS:6,MERC:5,Periphery:2,DC:5,TC:3</availability>
-		<model name='WVE-5Nb'>
-			<roles>urban</roles>
-			<availability>CLAN:3,CFM:4,CGS:4</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>CS:8,CLAN:3,NIOPS:8,CFM:5,BAN:5</availability>
+		</model>
+		<model name='WVE-5Nb'>
+			<roles>urban</roles>
+			<availability>CLAN:3,CFM:4,CGS:4</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -5459,29 +5444,29 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:4,NIOPS:5,DC:1</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:2</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:3,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:4,LA:10,MERC:5,FS:2</availability>
-		<model name='ZEU-6S'>
-			<availability>HL:6,General:8,Periphery.Deep:6,Periphery:8</availability>
-		</model>
 		<model name='ZEU-6Y'>
 			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:6,General:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:3</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3000.xml
+++ b/megamek/data/forcegenerator/3000.xml
@@ -608,14 +608,14 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.WD:5,CHH:2,CSR:2,CLAN:1,CCO:2,BAN:2,CGB:2</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
+		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.WD:8,CLAN:2-,MERC:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:3</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -634,18 +634,6 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,FS:8,Periphery:5,DC:8</availability>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:6,LA:6,IS:8,Periphery.Deep:7,BAN:2,DC:6,Periphery:8</availability>
-		</model>
 		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -653,6 +641,18 @@
 		<model name='ARC-2W'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:6,LA:6,IS:8,Periphery.Deep:7,BAN:2,DC:6,Periphery:8</availability>
+		</model>
+		<model name='ARC-2K'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -672,37 +672,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -712,17 +692,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -753,35 +753,35 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,CS:4-,OA:1,LA:4,IS:3,FWL:3,NIOPS:4-,FS:5,Periphery:1,TC:1,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		<model name='AS7-D-DC'>
+			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='AS7-RS'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1,MERC:0,DC:2</availability>
+		<model name='AS7-D'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:5,CCC:5,CSR:5,CW:5,CLAN:5,CNC:5,BAN:5</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
@@ -791,9 +791,6 @@
 		<availability>CW:1,CSJ:1,CCO:1,CJF:1,CB:1</availability>
 		<model name='(2531)'>
 			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(2531)'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -809,11 +806,11 @@
 		<model name='AWS-8R'>
 			<availability>CS:1,IS:2,FWL:4</availability>
 		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
-		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -832,6 +829,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -840,14 +845,6 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5</availability>
@@ -855,7 +852,7 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -867,7 +864,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -878,19 +875,7 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CLAN:3</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -898,12 +883,28 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:7</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -913,89 +914,85 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:9-,CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:5-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
+		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:4</availability>
 		</model>
 		<model name='BNC-3E'>
 			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:3</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,HL:4,CLAN:2,IS:5,FS:5,Periphery:6,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
-		</model>
-		<model name='BLR-1Gbc'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='BLR-2C'>
-			<availability>CS:1</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='BLR-1Gb'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='BLR-1Gbc'>
+			<availability>CLAN:1</availability>
+		</model>
 		<model name='BLR-1D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
+		<model name='BLR-2C'>
+			<availability>CS:1</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1011,15 +1008,15 @@
 			<roles>interceptor</roles>
 			<availability>CHH:7,CIH:7,CNC:9,General:8,CGS:7</availability>
 		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CFM:6,CGS:8,CJF:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -1031,17 +1028,17 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
+		<model name='6'>
+			<availability>General:2</availability>
 		</model>
 		<model name='4'>
 			<availability>General:3</availability>
 		</model>
-		<model name='6'>
-			<availability>General:2</availability>
-		</model>
 		<model name='5'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
@@ -1049,12 +1046,12 @@
 		<model name='(Armor)'>
 			<availability>IS:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1072,29 +1069,29 @@
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:3,CGS:9,CS:7,CDS:7,CW:9,CBS:9,CNC:9,FWL:2,NIOPS:7,CJF:7,CGB:9</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1128,13 +1125,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,OA:2-,CDS:6,CLAN:5,IS:2-,NIOPS:5,FWL:2-,DC:2-,Periphery:1</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -1150,13 +1147,13 @@
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -1174,6 +1171,9 @@
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,LA:2,Periphery.CM:2,Periphery.HR:2,Periphery.ME:2,FS:3,Periphery:2</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -1182,9 +1182,6 @@
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -1196,13 +1193,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -1214,11 +1211,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -1250,13 +1247,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:3,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1268,25 +1265,25 @@
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:1,CC:4,IS:2,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:4</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>DC:1</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,HL:6,CLAN:4,IS:6,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>DC:1</availability>
+			<availability>CC:3,MOC:3,OA:3</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,OA:3</availability>
+			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1303,17 +1300,17 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>IS:3,FS:3,MERC:3,Periphery:3</availability>
+			<availability>LA:3,IS:3,FS:4,MERC:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:3,IS:3,FS:4,MERC:4,Periphery:3</availability>
+			<availability>IS:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -1349,18 +1346,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:2,CS:5,CHH:4,LA:2,CLAN:1,IS:1,FWL:1,NIOPS:5,MERC:1,FS:1,CGB:4,DC:1</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CS:8,CHH:4,CLAN:1,NIOPS:8,BAN:4,CGB:4</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CS:8,CHH:4,CLAN:1,NIOPS:8,BAN:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1375,9 +1372,6 @@
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:5-,LA:4-,FWL:2-,MERC:2-,DC:7-</availability>
-		<model name='CGR-1L'>
-			<availability>CC:8</availability>
-		</model>
 		<model name='CGR-1A1'>
 			<roles>recon</roles>
 			<availability>CC:6-,LA:6-,FWL:6-,DC:6-</availability>
@@ -1388,19 +1382,22 @@
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:3,MERC:4</availability>
 		</model>
+		<model name='CGR-1L'>
+			<availability>CC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1416,8 +1413,8 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:2,LA:5,FWL:4,MERC:3,FS:3,CIR:2,TC:2,Periphery:2,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
@@ -1425,19 +1422,19 @@
 		<model name='CHP-W5b'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1+,CLAN:6,FS:1+,MERC:1+,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:3,CS:4-,OA:2,LA:3,IS:3,FWL:3,FS:3,MERC:3,Periphery:2,DC:3</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1465,20 +1462,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1498,14 +1495,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1513,29 +1507,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -1546,8 +1543,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1555,18 +1555,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1575,27 +1581,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1603,8 +1600,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -1622,29 +1619,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,CS:3-,LA:3,FWL:3,IS:3,NIOPS:3-,FS:4,MERC:3,DC:3</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,FS:3</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,BAN:2</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Commando IIC' unitType='Mek'>
@@ -1656,14 +1653,14 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>Periphery.R:4,MERC.KH:8,HL:3,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3,CIR:4,MERC:4,Periphery:3,TC:6</availability>
-		<model name='COM-1B'>
-			<roles>recon</roles>
-			<availability>LA:2</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1B'>
+			<roles>recon</roles>
+			<availability>LA:2</availability>
 		</model>
 		<model name='COM-1C'>
 			<roles>recon</roles>
@@ -1677,12 +1674,6 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,HL:1,IS:3,FS:3,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,FS:2</availability>
-		</model>
 		<model name='(Fission)'>
 			<availability>CC:1</availability>
 		</model>
@@ -1691,6 +1682,12 @@
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,FS:2</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -1702,45 +1699,45 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:1,NIOPS:6,BAN:2</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,CSR:1,CW:2,CSV:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,DC:2,TC:2,Periphery:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>LA:2,FS.AH:5,Periphery:2</availability>
@@ -1748,8 +1745,8 @@
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:2</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1760,11 +1757,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>CLAN:1-,CCO:2-,BAN:2</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1773,25 +1770,25 @@
 			<roles>raider</roles>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
 		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:8,CSR:6,CSV:6,CLAN:7,CFM:6,CGS:6,CS:8,CDS:6,CW:8,CBS:8,NIOPS:8,CJF:6,CGB:8</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
@@ -1799,17 +1796,18 @@
 		<model name='A'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>HL:6,General:8,Periphery.Deep:7,BAN:3,Periphery:8</availability>
@@ -1817,9 +1815,8 @@
 		<model name='CRD-3K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1827,11 +1824,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1839,13 +1836,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CS:6,CHH:4,CSR:4,CLAN:2,NIOPS:6,CJF:4</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1860,11 +1857,11 @@
 		<model name='Prime'>
 			<availability>CDS:7,CW:9,General:8,CJF:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
-		</model>
 		<model name='B'>
 			<availability>CW:5,CSV:4,CNC:4,General:5,CJF:6,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -1883,9 +1880,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
@@ -1893,6 +1887,9 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
@@ -1917,11 +1914,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CC:7,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7,CIR:9,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -1962,39 +1959,39 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CIH:4,CGS:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:6,CIH:6,CDS:6,CSV:5,CLAN:6,CFM:5,CSJ:5,CJF:6,CGB:5,CB:6</availability>
-		<model name='D'>
-			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2006,9 +2003,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:2,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:4</availability>
-		<model name='EGL-R6'>
-			<availability>LA:3,General:8,FS:3</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:4,FS:4</availability>
 		</model>
@@ -2019,15 +2013,18 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:3,General:8,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Space) [Flamer]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:8</availability>
@@ -2036,8 +2033,8 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -2069,32 +2066,32 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:2+,CIH:3+,CGS:3+,CB:2+</availability>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='A'>
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CIH:1,CSR:1,CDS:2,CSV:1,CLAN:1,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -2128,14 +2125,14 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:3,NIOPS:4,FWL:2</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2</availability>
+		</model>
 		<model name='EXT-4A'>
 			<availability>FWL:8</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:1</availability>
-		</model>
-		<model name='EXT-4D'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -2155,11 +2152,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -2171,28 +2168,24 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CIH:7,CDS:5,CW:8,CSV:3,CNC:4,CLAN:3,CSJ:4,CJF:6,CGB:3</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:4,LA:3,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:3,FS:9</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
 			<availability>LA:2,FWL:2,FS:5</availability>
@@ -2200,6 +2193,10 @@
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -2223,13 +2220,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -2241,59 +2238,59 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>MERC.WD:4,CIH:6,CLAN:4,BAN:3,CB:5</availability>
-		<model name='C'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FFL-4A'>
 			<availability>:0,MERC.WD:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,MERC.KH:8,LA:8</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -2307,17 +2304,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2325,9 +2320,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2373,11 +2370,11 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:6,CW:6,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:6,CCO:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
@@ -2399,17 +2396,17 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CGB:8</availability>
-		<model name='Prime'>
-			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:5,CW:7,CNC:7,General:5,CSJ:4,CJF:5,CGB:6</availability>
-		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:7,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CGB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:5,CW:7,CNC:7,General:5,CSJ:4,CJF:5,CGB:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CSV:5,General:7,CSJ:5,CGB:7</availability>
@@ -2443,20 +2440,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:6,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>CSV:8,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:6,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:5,NIOPS:9</availability>
-		<model name='GTHA-500'>
-			<availability>CS:6,NIOPS:6,Periphery.Deep:6,BAN:1</availability>
-		</model>
 		<model name='GTHA-500b'>
 			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='GTHA-500'>
+			<availability>CS:6,NIOPS:6,Periphery.Deep:6,BAN:1</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:5,FWL:5,MH:5,MERC:5</availability>
@@ -2482,23 +2479,23 @@
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:4,CIH:6,CDS:4,CW:6,CNC:6,CLAN:4,CCO:4,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CNC:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CIH:8,CNC:8,CLAN:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>CC:7,MOC:3,HL:4,CLAN:2,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -2509,12 +2506,12 @@
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:1,IS:1,FWL:1,MERC:1,TC:1,Periphery:1</availability>
-		<model name='B'>
-			<availability>CC:2,IS:2,FWL:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CC:2,IS:2,FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
@@ -2525,17 +2522,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:3,CS:7,CHH:5,CSR:5,CLAN:2,IS:3,FWL:3,NIOPS:7,FS:2,MERC:3,DC:3,Periphery:2</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2,Periphery.ME:2,FWL:2,NIOPS:0,MERC:2,Periphery:1</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -2547,11 +2544,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
-		<model name='HMR-HD'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,NIOPS:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:7,CLAN:5,BAN:2</availability>
@@ -2566,16 +2563,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:2,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:5</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy BattleMech Recovery Vehicle' unitType='Tank'>
@@ -2587,6 +2584,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2594,14 +2599,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2612,25 +2609,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2638,6 +2631,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2646,6 +2643,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2653,14 +2658,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -2678,18 +2675,18 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:5</availability>
+		<model name='HCT-213S'>
+			<availability>LA:5,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:5,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2704,17 +2701,21 @@
 			<roles>recon</roles>
 			<availability>FWL:4:3025</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,CHH:4,CLAN:1,FWL:1,NIOPS:3,CGB:4,CB:3</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2723,30 +2724,26 @@
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
 		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,Periphery.CM:7,IS:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC10)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:3,IS:3,Periphery:3</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
@@ -2757,46 +2754,46 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:1,CLAN:7,NIOPS:9,CFM:8,CJF:8,DC:1</availability>
+		<model name='HGN-733C'>
+			<availability>CC:2,:0,LA:2</availability>
+		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:2,:0,LA:2</availability>
 		</model>
-		<model name='HGN-733C'>
-			<availability>CC:2,:0,LA:2</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8,DC:8</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:3,MERC.WD:4,CLAN:2,CGS:3</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:1</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:2,BAN:1</availability>
-		</model>
-		<model name='HOP-4C'>
-			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='HOP-4B'>
 			<availability>MERC.WD:4</availability>
 		</model>
+		<model name='HOP-4C'>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,MERC.WD:2,OA:2,Periphery.HR:2,FS.CMM:3,FS.DMM:3,FS:3,MERC:2,Periphery.OS:2,FS.CrMM:3,Periphery:2,TC:2</availability>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -2826,22 +2823,22 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4N'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		<model name='HBK-4G'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4H'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:2,MERC:2,DC:2,Periphery:2</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
@@ -2856,14 +2853,6 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:4,CC:6,HL:3,IS:5,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:5,LA:8,FWL:4,DC:5</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -2872,15 +2861,23 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(LRM15)'>
+			<roles>fire_support</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:7,CSV:7,CLAN:6,NIOPS:4</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:3,BAN:1</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:3,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -2926,16 +2923,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>CC:9,MOC:8,HL:6,CLAN:9,IS:7,Periphery.Deep:7,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:2</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:2</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:2</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -2968,15 +2965,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -2993,16 +2990,16 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:5,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:3,NIOPS:4-,DC:6</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4,TC:3</availability>
-		</model>
 		<model name='(Cell)'>
 			<availability>DC:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4,TC:3</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -3024,17 +3021,17 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
@@ -3061,13 +3058,13 @@
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -3079,17 +3076,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3106,11 +3103,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CS:2,NIOPS:2</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -3126,11 +3123,11 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6</availability>
 		</model>
-		<model name='(SL)'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SL)'>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
@@ -3179,26 +3176,26 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:6</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -3224,9 +3221,9 @@
 			<roles>recon</roles>
 			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
 		</model>
-		<model name='D'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
@@ -3236,9 +3233,9 @@
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,CDS:6,CW:5,General:5,CSJ:4,CGS:6,CCO:4,CGB:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
+			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -3272,13 +3269,13 @@
 			<roles>fire_support</roles>
 			<availability>:0,DC:8</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -3311,15 +3308,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,HL:4,LA:5</availability>
@@ -3340,11 +3337,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:2,CLAN:1,IS:3,FS:5,TC:5,Periphery:4,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
-		<model name='LTN-G15b'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LTN-G15b'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -3360,14 +3357,14 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:5,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
-		</model>
-		<model name='3'>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
@@ -3376,13 +3373,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:2</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,FS:7</availability>
-		</model>
 		<model name='LCT-3V'>
 			<roles>recon</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='LCT-1V'>
+			<roles>recon</roles>
+			<availability>LA:4,General:8,FS:7</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -3395,14 +3392,14 @@
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CDS:8,CW:6,CBS:7,CSV:6,CLAN:7,CFM:7,CSJ:6,CJF:8,BAN:6,CGB:6,CB:7</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -3444,10 +3441,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -3455,6 +3448,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
@@ -3492,20 +3489,20 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:5,CIH:2,CDS:5,CW:9,CBS:2,CLAN:3,CSJ:5,CCO:5,CJF:5,BAN:2,CB:2</availability>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Magellan Jumpship' unitType='Jumpship'>
@@ -3532,14 +3529,14 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
@@ -3574,9 +3571,6 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,CLAN:3,IS:3,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
-		<model name='MAD-3M'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='MAD-3D'>
 			<availability>FS:6</availability>
 		</model>
@@ -3591,6 +3585,9 @@
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>FWL:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -3608,27 +3605,27 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:3,CSV:2,CLAN:3,CFM:3,CGS:3,CSA:3,CDS:3,CW:3,CBS:2,CNC:3,CSJ:8,CJF:3,CGB:3,CB:3</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:9</availability>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:9</availability>
+		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -3639,13 +3636,13 @@
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CHH:5,CLAN:3,FS:2,TC:5</availability>
-		<model name='(Basic)'>
-			<roles>apc</roles>
-			<availability>FS:8,TC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Basic)'>
+			<roles>apc</roles>
+			<availability>FS:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -3666,13 +3663,13 @@
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -3713,17 +3710,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -3731,31 +3728,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -3764,11 +3761,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3822,25 +3819,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -3870,10 +3867,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>CS:6,CHH:4,CDS:4,CBS:5,CLAN:5,NIOPS:6,MERC:2,CJF:5,CGB:4</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:5,CGS:7,BAN:3</availability>
@@ -3881,6 +3874,10 @@
 		<model name='MON-67'>
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -3893,9 +3890,6 @@
 		<availability>CLAN:1,IS:1</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
@@ -3915,6 +3909,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -3923,12 +3923,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -3954,21 +3948,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -3976,11 +3970,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -4002,12 +3996,12 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -4031,12 +4025,12 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:7,LA:4,PIR:4,Periphery.ME:4,FWL:9,MH:4,CIR:4,FS:4</availability>
+		<model name='(Fusion)'>
+			<availability>FWL:1</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
-		</model>
-		<model name='(Fusion)'>
-			<availability>FWL:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4050,17 +4044,17 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:5,CC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='ON1-V'>
 			<availability>IS:3,MH:3,TC:3</availability>
 		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1</availability>
 		</model>
 		<model name='ON1-K'>
 			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -4071,6 +4065,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:4,MOC:3,CS:4,HL:1,LA:5,CLAN:2-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,TC:3,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -4078,9 +4075,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:6,BAN:2</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -4091,22 +4085,22 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:4,CS:4,LA:4,CLAN:2-,FWL:4,IS:4,NIOPS:4,FS:4,MERC:4,DC:4,Periphery:1</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,BAN:3</availability>
 		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:4,FWL:6,NIOPS:6,FS:6,MERC:6,Periphery:3</availability>
-		<model name='OTL-4F'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='OTL-4D'>
 			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='OTL-4F'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -4125,10 +4119,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -4136,6 +4126,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:4,MERC.KH:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -4155,12 +4149,12 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
+		<model name='PNT-8Z'>
+			<availability>CC:2,LA:2,TC:2</availability>
+		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,Periphery:8,DC:8</availability>
-		</model>
-		<model name='PNT-8Z'>
-			<availability>CC:2,LA:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -4172,13 +4166,13 @@
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
@@ -4193,10 +4187,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>CC:9,MOC:7,HL:5,IS:9,Periphery.Deep:7,FS:9,CIR:7,Periphery:7,TC:7,OA:7,LA:9,FWL:9,DC:9</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -4204,6 +4194,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -4237,48 +4231,48 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>BAN:1</availability>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
+		<model name='PXH-1'>
 			<roles>recon</roles>
-			<availability>CLAN:6,BAN:2</availability>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>CC:4,MOC:7,HL:2,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,LA:5,FWL:4,MH:4,DC:5</availability>
-		<model name='(Standard)'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
-		</model>
 		<model name='(Missile)'>
 			<availability>MOC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -4310,13 +4304,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -4348,13 +4342,13 @@
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
@@ -4366,12 +4360,12 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
@@ -4394,24 +4388,18 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-5A'>
 			<availability>General:4,MERC:5,DC:5,Periphery:5</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
 		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,CLAN:4,NIOPS:8</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
@@ -4422,37 +4410,43 @@
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,CLAN:7,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
@@ -4460,11 +4454,11 @@
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:5,CNC:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:6,CNC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:7,CLAN:7,CNC:7</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -4498,20 +4492,20 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:6,BAN:2</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -4524,17 +4518,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -4564,31 +4558,31 @@
 		<model name='SB-27'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:8,LA:6,DC.AL:10,IS:7,FWL:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,DC:9</availability>
-		<model name='(Armor)'>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>OA:4,DC:2</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -4632,16 +4626,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,HL:8,LA:9,FWL:9,IS:10,Periphery.Deep:9,FS:9,DC:9,Periphery:10</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4669,11 +4663,11 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4700,9 +4694,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:3,CLAN:4,CFM:5,CGS:3,CS:4,CDS:3,CW:3,CBS:3,LA:1-,NIOPS:4,CJF:5,CGB:5,DC:1</availability>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
@@ -4712,9 +4703,16 @@
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:6,TC:7</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>HL:6,LA:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4723,10 +4721,6 @@
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>HL:6,LA:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:4,CSR:4,CDS:4,CW:4,CSV:4,CNC:6,CFM:4,CSJ:5,CB:4</availability>
@@ -4734,37 +4728,37 @@
 			<roles>recon</roles>
 			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:7,CGB:7</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5,CGB:1</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:2,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:2,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -4784,11 +4778,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:1,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='SHG-2E'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -4807,44 +4801,50 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
-		<model name='SL-15'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:4,DC:4</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>MERC:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:4</availability>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -4852,10 +4852,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -4880,10 +4876,6 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:5</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>FS.CMM:3</availability>
-		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:5,TC:8</availability>
@@ -4891,6 +4883,10 @@
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:4,DC:8</availability>
+		</model>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>FS.CMM:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -4909,10 +4905,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>CC:5,MOC:2,IS:2,FS:5,MERC:4,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:2,Periphery:8</availability>
 		</model>
@@ -4920,14 +4912,15 @@
 			<roles>anti_infantry</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
-		</model>
-		<model name='STK-4N'>
-			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4935,8 +4928,11 @@
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4947,11 +4943,11 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
@@ -4981,16 +4977,16 @@
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -5003,6 +4999,10 @@
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:4,LA:3,PIR:3,FWL:3,IS:4,FS:7,MERC:3,DC:5</availability>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>IS:4</availability>
@@ -5010,18 +5010,14 @@
 		<model name='(SRM)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:6,CS:4,LA:3,NIOPS:4,FS:1</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -5032,14 +5028,14 @@
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:3,FS.DMM:8</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,FS:3,TC:2,Periphery:1</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
@@ -5051,11 +5047,11 @@
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:5,CGB:8</availability>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
@@ -5083,10 +5079,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -5098,22 +5094,22 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:9,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:9,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -5124,30 +5120,30 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:8,General:8,CJF:9,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
@@ -5175,12 +5171,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -5192,11 +5188,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,CS:7,CDS:5,CW:7,CBS:5,CNC:5,FWL:3,NIOPS:7,CJF:7,CGB:7</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:8,DC:8</availability>
@@ -5226,28 +5222,28 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:3,CLAN:3,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,HL:2,CLAN:3,IS:8,Periphery.Deep:6,FS:7,MERC:8,Periphery:4,TC:4,CS:5-,LA:8,NIOPS:5-,MH:4,DC:8</availability>
-		<model name='TDR-5Sb'>
-			<availability>CHH:3,CSR:3,CDS:3,CW:3,CLAN:3,CNC:3,CJF:3,BAN:1,CGB:3</availability>
-		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:8</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,HL:6,LA:5,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
+		<model name='TDR-5SS'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>CHH:3,CSR:3,CDS:3,CW:3,CLAN:3,CNC:3,CJF:3,BAN:1,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -5258,13 +5254,13 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:4,CLAN:3,NIOPS:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
@@ -5279,12 +5275,12 @@
 			<roles>escort</roles>
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -5302,9 +5298,6 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
@@ -5317,41 +5310,41 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,NIOPS:6</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
 		<model name='TBT-5S'>
 			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,NIOPS:6</availability>
-		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:7,CLAN:5,BAN:2</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -5377,8 +5370,8 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:4,CJF:4,CGB:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5386,23 +5379,24 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:3,CLAN:4,CCO:3,CDS:4,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
@@ -5415,12 +5409,11 @@
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -5457,17 +5450,24 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:2,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:8,FS:8,MERC:8,TC:8</availability>
-		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:8,FS:8,MERC:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
@@ -5475,13 +5475,6 @@
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
@@ -5511,11 +5504,11 @@
 		<model name='VTR-9A1'>
 			<availability>CC:1,CS:1,FS:1</availability>
 		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,FS:1</availability>
-		</model>
 		<model name='VTR-9S'>
 			<availability>LA:4,CIR:4</availability>
+		</model>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -5540,9 +5533,6 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
@@ -5552,17 +5542,20 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:5,CGS:6,CJF:6</availability>
+		<model name='2'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:7,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -5575,21 +5568,17 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,LA:5,FWL:4,IS:1,FS:4,DC:5</availability>
-		<model name='VNL-K70'>
-			<availability>DC:3</availability>
-		</model>
 		<model name='VNL-K100'>
 			<availability>FS:3</availability>
 		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='VNL-K70'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -5611,14 +5600,14 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CIH:7,CW:7,CSV:7,CLAN:8,CNC:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:9</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:5</availability>
@@ -5626,10 +5615,6 @@
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
 		<availability>MERC:2,Periphery:1</availability>
-		<model name='(2312)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2312)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
@@ -5643,6 +5628,12 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='10'>
+			<availability>CSJ:5</availability>
+		</model>
 		<model name='12'>
 			<availability>CSJ:5</availability>
 		</model>
@@ -5653,26 +5644,17 @@
 		<model name='11'>
 			<availability>CSJ:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='10'>
-			<availability>CSJ:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,HL:4,LA:9,CLAN:3,FWL:9,IS:8,NIOPS:6-,Periphery.Deep:5,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4</availability>
 		</model>
+		<model name='WHM-6R'>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-7A'>
 			<availability>CLAN:1</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FS.DMM:2,FS:1,DC:4</availability>
@@ -5680,58 +5662,61 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:4,FS.CH:7,IS:6,Periphery.Deep:4,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
 		<model name='H-7'>
 			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 		</model>
-		<model name='H-7C'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='H-7C'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,HL:4,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:2,Periphery:6</availability>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='WSP-1W'>
 			<roles>recon</roles>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -5758,6 +5743,10 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5766,18 +5755,14 @@
 			<roles>recon</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:4-,CLAN:3-,BAN:2</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -5789,13 +5774,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:4,CIH:2,CLAN:3,IS:4,NIOPS:6,CFM:4,FS:5,MERC:4,Periphery:1,DC:5,TC:2</availability>
-		<model name='WVE-5Nb'>
-			<roles>urban</roles>
-			<availability>CLAN:2,CFM:3,CGS:3</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>CS:8,CLAN:2,NIOPS:8,CFM:4,BAN:4</availability>
+		</model>
+		<model name='WVE-5Nb'>
+			<roles>urban</roles>
+			<availability>CLAN:2,CFM:3,CGS:3</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -5848,11 +5833,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:1</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,CLAN:2,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
@@ -5863,11 +5848,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:2</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3028.xml
+++ b/megamek/data/forcegenerator/3028.xml
@@ -649,17 +649,17 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.WD:5,CHH:2,CSR:2,CLAN:1,CCO:2,BAN:2,CGB:2</availability>
-		<model name='ANH-1E'>
-			<availability>MERC.WD:6</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.WD:6,CLAN:2-,MERC:8</availability>
 		</model>
+		<model name='ANH-1E'>
+			<availability>MERC.WD:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:3</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -678,18 +678,6 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:4,DC:8</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:6,LA:6,FRR:6,IS:8,Periphery.Deep:7,BAN:2,DC:6,Periphery:8</availability>
-		</model>
 		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -697,6 +685,18 @@
 		<model name='ARC-2W'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:6,LA:6,FRR:6,IS:8,Periphery.Deep:7,BAN:2,DC:6,Periphery:8</availability>
+		</model>
+		<model name='ARC-2K'>
+			<roles>fire_support</roles>
+			<availability>FRR:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -716,37 +716,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -756,17 +736,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -800,35 +800,35 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,FRR:4,IS:3,SIC:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,LA:4,FWL:3,NIOPS:4-,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		<model name='AS7-D-DC'>
+			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='AS7-RS'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1,MERC:0,DC:2</availability>
+		<model name='AS7-D'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:5,CCC:5,CSR:5,CW:5,CLAN:5,CNC:5,BAN:5</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
@@ -846,11 +846,11 @@
 		<model name='AWS-8R'>
 			<availability>CS:1,IS:2,FWL:4</availability>
 		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
-		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -878,6 +878,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -886,14 +894,6 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5</availability>
@@ -901,7 +901,7 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -913,7 +913,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -924,19 +924,7 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CLAN:3</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -944,12 +932,28 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:7</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -959,31 +963,27 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,SIC:6-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:7-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
-		<model name='BNC-3S'>
-			<availability>LA:3</availability>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:4</availability>
@@ -991,45 +991,51 @@
 		<model name='BNC-3E'>
 			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
+		<model name='BNC-3S'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:3</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:6,HL:4,FRR:4,CLAN:2,IS:5,SIC:6,FS:5,Periphery:6,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1</availability>
@@ -1037,17 +1043,11 @@
 		<model name='BLR-1S'>
 			<availability>LA:3</availability>
 		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
 		<model name='BLR-1G'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1063,15 +1063,15 @@
 			<roles>interceptor</roles>
 			<availability>CHH:7,CIH:7,CNC:9,General:8,CGS:7</availability>
 		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CFM:6,CGS:8,CJF:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -1083,17 +1083,17 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
+		<model name='6'>
+			<availability>General:2</availability>
 		</model>
 		<model name='4'>
 			<availability>General:3</availability>
 		</model>
-		<model name='6'>
-			<availability>General:2</availability>
-		</model>
 		<model name='5'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
@@ -1101,12 +1101,12 @@
 		<model name='(Armor)'>
 			<availability>IS:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1124,29 +1124,29 @@
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,CSR:7,CSV:7,FRR:1,CLAN:8,CFM:7,FWL.OH:2,MERC:1,FS:1,CGS:9,CS:7,CDS:7,CW:9,CBS:9,CNC:9,FWL:1,NIOPS:7,CJF:7,CGB:9</availability>
-		<model name='BL-6-KNT'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1193,13 +1193,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,OA:2-,CDS:6,CLAN:5,IS:2-,NIOPS:5,FWL:2-,DC:2-,Periphery:1</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -1215,13 +1215,13 @@
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -1239,6 +1239,9 @@
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,Periphery.CM:4,Periphery.HR:4,Periphery.ME:4,SIC:4,FS:5,Periphery:2</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -1247,9 +1250,6 @@
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -1261,13 +1261,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -1279,11 +1279,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -1315,13 +1315,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1333,40 +1333,40 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:3,SIC:2</availability>
-		<model name='CTF-1X'>
-			<availability>General:8,Periphery:8</availability>
-		</model>
 		<model name='CTF-2X'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='CTF-0X'>
 			<availability>CC:1</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FS:1</availability>
 		</model>
-		<model name='CTF-0X'>
-			<availability>CC:1</availability>
+		<model name='CTF-1X'>
+			<availability>General:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:1,CC:3,FRR:5,IS:2,SIC:3,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:4</availability>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:3,DC:4:3033</availability>
+		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,HL:6,CLAN:4,IS:4,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:3,DC:4:3033</availability>
+			<availability>CC:3,MOC:3,OA:3,SIC:3</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,OA:3,SIC:3</availability>
+			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1383,17 +1383,17 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,SIC:2,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>IS:3,FS:3,MERC:3,Periphery:3</availability>
+			<availability>LA:4,IS:3,FS:4,MERC:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,FRR:8,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:4,IS:3,FS:4,MERC:4,Periphery:3</availability>
+			<availability>IS:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -1429,18 +1429,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:2,CS:5,CHH:4,LA:2,CLAN:1,IS:1,FWL:1,NIOPS:5,MERC:1,FS:1,CGB:4,DC:1</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>CS:8,CHH:4,CLAN:1,NIOPS:8,BAN:4,CGB:4</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>CS:8,CHH:4,CLAN:1,NIOPS:8,BAN:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1455,9 +1455,6 @@
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:5-,LA:4-,FRR:7-,FWL:3-,SIC:5-,MERC:3-,DC:7-</availability>
-		<model name='CGR-1L'>
-			<availability>CC:8,SIC:6,Periphery:3</availability>
-		</model>
 		<model name='CGR-1A9'>
 			<availability>FRR:2+,DC:2+</availability>
 		</model>
@@ -1471,19 +1468,22 @@
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:3,MERC:4</availability>
 		</model>
+		<model name='CGR-1L'>
+			<availability>CC:8,SIC:6,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1499,8 +1499,8 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:4,FS:3,CIR:2,Periphery:2,TC:2,OA:2,LA:7,FWL:4,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:1+,FRR:1+,CLAN:6,SIC:1+,FS:1+,MERC:1+,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
@@ -1508,19 +1508,19 @@
 		<model name='CHP-W5b'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1+,FRR:1+,CLAN:6,SIC:1+,FS:1+,MERC:1+,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:3,CS:4-,OA:1,LA:3,IS:3,FWL:3,FS:3,MERC:3,Periphery:2,DC:3</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2,SIC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2,SIC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1548,20 +1548,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1581,14 +1581,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1596,29 +1593,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -1629,8 +1629,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1638,18 +1641,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1658,27 +1667,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1686,8 +1686,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -1705,29 +1705,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,CS:3-,LA:3,FRR:3,IS:3,FWL:3,NIOPS:3-,SIC:4,FS:4,MERC:3,DC:3</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,FS:3</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,BAN:2</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Comitatus JumpShip' unitType='Jumpship'>
@@ -1745,14 +1745,14 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:3,FRR:3,CIR:4,MERC:4,FS:3,Periphery:3,TC:6,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
-		<model name='COM-1B'>
-			<roles>recon</roles>
-			<availability>LA:2</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1B'>
+			<roles>recon</roles>
+			<availability>LA:2</availability>
 		</model>
 		<model name='COM-1C'>
 			<roles>recon</roles>
@@ -1770,17 +1770,17 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,HL:1,FRR:3,IS:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,FS:2</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -1792,45 +1792,45 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:1,NIOPS:6,BAN:2</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,CSR:1,CW:2,CSV:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,FS:8,MERC:3,CIR:2,Periphery:2,TC:2,OA:3,LA:4,FWL:2,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>LA:2,FS.AH:5,Periphery:2</availability>
@@ -1838,8 +1838,8 @@
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:2</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1850,11 +1850,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>CLAN:1-,CCO:2-,BAN:2</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1863,25 +1863,25 @@
 			<roles>raider</roles>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8,DC:6+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
 		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8,DC:6+</availability>
+		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:8,CSR:6,CSV:6,CLAN:7,CFM:6,CGS:6,CS:8,CDS:6,CW:8,CBS:8,NIOPS:8,CJF:6,CGB:8</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -1895,17 +1895,18 @@
 		<model name='A'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9,SIC:8</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>HL:6,General:8,Periphery.Deep:7,BAN:3,Periphery:8</availability>
@@ -1913,9 +1914,8 @@
 		<model name='CRD-3K'>
 			<availability>FRR:5,DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9,SIC:8</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -1923,11 +1923,11 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,FRR:5,IS:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
-		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
@@ -1935,13 +1935,13 @@
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CS:6,CHH:4,CSR:4,CLAN:2,NIOPS:6,CJF:4</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
@@ -1956,11 +1956,11 @@
 		<model name='Prime'>
 			<availability>CDS:7,CW:9,General:8,CJF:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
-		</model>
 		<model name='B'>
 			<availability>CW:5,CSV:4,CNC:4,General:5,CJF:6,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -1979,9 +1979,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:4,FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
@@ -1989,6 +1986,9 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
@@ -2013,11 +2013,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,HL:7,FRR:7,IS:7,Periphery.Deep:8,SIC:7,FS:7,CIR:9,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -2064,48 +2064,48 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CIH:4,CGS:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,FRR:10,MERC:4,DC:10</availability>
-		<model name='DRG-1C'>
-			<availability>FRR:2,DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>FRR:8,MERC:8,DC:8,Periphery:8</availability>
+		</model>
+		<model name='DRG-1C'>
+			<availability>FRR:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:6,CIH:7,CDS:6,CSV:5,CLAN:6,CFM:5,CSJ:5,CJF:6,CGB:9,CB:7</availability>
-		<model name='D'>
-			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>LA:5,FRR:4</availability>
-		<model name='(SRM)'>
-			<availability>CC:8,General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CC:8,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2117,9 +2117,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:3,General:8,FS:3</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:3,FS:3</availability>
 		</model>
@@ -2130,15 +2127,18 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:3,General:8,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Space) [Flamer]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:8</availability>
@@ -2147,8 +2147,8 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -2180,32 +2180,32 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:2+,CIH:3+,CGS:3+,CB:2+</availability>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='A'>
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CIH:1,CDS:2,CSV:1,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -2239,14 +2239,14 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:3,FWL:2,NIOPS:4</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2</availability>
+		</model>
 		<model name='EXT-4A'>
 			<availability>FWL:8</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:1</availability>
-		</model>
-		<model name='EXT-4D'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -2266,11 +2266,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -2282,28 +2282,24 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CIH:7,CDS:5,CW:8,CSV:4,CNC:4,CLAN:3,CSJ:4,CJF:6,CGB:4</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:4,LA:5,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:6,SIC:5,FS:9</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
 			<availability>LA:2,FWL:2,FS:5</availability>
@@ -2311,6 +2307,10 @@
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -2334,13 +2334,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -2352,59 +2352,59 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>MERC.WD:4,CIH:6,CLAN:4,BAN:3,CB:5</availability>
-		<model name='C'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FFL-4A'>
 			<availability>:0,MERC.WD:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1,LA.SR:2</availability>
+		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-8K'>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,MERC.KH:8,LA:8</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -2418,17 +2418,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2436,9 +2434,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2484,11 +2484,11 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:6,CW:6,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:6,CCO:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
@@ -2510,17 +2510,17 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CDS:4,CSR:3,CNC:3,CLAN:3,CSJ:3,CJF:3,BAN:2,CGB:8,CB:3</availability>
-		<model name='Prime'>
-			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:5,CW:7,CNC:7,General:5,CSJ:4,CJF:5,CGB:6</availability>
-		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:7,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CGB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:5,CW:7,CNC:7,General:5,CSJ:4,CJF:5,CGB:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CSV:5,General:7,CSJ:5,CGB:7</availability>
@@ -2554,20 +2554,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:6,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>CSV:8,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:6,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:6,NIOPS:9</availability>
-		<model name='GTHA-500'>
-			<availability>CS:6,NIOPS:6,Periphery.Deep:6,BAN:1</availability>
-		</model>
 		<model name='GTHA-500b'>
 			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='GTHA-500'>
+			<availability>CS:6,NIOPS:6,Periphery.Deep:6,BAN:1</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:6,FWL:6,MH:6,MERC:6</availability>
@@ -2593,23 +2593,23 @@
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:4,CIH:6,CDS:4,CW:6,CNC:6,CLAN:4,CCO:4,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CNC:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CIH:8,CNC:8,CLAN:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6,FRR:4,MERC:4</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6,FRR:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -2620,12 +2620,12 @@
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:1,IS:1,FWL:1,SIC:3,MERC:1,TC:1,Periphery:1</availability>
-		<model name='B'>
-			<availability>CC:2,IS:2,FWL:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CC:2,IS:2,FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
@@ -2636,17 +2636,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:3,CS:7,CHH:5,CSR:5,CLAN:2,IS:3,FWL:3,NIOPS:7,FS:2,MERC:3,DC:3,Periphery:2</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2,Periphery.ME:2,FWL:2,NIOPS:0,MERC:2,Periphery:1</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -2658,11 +2658,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
-		<model name='HMR-HD'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,NIOPS:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:7,CLAN:5,BAN:2</availability>
@@ -2670,23 +2670,23 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CSJ:6</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Laser Platform' unitType='Tank'>
@@ -2698,16 +2698,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:5</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 		<model name='&apos;Mini-Peggy&apos;'>
 			<roles>recon</roles>
@@ -2733,6 +2733,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2740,14 +2748,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2758,25 +2758,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,SIC:4,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,SIC:4,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2784,6 +2780,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2792,6 +2792,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2799,14 +2807,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -2824,18 +2824,18 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:5</availability>
+		<model name='HCT-213S'>
+			<availability>LA:5,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:5,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -2850,17 +2850,21 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,CHH:4,CLAN:1,FWL:1,NIOPS:3,CGB:4,CB:3</availability>
+		<model name='HER-1S'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
 		<model name='HER-1B'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
@@ -2869,30 +2873,26 @@
 			<roles>recon</roles>
 			<availability>:0,FWL:8</availability>
 		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,Periphery.CM:7,IS:4-,Periphery.Deep:6,MERC:5,Periphery:5</availability>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC10)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:3,IS:3,Periphery:3</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -2911,46 +2911,46 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:1,CLAN:7,NIOPS:9,CFM:8,SIC:1,CJF:8,DC:1</availability>
+		<model name='HGN-733C'>
+			<availability>CC:2,:0,LA:2,SIC:2</availability>
+		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
-		<model name='HGN-733C'>
-			<availability>CC:2,:0,LA:2,SIC:2</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8,SIC:8,DC:8</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8,DC:4+</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8,SIC:8,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:3,MERC.WD:2,CLAN:2,CGS:3</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:1</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:2,BAN:1</availability>
-		</model>
-		<model name='HOP-4C'>
-			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='HOP-4B'>
 			<availability>MERC.WD:4</availability>
 		</model>
+		<model name='HOP-4C'>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,MERC.WD:5,OA:2,Periphery.HR:3,FS.CMM:5,FS.DMM:5,FS:5,MERC:2,Periphery.OS:3,FS.CrMM:5,Periphery:2,TC:2</availability>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -2980,22 +2980,22 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4N'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		<model name='HBK-4G'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4H'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:3,MERC:3,DC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
@@ -3010,14 +3010,6 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:4,CC:6,HL:3,FRR:5,IS:5,SIC:6,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:5,LA:8,FWL:4,DC:5</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -3026,15 +3018,23 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(LRM15)'>
+			<roles>fire_support</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,CIH:7,CSV:7,CLAN:6,NIOPS:4</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:3,BAN:1</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:3,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -3080,16 +3080,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:6,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:2</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:2</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:2</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -3122,15 +3122,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -3147,13 +3147,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:5,MOC:5,CC:3,HL:3,FRR:5,FS.AH:5,IS:5,Periphery.Deep:5,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:6,FWL:3,NIOPS:4-,DC:6</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4,TC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4,TC:3</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -3175,17 +3175,17 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
@@ -3212,9 +3212,6 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:6,CLAN:4,CGB:7</availability>
-		<model name='B'>
-			<availability>General:4</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
@@ -3224,16 +3221,19 @@
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>DC:1</availability>
+		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -3245,17 +3245,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3272,11 +3272,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CS:2,NIOPS:2</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Transport' unitType='VTOL'>
@@ -3298,8 +3298,8 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6</availability>
 		</model>
-		<model name='(SL)'>
-			<availability>IS:2</availability>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
@@ -3308,12 +3308,12 @@
 		<model name='(Clan)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(SL)'>
+			<availability>IS:2</availability>
+		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kimagure Pursuit Cruiser' unitType='Warship'>
@@ -3358,26 +3358,26 @@
 		<model name='KTO-19'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:6</availability>
+		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -3403,9 +3403,9 @@
 			<roles>recon</roles>
 			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
 		</model>
-		<model name='D'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
@@ -3415,9 +3415,9 @@
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,CDS:6,CW:5,General:5,CSJ:4,CGS:6,CCO:4,CGB:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
+			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -3451,13 +3451,13 @@
 			<roles>fire_support</roles>
 			<availability>:0,FRR:8,DC:8</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -3490,15 +3490,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,HL:4,LA:5</availability>
@@ -3519,11 +3519,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:3,SIC:6,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
-		<model name='LTN-G15b'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LTN-G15b'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -3539,14 +3539,14 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:6,CLAN:5,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
-		</model>
-		<model name='3'>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
@@ -3559,13 +3559,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:2</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:8,FS:7</availability>
-		</model>
 		<model name='LCT-3V'>
 			<roles>recon</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='LCT-1V'>
+			<roles>recon</roles>
+			<availability>LA:4,General:8,FS:7</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -3578,14 +3578,14 @@
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CDS:8,CW:6,CBS:7,CSV:6,CLAN:7,CFM:7,CSJ:6,CJF:8,BAN:6,CGB:6,CB:7</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -3627,10 +3627,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -3638,6 +3634,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
@@ -3675,20 +3675,20 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CIH:3,CDS:5,CW:9,CBS:3,CLAN:3,CSJ:6,CCO:5,CJF:5,BAN:2,CB:3</availability>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Magellan Jumpship' unitType='Jumpship'>
@@ -3715,14 +3715,14 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
@@ -3757,9 +3757,6 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
-		<model name='MAD-3M'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='MAD-3D'>
 			<availability>FS:6</availability>
 		</model>
@@ -3775,6 +3772,9 @@
 		<model name='MAD-1R'>
 			<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
 		</model>
+		<model name='MAD-3M'>
+			<availability>FWL:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
@@ -3784,27 +3784,27 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:3,CSV:2,CLAN:3,CFM:3,CGS:3,BAN:2,CSA:4,CDS:4,CW:3,CBS:3,CNC:3,CSJ:8,CJF:4,CGB:4,CB:3</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:9</availability>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:9</availability>
+		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -3815,13 +3815,13 @@
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CHH:5,CLAN:3,FS:4,TC:6</availability>
-		<model name='(Basic)'>
-			<roles>apc</roles>
-			<availability>FS:8,TC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Basic)'>
+			<roles>apc</roles>
+			<availability>FS:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -3842,13 +3842,13 @@
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -3889,17 +3889,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -3907,31 +3907,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -3940,11 +3940,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -3998,25 +3998,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -4046,14 +4046,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:1,CHH:4,CLAN:5,MERC:2,Periphery:1,TC:1,CS:6,OA:1,CDS:4,CBS:5,NIOPS:6,CJF:5,CGB:4,DC:1</availability>
-		<model name='MON-68'>
-			<roles>recon</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
@@ -4061,6 +4053,14 @@
 		<model name='MON-67'>
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='MON-68'>
+			<roles>recon</roles>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -4073,9 +4073,6 @@
 		<availability>CLAN:1,IS:1</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
@@ -4095,6 +4092,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -4103,12 +4106,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -4134,21 +4131,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -4156,11 +4153,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -4182,12 +4179,12 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -4211,12 +4208,12 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:6,LA:5,PIR:4,Periphery.ME:4,FWL:9,MH:4,SIC:5,FS:5,CIR:4</availability>
+		<model name='(Fusion)'>
+			<availability>FWL:1</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3,SIC:3</availability>
-		</model>
-		<model name='(Fusion)'>
-			<availability>FWL:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4230,17 +4227,17 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='ON1-V'>
 			<availability>IS:3,MH:3,TC:3</availability>
 		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1</availability>
 		</model>
 		<model name='ON1-K'>
 			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -4251,6 +4248,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:4,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,TC:3,CS:4,LA:5,NIOPS:4,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -4258,9 +4258,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:6,BAN:2</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -4271,22 +4268,22 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:4,CS:4,LA:4,FRR:4,CLAN:2-,IS:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:1,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,BAN:3</availability>
 		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:4,FWL:6,NIOPS:6,FS:6,MERC:6,Periphery:3</availability>
-		<model name='OTL-4F'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='OTL-4D'>
 			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='OTL-4F'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -4305,10 +4302,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:2,CC:2,FRR:5,IS:3,Periphery.Deep:4,SIC:3,FS:4,CIR:3,FS.CrMM:6,Periphery:2,TC:2,CS:6,OA:2,LA:4,FS.CMM:6,FS.DMM:6,FWL:3,NIOPS:6,DC:3</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -4316,6 +4309,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,FS:3,MERC:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -4349,13 +4346,13 @@
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:6,FS:8,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
@@ -4376,10 +4373,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:7,CC:9,HL:5,FRR:8,IS:9,Periphery.Deep:7,SIC:9,FS:9,CIR:7,Periphery:7,TC:7,OA:7,LA:9,FWL:9,DC:9</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -4387,6 +4380,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -4405,11 +4402,11 @@
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:8-,LA:3-,FRR:5-,FWL:5-,IS:5-,SIC:8-,FS:5-,MERC:6-,DC:6-</availability>
-		<model name='(Cargo)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Kurita)'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,DC:6</availability>
@@ -4426,48 +4423,48 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:8,BAN:6,Periphery:8</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>BAN:1</availability>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>FRR:6,DC:6</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
+		<model name='PXH-1'>
 			<roles>recon</roles>
-			<availability>CLAN:6,BAN:1</availability>
+			<availability>General:8,BAN:6,Periphery:8</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:5,FWL:4,MH:4,DC:5</availability>
-		<model name='(Standard)'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
-		</model>
 		<model name='(Missile)'>
 			<availability>MOC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -4511,13 +4508,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -4549,13 +4546,13 @@
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
@@ -4567,12 +4564,12 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
@@ -4595,24 +4592,18 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>CC:3,MOC:5,HL:2,FRR:7,IS:5,Periphery.Deep:4,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-5A'>
 			<availability>General:4,MERC:5,DC:5,Periphery:5</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
 		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,CLAN:4,NIOPS:8</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
@@ -4622,6 +4613,12 @@
 		</model>
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2</availability>
+		</model>
+		<model name='RPR-102'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
@@ -4633,34 +4630,34 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,SIC:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>FRR:8,DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,SIC:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
@@ -4668,11 +4665,11 @@
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:5,CNC:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:6,CNC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:6,CLAN:6,CNC:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -4710,20 +4707,20 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:6,BAN:2</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
@@ -4742,17 +4739,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -4782,31 +4779,31 @@
 		<model name='SB-27'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:8,DC.AL:10,FRR:9,IS:7,SIC:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,LA:6,FWL:7,DC:9</availability>
-		<model name='(Armor)'>
-			<availability>IS:4,Periphery:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>OA:3,FRR:1,DC:1</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,FRR:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -4860,16 +4857,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,HL:8,LA:9,FRR:10,FWL:9,IS:10,Periphery.Deep:9,SIC:9,FS:9,DC:9,Periphery:10</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4897,11 +4894,11 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4928,9 +4925,6 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:3,CLAN:4,CFM:5,CGS:3,CS:4,CDS:3,CW:3,CBS:3,LA:1-,NIOPS:4,CJF:5,CGB:5,DC:1</availability>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
@@ -4940,9 +4934,16 @@
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,Periphery.R:6,OA:7,MERC.KH:6,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:3,CIR:3,Periphery:6,TC:7</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>HL:6,LA:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4951,10 +4952,6 @@
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>HL:6,LA:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:5,CDS:4,CW:4,CSV:5,CNC:7,CFM:5,CSJ:6,CB:5</availability>
@@ -4962,37 +4959,37 @@
 			<roles>recon</roles>
 			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:7,CGB:7</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5,CGB:1</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:2,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>FRR:8,DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>FRR:8,DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:2,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -5012,11 +5009,11 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:1,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='SHG-2E'>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -5035,44 +5032,50 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:5</availability>
-		<model name='SL-15'>
-			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:4,FRR:4,DC:4</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>FRR:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>FRR:4,DC:4</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:4,FRR:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:5</availability>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -5080,10 +5083,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -5108,10 +5107,6 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:4,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>LA:8,FS.CMM:3</availability>
-		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FRR:2,General:8,Periphery.Deep:8,FS:8,MERC:8,DC:3,TC:8</availability>
@@ -5119,6 +5114,10 @@
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:4,FRR:8,DC:8</availability>
+		</model>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>LA:8,FS.CMM:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -5137,10 +5136,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:5,FRR:6,IS:2,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>HL:6,FRR:2,IS:8,Periphery.Deep:7,FS:2,Periphery:8</availability>
 		</model>
@@ -5148,14 +5143,15 @@
 			<roles>anti_infantry</roles>
 			<availability>FRR:8,DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:8,FRR:7,CLAN:5,IS:9,Periphery.Deep:9,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
-		</model>
-		<model name='STK-4N'>
-			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5163,8 +5159,11 @@
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -5175,11 +5174,11 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
@@ -5209,16 +5208,16 @@
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -5231,6 +5230,10 @@
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:5,LA:4,FRR:4,PIR:4,FWL:4,IS:5,SIC:5,FS:7,MERC:4,DC:5</availability>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>IS:6</availability>
@@ -5238,18 +5241,14 @@
 		<model name='(SRM)'>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:6,CS:4,LA:3,NIOPS:4,FS:1</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -5260,33 +5259,33 @@
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,SIC:3,FS:3,TC:2,Periphery:1</availability>
 		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>LA:6,FRR:2,FS:4</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
@@ -5314,10 +5313,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -5329,22 +5328,22 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:9,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:9,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -5355,30 +5354,30 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:8,General:8,CJF:9,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
@@ -5406,12 +5405,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -5423,11 +5422,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,CS:7,CDS:5,CW:7,CBS:5,CNC:5,FWL:3,NIOPS:7,CJF:7,CGB:7</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:8,DC:8</availability>
@@ -5457,28 +5456,28 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,HL:2,CLAN:3,IS:8,Periphery.Deep:6,FS:7,MERC:8,Periphery:4,TC:4,CS:5-,LA:8,NIOPS:5-,MH:4,DC:8</availability>
-		<model name='TDR-5Sb'>
-			<availability>CHH:3,CSR:3,CDS:3,CW:3,CLAN:3,CNC:3,CJF:3,BAN:1,CGB:3</availability>
-		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:8</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:8,HL:6,LA:5,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:8,MERC:2</availability>
+		<model name='TDR-5SS'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>CHH:3,CSR:3,CDS:3,CW:3,CLAN:3,CNC:3,CJF:3,BAN:1,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -5489,22 +5488,22 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:4,CLAN:3,NIOPS:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>FRR:4,DC:7</availability>
-		<model name='TKG-150'>
-			<availability>FRR:8,DC:6</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>FRR:8,DC:8</availability>
+		</model>
+		<model name='TKG-150'>
+			<availability>FRR:8,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
@@ -5513,12 +5512,12 @@
 			<roles>escort</roles>
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -5536,9 +5535,6 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,SIC:8,MERC:3,TC:2</availability>
@@ -5551,45 +5547,45 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:3,SIC:8,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:5,CC:5,FRR:5,IS:5,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,NIOPS:6</availability>
+		</model>
+		<model name='TBT-7K'>
+			<roles>fire_support</roles>
+			<availability>FRR:2,DC:4</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:4</availability>
 		</model>
 		<model name='TBT-5S'>
 			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
-		<model name='TBT-7K'>
-			<roles>fire_support</roles>
-			<availability>FRR:2,DC:4</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,NIOPS:6</availability>
-		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:7,CLAN:5,BAN:2</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -5615,8 +5611,8 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:4,CGB:6</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5624,23 +5620,24 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
@@ -5653,12 +5650,11 @@
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -5695,17 +5691,24 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:3,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:8,FS:8,MERC:8,TC:8</availability>
-		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:8,FS:8,MERC:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
@@ -5713,13 +5716,6 @@
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
@@ -5749,11 +5745,11 @@
 		<model name='VTR-9A1'>
 			<availability>CC:1,CS:1,SIC:1,FS:1</availability>
 		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,SIC:1,FS:1</availability>
-		</model>
 		<model name='VTR-9S'>
 			<availability>LA:4,CIR:4</availability>
+		</model>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,SIC:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -5769,8 +5765,8 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10,FRR:2,SIC:10</availability>
-		<model name='VND-1SIC'>
-			<availability>SIC:2</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>FRR:8</availability>
 		</model>
 		<model name='VND-1X'>
 			<availability>CC:1</availability>
@@ -5778,15 +5774,12 @@
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>FRR:8</availability>
+		<model name='VND-1SIC'>
+			<availability>SIC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
@@ -5796,17 +5789,20 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:5,CGS:6,CJF:6</availability>
+		<model name='2'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:7,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -5819,21 +5815,17 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,LA:5,FRR:5,FWL:4,IS:1,FS:4,DC:5</availability>
-		<model name='VNL-K70'>
-			<availability>FRR:3,DC:3</availability>
-		</model>
 		<model name='VNL-K100'>
 			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='VNL-K70'>
+			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -5855,14 +5847,14 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CIH:7,CW:7,CSV:7,CLAN:8,CNC:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:9</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:5</availability>
@@ -5870,10 +5862,6 @@
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
 		<availability>MERC:2,Periphery:1</availability>
-		<model name='(2312)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2312)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
@@ -5887,6 +5875,12 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='10'>
+			<availability>CSJ:6</availability>
+		</model>
 		<model name='12'>
 			<availability>CSJ:5</availability>
 		</model>
@@ -5897,26 +5891,17 @@
 		<model name='11'>
 			<availability>CSJ:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='10'>
-			<availability>CSJ:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,HL:4,LA:9,CLAN:3,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4,SIC:4</availability>
 		</model>
+		<model name='WHM-6R'>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-7A'>
 			<availability>CLAN:1</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FRR:4,FS.DMM:2,FS:1,DC:4</availability>
@@ -5924,58 +5909,61 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:4,FS.CH:7,FRR:5,IS:6,Periphery.Deep:4,SIC:8,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
 		<model name='H-7'>
 			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 		</model>
-		<model name='H-7C'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='H-7C'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,HL:4,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:2,Periphery:6</availability>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='WSP-1W'>
 			<roles>recon</roles>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4,SIC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>FRR:4,DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -6002,6 +5990,10 @@
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:7,HL:3,FRR:7,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -6010,18 +6002,14 @@
 			<roles>recon</roles>
 			<availability>FRR:6,DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:2-,CLAN:2-,BAN:2</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -6033,13 +6021,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CS:6,CC:4,CIH:2,CLAN:3,IS:4,NIOPS:6,CFM:4,MERC:4,FS:5,Periphery:1,DC:5,TC:2</availability>
-		<model name='WVE-5Nb'>
-			<roles>urban</roles>
-			<availability>CLAN:2,CFM:3,CGS:3</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>CS:8,CLAN:1,NIOPS:8,CFM:4,BAN:4</availability>
+		</model>
+		<model name='WVE-5Nb'>
+			<roles>urban</roles>
+			<availability>CLAN:2,CFM:3,CGS:3</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -6092,20 +6080,20 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:1</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,CLAN:2,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:4,LA:10,FRR:4,FS:5-,MERC:5</availability>
-		<model name='ZEU-6S'>
-			<availability>HL:6,General:8,Periphery.Deep:6,FS:8,Periphery:8</availability>
-		</model>
 		<model name='ZEU-6T'>
 			<availability>LA:3</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:6,General:8,Periphery.Deep:6,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>
@@ -6116,11 +6104,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:2</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3039.xml
+++ b/megamek/data/forcegenerator/3039.xml
@@ -698,20 +698,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.WD:5,CHH:2,CSR:2,CLAN:1,MERC:3,CCO:2,BAN:2,CGB:2</availability>
-		<model name='ANH-1E'>
-			<availability>MERC.WD:6</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.KH:6,MERC.WD:2,CLAN:2-,MERC:6</availability>
+		</model>
+		<model name='ANH-1E'>
+			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.WD:4+</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:3</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -730,29 +730,29 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
+		<model name='ARC-2Rb'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
+		<model name='ARC-2W'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
 		<model name='ARC-2S'>
 			<roles>fire_support</roles>
 			<availability>LA:8</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:4,DC:8</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,LA:6,FRR:6,IS:8,Periphery.Deep:7,BAN:2,DC:6,Periphery:8</availability>
 		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>FWL:4+</availability>
 		</model>
-		<model name='ARC-2W'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>MERC.WD:8</availability>
+			<availability>FRR:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -772,37 +772,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -812,17 +792,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -856,35 +856,35 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,FRR:4,IS:3,SIC:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,LA:4,FWL:3,NIOPS:4-,DC:5</availability>
-		<model name='AS7-D'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		<model name='AS7-D-DC'>
+			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='AS7-RS'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1,MERC:0,DC:2</availability>
+		<model name='AS7-D'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:5,CCC:5,CSR:5,CW:5,CLAN:5,CNC:5,BAN:5</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
@@ -892,13 +892,13 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:3,OA:2,LA:4,IS:2,FWL:1,SIC:3,FS:4,CIR:2,TC:2,Periphery:1,DC:1</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:6+,FS:6+</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>LA:8,General:8,FS:8</availability>
+		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:6+,FS:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
@@ -906,11 +906,11 @@
 		<model name='AWS-8R'>
 			<availability>CS:1,IS:2,FWL:4</availability>
 		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
-		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -944,6 +944,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -952,14 +960,6 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5</availability>
@@ -967,7 +967,7 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -979,7 +979,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -990,19 +990,7 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:5,CLAN:3</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1010,12 +998,28 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:7</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -1025,23 +1029,19 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1051,8 +1051,8 @@
 		<model name='BNC-3MC'>
 			<availability>MOC:9</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:4</availability>
@@ -1060,48 +1060,51 @@
 		<model name='BNC-3E'>
 			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
+		<model name='BNC-3S'>
+			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:6,MOC:5,HL:3,FRR:4,CLAN:2,IS:5,SIC:6,FS:5,Periphery:5,TC:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>FWL:4+</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1</availability>
@@ -1109,17 +1112,14 @@
 		<model name='BLR-1S'>
 			<availability>LA:5</availability>
 		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
 		<model name='BLR-1G'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
+		<model name='BLR-3M'>
+			<availability>FWL:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1135,15 +1135,15 @@
 			<roles>interceptor</roles>
 			<availability>CHH:7,CIH:7,CNC:9,General:8,CGS:7</availability>
 		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CFM:6,CGS:8,CJF:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -1155,17 +1155,17 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
+		<model name='6'>
+			<availability>General:2</availability>
 		</model>
 		<model name='4'>
 			<availability>General:3</availability>
 		</model>
-		<model name='6'>
-			<availability>General:2</availability>
-		</model>
 		<model name='5'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
@@ -1173,12 +1173,12 @@
 		<model name='(Armor)'>
 			<availability>IS:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1196,29 +1196,29 @@
 		<model name='C'>
 			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,CSR:7,CSV:7,FRR:1,CLAN:8,CFM:7,FWL.OH:2,FS:1,MERC:1,CGS:9,DC.GHO:3,CS:7,CDS:7,CW:9,CBS:9,LA:1,CNC:9,FWL:1,NIOPS:7,CJF:7,CGB:9,DC:1</availability>
-		<model name='BL-6-KNT'>
-			<availability>DC.GHO:4,CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-6-KNT'>
+			<availability>DC.GHO:4,CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:6</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
@@ -1234,14 +1234,14 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>MOC:4,CC:5-,OA:4,HL:2,IS:2,SIC:5,MERC:4,FS:6,Periphery:4,TC:4</availability>
-		<model name='BJ-3'>
-			<availability>SIC:2+,FS:2+</availability>
-		</model>
 		<model name='BJ-1DC'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='BJ-3'>
+			<availability>SIC:2+,FS:2+</availability>
 		</model>
 		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
@@ -1268,13 +1268,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,OA:2-,CDS:6,CLAN:5,IS:2-,NIOPS:5,FWL:2-,DC:2-,Periphery:1</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -1290,13 +1290,13 @@
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -1314,6 +1314,9 @@
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,SIC:4,FS:7,CIR:4,Periphery:3</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -1322,9 +1325,6 @@
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -1336,13 +1336,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -1354,11 +1354,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -1390,13 +1390,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1408,54 +1408,47 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:7,SIC:5,FS:5</availability>
-		<model name='CTF-1X'>
-			<availability>General:8,Periphery:8</availability>
-		</model>
 		<model name='CTF-2X'>
 			<availability>CC:4,SIC:2,FS:1,MERC:1</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FS:1</availability>
 		</model>
+		<model name='CTF-1X'>
+			<availability>General:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:3,FRR:5,IS:2,SIC:3,MERC:1,FS:2,CIR:2,TC:2,Periphery:2,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:6</availability>
-		<model name='CPLT-K3'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>DC:6+</availability>
+			<availability>FRR:3,DC:6</availability>
 		</model>
 		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
 			<availability>CC:8,HL:6,CLAN:4,IS:3,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
 		</model>
-		<model name='CPLT-A1'>
+		<model name='CPLT-C4'>
 			<roles>fire_support</roles>
-			<availability>CC:4,SIC:4</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:3,DC:6</availability>
+			<availability>CC:3,MOC:3,OA:3,SIC:3</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,OA:3,SIC:3</availability>
+			<availability>DC:6+</availability>
+		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:4,SIC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSJ:4</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -1463,6 +1456,13 @@
 		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -1479,17 +1479,17 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,SIC:3,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>IS:3,FS:3,MERC:3,Periphery:3</availability>
+			<availability>LA:4,IS:3,FS:4,MERC:4,Periphery:3</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,LA:8,FRR:8,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:4,IS:3,FS:4,MERC:4,Periphery:3</availability>
+			<availability>IS:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -1525,18 +1525,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:2,CHH:4,CLAN:1,IS:1,SIC:3,MERC:1,FS:1,CS:5,DC.GHO:4,LA:2,FWL:1,NIOPS:5,CGB:4,DC:1</availability>
-		<model name='CHP-1N'>
-			<roles>recon</roles>
-			<availability>DC.GHO:8,CS:8,CHH:4,CLAN:1,NIOPS:8,MERC.SI:8,BAN:4,CGB:4</availability>
+		<model name='CHP-1Nb'>
+			<availability>CLAN:1</availability>
 		</model>
 		<model name='CHP-2N'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
-		<model name='CHP-1Nb'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='CHP-1N2'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='CHP-1N'>
+			<roles>recon</roles>
+			<availability>DC.GHO:8,CS:8,CHH:4,CLAN:1,NIOPS:8,MERC.SI:8,BAN:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1551,9 +1551,6 @@
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:5-,LA:4-,FRR:7-,FWL:3-,SIC:5-,MERC:3-,DC:7-</availability>
-		<model name='CGR-1L'>
-			<availability>CC:8,HL:2,SIC:6,Periphery:4</availability>
-		</model>
 		<model name='CGR-1A9'>
 			<availability>FRR:3+,DC:3+</availability>
 		</model>
@@ -1567,19 +1564,22 @@
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:3,MERC:4</availability>
 		</model>
+		<model name='CGR-1L'>
+			<availability>CC:8,HL:2,SIC:6,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
@@ -1595,8 +1595,8 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:4,FS:5,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:1+,FRR:1+,CLAN:6,SIC:1+,FS:1+,MERC:1+,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
@@ -1604,19 +1604,19 @@
 		<model name='CHP-W5b'>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:1+,FRR:1+,CLAN:6,SIC:1+,FS:1+,MERC:1+,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:3,CS:4-,OA:1,LA:3,IS:3,FWL:6,FS:3,MERC:3,Periphery:2,DC:3</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:2,SIC:2</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:2,SIC:2</availability>
 		</model>
 		<model name='CDA-3C'>
 			<roles>training</roles>
@@ -1644,20 +1644,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -1677,14 +1677,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -1692,29 +1689,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -1725,8 +1725,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1734,18 +1737,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -1754,27 +1763,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -1782,8 +1782,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -1801,29 +1801,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,CS:3-,LA:3,FRR:3,IS:3,FWL:3,NIOPS:3-,SIC:4,FS:4,MERC:3,DC:3</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:3,SIC:3,FS:3</availability>
+		</model>
 		<model name='CLNT-1-2R'>
 			<availability>CC:1,SIC:1,FS:1</availability>
 		</model>
 		<model name='CLNT-2-3T'>
 			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:3,SIC:3,FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,BAN:2</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,NIOPS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Combat Engineer' unitType='Infantry'>
@@ -1848,14 +1848,14 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:3,FRR:4,CIR:4,MERC:4,FS:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
-		<model name='COM-1B'>
-			<roles>recon</roles>
-			<availability>LA:2</availability>
-		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
+		</model>
+		<model name='COM-1B'>
+			<roles>recon</roles>
+			<availability>LA:2</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
@@ -1869,17 +1869,17 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,HL:1,FRR:3,IS:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8,SIC:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>SIC:5,FS:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8,SIC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -1898,45 +1898,45 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:3,NIOPS:6,BAN:2</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,CSR:1,CW:2,CSV:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:6,FWL:2,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>LA:2,FS.AH:5,Periphery:2</availability>
@@ -1944,8 +1944,8 @@
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:2</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -1956,11 +1956,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>CLAN:1-,CCO:2-,BAN:2</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -1969,25 +1969,25 @@
 			<roles>raider</roles>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8,DC:8+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
 		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8,DC:8+</availability>
+		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:8,CSR:6,CSV:6,CLAN:7,CFM:6,CGS:6,CS:8,DC.GHO:4,CDS:6,CW:8,CBS:8,NIOPS:8,CJF:6,CGB:8</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -2001,17 +2001,18 @@
 		<model name='A'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='CRD-2R'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9,SIC:8</availability>
 		</model>
 		<model name='CRD-3R'>
 			<availability>HL:5,General:7,Periphery.Deep:7,BAN:3,Periphery:7</availability>
@@ -2019,9 +2020,8 @@
 		<model name='CRD-3K'>
 			<availability>FRR:5,DC:5</availability>
 		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9,SIC:8</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
@@ -2029,31 +2029,31 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,FRR:5,IS:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-10-Z'>
-			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-11-A'>
 			<availability>CC:1+,CS:1+,LA:1+,FWL:1+,IS:1+,FS:1+,DC:1+</availability>
 		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='CP-10-HQ'>
-			<availability>IS:2</availability>
+		<model name='CP-10-Z'>
+			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
+		<model name='CP-10-HQ'>
+			<availability>IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CS:6,CHH:4,CSR:4,CLAN:2,NIOPS:6,CJF:4</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Daboku' unitType='Mek'>
@@ -2074,11 +2074,11 @@
 		<model name='Prime'>
 			<availability>CDS:7,CW:9,General:8,CJF:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
-		</model>
 		<model name='B'>
 			<availability>CW:5,CSV:4,CNC:4,General:5,CJF:6,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -2097,9 +2097,6 @@
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:5,FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
@@ -2107,6 +2104,9 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
@@ -2131,11 +2131,11 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,HL:8,FRR:7,IS:7,Periphery.Deep:9,SIC:7,FS:9,CIR:9,Periphery:10,TC:9,CS:6-,OA:9,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard Mk. II)'>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -2164,11 +2164,11 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
-		<model name='DV-7D'>
-			<availability>FS:4+</availability>
-		</model>
 		<model name='DV-6M'>
 			<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='DV-7D'>
+			<availability>FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -2179,60 +2179,60 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>LA:1+,FS:1+</availability>
-		<model name='DVS-1D'>
-			<availability>LA:8,FS:8,TC:8</availability>
-		</model>
 		<model name='DVS-2'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='DVS-1D'>
+			<availability>LA:8,FS:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CIH:4,CGS:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,FRR:10,MERC:4,DC:10</availability>
+		<model name='DRG-1N'>
+			<availability>FRR:8,MERC:8,DC:8,Periphery:8</availability>
+		</model>
 		<model name='DRG-5N'>
 			<availability>DC:4+</availability>
 		</model>
 		<model name='DRG-1C'>
 			<availability>FRR:1,DC:1</availability>
 		</model>
-		<model name='DRG-1N'>
-			<availability>FRR:8,MERC:8,DC:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:6,CIH:7,CDS:6,CSV:5,CLAN:6,CFM:5,CSJ:5,CJF:6,CGB:9,CB:7</availability>
-		<model name='D'>
-			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,HL:1,LA:7,FRR:4,FWL:3,IS:3,SIC:2,FS:6,MERC:3,CC.CHG:4,DC:3,Periphery:3</availability>
-		<model name='(SRM)'>
-			<availability>CC:8,General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CC:8,General:4</availability>
 		</model>
 		<model name='(ERLL)'>
 			<availability>LA:1+,FS:1+</availability>
@@ -2247,9 +2247,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:3,General:8,FS:3</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:3,FS:3</availability>
 		</model>
@@ -2260,15 +2257,18 @@
 			<roles>ground_support</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:3,General:8,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Space) [Flamer]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:8</availability>
@@ -2277,8 +2277,8 @@
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -2310,32 +2310,32 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:2+,CIH:3+,CGS:3+,CB:2+</availability>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='A'>
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CS:5,CIH:1,CDS:2,CSV:1,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -2369,14 +2369,14 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:3,FWL:2,NIOPS:4</availability>
+		<model name='EXT-4D'>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2,DC:8</availability>
+		</model>
 		<model name='EXT-4A'>
 			<availability>FWL:8</availability>
 		</model>
 		<model name='EXT-4Db'>
 			<availability>CLAN:1</availability>
-		</model>
-		<model name='EXT-4D'>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:2,DC:8</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -2396,11 +2396,11 @@
 		<model name='FLC-4Nb-PP'>
 			<availability>BAN:2</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -2412,28 +2412,24 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CIH:7,CDS:5,CW:8,CSV:5,CNC:4,CLAN:4,CSJ:4,CJF:6,CGB:5</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:6,HL:5,LA:7,Periphery.HR:6,Periphery.MW:6,Periphery.CM:6,FWL:6,SIC:6,FS:9</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
 			<availability>LA:3,FWL:2,FS:5</availability>
@@ -2441,6 +2437,10 @@
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -2460,6 +2460,10 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
@@ -2468,17 +2472,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -2490,62 +2490,62 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:5,MERC.WD:4,CIH:6,CLAN:4,BAN:3,CB:5</availability>
-		<model name='C'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:3+</availability>
 		</model>
 		<model name='FFL-4A'>
 			<availability>:0,MERC.WD:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1,LA.SR:2</availability>
+		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-8K'>
-			<availability>DC.GHO:8,CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,MERC.KH:8,LA:8</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>DC.GHO:8,CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -2559,17 +2559,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -2577,9 +2575,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -2625,25 +2625,25 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:6,CW:6,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:6,CCO:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:5,HL:3,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:5,FS:8,CIR:6,Periphery:5,TC:6,CS:6,OA:8,LA:7,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>FWL:3</availability>
+		</model>
 		<model name='GAL-200'>
 			<availability>MOC:3,LA:3,FRR:3,DC:3,Periphery:3</availability>
 		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:8</availability>
-		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -2655,17 +2655,17 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CDS:5,CSR:4,CNC:4,CLAN:5,CSJ:6,CJF:5,BAN:3,CGB:8,CB:5</availability>
-		<model name='Prime'>
-			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:5,CW:7,CNC:7,General:4,CSJ:4,CJF:5,CGB:6</availability>
-		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:7,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CGB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:5,CW:7,CNC:7,General:4,CSJ:4,CJF:5,CGB:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CSV:5,General:7,CSJ:5,CGB:7</availability>
@@ -2709,20 +2709,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:6,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>CSV:8,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:6,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:8,NIOPS:9</availability>
-		<model name='GTHA-500'>
-			<availability>CS:6,NIOPS:6,Periphery.Deep:6,BAN:1</availability>
-		</model>
 		<model name='GTHA-500b'>
 			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='GTHA-500'>
+			<availability>CS:6,NIOPS:6,Periphery.Deep:6,BAN:1</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:8,FWL:8,MH:8,MERC:8</availability>
@@ -2751,23 +2751,23 @@
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:4,CIH:6,CDS:4,CW:6,CNC:6,CLAN:4,CCO:4,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CNC:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CIH:8,CNC:8,CLAN:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6,FRR:4,MERC:4</availability>
+		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 		<model name='GRF-1N'>
 			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6,FRR:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
@@ -2778,12 +2778,12 @@
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:1,IS:1,FWL:1,SIC:3,MERC:1,TC:1,Periphery:1</availability>
-		<model name='B'>
-			<availability>CC:2,IS:2,FWL:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CC:2,IS:2,FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
@@ -2794,17 +2794,17 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:3,CHH:5,CSR:5,CLAN:1,IS:3,FS:2,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:3,NIOPS:7,DC:3</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8</availability>
+			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2,Periphery.ME:2,FWL:2,NIOPS:0,MERC:2,Periphery:1</availability>
 		</model>
-		<model name='GLT-4L'>
+		<model name='GLT-3N'>
 			<roles>raider</roles>
-			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
+			<availability>CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HALO Paratrooper' unitType='Infantry'>
@@ -2823,11 +2823,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
-		<model name='HMR-HD'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,NIOPS:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:7,CLAN:5,BAN:2</availability>
@@ -2835,23 +2835,23 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,CSV:5,CNC:5,CSJ:6,CJF:4</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Laser Platform' unitType='Tank'>
@@ -2863,16 +2863,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:2,FRR:6,Periphery.Deep:4,MERC:6,Periphery:4,FWL.pm:8,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 		<model name='&apos;Mini-Peggy&apos;'>
 			<roles>recon</roles>
@@ -2881,11 +2881,11 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='HTM-27T'>
-			<availability>DC:3+</availability>
-		</model>
 		<model name='HTM-26T'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -2925,6 +2925,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -2932,14 +2940,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -2950,25 +2950,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,SIC:4,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>CC:4,MOC:5,OA:5,LA:2,General:4,FWL:5,SIC:4,FS:3,MERC:4,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2976,6 +2972,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -2984,6 +2984,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -2991,14 +2999,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -3016,18 +3016,18 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:4,FS:5</availability>
+		<model name='HCT-213S'>
+			<availability>LA:5,FS:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:5,FS:4</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -3042,53 +3042,53 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:4,CLAN:1,FWL:3,NIOPS:3,CGB:4,CB:2</availability>
-		<model name='HER-1B'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>:0,FWL:4</availability>
+			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:3+</availability>
 		</model>
+		<model name='HER-1B'>
+			<roles>recon</roles>
+			<availability>:0,FWL:4</availability>
+		</model>
 		<model name='HER-1A'>
 			<roles>recon</roles>
 			<availability>:0,FWL:6</availability>
 		</model>
-		<model name='HER-1S'>
-			<roles>recon</roles>
-			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,Periphery.CM:7,IS:4-,Periphery.Deep:6,SIC:8,MERC:5,Periphery:5</availability>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC10)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:3,IS:3,Periphery:3</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -3107,46 +3107,46 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:1,CLAN:7,NIOPS:9,CFM:8,SIC:1,CJF:8,DC:3</availability>
+		<model name='HGN-733C'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
+		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
-		<model name='HGN-733C'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
+		<model name='HGN-733'>
+			<availability>CC:8,:0,LA:8,SIC:8,DC:8</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:8,DC:3+</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:8,:0,LA:8,SIC:8,DC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:3,MERC.WD:1,CLAN:2,CGS:3</availability>
-		<model name='HOP-4Cb'>
-			<availability>CHH:8,CLAN:2,BAN:1</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:2,BAN:1</availability>
-		</model>
-		<model name='HOP-4C'>
-			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='HOP-4B'>
 			<availability>MERC.WD:4</availability>
 		</model>
+		<model name='HOP-4C'>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:8,CLAN:2,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:6,FS.DMM:6,FS:5,MERC:4,Periphery.OS:3,FS.CrMM:6,Periphery:2,TC:2</availability>
-		<model name='HNT-151'>
-			<roles>recon,urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='HNT-152'>
 			<roles>recon,urban</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='HNT-151'>
+			<roles>recon,urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -3176,25 +3176,25 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4N'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		<model name='HBK-4G'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4H'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:3,MERC:3,DC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-5M'>
-			<availability>FWL:3+</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-5M'>
+			<availability>FWL:3+</availability>
+		</model>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
@@ -3209,14 +3209,6 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -3225,21 +3217,29 @@
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(LRM15)'>
+			<roles>fire_support</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>DC.GHO:6,CS:4,CIH:7,CSV:7,CLAN:6,NIOPS:4</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:3,BAN:1</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:8</availability>
 		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:3,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -3285,16 +3285,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:6,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:2</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:2</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:2</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -3327,15 +3327,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -3352,13 +3352,13 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:6,MOC:5,CC:3,DC.LV:7,HL:3,FRR:5,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:6,FWL:3,NIOPS:4-,DC:5</availability>
-		<model name='(Flamer)'>
-			<roles>recon,raider</roles>
-			<availability>IS:4,TC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<roles>recon,raider</roles>
+			<availability>IS:4,TC:3</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
@@ -3380,17 +3380,17 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
@@ -3417,9 +3417,6 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:7,CLAN:4,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
@@ -3429,32 +3426,35 @@
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:4,CW:4,CSV:6,CNC:8,CLAN:4,CSJ:4,CGS:4,CCO:5,CB:6</availability>
-		<model name='2'>
-			<availability>CCC:5,CSV:5,CNC:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CCC:4,CSV:4,CNC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,CLAN:8,CNC:8</availability>
 		</model>
+		<model name='2'>
+			<availability>CCC:5,CSV:5,CNC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
-		<model name='JR7-K'>
+		<model name='JR7-F'>
 			<roles>raider</roles>
-			<availability>DC:3+</availability>
+			<availability>DC:1</availability>
 		</model>
 		<model name='JR7-D'>
 			<roles>raider</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='JR7-F'>
+		<model name='JR7-K'>
 			<roles>raider</roles>
-			<availability>DC:1</availability>
+			<availability>DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -3466,17 +3466,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -3493,11 +3493,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CS:2,NIOPS:2</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -3525,11 +3525,8 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
-		<model name='(SL)'>
-			<availability>IS:2</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:3</availability>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Scout)'>
 			<roles>recon</roles>
@@ -3538,12 +3535,15 @@
 		<model name='(Clan)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(SL)'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kimagure Pursuit Cruiser' unitType='Warship'>
@@ -3588,29 +3588,29 @@
 		<model name='KTO-19'>
 			<availability>DC.GHO:8,CS:8,DC.SL:4,CLAN:6,NIOPS:8,MERC.SI:8,BAN:7</availability>
 		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
-		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:6</availability>
 		</model>
 		<model name='KTO-20'>
 			<availability>DC:8</availability>
 		</model>
+		<model name='KTO-19b'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -3636,9 +3636,9 @@
 			<roles>recon</roles>
 			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
 		</model>
-		<model name='D'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
@@ -3648,9 +3648,9 @@
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,CDS:6,CW:5,General:5,CSJ:4,CGS:6,CCO:4,CGB:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
+			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -3684,13 +3684,13 @@
 			<roles>fire_support</roles>
 			<availability>:0,FRR:8,DC:8</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:6</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -3723,15 +3723,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,HL:4,LA:5</availability>
@@ -3752,11 +3752,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:4,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
-		<model name='LTN-G15b'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LTN-G15b'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -3772,14 +3772,14 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:7,CLAN:5,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
-		</model>
-		<model name='3'>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
@@ -3792,13 +3792,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:7,BAN:2</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:4,General:7,FS:7</availability>
-		</model>
 		<model name='LCT-3V'>
 			<roles>recon</roles>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='LCT-1V'>
+			<roles>recon</roles>
+			<availability>LA:4,General:7,FS:7</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -3811,14 +3811,14 @@
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CDS:8,CW:6,CBS:7,CSV:6,CLAN:7,CFM:7,CSJ:6,CJF:8,BAN:6,CGB:6,CB:7</availability>
+		<model name='B'>
+			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -3860,10 +3860,6 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -3871,6 +3867,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
@@ -3908,20 +3908,20 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CIH:4,CDS:6,CW:9,CBS:4,CLAN:5,CSJ:6,CCO:6,CJF:6,BAN:3,CB:4</availability>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Magellan Jumpship' unitType='Jumpship'>
@@ -3948,14 +3948,14 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
@@ -3990,14 +3990,11 @@
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
-		<model name='MAD-5D'>
-			<availability>LA:3+,FRR:3+,FS:3+,DC:4+</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>FWL:5</availability>
-		</model>
 		<model name='MAD-3D'>
 			<availability>FS:6</availability>
+		</model>
+		<model name='MAD-5D'>
+			<availability>LA:3+,FRR:3+,FS:3+,DC:4+</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,HL:6,IS:8,Periphery.Deep:7,Periphery:8,TC:8</availability>
@@ -4011,6 +4008,9 @@
 		<model name='MAD-1R'>
 			<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
 		</model>
+		<model name='MAD-3M'>
+			<availability>FWL:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
@@ -4020,27 +4020,27 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:2,CSA:4,CDS:4,CW:3,CBS:3,CNC:3,CSJ:8,CJF:4,CGB:5,CB:4</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:9</availability>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:9</availability>
+		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
@@ -4057,6 +4057,10 @@
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CHH:5,CLAN:3,FS:5,TC:7</availability>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Intermediate)'>
 			<roles>apc</roles>
 			<availability>TC:8</availability>
@@ -4064,10 +4068,6 @@
 		<model name='(Basic)'>
 			<roles>apc</roles>
 			<availability>FS:8,TC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -4088,13 +4088,13 @@
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -4135,17 +4135,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -4153,31 +4153,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -4186,11 +4186,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -4254,25 +4254,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:2+,MERC:1+,DC:2+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -4302,14 +4302,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:1,CHH:4,CLAN:5,MERC:1,Periphery:1,TC:1,CS:6,DC.GHO:6,OA:1,CDS:4,CBS:5,NIOPS:6,CJF:5,CGB:4,DC:1</availability>
-		<model name='MON-68'>
-			<roles>recon</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
@@ -4317,6 +4309,14 @@
 		<model name='MON-67'>
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='MON-68'>
+			<roles>recon</roles>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -4329,9 +4329,6 @@
 		<availability>CLAN:1,IS:1</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
@@ -4351,6 +4348,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -4359,12 +4362,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -4390,21 +4387,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -4412,11 +4409,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -4438,12 +4435,12 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -4454,8 +4451,7 @@
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CNC:4</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -4465,7 +4461,8 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -4484,12 +4481,12 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:6,LA:6,PIR:4,Periphery.ME:4,FWL:9,MH:4,SIC:6,FS:7,CIR:4</availability>
+		<model name='(Fusion)'>
+			<availability>FWL:2</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3,SIC:3</availability>
-		</model>
-		<model name='(Fusion)'>
-			<availability>FWL:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4503,17 +4500,17 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='ON1-V'>
 			<availability>IS:3,MH:3,TC:3</availability>
 		</model>
-		<model name='ON1-VA'>
-			<availability>IS:2</availability>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1</availability>
 		</model>
 		<model name='ON1-K'>
 			<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -4524,6 +4521,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:3,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,TC:3,CS:4,LA:5,NIOPS:4,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -4531,9 +4531,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:6,BAN:2</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -4544,26 +4541,26 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:3,FRR:4,CLAN:2-,IS:3,SIC:3,FS:3,MERC:4,Periphery:1,CS:4,LA:3,FWL:4,NIOPS:4,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='OTT-7K'>
+			<roles>recon,spotter</roles>
+			<availability>DC:3+</availability>
 		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,BAN:3</availability>
 		</model>
-		<model name='OTT-7K'>
-			<roles>recon,spotter</roles>
-			<availability>DC:3+</availability>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:4,FWL:6,NIOPS:6,FS:6,MERC:6,Periphery:3</availability>
-		<model name='OTL-4F'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='OTL-4D'>
 			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='OTL-4F'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -4582,10 +4579,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:4,FS:6,CIR:4,FS.CrMM:7,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:7,FS.DMM:7,FWL:4,NIOPS:6,DC:5</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,SIC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -4593,6 +4586,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,SIC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -4626,13 +4623,13 @@
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:7,FS:9,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
@@ -4653,10 +4650,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:6,CC:8,HL:4,FRR:8,IS:8,Periphery.Deep:6,SIC:8,FS:8,CIR:6,Periphery:6,TC:6,OA:6,LA:8,FWL:8,DC:8</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -4664,6 +4657,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -4682,11 +4679,11 @@
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:6-,LA:2-,FRR:5-,FWL:3-,IS:3-,SIC:6-,FS:3-,MERC:4-,DC:4-</availability>
-		<model name='(Cargo)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Kurita)'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,DC:4</availability>
@@ -4703,66 +4700,66 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
-		<model name='PXH-1c (Special)'>
+		<model name='PXH-2'>
 			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
+			<availability>BAN:1</availability>
 		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:7,BAN:6,Periphery:7</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FS:4+,MERC:3+</availability>
-		</model>
-		<model name='PXH-2'>
-			<roles>recon</roles>
-			<availability>BAN:1</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>FWL:4+</availability>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
 			<availability>FRR:6,DC:6</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:6,BAN:1</availability>
-		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:4+</availability>
 		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>FWL:4+</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:7,BAN:6,Periphery:7</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FS:4+,MERC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:4,DC:5</availability>
-		<model name='(Standard)'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
-		</model>
 		<model name='(Missile)'>
 			<availability>MOC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -4806,13 +4803,13 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Predator Tank Destroyer' unitType='Tank'>
@@ -4844,13 +4841,13 @@
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
@@ -4862,12 +4859,12 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
@@ -4890,24 +4887,18 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
-		<model name='QKD-4H'>
-			<availability>General:4</availability>
-		</model>
 		<model name='QKD-5A'>
 			<availability>General:4,MERC:5,DC:5,Periphery:5</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
 		</model>
+		<model name='QKD-4H'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,CLAN:4,NIOPS:8</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
@@ -4918,9 +4909,18 @@
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:5,SIC:3,FS:3</availability>
+		<model name='RVN-4X'>
+			<availability>CC:2</availability>
+		</model>
 		<model name='RVN-1X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:5,SIC:3,FS:3</availability>
@@ -4929,47 +4929,44 @@
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='RVN-2X'>
-			<availability>FS:1</availability>
-		</model>
 		<model name='RVN-3X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:1</availability>
 		</model>
-		<model name='RVN-4X'>
-			<availability>CC:2</availability>
+		<model name='RVN-2X'>
+			<availability>FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
-		<model name='F-100a'>
-			<availability>CC:5,FWL:5,SIC:5,MERC:5,DC:4</availability>
-		</model>
 		<model name='F-100b'>
 			<availability>FRR:8,DC:8</availability>
+		</model>
+		<model name='F-100a'>
+			<availability>CC:5,FWL:5,SIC:5,MERC:5,DC:4</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
@@ -4977,11 +4974,11 @@
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:5,CNC:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:6,CNC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:6,CLAN:6,CNC:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -5019,20 +5016,20 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:6,BAN:2</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,NIOPS:8</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:4,General:4,NIOPS:4</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:6,BAN:2</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,NIOPS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
@@ -5051,17 +5048,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CGB:7</availability>
@@ -5091,20 +5088,20 @@
 		<model name='SB-27'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:4,CJF:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5125,22 +5122,22 @@
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:9,DC.AL:10,FRR:9,IS:7,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,LA:8,FWL:8,DC:9</availability>
-		<model name='(Armor)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>OA:3,FRR:1,DC:1</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,FRR:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -5194,16 +5191,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:9,HL:8,LA:9,FRR:10,FWL:9,IS:10,Periphery.Deep:9,SIC:9,FS:9,DC:9,Periphery:10</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -5231,11 +5228,11 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5262,14 +5259,8 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:3,CLAN:4,CFM:5,CGS:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:1-,NIOPS:4,CJF:5,CGB:5,DC:1</availability>
-		<model name='STN-3KB'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:8</availability>
-		</model>
-		<model name='STN-3M'>
-			<availability>DC.GHO:8</availability>
 		</model>
 		<model name='STN-3K'>
 			<availability>LA:8,DC:8</availability>
@@ -5277,9 +5268,19 @@
 		<model name='STN-3KA'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='STN-3M'>
+			<availability>DC.GHO:8</availability>
+		</model>
+		<model name='STN-3KB'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:4,CIR:3,Periphery:6,TC:7</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>HL:6,LA:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -5288,10 +5289,6 @@
 			<roles>interceptor</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>HL:6,LA:8,Periphery.Deep:7,FS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:5,CDS:4,CW:4,CSV:5,CNC:8,CFM:5,CSJ:6,CB:5</availability>
@@ -5299,37 +5296,37 @@
 			<roles>recon</roles>
 			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:7,CGB:7</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5,CGB:1</availability>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:2,Periphery:8</availability>
+		<model name='SHD-2K'>
+			<availability>FRR:8,DC:9</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:10</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>FRR:8,DC:9</availability>
+		<model name='SHD-2H'>
+			<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:2,Periphery:8</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>FWL:5+</availability>
@@ -5355,14 +5352,14 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:1,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:5</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='SHG-2F'>
 			<availability>MERC.WD:6</availability>
-		</model>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -5381,47 +5378,53 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:5,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:5,NIOPS:3,DC:8</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:3,FRR:3,DC:3</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>DC:4+</availability>
-		</model>
-		<model name='SL-15'>
-			<availability>HL:5,IS:7,Periphery.Deep:7,FS:0,Periphery:7</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>FRR:3,MERC:3,DC:3</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:5,IS:7,Periphery.Deep:7,FS:0,Periphery:7</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>FRR:3,DC:3</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:3,FRR:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6</availability>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -5429,10 +5432,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -5457,10 +5456,6 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>LA:8,FS.CMM:3</availability>
-		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FRR:2,General:8,Periphery.Deep:8,FS:8,MERC:8,DC:2,TC:8</availability>
@@ -5468,6 +5463,10 @@
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:4,FRR:8,DC:8</availability>
+		</model>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>LA:8,FS.CMM:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -5486,10 +5485,6 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:5,FRR:6,IS:2,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>HL:6,FRR:2,IS:8,Periphery.Deep:7,FS:2,Periphery:8</availability>
 		</model>
@@ -5497,14 +5492,15 @@
 			<roles>anti_infantry</roles>
 			<availability>FRR:8,DC:8</availability>
 		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:8,FRR:7,CLAN:5,IS:9,Periphery.Deep:9,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
-		</model>
-		<model name='STK-4N'>
-			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5512,8 +5508,11 @@
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -5536,11 +5535,11 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
@@ -5570,16 +5569,16 @@
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -5592,6 +5591,10 @@
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:5,LA:6,FRR:4,PIR:3,FWL:3,IS:5,SIC:5,FS:9,MERC:3,DC:3</availability>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>IS:6</availability>
@@ -5599,18 +5602,14 @@
 		<model name='(SRM)'>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:6,CS:4,LA:3,NIOPS:4,SIC:6,FS:1</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -5618,33 +5617,33 @@
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,SIC:3,FS:3,TC:2,Periphery:1</availability>
 		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:4,HL:2,LA:8,FRR:2,SIC:3,FS:5</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
@@ -5672,10 +5671,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -5687,22 +5686,22 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:9,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:9,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -5713,30 +5712,30 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
+		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:8,General:8,CJF:9,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
@@ -5767,12 +5766,12 @@
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -5784,11 +5783,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,CS:7,DC.GHO:5,CDS:5,CW:7,CBS:5,CNC:5,FWL:3,NIOPS:7,CJF:7,CGB:7</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:8,DC:8</availability>
@@ -5818,34 +5817,34 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:8,HL:2,CLAN:3,IS:8,Periphery.Deep:6,FS:7,MERC:8,Periphery:4,TC:4,CS:5-,LA:8,NIOPS:5-,MH:4,DC:8</availability>
-		<model name='TDR-5Sb'>
-			<availability>CHH:3,CSR:3,CDS:3,CW:3,CLAN:3,CNC:3,CJF:3,BAN:1,CGB:3</availability>
-		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:8</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:8,HL:6,LA:5,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='TDR-9SE'>
 			<availability>MERC.ELH:3+</availability>
 		</model>
 		<model name='TDR-5SE'>
 			<availability>MERC.ELH:8,MERC:2</availability>
 		</model>
+		<model name='TDR-5S'>
+			<availability>CC:8,HL:6,LA:5,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
 		<model name='TDR-7M'>
 			<availability>FWL:3+</availability>
+		</model>
+		<model name='TDR-5SS'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>CHH:3,CSR:3,CDS:3,CW:3,CLAN:3,CNC:3,CJF:3,BAN:1,CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -5856,22 +5855,22 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:4,CLAN:3,NIOPS:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>FRR:5,DC:7</availability>
-		<model name='TKG-150'>
-			<availability>FRR:8,DC:5</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>FRR:8,DC:8</availability>
+		</model>
+		<model name='TKG-150'>
+			<availability>FRR:8,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
@@ -5880,12 +5879,12 @@
 			<roles>escort</roles>
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -5903,9 +5902,6 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:2</availability>
@@ -5918,21 +5914,23 @@
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:5,CC:5,FRR:5,IS:5,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,NIOPS:6</availability>
 		</model>
 		<model name='TBT-7M'>
 			<roles>fire_support</roles>
@@ -5942,25 +5940,23 @@
 			<roles>fire_support</roles>
 			<availability>FRR:2,DC:4</availability>
 		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,NIOPS:6</availability>
+		<model name='TBT-5J'>
+			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
-		<model name='TRN-3U'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:7,CLAN:5,BAN:2</availability>
+		</model>
+		<model name='TRN-3U'>
+			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -5993,8 +5989,8 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:4,CGB:6</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6002,23 +5998,24 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
@@ -6031,12 +6028,11 @@
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
-		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:5,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Union C' unitType='Dropship'>
@@ -6073,17 +6069,24 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:5,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:6,FS:8,MERC:8,TC:8</availability>
-		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:6,FS:8,MERC:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
@@ -6091,13 +6094,6 @@
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
@@ -6127,11 +6123,11 @@
 		<model name='VTR-9A1'>
 			<availability>CC:1,CS:1,SIC:1,FS:1</availability>
 		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,SIC:1,FS:1</availability>
-		</model>
 		<model name='VTR-9S'>
 			<availability>LA:4,CIR:4</availability>
+		</model>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,SIC:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -6147,8 +6143,8 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10,FRR:2,SIC:10</availability>
-		<model name='VND-1SIC'>
-			<availability>SIC:2</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>FRR:8</availability>
 		</model>
 		<model name='VND-1X'>
 			<availability>CC:1,SIC:1</availability>
@@ -6156,15 +6152,12 @@
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>FRR:8</availability>
+		<model name='VND-1SIC'>
+			<availability>SIC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
@@ -6174,17 +6167,20 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:5,CGS:6,CJF:6</availability>
+		<model name='2'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:7,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -6197,21 +6193,17 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,CS:6,LA:5,FRR:5,FWL:4,IS:1,FS:4,DC:5</availability>
-		<model name='VNL-K70'>
-			<availability>FRR:3,DC:3</availability>
-		</model>
 		<model name='VNL-K100'>
 			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='VNL-K70'>
+			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -6233,14 +6225,14 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CIH:7,CW:7,CSV:7,CLAN:8,CNC:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:9</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:5</availability>
@@ -6248,10 +6240,6 @@
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
 		<availability>MERC:2,Periphery:1</availability>
-		<model name='(2312)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2312)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
@@ -6265,6 +6253,12 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='10'>
+			<availability>CSJ:6</availability>
+		</model>
 		<model name='12'>
 			<availability>CSJ:5</availability>
 		</model>
@@ -6275,29 +6269,17 @@
 		<model name='11'>
 			<availability>CSJ:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='10'>
-			<availability>CSJ:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,HL:4,LA:9,CLAN:3,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4,SIC:4</availability>
 		</model>
+		<model name='WHM-6R'>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
+		</model>
 		<model name='WHM-7A'>
 			<availability>CLAN:1</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>FWL:4+</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FRR:4,FS.DMM:2,FS:1,DC:4</availability>
@@ -6305,61 +6287,67 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-7M'>
+			<availability>FWL:4+</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:4,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,SIC:7,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:5</availability>
 		<model name='H-7'>
 			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 		</model>
-		<model name='H-7C'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='H-7C'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:1+</availability>
 		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,HL:4,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:2,Periphery:6</availability>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='WSP-1W'>
 			<roles>recon</roles>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:4,SIC:4</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>FRR:4,DC:4</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -6386,18 +6374,22 @@
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MERC.KH:5,MERC.WD:3,LA:4,FS:4,MERC:2</availability>
-		<model name='WLF-1A'>
-			<availability>MERC.KH:1,LA:1</availability>
-		</model>
 		<model name='WLF-1'>
 			<availability>MERC.KH:5,LA:5,FS:5,MERC:8</availability>
 		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1,LA:1</availability>
 		</model>
+		<model name='WLF-1A'>
+			<availability>MERC.KH:1,LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:6,HL:3,FRR:7,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -6406,18 +6398,14 @@
 			<roles>recon</roles>
 			<availability>FRR:6,DC:6</availability>
 		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,Periphery.ME:4,FWL:10</availability>
-		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>CW:1-,CLAN:1-,BAN:2</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -6429,13 +6417,13 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,CIH:2,CLAN:3,IS:4,CFM:4,MERC:4,FS:5,Periphery:1,TC:2,CS:6,DC.GHO:6,NIOPS:6,DC:5</availability>
-		<model name='WVE-5Nb'>
-			<roles>urban</roles>
-			<availability>CLAN:2,CFM:3,CGS:3</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>DC.GHO:8,CS:8,NIOPS:8,CFM:4,BAN:4</availability>
+		</model>
+		<model name='WVE-5Nb'>
+			<roles>urban</roles>
+			<availability>CLAN:2,CFM:3,CGS:3</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -6488,26 +6476,26 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
-		<model name='ZRO-116b'>
-			<availability>CSR:1</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:8,CLAN:2,NIOPS:8</availability>
+		</model>
+		<model name='ZRO-116b'>
+			<availability>CSR:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:4,LA:10,FRR:4,FS:6-,MERC:5</availability>
-		<model name='ZEU-6S'>
-			<availability>HL:6,General:6,Periphery.Deep:6,FS:8,Periphery:8</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>LA:4+</availability>
+		</model>
+		<model name='ZEU-6T'>
+			<availability>LA:4,FS:6</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:1+</availability>
 		</model>
-		<model name='ZEU-6T'>
-			<availability>LA:4,FS:6</availability>
+		<model name='ZEU-6S'>
+			<availability>HL:6,General:6,Periphery.Deep:6,FS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>
@@ -6518,11 +6506,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:2</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3050.xml
+++ b/megamek/data/forcegenerator/3050.xml
@@ -885,20 +885,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,CLAN:1,MERC:3,CCO:2,BAN:2,CGB:2</availability>
-		<model name='ANH-1E'>
-			<availability>MERC.WD:5</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.KH:3,CLAN:2-,MERC:5</availability>
+		</model>
+		<model name='ANH-1E'>
+			<availability>MERC.WD:5</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:4+,MERC.WD:6+</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:3</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -924,45 +924,45 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,WOB:4-,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
-		<model name='ARC-2S'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>LA:8</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:4,DC:8</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>FRR:4+</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:4+,FS:3+</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:4,LA:6,FRR:6,IS:6,Periphery.Deep:6,BAN:2,DC:6,Periphery:6</availability>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='ARC-5W'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:4+,LA:2+,MERC:2+</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2W'>
 			<roles>fire_support</roles>
-			<availability>CLAN:6,BAN:2</availability>
+			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:8</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CW:2</availability>
 		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:4+,FS:3+</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:4+</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:4,LA:6,FRR:6,IS:6,Periphery.Deep:6,BAN:2,DC:6,Periphery:6</availability>
+		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CS:4+,FWL:6+,WOB:4</availability>
 		</model>
-		<model name='ARC-2W'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>MERC.WD:6</availability>
+			<availability>FRR:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -982,37 +982,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1022,17 +1002,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -1070,20 +1070,35 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,FRR:4,CLAN:2,IS:3,WOB:4-,SIC:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,LA:4,FWL:4,NIOPS:4-,DC:6</availability>
-		<model name='AS7-K-DC'>
-			<availability>FRR:3+,DC:3+</availability>
+		<model name='AS7-K'>
+			<availability>CS:2+,DC:4+</availability>
+		</model>
+		<model name='AS7-D-DC'>
+			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:2,CLAN:8,FS:2,DC:2</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:3+,DC:3+</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>DC:1+</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
@@ -1092,32 +1107,17 @@
 		<model name='AS7-S'>
 			<availability>LA:5+,FS:4,MERC:3+</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>DC:1+</availability>
-		</model>
-		<model name='AS7-D'>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1,MERC:0,DC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>CS:2+,DC:4+</availability>
-		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:4,CCC:4,CSR:4,CW:5,CLAN:4,CNC:5,BAN:5</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
@@ -1125,13 +1125,13 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:3,OA:2,LA:4,IS:2,FWL:1,SIC:3,FS:4,CIR:2,TC:2,Periphery:1,DC:1</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8+,FS:8+</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>LA:6,General:6,FS:6</availability>
+		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8+,FS:8+</availability>
 		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
@@ -1139,11 +1139,11 @@
 		<model name='AWS-8R'>
 			<availability>IS:2,FWL:4</availability>
 		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
-		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
@@ -1166,12 +1166,12 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>LA:5+,FS:3+</availability>
-		<model name='AXM-1N'>
-			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
-		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>LA:6,FS:4</availability>
+		</model>
+		<model name='AXM-1N'>
+			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
@@ -1187,6 +1187,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -1195,14 +1203,6 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5,MERC:4</availability>
@@ -1210,7 +1210,7 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1222,7 +1222,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1239,19 +1239,7 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CLAN:2</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1259,12 +1247,28 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:6</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -1274,23 +1278,19 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1300,8 +1300,8 @@
 		<model name='BNC-3MC'>
 			<availability>MOC:9</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:4</availability>
@@ -1309,39 +1309,39 @@
 		<model name='BNC-3E'>
 			<availability>HL:4,General:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
+		<model name='BNC-3S'>
+			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
+		</model>
 		<model name='BNC-5S'>
 			<availability>LA:6+</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -1360,14 +1360,17 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:3,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,CJF:2,DC:5</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>CS:4+,CC:3+,FWL:5+,WOB:4+,SIC:3+,MERC:3+</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:8</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1,WOB:1</availability>
@@ -1375,20 +1378,17 @@
 		<model name='BLR-1S'>
 			<availability>LA:5</availability>
 		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
 		<model name='BLR-3S'>
 			<availability>LA:4+,FS:3+</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:4,BAN:8,Periphery:8</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
+		<model name='BLR-3M'>
+			<availability>CS:4+,CC:3+,FWL:5+,WOB:4+,SIC:3+,MERC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1404,15 +1404,15 @@
 			<roles>interceptor</roles>
 			<availability>CHH:7,CIH:7,CNC:9,General:8,CGS:7</availability>
 		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CFM:6,CGS:8,CJF:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -1424,17 +1424,17 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:2,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
+		<model name='6'>
+			<availability>General:1</availability>
 		</model>
 		<model name='4'>
 			<availability>General:2</availability>
 		</model>
-		<model name='6'>
-			<availability>General:1</availability>
-		</model>
 		<model name='5'>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
@@ -1442,12 +1442,12 @@
 		<model name='(Armor)'>
 			<availability>IS:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1462,15 +1462,15 @@
 		<model name='B'>
 			<availability>CW:5,CNC:7,General:6,CJF:8,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CCO:5</availability>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:1,CW:2,CSV:2,CNC:1,CLAN:1,General:2,CSJ:2,CJF:2,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -1478,26 +1478,26 @@
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+		<model name='E'>
+			<availability>CCO:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,FRR:2,CLAN:8,CFM:7,FS:1,DC.GHO:3,OA:1,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,TC:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
-		<model name='BL-6-KNT'>
-			<availability>DC.GHO:4,CS:6,FRR:3+,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,BAN:6,DC:3+</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:5,CLAN:5,FWL:4+,NIOPS:5,WOB:5,CGS:6,BAN:2</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-9-KNT'>
+			<availability>CS:5+,WOB:5+</availability>
+		</model>
+		<model name='BL-6-KNT'>
+			<availability>DC.GHO:4,CS:6,FRR:3+,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,BAN:6,DC:3+</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>CS:5+,WOB:5+</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -1509,13 +1509,13 @@
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -1534,20 +1534,20 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:5-,MOC:4,OA:4,HL:2,IS:2,SIC:6,FS:7,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:1+,SIC:3+,FS:2+</availability>
-		</model>
 		<model name='BJ-1DC'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='BJ-2'>
-			<availability>CS:3+,WOB:3+,SIC:3+,FS:3+</availability>
+		<model name='BJ-3'>
+			<availability>CC:1+,SIC:3+,FS:2+</availability>
 		</model>
 		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
+		</model>
+		<model name='BJ-2'>
+			<availability>CS:3+,WOB:3+,SIC:3+,FS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
@@ -1578,13 +1578,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,OA:1-,CDS:6,CLAN:5,IS:2-,NIOPS:5,FWL:2-,WOB:5,DC:2-,Periphery:1</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:8,FRR:2+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -1600,13 +1600,13 @@
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -1624,6 +1624,9 @@
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,SIC:4,FS:7,CIR:4,Periphery:3</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -1632,9 +1635,6 @@
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -1646,13 +1646,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -1664,11 +1664,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -1712,13 +1712,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1730,65 +1730,58 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:8,LA:3,SIC:5,FS:5,MERC:2</availability>
-		<model name='CTF-1X'>
-			<availability>General:8,Periphery:8</availability>
-		</model>
 		<model name='CTF-2X'>
 			<availability>CC:6,SIC:2,FS:1,MERC:1</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>LA:3+,FS:3+</availability>
 		</model>
+		<model name='CTF-3L'>
+			<availability>CC:5+</availability>
+		</model>
 		<model name='CTF-4X'>
 			<availability>FS:3</availability>
 		</model>
-		<model name='CTF-3L'>
-			<availability>CC:5+</availability>
+		<model name='CTF-1X'>
+			<availability>General:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,FS:1,CIR:2,TC:2,Periphery:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
-		<model name='CPLT-K3'>
+		<model name='CPLT-K2'>
 			<roles>fire_support</roles>
-			<availability>DC:6+</availability>
+			<availability>FRR:3,DC:6</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:6,HL:4,CLAN:4,IS:2,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+		</model>
+		<model name='CPLT-C4'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,OA:3,SIC:2</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4+,CS:2,WOB:2</availability>
 		</model>
-		<model name='CPLT-C1'>
+		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
-			<availability>CC:6,HL:4,CLAN:4,IS:2,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='CPLT-K3'>
+			<roles>fire_support</roles>
+			<availability>DC:6+</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:4,SIC:4</availability>
 		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:3,DC:6</availability>
-		</model>
-		<model name='CPLT-C1b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='CPLT-C4'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,OA:3,SIC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSJ:5</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -1796,6 +1789,13 @@
 		</model>
 		<model name='D'>
 			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
@@ -1838,26 +1838,26 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-D3'>
-			<availability>FS:2+</availability>
-		</model>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>IS:2,FS:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:2+,FS:3+</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>SIC:2+,FS:6+</availability>
+			<availability>LA:3,IS:2,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:6,LA:6,FRR:6,General:6,FWL:6,Periphery.Deep:7,FS:6,MERC:6,Periphery:8</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-D'>
+			<availability>SIC:2+,FS:6+</availability>
+		</model>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:3,IS:2,FS:4,MERC:4,Periphery:2</availability>
+			<availability>IS:2,FS:3,MERC:3,Periphery:3</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FS:2+</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:2+,FS:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -1899,18 +1899,18 @@
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:4,CHH:3,CLAN:2,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:5,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+		<model name='CHP-2N'>
+			<availability>IS:8,NIOPS:0</availability>
+		</model>
 		<model name='CHP-3N'>
 			<availability>CS:4,WOB:5</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:3+,CS:4,LA:3+,IS:3+,MERC:3+</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CHH:3,WOB:8,SIC:3,FS:3,MERC:3,BAN:4,DC.GHO:6,CS:8,LA:3,NIOPS:8,MERC.SI:8,DC:3,CGB:3</availability>
-		</model>
-		<model name='CHP-2N'>
-			<availability>IS:8,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:3+,CS:4,LA:3+,IS:3+,MERC:3+</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -1928,8 +1928,8 @@
 		<model name='CGR-3K'>
 			<availability>CC:2,FRR:3,MERC:2,DC:4</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>CC:6,HL:2,SIC:6,Periphery:4</availability>
+		<model name='CGR-C'>
+			<availability>DC:3</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>FRR:5,DC:5</availability>
@@ -1944,36 +1944,32 @@
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:3,MERC:4</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:3</availability>
+		<model name='CGR-1L'>
+			<availability>CC:6,HL:2,SIC:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,WOB:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+		<model name='F-12-S'>
+			<availability>FWL:5,WOB:5</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
+		</model>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:7,HL:5,General:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
+		</model>
 		<model name='F-11'>
 			<availability>FWL:5+</availability>
 		</model>
 		<model name='F-14-S'>
 			<availability>FWL:4+</availability>
 		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:7,HL:5,General:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
-		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
-		</model>
-		<model name='F-12-S'>
-			<availability>FWL:5,WOB:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:6,NIOPS:6,WOB:6</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
@@ -1982,11 +1978,15 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Speed)'>
+			<roles>recon</roles>
+			<availability>CS:4,WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:4+,FRR:2+,CLAN:6,WOB:6,SIC:2+,FS:2+,MERC:2+,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
@@ -1994,27 +1994,27 @@
 		<model name='CHP-W5b'>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+		<model name='CHP-W7'>
+			<availability>LA:4+,FRR:2+,CLAN:6,WOB:6,SIC:2+,FS:2+,MERC:2+,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:3,CS:4-,OA:1,LA:3,IS:3,FWL:6,WOB:4-,FS:3,MERC:3,Periphery:2,DC:4</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:1,SIC:1</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDA-3C'>
-			<roles>training</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='CDA-3M'>
 			<roles>recon</roles>
 			<availability>FWL:6+,IS:2+,MERC:5+</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:1,SIC:1</availability>
+		</model>
+		<model name='CDA-3C'>
+			<roles>training</roles>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -2038,20 +2038,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -2071,14 +2071,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -2086,29 +2083,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -2119,8 +2119,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -2128,18 +2131,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -2148,27 +2157,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -2176,8 +2176,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -2202,32 +2202,32 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,CS:3-,LA:3,FRR:3,IS:3,FWL:3,NIOPS:3-,WOB:3-,SIC:4,FS:4,MERC:3,DC:3</availability>
-		<model name='CLNT-1-2R'>
-			<availability>CC:1,SIC:1,FS:1</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
-		</model>
 		<model name='CLNT-2-4T'>
 			<availability>CC:3,SIC:3,FS:3</availability>
 		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:3+,CS:3</availability>
 		</model>
+		<model name='CLNT-1-2R'>
+			<availability>CC:1,SIC:1,FS:1</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:8,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,WOB:5</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,NIOPS:4,WOB:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,NIOPS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Combat Engineer' unitType='Infantry'>
@@ -2252,18 +2252,18 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:3,FRR:4,FS:5,CIR:4,MERC:5,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
-		<model name='COM-1B'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>LA:2</availability>
+			<availability>LA:6+,FRR:3+</availability>
 		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
 		</model>
-		<model name='COM-5S'>
+		<model name='COM-1B'>
 			<roles>recon</roles>
-			<availability>LA:6+,FRR:3+</availability>
+			<availability>LA:2</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
@@ -2277,17 +2277,17 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:3,HL:1,FRR:3,IS:3,WOB:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8,SIC:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>SIC:5,FS:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8,SIC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -2306,24 +2306,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:2</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,MERC.WD:1,CSR:1,CW:1,CSV:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -2335,17 +2335,17 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Copperhead' unitType='Mek'>
@@ -2356,8 +2356,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V14'>
+			<availability>LA:4+,FRR:3+,FS:4+,MERC:3+</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>LA:2,FS.AH:5,Periphery:2</availability>
@@ -2365,11 +2368,8 @@
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='CSR-V14'>
-			<availability>LA:4+,FRR:3+,FS:4+,MERC:3+</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:2</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -2380,11 +2380,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -2393,28 +2393,28 @@
 			<roles>raider</roles>
 			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:8,CS:6,CLAN:6,NIOPS:6,WOB:6,BAN:8,DC:8+</availability>
-		</model>
-		<model name='CRB-C'>
-			<availability>DC:4+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,NIOPS:0,Periphery:6</availability>
 		</model>
+		<model name='CRB-C'>
+			<availability>DC:4+</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:8,CS:6,CLAN:6,NIOPS:6,WOB:6,BAN:8,DC:8+</availability>
+		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:8,CSR:6,CSV:6,CLAN:7,CFM:6,WOB:8,CGS:6,CS:8,DC.GHO:4,CDS:6,CW:8,CBS:8,NIOPS:8,CJF:6,CGB:8</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:8,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -2428,20 +2428,30 @@
 		<model name='A'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:3,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,WOB:6-,Periphery:5</availability>
-		<model name='CRD-4D'>
-			<availability>FS:4+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:9,SIC:8</availability>
 		</model>
-		<model name='CRD-2R'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		<model name='CRD-3R'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:3,Periphery:6</availability>
+		</model>
+		<model name='CRD-5M'>
+			<availability>FWL:4+,WOB:4</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>FRR:5,DC:5</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>LA:3+,FRR:4+,MERC:3+,FS:3+,DC:4+</availability>
 		</model>
 		<model name='CRD-4BR'>
 			<availability>MERC:4</availability>
@@ -2449,60 +2459,50 @@
 		<model name='CRD-5S'>
 			<availability>LA:4+,FS:3+,MERC:3+</availability>
 		</model>
-		<model name='CRD-3R'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:3,Periphery:6</availability>
-		</model>
 		<model name='CRD-4L'>
 			<availability>CC:4+</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:5,DC:5</availability>
-		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:9,SIC:8</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>FWL:4+,WOB:4</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:5</availability>
 		</model>
-		<model name='CRD-4K'>
-			<availability>LA:3+,FRR:4+,MERC:3+,FS:3+,DC:4+</availability>
+		<model name='CRD-4D'>
+			<availability>FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-11-C'>
-			<roles>spotter</roles>
-			<availability>DC:2+</availability>
-		</model>
-		<model name='CP-10-Z'>
-			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+		<model name='CP-10-Q'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='CP-11-A'>
 			<availability>CC:1+,CS:1,LA:1+,FWL:1+,IS:1+,WOB:1,FS:1+,DC:2+</availability>
 		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='CP-10-HQ'>
-			<availability>IS:2</availability>
+		<model name='CP-10-Z'>
+			<availability>OA:8,General:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
+		<model name='CP-11-C'>
+			<roles>spotter</roles>
+			<availability>DC:2+</availability>
+		</model>
+		<model name='CP-10-HQ'>
+			<availability>IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CS:6,CHH:4,CSR:4,CLAN:2,NIOPS:6,WOB:5,CJF:4</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CS:8,General:8,NIOPS:8,WOB:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Daboku' unitType='Mek'>
@@ -2526,24 +2526,24 @@
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:2,CDS:5,CW:6,CBS:3,CNC:4,CLAN:4,CSJ:8,CJF:5,BAN:2,CGB:4,CB:4</availability>
-		<model name='W'>
-			<availability>MERC.WD:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:9,General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CCO:4</availability>
+		<model name='W'>
+			<availability>MERC.WD:5</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:5,CSV:4,CNC:4,General:5,CJF:6,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CCO:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:8,CSV:5,General:7,CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -2565,18 +2565,15 @@
 		<model name='DRT-3S'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='DRT-4S'>
-			<availability>LA:2,FS:4</availability>
-		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:3</availability>
+		</model>
+		<model name='DRT-4S'>
+			<availability>LA:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:5,FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
@@ -2592,6 +2589,9 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
@@ -2616,14 +2616,14 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,HL:8,FRR:7,IS:7,Periphery.Deep:9,WOB:6-,SIC:8,FS:9,CIR:9,Periphery:10,TC:9,CS:6-,OA:9,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:3+,CS:3,LA:3+,FRR:3+,FWL:3+,IS:2+,WOB:3,SIC:3+,FS:3+,DC:3+</availability>
 		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -2652,11 +2652,11 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:7,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
-		<model name='DV-7D'>
-			<availability>FS:5+</availability>
-		</model>
 		<model name='DV-6M'>
 			<availability>HL:6,CLAN:4,IS:7-,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='DV-7D'>
+			<availability>FS:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -2667,69 +2667,69 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>LA:1+,FS:2+,TC:2</availability>
-		<model name='DVS-1D'>
-			<availability>LA:6,FS:6,TC:8</availability>
-		</model>
 		<model name='DVS-2'>
 			<availability>IS:6</availability>
+		</model>
+		<model name='DVS-1D'>
+			<availability>LA:6,FS:6,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CIH:4,CGS:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,FRR:10,MERC:3,DC:9</availability>
+		<model name='DRG-1N'>
+			<availability>FRR:6,MERC:6,DC:6,Periphery:6</availability>
+		</model>
 		<model name='DRG-5N'>
 			<availability>FRR:4+,MERC:4+,DC:5+</availability>
 		</model>
 		<model name='DRG-1C'>
 			<availability>FRR:1,DC:1</availability>
 		</model>
-		<model name='DRG-1N'>
-			<availability>FRR:6,MERC:6,DC:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:3,CHH:6,CIH:7,CDS:5,CSV:5,CLAN:6,CFM:5,CSJ:5,CJF:5,CGB:9,CB:7</availability>
-		<model name='D'>
-			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CCO:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,HL:1,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
-		<model name='(SRM)'>
-			<availability>CC:8,General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>LA:6+</availability>
+		<model name='(SRM)'>
+			<availability>CC:8,General:4</availability>
 		</model>
 		<model name='(ERLL)'>
 			<availability>LA:1+,FS:1+</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2741,9 +2741,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:2,General:8,FS:2</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:3,FS:3</availability>
 		</model>
@@ -2754,28 +2751,31 @@
 			<roles>ground_support</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:2,General:8,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,MERC.WD:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -2786,11 +2786,11 @@
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>LA:5,MH:2,SIC:3,FS:9,MERC:5,TC:2,DC:3</availability>
-		<model name='ENF-4R'>
-			<availability>LA:6,General:8,FS:8,TC:8</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>LA:2+,FS:4+</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>LA:6,General:8,FS:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -2810,32 +2810,32 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:3+,CIH:3+,CGS:3+,CB:2+</availability>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='A'>
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CS:5,CIH:1,CDS:2,CSV:1,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
@@ -2869,11 +2869,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:2,FWL:1,NIOPS:4,WOB:4</availability>
-		<model name='EXT-4A'>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:2,DC:8</availability>
+		</model>
+		<model name='EXT-4A'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -2896,11 +2896,11 @@
 		<model name='FLC-4P'>
 			<availability>MERC.WD:4+</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -2912,28 +2912,24 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:4,CHH:5,CIH:7,CDS:5,CW:8,CSV:5,CNC:4,CLAN:4,CSJ:4,CJF:6,CGB:5</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:5,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:6,HL:5,LA:7,Periphery.HR:6,Periphery.MW:6,Periphery.CM:6,FWL:6,SIC:6,FS:9</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
 			<availability>LA:3,FWL:2,FS:5</availability>
@@ -2941,6 +2937,10 @@
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -2960,6 +2960,14 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
+		<model name='(Light Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
@@ -2968,21 +2976,13 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(UAC5)'>
 			<roles>field_gun</roles>
@@ -2991,28 +2991,28 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CJF:3</availability>
-		<model name='Prime'>
+		<model name='B'>
+			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CW:6,General:8,CGB:6</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
+		<model name='A'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CW:6,General:8,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -3031,14 +3031,14 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:5,MERC.WD:3,CIH:5,CLAN:3,WOB:5,BAN:2,CB:4</availability>
-		<model name='C'>
-			<availability>MERC.WD:4,CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:4+</availability>
 		</model>
 		<model name='FFL-4A'>
 			<availability>:0,MERC.WD:3-</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4,CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FFL-4C'>
 			<availability>CS:5,WOB:5</availability>
@@ -3046,6 +3046,10 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:5,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1,LA.SR:2</availability>
+		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
@@ -3055,10 +3059,6 @@
 			<roles>recon</roles>
 			<availability>CC:2+,CS:2+,MOC:2+,LA:3+,FRR:2+,General:2+,FS:2+,TC:2+</availability>
 		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
-		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
 			<availability>LA:3+,FS:2+</availability>
@@ -3066,38 +3066,38 @@
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,CLAN:5,CFM:6,WOB:5,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
-		<model name='FLS-8K'>
-			<availability>DC.GHO:8,CS:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8</availability>
-		</model>
 		<model name='FLS-7K'>
 			<availability>:0,MERC.KH:6,LA:6</availability>
+		</model>
+		<model name='FLS-8K'>
+			<availability>DC.GHO:8,CS:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:8,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -3114,17 +3114,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -3132,9 +3130,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -3160,11 +3160,11 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CS:3,CHH:5,CW:4,CLAN:2,CJF:4,CGB:5</availability>
-		<model name='CX-17'>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
@@ -3183,25 +3183,25 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:5,CW:5,CLAN:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:6,CCO:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:4,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>CS:3,MOC:3,LA:3,FRR:3,FWL:5,FS:3,MERC:3,CIR:3</availability>
+		</model>
 		<model name='GAL-200'>
 			<availability>MOC:3,LA:3,FRR:3,IS:1,DC:3,Periphery:3</availability>
 		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:8</availability>
-		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>CS:3,MOC:3,LA:3,FRR:3,FWL:5,FS:3,MERC:3,CIR:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -3213,17 +3213,17 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,MERC.WD:2,CDS:5,CSR:4,CNC:5,CLAN:5,CSJ:7,CJF:6,BAN:3,CGB:8,CB:6</availability>
-		<model name='Prime'>
-			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:5,CW:7,CNC:7,General:4,CSJ:4,CJF:5,CGB:6</availability>
-		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CW:8,CSV:7,General:8,CSJ:7,CJF:9,CGB:9</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:7,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CGB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:5,CW:7,CNC:7,General:4,CSJ:4,CJF:5,CGB:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CSV:5,General:7,CSJ:5,CGB:7</availability>
@@ -3274,20 +3274,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:6,CLAN:2</availability>
-		<model name='(Standard)'>
-			<availability>CSV:8,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:6,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:9,CDS:5,Periphery.MW:3,PIR:3,CLAN:5,Periphery.ME:3,CNC:5,FWL:8,NIOPS:9,WOB:9,MERC:4</availability>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:3,HL:2,CNC:3,FWL:4,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:4,BAN:1,Periphery:4</availability>
-		</model>
 		<model name='GTHA-500b'>
 			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:3,HL:2,CNC:3,FWL:4,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:4,BAN:1,Periphery:4</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:8,FWL:8,MH:8,MERC:8</availability>
@@ -3301,17 +3301,17 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,DC:8</availability>
-		<model name='DRG-C'>
-			<availability>FRR:4+,DC:4+</availability>
-		</model>
 		<model name='DRG-1G'>
 			<availability>FRR:8,DC:8</availability>
 		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:3+,DC:4+</availability>
+		</model>
+		<model name='DRG-C'>
+			<availability>FRR:4+,DC:4+</availability>
+		</model>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -3322,11 +3322,11 @@
 		<model name='GHR-5H'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='GHR-C'>
-			<availability>DC:2+</availability>
-		</model>
 		<model name='GHR-5N'>
 			<availability>General:2</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -3341,14 +3341,14 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
@@ -3362,14 +3362,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:4</availability>
@@ -3377,29 +3377,29 @@
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:4,MERC.WD:3,CIH:6,CDS:4,CW:6,CNC:6,CLAN:4,CCO:4,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CLAN:6,CNC:6</availability>
-		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CIH:8,CNC:8,CLAN:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CLAN:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,WOB:4,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
-		<model name='GRF-3M'>
-			<availability>LA:4+,FWL:4+</availability>
+		<model name='GRF-1S'>
+			<availability>LA:6,FRR:4,MERC:4</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>HL:5,General:7,Periphery.Deep:7,BAN:2,Periphery:7</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:6,FRR:4,MERC:4</availability>
+		<model name='GRF-3M'>
+			<availability>LA:4+,FWL:4+</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>LA:4+,FRR:4+,FS:4+,MERC:4+,DC:4+</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>HL:5,General:7,Periphery.Deep:7,BAN:2,Periphery:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
@@ -3416,12 +3416,12 @@
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:1,IS:1,FWL:1,SIC:3,MERC:1,TC:1,Periphery:1</availability>
-		<model name='B'>
-			<availability>CC:2,IS:2,FWL:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CC:2,IS:2,FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
@@ -3432,21 +3432,21 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:5,NIOPS:7,DC:4</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8,DC:8</availability>
+			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,NIOPS:0,MERC:7,Periphery:7</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:2,Periphery.ME:2,FWL:2,NIOPS:0,MERC:2</availability>
 		</model>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,NIOPS:0,MERC:7,Periphery:7</availability>
-		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:4+,FWL:4+,WOB:3,FS:4+</availability>
+		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
@@ -3486,11 +3486,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7,WOB:7,DC:2</availability>
-		<model name='HMR-HD'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:6,CLAN:5,BAN:2</availability>
@@ -3498,23 +3498,23 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CDS:4,CSV:5,CNC:5,CLAN:2,CSJ:6,CJF:4,CCO:2,CGB:2</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Harasser Laser Platform' unitType='Tank'>
@@ -3526,16 +3526,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 		<model name='&apos;Mini-Peggy&apos;'>
 			<roles>recon</roles>
@@ -3544,11 +3544,11 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:4,DC:8</availability>
-		<model name='HTM-27T'>
-			<availability>FRR:4+,DC:3+</availability>
-		</model>
 		<model name='HTM-26T'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>FRR:4+,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -3584,11 +3584,11 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>MERC.KH:3,LA:6,FRR:3,FS:4,MERC:3,DC:4</availability>
-		<model name='HCT-5S'>
-			<availability>LA:4+,FRR:2+,FS:4+</availability>
-		</model>
 		<model name='HCT-3NH'>
 			<availability>DC:5</availability>
+		</model>
+		<model name='HCT-5S'>
+			<availability>LA:4+,FRR:2+,FS:4+</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
@@ -3604,6 +3604,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:3,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -3611,14 +3619,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -3629,25 +3629,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:4,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -3656,6 +3652,10 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -3663,6 +3663,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -3670,14 +3678,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8,WOB:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -3695,18 +3695,18 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:3,FS:4</availability>
+		<model name='HCT-213S'>
+			<availability>LA:4,FS:3</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:4,FS:3</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:3,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -3734,13 +3734,13 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
 		</model>
 		<model name='HER-5S'>
 			<roles>recon</roles>
@@ -3749,50 +3749,50 @@
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:3,FWL:4,NIOPS:3,WOB:3,CGB:3,CB:2</availability>
-		<model name='HER-1B'>
-			<roles>recon</roles>
-			<availability>:0,FWL:2</availability>
-		</model>
 		<model name='HER-3S2'>
 			<roles>recon,spotter</roles>
 			<availability>FWL:2+</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:3+,WOB:3</availability>
-		</model>
-		<model name='HER-3S'>
-			<roles>recon</roles>
-			<availability>FWL:4+,WOB:4+</availability>
-		</model>
-		<model name='HER-1A'>
-			<roles>recon</roles>
-			<availability>:0,FWL:4</availability>
 		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>DC.GHO:8,CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
+		<model name='HER-3S'>
+			<roles>recon</roles>
+			<availability>FWL:4+,WOB:4+</availability>
+		</model>
+		<model name='HER-1B'>
+			<roles>recon</roles>
+			<availability>:0,FWL:2</availability>
+		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:3+,WOB:3</availability>
+		</model>
+		<model name='HER-1A'>
+			<roles>recon</roles>
+			<availability>:0,FWL:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:4-,CDS:2,Periphery.CM:7,CNC:2,IS:4-,Periphery.Deep:6,WOB:4-,SIC:8,MERC:4,Periphery:4</availability>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC10)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:3,IS:3,Periphery:3</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -3811,20 +3811,20 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:3,CLAN:7,NIOPS:9,CFM:8,WOB:9,SIC:1,CJF:8,DC:2</availability>
+		<model name='HGN-733C'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
+		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
-		<model name='HGN-733C'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
+		<model name='HGN-733'>
+			<availability>CC:6,:0,LA:6,SIC:6,DC:6</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>DC.GHO:8,CS:6,CLAN:6,NIOPS:6,WOB:6,MERC.SI:8,BAN:8</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:6,:0,LA:6,SIC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -3835,20 +3835,20 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:2,MERC.WD:1,CLAN:2,CGS:3</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='HOP-4B'>
+			<availability>MERC.WD:3</availability>
+		</model>
+		<model name='HOP-4D'>
+			<availability>MERC.WD:8</availability>
+		</model>
 		<model name='C'>
 			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:8,CLAN:2</availability>
-		</model>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='HOP-4D'>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='HOP-4B'>
-			<availability>MERC.WD:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -3856,16 +3856,16 @@
 		<model name='HNT-161'>
 			<availability>MERC.WD:6-</availability>
 		</model>
+		<model name='HNT-152'>
+			<roles>recon,urban</roles>
+			<availability>IS:3</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FS:4+,MERC:4+</availability>
-		</model>
-		<model name='HNT-152'>
-			<roles>recon,urban</roles>
-			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -3895,25 +3895,25 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,WOB:5-,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
-		<model name='HBK-4N'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		<model name='HBK-4G'>
+			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4H'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:3,MERC:3,DC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-5M'>
-			<availability>CS:3+,CC:2+,FRR:2+,FWL:4+,WOB:3+,MERC:3+</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-5M'>
+			<availability>CS:3+,CC:2+,FRR:2+,FWL:4+,WOB:3+,MERC:3+</availability>
+		</model>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
@@ -3928,44 +3928,44 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM10)'>
-			<roles>fire_support</roles>
-			<availability>General:3</availability>
 		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
 			<availability>LA:7+,FS:3+</availability>
 		</model>
+		<model name='(LRM10)'>
+			<roles>fire_support</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='(LRM15)'>
+			<roles>fire_support</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>DC.GHO:6,CS:4,CIH:7,CSV:7,CLAN:6,NIOPS:4,WOB:4,DC:2</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:4,LA:4,WOB:4,MERC:4</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:8,General:4,CLAN:6,NIOPS:8,MERC.SI:8,WOB:6,BAN:8</availability>
 		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>CS:4,LA:4,WOB:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -3976,28 +3976,28 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,LA:8,FWL:8,IS:8,WOB:8,FS:8,DC:8</availability>
-		<model name='(Level I) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
 		<model name='(Level I) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 	</chassis>
@@ -4019,11 +4019,11 @@
 		<model name='C'>
 			<availability>MERC.WD:2,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
-			<availability>MERC.WD:4</availability>
-		</model>
 		<model name='IMP-2E'>
 			<availability>MERC.WD:6</availability>
+		</model>
+		<model name='IMP-3E'>
+			<availability>MERC.WD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
@@ -4048,16 +4048,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:6,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:1</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:1</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:1</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -4090,15 +4090,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>LA:2,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -4115,29 +4115,29 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:6,MOC:5,CC:3,DC.LV:7,HL:3,FRR:5,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,WOB:3-,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:3-,OA:5,LA:6,FWL:3,NIOPS:3-,DC:5</availability>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>IS:4</availability>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4,TC:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Kurita)'>
 			<roles>recon,raider</roles>
-			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
+			<availability>DC:6,TC:3</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Kurita)'>
-			<roles>recon,raider</roles>
-			<availability>DC:6,TC:3</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>recon,raider</roles>
 			<availability>HL:6,General:4,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
@@ -4157,39 +4157,43 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,LA:4,FRR:5,IS:2,FWL:3,NIOPS:3,WOB:3,SIC:6,MERC:3,FS:8,DC:3</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>OA:4+,LA:4+,FRR:4+,FS:4+,MERC:4+,DC:4+</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>CC:8,FRR:8,IS:8,SIC:8,FS:8</availability>
+		</model>
+		<model name='JM6-DG'>
+			<availability>General:1</availability>
 		</model>
 		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2</availability>
 		</model>
-		<model name='JM6-DG'>
-			<availability>General:1</availability>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>OA:4+,LA:4+,FRR:4+,FS:4+,MERC:4+,DC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+		<model name='JVN-10P'>
+			<roles>recon</roles>
+			<availability>FS:4+</availability>
+		</model>
 		<model name='JVN-10F &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
 			<availability>MOC:2,IS:2,FS:6,MERC:2,TC:2,Periphery:2</availability>
@@ -4198,16 +4202,9 @@
 			<roles>recon</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='JVN-10P'>
-			<roles>recon</roles>
-			<availability>FS:4+</availability>
-		</model>
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:4,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
@@ -4217,32 +4214,35 @@
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:4,CW:4,CSV:6,CNC:8,CLAN:4,CSJ:5,CGS:4,CCO:5,CB:6</availability>
-		<model name='2'>
-			<availability>CCC:6,CSV:6,CNC:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,CLAN:8,CNC:8</availability>
 		</model>
+		<model name='2'>
+			<availability>CCC:6,CSV:6,CNC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:3,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
-		<model name='JR7-K'>
+		<model name='JR7-F'>
 			<roles>raider</roles>
-			<availability>FRR:4+,DC:5+</availability>
+			<availability>FS.DMM:1,DC:2</availability>
 		</model>
 		<model name='JR7-D'>
 			<roles>raider</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
-		<model name='JR7-F'>
+		<model name='JR7-K'>
 			<roles>raider</roles>
-			<availability>FS.DMM:1,DC:2</availability>
+			<availability>FRR:4+,DC:5+</availability>
 		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
@@ -4258,17 +4258,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -4285,11 +4285,11 @@
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CS:2,NIOPS:2</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -4317,21 +4317,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kimagure Pursuit Cruiser' unitType='Warship'>
@@ -4376,11 +4376,11 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:7,CHH:3,CDS:3,CSV:3,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:6,MERC:3,DC:5</availability>
+		<model name='KTO-C'>
+			<availability>DC:4+</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:8,CS:8,DC.SL:4,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:4+,MERC:4+,BAN:7</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:6,MERC:6,DC:4</availability>
@@ -4388,23 +4388,23 @@
 		<model name='KTO-20'>
 			<availability>CS:4,WOB:4,MERC:4,DC:8</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>DC:4+</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -4444,13 +4444,9 @@
 			<roles>recon</roles>
 			<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
 		</model>
-		<model name='D'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<roles>recon</roles>
-			<availability>CCO:5</availability>
+			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
@@ -4460,21 +4456,25 @@
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,CDS:6,CW:5,General:5,CSJ:4,CGS:6,CCO:4,CGB:6</availability>
 		</model>
-		<model name='Prime'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
+			<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+		</model>
+		<model name='E'>
+			<roles>recon</roles>
+			<availability>CCO:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:5,CLAN:3,CJF:5</availability>
-		<model name='2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
 	</chassis>
@@ -4503,13 +4503,13 @@
 			<roles>fire_support</roles>
 			<availability>:0,FRR:6,DC:6</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,FRR:3+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:3+</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4,WOB:4</availability>
+		</model>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,FRR:3+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -4542,15 +4542,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,HL:4,LA:5</availability>
@@ -4571,11 +4571,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:5,WOB:5-,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
-		<model name='LTN-G15b'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LTN-G15b'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
@@ -4583,17 +4583,17 @@
 		<model name='B'>
 			<availability>CIH:6,CDS:4,General:5,CGB:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,General:5,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CGB:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CW:7,General:7,CGB:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:4,CIH:5,CW:5,CBS:4,CSV:5,CNC:3,General:3,CSJ:3,CJF:2,CGB:3,CB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CGB:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,General:5,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -4613,22 +4613,18 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:7,CLAN:5,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:1-,IS:9,NIOPS:6-,Periphery.Deep:5,WOB:6-,Periphery:6</availability>
-		<model name='LCT-3M'>
-			<roles>recon</roles>
-			<availability>MOC:2+,FWL:4+,IS:2+,MERC:3+</availability>
-		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
 			<availability>CC:2,SIC:2</availability>
@@ -4637,17 +4633,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:3,General:6,FS:6</availability>
-		</model>
 		<model name='LCT-3V'>
 			<roles>recon</roles>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>FS:4+,MERC:2+</availability>
+			<availability>LA:3,General:6,FS:6</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -4657,18 +4649,23 @@
 			<roles>recon</roles>
 			<availability>LA:4+,FRR:2+,MERC:2+</availability>
 		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:2+,FWL:4+,IS:2+,MERC:3+</availability>
+		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:7,MERC:4</availability>
 		</model>
+		<model name='LCT-3D'>
+			<roles>recon</roles>
+			<availability>FS:4+,MERC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CDS:7,CW:6,CBS:7,CSV:6,CLAN:6,CFM:7,CSJ:6,CJF:8,BAN:6,CGB:6,CB:7</availability>
-		<model name='A'>
-			<availability>General:7,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:9</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CCO:5</availability>
@@ -4676,8 +4673,11 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:7,CGB:8</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -4704,31 +4704,27 @@
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
-		<model name='LCF-R16K'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>FRR:3+,DC:4+</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:3,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:3</availability>
+		<model name='LCF-R16'>
+			<availability>LA:4+,FS:3+</availability>
+		</model>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:1</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:8,FS:8</availability>
 		</model>
-		<model name='LCF-R16'>
-			<availability>LA:4+,FS:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -4736,6 +4732,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
@@ -4773,8 +4773,8 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CIH:4,CLAN:5,CCO:6,BAN:3,CSA:6,MERC.WD:6,CDS:6,CW:9,CBS:4,CSJ:6,CJF:6,CB:4</availability>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -4787,14 +4787,14 @@
 		<model name='D'>
 			<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:4,General:5,CJF:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Magellan Jumpship' unitType='Jumpship'>
@@ -4821,14 +4821,14 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:5,CNC:7,General:6,CJF:5,CGB:8</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:4,CNC:5,General:4,CGB:4</availability>
@@ -4860,32 +4860,26 @@
 		<model name='MAD-5A'>
 			<availability>MERC.WD:4+</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:1</availability>
-		</model>
 		<model name='MAD-4A'>
 			<availability>MERC:8</availability>
+		</model>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:2</availability>
+		<model name='MAD-3D'>
+			<availability>FS:6</availability>
+		</model>
 		<model name='MAD-5D'>
 			<availability>LA:4+,FRR:4+,WOB:2+,FS:4+,MERC:2+,DC:5+</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:1+,FS:1+,DC:1+</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>LA:3+,FS:3+</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:4,Periphery.ME:4,FWL:5,MH:4,MERC:4</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>CS:2+,FWL:3+,IS:2+,WOB:2+</availability>
 		</model>
-		<model name='MAD-3D'>
-			<availability>FS:6</availability>
+		<model name='C'>
+			<availability>LA:1+,FS:1+,DC:1+</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:4-,HL:6,IS:6,Periphery.Deep:7,WOB:4-,Periphery:8,TC:8</availability>
@@ -4899,6 +4893,12 @@
 		<model name='MAD-1R'>
 			<availability>CS:6,CLAN:1,NIOPS:6,WOB:6,MERC:0,BAN:2</availability>
 		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:4,Periphery.ME:4,FWL:5,MH:4,MERC:4</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>LA:3+,FS:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
@@ -4908,30 +4908,30 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:3,CSA:4,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:5,CB:4</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:9</availability>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGB:6</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CCO:4</availability>
@@ -4951,6 +4951,10 @@
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CHH:5,CLAN:3,FS:5,TC:7</availability>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:4</availability>
+		</model>
 		<model name='(Intermediate)'>
 			<roles>apc</roles>
 			<availability>TC:6</availability>
@@ -4958,10 +4962,6 @@
 		<model name='(Basic)'>
 			<roles>apc</roles>
 			<availability>FS:8,TC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -4978,29 +4978,29 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:3,FRR:7,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>LA:5,FS:5,DC:6</availability>
-		</model>
 		<model name='(SRM2)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(SRM4)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Anti-Infantry)'>
-			<roles>apc,spotter,anti_infantry</roles>
-			<availability>DC:4</availability>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 		<model name='(Fire Support)'>
 			<roles>apc,fire_support</roles>
 			<availability>LA:4,IS:2,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>LA:5,FS:5,DC:6</availability>
+		</model>
+		<model name='(Anti-Infantry)'>
+			<roles>apc,spotter,anti_infantry</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -5041,17 +5041,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -5059,31 +5059,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:5,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -5092,11 +5092,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -5177,25 +5177,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:3+,MERC:1+,DC:3+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>CC:1,General:2,MERC:8,DC:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:2,MERC:6,DC:2</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:2,MERC:6,DC:2</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>CC:1,General:2,MERC:8,DC:1</availability>
+			<availability>CC:2,MERC:6,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -5232,14 +5232,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:1,CHH:3,CLAN:4,WOB:4,MERC:1,Periphery:1,TC:1,CS:6,DC.GHO:5,OA:1,CDS:3,CBS:4,NIOPS:6,CJF:4,CGB:3,DC:1</availability>
-		<model name='MON-68'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:5,CGS:6,BAN:2</availability>
@@ -5247,6 +5239,14 @@
 		<model name='MON-67'>
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:4,Periphery:4</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
+		</model>
+		<model name='MON-68'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -5259,9 +5259,6 @@
 		<availability>CLAN:2,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
@@ -5281,6 +5278,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -5289,12 +5292,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -5320,21 +5317,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -5342,11 +5339,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
@@ -5357,20 +5354,20 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CJF:2</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
@@ -5392,12 +5389,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,WOB:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -5408,8 +5405,7 @@
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CNC:6</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -5419,7 +5415,8 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -5438,18 +5435,18 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:6,FRR:3,IS:3,SIC:7,MERC:3,FS:7,CIR:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4,DC:3</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>IS:4</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3,LA:3,FWL:3,SIC:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='(3053 Upgrade)'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -5463,20 +5460,20 @@
 		<model name='ON1-MA'>
 			<availability>FWL:2+</availability>
 		</model>
+		<model name='ON1-V'>
+			<availability>IS:3,MH:3,TC:3</availability>
+		</model>
 		<model name='ON1-V-DC'>
 			<availability>FWL:1</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:5,General:7,CLAN:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 		<model name='ON1-M'>
 			<availability>CS:3+,FWL:4+,WOB:3+</availability>
 		</model>
-		<model name='ON1-V'>
-			<availability>IS:3,MH:3,TC:3</availability>
-		</model>
 		<model name='ON1-VA'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='ON1-K'>
-			<availability>HL:5,General:7,CLAN:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -5487,6 +5484,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:3,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,WOB:4,SIC:3,Periphery:3,TC:3,CS:4,LA:4,NIOPS:4,DC:6</availability>
+		<model name='OSR-3C'>
+			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -5494,9 +5494,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:4</availability>
@@ -5510,29 +5507,29 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:4,LA:2,FWL:4,NIOPS:4,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='OTT-7K'>
+			<roles>recon,spotter</roles>
+			<availability>DC:4+</availability>
 		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,BAN:2</availability>
 		</model>
-		<model name='OTT-7K'>
-			<roles>recon,spotter</roles>
-			<availability>DC:4+</availability>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:1,IS:4,FWL:5,NIOPS:6,WOB:6,FS:5,MERC:5,Periphery:3</availability>
+		<model name='OTL-4D'>
+			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
+		</model>
 		<model name='OTL-5M'>
 			<availability>FWL:4+,WOB:3+</availability>
 		</model>
 		<model name='OTL-4F'>
 			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-4D'>
-			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -5551,10 +5548,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:9,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:9,FS.DMM:9,FWL:6,NIOPS:6,DC:7</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,SIC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -5562,6 +5555,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:3,MERC.KH:3,HL:2,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:4,PIR:3,General:3,FWL:3,DC:3</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,SIC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -5585,13 +5582,13 @@
 			<roles>fire_support</roles>
 			<availability>DC:4+</availability>
 		</model>
-		<model name='PNT-C'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4+,FRR:4+,FS.DMM:4+,MERC:4+,DC:4+</availability>
-		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,Periphery:8,DC:8</availability>
+		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:4+,FRR:4+,FS.DMM:4+,MERC:4+,DC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -5603,13 +5600,13 @@
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:9,CIR:6,Periphery:9,TC:9,CS:6-,OA:5,LA:8,FWL:7,DC:6</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
@@ -5630,10 +5627,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:3,FRR:6,IS:6,Periphery.Deep:8,WOB:5-,SIC:7,FS:7,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:7,FWL:6,DC:7</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -5641,6 +5634,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -5659,11 +5656,11 @@
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:4-,LA:2-,FRR:3-,FWL:2-,IS:2-,SIC:3-,FS:2-,MERC:3-,DC:3-</availability>
-		<model name='(Cargo)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,DC:2</availability>
@@ -5671,23 +5668,23 @@
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CW:6</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CIH:7,General:8,CCO:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:4,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:4</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:4,CIH:6,General:5,CCO:4,CGB:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CIH:7,General:8,CCO:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CSA:7,General:6,CCO:7,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:4,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -5701,41 +5698,29 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,WOB:7,Periphery:4,CGB:2</availability>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
-		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:5,MERC:4</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:6,BAN:6,Periphery:6</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FS:5+,MERC:4+</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>FWL:6+,IS:2+</availability>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
@@ -5745,22 +5730,34 @@
 			<roles>recon</roles>
 			<availability>FRR:5+,DC:5+</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:6,BAN:1</availability>
-		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:6+,MERC:3+</availability>
 		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>FWL:6+,IS:2+</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:6,BAN:6,Periphery:6</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FS:5+,MERC:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,WOB:6-,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:5,DC:5</availability>
-		<model name='(Standard)'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
-		</model>
 		<model name='(Missile)'>
 			<availability>MOC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -5810,26 +5807,26 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CW:7,CGS:5,CCO:5</availability>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:9,CGB:9</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:3,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,CIH:6,General:5,CSJ:6</availability>
@@ -5868,10 +5865,6 @@
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8,General:4</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:2+</availability>
@@ -5879,6 +5872,10 @@
 		<model name='(Sealed)'>
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
@@ -5890,12 +5887,12 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:5,CSV:4,General:3,CSJ:4,CJF:4,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:9</availability>
@@ -5918,23 +5915,23 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
-		<model name='QKD-4H'>
-			<availability>General:3</availability>
+		<model name='QKD-5K'>
+			<availability>DC:2+</availability>
 		</model>
 		<model name='QKD-5A'>
 			<availability>General:3,MERC:4,DC:4,Periphery:4</availability>
 		</model>
-		<model name='QKD-5K'>
+		<model name='QKD-C'>
 			<availability>DC:2+</availability>
-		</model>
-		<model name='QKD-5M'>
-			<availability>FWL:4+</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:6,OA:6,HL:4,Periphery.Deep:6,FWL:6,IS:6,Periphery:6,DC:6,TC:6</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>DC:2+</availability>
+		<model name='QKD-4H'>
+			<availability>General:3</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>FWL:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
@@ -5945,12 +5942,6 @@
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,LA:3,CLAN:3,NIOPS:8,WOB:8</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
@@ -5961,14 +5952,23 @@
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2,CNC:1</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>DC:2+</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
@@ -5980,12 +5980,16 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:7,SIC:3,FS:4</availability>
+		<model name='RVN-4X'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>FWL:3,MERC:3</availability>
+		</model>
 		<model name='RVN-1X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:5,SIC:3,FS:3</availability>
@@ -5994,69 +5998,62 @@
 			<roles>spotter</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='RVN-2X'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>FWL:3,MERC:3</availability>
-		</model>
 		<model name='RVN-3X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='RVN-4X'>
-			<availability>CC:8</availability>
+		<model name='RVN-2X'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,WOB:9,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CNC:3</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:3,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+		<model name='F-700a'>
+			<availability>CC:3+,FWL:3+,WOB:3+,MERC:3+</availability>
+		</model>
+		<model name='F-100b'>
+			<availability>FRR:8,DC:8</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,SIC:5,MERC:5,DC:2</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:4+,FWL:4+,WOB:8,MERC:4+</availability>
 		</model>
-		<model name='F-100b'>
-			<availability>FRR:8,DC:8</availability>
-		</model>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
-		</model>
-		<model name='F-700a'>
-			<availability>CC:3+,FWL:3+,WOB:3+,MERC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:4,CNC:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:6,CNC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:6,CLAN:6,CNC:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -6068,18 +6065,9 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:7-,CS:6-,HL:3,FRR:8-,IS:8-,Periphery.Deep:5,FWL:8-,NIOPS:6-,WOB:6-,SIC:7-,FS:9-,Periphery:5</availability>
-		<model name='C'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>LA:4+,FS:4+,MERC:3+</availability>
-		</model>
 		<model name='RFL-3C'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FS:3</availability>
-		</model>
-		<model name='RFL-5M'>
-			<availability>FWL:3+</availability>
 		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
@@ -6088,6 +6076,15 @@
 		<model name='RFL-3N'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,BAN:1,Periphery:8</availability>
+		</model>
+		<model name='RFL-5D'>
+			<availability>LA:4+,FS:4+,MERC:3+</availability>
+		</model>
+		<model name='RFL-5M'>
+			<availability>FWL:3+</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
@@ -6103,20 +6100,20 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:8,General:8,NIOPS:8,WOB:6</availability>
+		</model>
 		<model name='RGU-133L'>
 			<availability>CS:3,General:4,NIOPS:3,WOB:2</availability>
 		</model>
 		<model name='RGU-133F'>
 			<availability>CS:6,General:6,NIOPS:6,WOB:4</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:8,General:8,NIOPS:8,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
@@ -6138,17 +6135,17 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,MERC.WD:6,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:3,General:6,CJF:4,CGB:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CCO:4</availability>
@@ -6185,20 +6182,20 @@
 		<model name='SB-27'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,CJF:6</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6213,34 +6210,34 @@
 		<model name='S-4X'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='S-3'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='S-4C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='S-3'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:2,DC:9</availability>
+		<model name='(Standard)'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(Clan Cargo)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>OA:3,FRR:1,DC:1</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,FRR:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -6268,13 +6265,13 @@
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>LA:2,FS:4</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>LA:6,FS:4</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>LA:6,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek AC Carrier' unitType='Tank'>
@@ -6309,16 +6306,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:8,HL:7,LA:8,FRR:10,FWL:8,IS:9,Periphery.Deep:8,SIC:8,FS:8,DC:8,Periphery:9</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -6349,11 +6346,11 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -6380,14 +6377,8 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:3,CLAN:4,CFM:5,WOB:4,CGS:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:2,NIOPS:4,CJF:5,CGB:5,DC:2</availability>
-		<model name='STN-3KB'>
-			<availability>LA:3</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
-		<model name='STN-3M'>
-			<availability>DC.GHO:8,DC:1+</availability>
 		</model>
 		<model name='STN-3K'>
 			<availability>LA:6,DC:6</availability>
@@ -6395,9 +6386,23 @@
 		<model name='STN-3KA'>
 			<availability>LA:3</availability>
 		</model>
+		<model name='STN-3M'>
+			<availability>DC.GHO:8,DC:1+</availability>
+		</model>
+		<model name='STN-3KB'>
+			<availability>LA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:2,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2</availability>
+		<model name='SYD-Z2'>
+			<roles>interceptor</roles>
+			<availability>HL:4,LA:6,Periphery.Deep:6,FS:6,Periphery:6</availability>
+		</model>
+		<model name='SYD-Z2A'>
+			<roles>interceptor</roles>
+			<availability>LA:5+,FRR:3+,FS:5+,MERC:3+</availability>
+		</model>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
 			<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -6406,14 +6411,6 @@
 			<roles>interceptor</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='SYD-Z2A'>
-			<roles>interceptor</roles>
-			<availability>LA:5+,FRR:3+,FS:5+,MERC:3+</availability>
-		</model>
-		<model name='SYD-Z2'>
-			<roles>interceptor</roles>
-			<availability>HL:4,LA:6,Periphery.Deep:6,FS:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
 		<availability>CCC:5,CSR:5,CDS:4,CW:4,CSV:5,CNC:8,CFM:5,CSJ:6,CJF:2,CB:5</availability>
@@ -6421,46 +6418,46 @@
 			<roles>recon</roles>
 			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:6,CGB:7</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,WOB:6-,BAN:2,Periphery:5,CGB:1</availability>
+		<model name='SHD-2K'>
+			<availability>FRR:7,MERC:4,DC:8</availability>
+		</model>
 		<model name='SHD-2D2'>
 			<availability>LA:3+,FS:4+</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:6,General:8,Periphery.Deep:7,BAN:2,Periphery:8</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>FRR:7,MERC:4,DC:8</availability>
+		<model name='SHD-2H'>
+			<availability>HL:6,General:8,Periphery.Deep:7,BAN:2,Periphery:8</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>CC:3+,FRR:3+,FWL:6+,IS:3+,MERC:3+,DC:3+</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -6483,14 +6480,14 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:1,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:4</availability>
+		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='SHG-2F'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -6509,37 +6506,43 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:5,Periphery.DD:3,FRR:7,IS:4,WOB:3-,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:8</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:2,FRR:2,DC:2</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>FRR:4+,DC:5+</availability>
-		</model>
-		<model name='SL-15'>
-			<availability>HL:4,IS:6,Periphery.Deep:6,FS:0,Periphery:6</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>FRR:2,MERC:2,DC:2</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:4,IS:6,Periphery.Deep:6,FS:0,Periphery:6</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>FRR:2,DC:2</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:2,FRR:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -6556,12 +6559,12 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6</availability>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -6569,10 +6572,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -6597,9 +6596,8 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>LA:8,FS.CMM:3</availability>
+		<model name='SPR-6D'>
+			<availability>FS:4+</availability>
 		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -6609,8 +6607,9 @@
 			<roles>interceptor</roles>
 			<availability>OA:4,FRR:8,DC:8</availability>
 		</model>
-		<model name='SPR-6D'>
-			<availability>FS:4+</availability>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>LA:8,FS.CMM:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -6636,19 +6635,19 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:4,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>HL:4,FRR:2,IS:6,Periphery.Deep:6,FS:2,Periphery:6</availability>
-		</model>
-		<model name='SDR-7M'>
-			<availability>MOC:2+,CC:4+,FWL:4+,SIC:4+,FS:4+,MERC:2+,DC:5+</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:6,DC:6</availability>
+		</model>
+		<model name='SDR-7M'>
+			<availability>MOC:2+,CC:4+,FWL:4+,SIC:4+,FS:4+,MERC:2+,DC:5+</availability>
+		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
@@ -6660,11 +6659,11 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:8,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:6,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+		<model name='STK-5M'>
+			<availability>CC:2+,MOC:2+,FWL:5+,IS:2+,DC:4+,TC:2+</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -6672,11 +6671,11 @@
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:2+,MOC:2+,FWL:5+,IS:2+,DC:4+,TC:2+</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
+		<model name='STK-4N'>
+			<availability>MOC:2,OA:2,IS:2,Periphery:2,TC:2</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>LA:4+,FS:3+</availability>
@@ -6709,19 +6708,15 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:4-,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>FWL:4+,WOB:4</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
@@ -6730,6 +6725,10 @@
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>FWL:4+,WOB:4</availability>
+		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -6737,15 +6736,15 @@
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,FS:1,MERC:5,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='F-94'>
 			<availability>IS:2+</availability>
 		</model>
 		<model name='F-92'>
 			<availability>FWL:3+,IS:2+</availability>
-		</model>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:8</availability>
 		</model>
 		<model name='F-90'>
 			<availability>CS:7,LA:4,IS:7,FS:7,Periphery:7</availability>
@@ -6753,16 +6752,16 @@
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -6775,6 +6774,10 @@
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:4,FRR:4,IS:5,WOB:4-,SIC:6,FS:9,MERC:3,CS:4-,CDS:2,LA:6,PIR:3,FWL:3,DC:3</availability>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>IS:6</availability>
@@ -6782,18 +6785,14 @@
 		<model name='(SRM)'>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:5,CS:4,MERC.WD:2-,LA:3,NIOPS:4,WOB:4,SIC:6</availability>
-		<model name='STC-2C'>
-			<availability>CC:8,General:8</availability>
-		</model>
 		<model name='STC-2S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='STC-2C'>
+			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -6801,14 +6800,14 @@
 		<model name='STU-K5'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,SIC:2,FS:2,TC:2,Periphery:1</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>LA:4+,FS:6+,MERC:4+</availability>
@@ -6816,21 +6815,21 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:4,HL:2,LA:8,FRR:2,SIC:3,MERC:3,FS:6</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8,WOB:0</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
@@ -6858,10 +6857,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:3</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -6873,22 +6872,22 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:4</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:6,NIOPS:8,WOB:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:9,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:9,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -6906,42 +6905,42 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,MERC.WD:3,CDS:6,CW:6,CNC:6,CSJ:7,CJF:10,CGB:6,CB:5</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
+		<model name='D'>
+			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CCO:4</availability>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:8,General:8,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:6,General:5,CSJ:3,CGS:4,CGB:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CW:5,General:5,CJF:6,CGB:4</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CCO:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -6960,24 +6959,24 @@
 		<model name='THE-S'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='THE-N1'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
 		<model name='THE-T'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
 		</model>
+		<model name='THE-N1'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -6989,11 +6988,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,WOB:7,FS:2,CS:7,DC.GHO:5,CDS:5,CW:7,CBS:5,CNC:5,FWL:4,NIOPS:7,CJF:7,CGB:7</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>DC.GHO:8,CS:8,FRR:3+,CLAN:6,FWL:4+,NIOPS:8,WOB:8,FS:4+,BAN:8,DC:4+</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:8,MERC:6,DC:6</availability>
@@ -7027,37 +7026,37 @@
 			<roles>escort,ground_support</roles>
 			<availability>MOC:2+,LA:4+,FRR:3+,MH:2+,MERC:3+</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:7,HL:2,CLAN:2,IS:8,Periphery.Deep:6,WOB:4-,FS:7,MERC:8,Periphery:4,TC:4,CS:5-,LA:8,NIOPS:5-,MH:4,DC:8</availability>
-		<model name='TDR-5Sb'>
-			<availability>CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,CNC:2,CJF:2,CGB:2</availability>
+		<model name='TDR-9SE'>
+			<availability>LA:2+,MERC.ELH:5+,MERC:2+,FS:2+</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>LA:4+,FS:3+</availability>
 		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:8,MERC:4</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:6,MERC:1</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:7,HL:5,LA:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='TDR-9SE'>
-			<availability>LA:2+,MERC.ELH:5+,MERC:2+,FS:2+</availability>
-		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:6,MERC:1</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CS:2+,FWL:5+,WOB:2+</availability>
+		</model>
+		<model name='TDR-5SS'>
+			<availability>LA:8,MERC:4</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,CNC:2,CJF:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -7068,25 +7067,25 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:4,CLAN:3,NIOPS:3,WOB:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>FRR:6,DC:8</availability>
-		<model name='TKG-150'>
-			<availability>FRR:6,DC:5</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='TKG-150'>
+			<availability>FRR:6,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
@@ -7095,15 +7094,15 @@
 			<roles>escort</roles>
 			<availability>CS:3,NIOPS:3,WOB:3</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:3,BAN:2</availability>
+		<model name='THK-63'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='&apos;C&apos;'>
 			<availability>CW:3</availability>
 		</model>
-		<model name='THK-63'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
+		<model name='THK-63b'>
+			<availability>CLAN:3,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
@@ -7121,39 +7120,38 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:3,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:3</availability>
+		<model name='TR-13A'>
+			<availability>CC:4+</availability>
+		</model>
 		<model name='TR-14 &apos;AC&apos;'>
 			<availability>General:5,FWL:8</availability>
 		</model>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='TR-13A'>
-			<availability>CC:4+</availability>
-		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:5-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:5,IS:6,NIOPS:2,WOB:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,FWL:2+,NIOPS:6,WOB:6,MERC:2+</availability>
 		</model>
 		<model name='TBT-7M'>
 			<roles>fire_support</roles>
@@ -7163,13 +7161,11 @@
 			<roles>fire_support</roles>
 			<availability>FRR:2,DC:4</availability>
 		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,FWL:2+,NIOPS:6,WOB:6,MERC:2+</availability>
+		<model name='TBT-5J'>
+			<availability>FWL:4</availability>
 		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:6,CS:2,MOC:6,LA:6,FWL:5,IS:6,NIOPS:2,WOB:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -7204,8 +7200,8 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CGB:6</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -7213,8 +7209,8 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
@@ -7222,36 +7218,37 @@
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CGS:7,CJF:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CJF:7,CGS:7</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:7,General:7,CGB:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,MERC.WD:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CCO:5</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
 			<availability>CDS:4,CW:3,CSV:3,CNC:3,General:2,CSJ:4,CJF:5,CGB:4,CB:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CCO:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
@@ -7260,16 +7257,15 @@
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CDS:2,CW:1,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CGB:2</availability>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:7,General:7,CCO:5,CGB:8</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CGB:4</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CDS:2,CW:1,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CGB:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
@@ -7303,21 +7299,17 @@
 			<roles>urban</roles>
 			<availability>CC:6,SIC:6</availability>
 		</model>
-		<model name='UM-R63'>
-			<roles>urban</roles>
-			<availability>CC:4+,CS:3,MERC:2+</availability>
-		</model>
 		<model name='UM-R60'>
 			<roles>urban</roles>
 			<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
+		<model name='UM-R63'>
+			<roles>urban</roles>
+			<availability>CC:4+,CS:3,MERC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:5,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:5,FS:7,MERC:7,TC:7</availability>
-		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:4,FS:4,MERC:4</availability>
@@ -7326,9 +7318,20 @@
 			<roles>recon,fire_support</roles>
 			<availability>LA:5+,FS:4+</availability>
 		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:5,FS:7,MERC:7,TC:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
@@ -7336,13 +7339,6 @@
 		<model name='Prime'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
@@ -7372,29 +7368,29 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:2,FRR:6,IS:4,Periphery.Deep:4,WOB:5,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:5-,CJF:3,DC:6</availability>
-		<model name='VTR-C'>
-			<availability>DC:3</availability>
-		</model>
 		<model name='VTR-9B'>
 			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-9D'>
-			<availability>LA:4+,SIC:4+,FS:5+</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
-		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
 		</model>
 		<model name='VTR-9K'>
 			<availability>FRR:4+,DC:4+</availability>
 		</model>
+		<model name='VTR-C'>
+			<availability>DC:3</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
+		</model>
 		<model name='VTR-9S'>
 			<availability>LA:4,CIR:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
+		</model>
+		<model name='VTR-9D'>
+			<availability>LA:4+,SIC:4+,FS:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -7410,11 +7406,8 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10,FRR:2,MH:3,SIC:10,MERC:5,TC:4</availability>
-		<model name='VND-1SIC'>
-			<availability>SIC:2</availability>
-		</model>
-		<model name='VND-3L'>
-			<availability>CC:3+</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>FRR:8</availability>
 		</model>
 		<model name='VND-1X'>
 			<availability>CC:1,SIC:1</availability>
@@ -7422,8 +7415,11 @@
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>FRR:8</availability>
+		<model name='VND-3L'>
+			<availability>CC:3+</availability>
+		</model>
+		<model name='VND-1SIC'>
+			<availability>SIC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -7437,9 +7433,6 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
@@ -7449,17 +7442,20 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:4,CGS:6,CJF:6</availability>
+		<model name='2'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -7472,30 +7468,26 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,CS:6,LA:5,FRR:5,IS:1,FWL:4,WOB:6,FS:4,DC:5</availability>
-		<model name='VNL-K70'>
-			<availability>FRR:3,DC:3</availability>
-		</model>
 		<model name='VNL-K100'>
 			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
+		<model name='VNL-K70'>
+			<availability>FRR:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>MERC:3,TC:3</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:4+</availability>
-		</model>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
@@ -7504,13 +7496,13 @@
 			<roles>anti_infantry</roles>
 			<availability>General:8,FS:4</availability>
 		</model>
-		<model name='VT-5M'>
-			<roles>anti_infantry</roles>
-			<availability>FWL:4+</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='VT-5M'>
+			<roles>anti_infantry</roles>
+			<availability>FWL:4+</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -7519,28 +7511,24 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,MERC.WD:3,CIH:7,CW:7,CSV:7,CLAN:8,CNC:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:9</availability>
 		</model>
-		<model name='D'>
-			<availability>CCO:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:5,General:6,CJF:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:5</availability>
+		</model>
+		<model name='D'>
+			<availability>CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
 		<availability>MERC:2,Periphery:1</availability>
-		<model name='(2312)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2312)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
@@ -7560,6 +7548,12 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='10'>
+			<availability>CSJ:6</availability>
+		</model>
 		<model name='12'>
 			<availability>CSJ:5</availability>
 		</model>
@@ -7570,21 +7564,9 @@
 		<model name='11'>
 			<availability>CSJ:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='10'>
-			<availability>CSJ:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:6-,HL:4,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:2+,FS:2+,DC:2+</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:4,SIC:3</availability>
 		</model>
@@ -7592,14 +7574,8 @@
 			<roles>spotter</roles>
 			<availability>DC:4+</availability>
 		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='WHM-7S'>
-			<availability>LA:4+,FS:3+,MERC:2+</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:3+,CC:2+,FRR:2+,FWL:6+,WOB:3+,DC:2+,Periphery:2+</availability>
+		<model name='WHM-6R'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FRR:3,FS.DMM:2,FS:1,DC:4</availability>
@@ -7607,73 +7583,85 @@
 		<model name='WHM-6D'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='WHM-7M'>
+			<availability>CS:3+,CC:2+,FRR:2+,FWL:6+,WOB:3+,DC:2+,Periphery:2+</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>LA:4+,FS:3+,MERC:2+</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:2+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:4,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:5</availability>
 		<model name='H-7'>
 			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 		</model>
-		<model name='H-7C'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='H-7C'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2+</availability>
 		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:4-,HL:4,IS:10,NIOPS:4-,Periphery.Deep:5,WOB:4-,CIR:2,Periphery:6</availability>
-		<model name='WSP-1A'>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
+			<availability>MERC.WD:6+</availability>
 		</model>
 		<model name='WSP-1W'>
 			<roles>recon</roles>
 			<availability>MERC.WD:6</availability>
 		</model>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>LA:6+,FS:4+,MERC:2+</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:6+</availability>
-		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:4,SIC:4</availability>
 		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:3+,MOC:3+,FWL:6+,WOB:6,MH:3+,MERC:3+,DC:3+</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1L'>
 			<roles>recon</roles>
-			<availability>FRR:4,DC:4</availability>
+			<availability>CC:4,SIC:4</availability>
+		</model>
+		<model name='WSP-1D'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -7693,13 +7681,13 @@
 			<roles>fire_support</roles>
 			<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='WTH-2'>
-			<roles>fire_support</roles>
-			<availability>CS:4,OA:2+,FS:2+,DC:2+,TC:2+</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>FRR:2,DC:2</availability>
+		</model>
+		<model name='WTH-2'>
+			<roles>fire_support</roles>
+			<availability>CS:4,OA:2+,FS:2+,DC:2+,TC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
@@ -7710,33 +7698,21 @@
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MERC.KH:6,MERC.WD:4,LA:7,FRR:4,FS:5,MERC:3</availability>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:3,FS:4,MERC:3</availability>
-		</model>
-		<model name='WLF-1A'>
-			<availability>MERC.KH:1,LA:1</availability>
-		</model>
 		<model name='WLF-1'>
 			<availability>MERC.KH:5,LA:6,FS:7,MERC:8</availability>
 		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:3,FS:4,MERC:3</availability>
+		</model>
 		<model name='WLF-1B'>
+			<availability>MERC.KH:1,LA:1</availability>
+		</model>
+		<model name='WLF-1A'>
 			<availability>MERC.KH:1,LA:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:6,HL:3,FRR:7,IS:7,Periphery.Deep:5,WOB:5-,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
-		<model name='WVR-6R'>
-			<roles>recon</roles>
-			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>LA:3+,FS:4+</availability>
-		</model>
-		<model name='WVR-6K'>
-			<roles>recon</roles>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='WVR-7M'>
 			<roles>recon</roles>
 			<availability>FWL:4+,WOB:4</availability>
@@ -7749,14 +7725,26 @@
 			<roles>recon</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:9</availability>
 		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>LA:3+,FS:4+</availability>
+		</model>
+		<model name='WVR-6K'>
+			<roles>recon</roles>
+			<availability>FRR:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
@@ -7768,17 +7756,17 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,CIH:2,FRR:4,CLAN:3,IS:4,CFM:4,WOB:6,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:6,NIOPS:6,DC:5</availability>
-		<model name='WVE-9N'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CS:6,WOB:6</availability>
+			<availability>DC.GHO:8,CS:8,FRR:8,NIOPS:8,WOB:8,CFM:3,FS:4+,MERC:4+,BAN:4,DC:4+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:1,CFM:2,CGS:2</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-9N'>
 			<roles>urban</roles>
-			<availability>DC.GHO:8,CS:8,FRR:8,NIOPS:8,WOB:8,CFM:3,FS:4+,MERC:4+,BAN:4,DC:4+</availability>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -7839,20 +7827,20 @@
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:4,LA:10,FRR:4,IS:2,FS:7-,MERC:5</availability>
-		<model name='ZEU-6S'>
-			<availability>HL:6,General:5,Periphery.Deep:6,FS:6,Periphery:8</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>LA:5+,FS:3+</availability>
 		</model>
-		<model name='ZEU-9S2'>
-			<availability>LA:2+,FS:2+</availability>
+		<model name='ZEU-6T'>
+			<availability>LA:4,FS:8</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:1+</availability>
 		</model>
-		<model name='ZEU-6T'>
-			<availability>LA:4,FS:8</availability>
+		<model name='ZEU-9S2'>
+			<availability>LA:2+,FS:2+</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:6,General:5,Periphery.Deep:6,FS:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>
@@ -7863,11 +7851,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3055.xml
+++ b/megamek/data/forcegenerator/3055.xml
@@ -954,20 +954,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:3,CLAN:1,MERC:3,CCO:2,CWIE:2,BAN:2,CGB:2</availability>
-		<model name='ANH-1E'>
-			<availability>MERC.WD:4</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.KH:1,CLAN:2-,MERC:4</availability>
+		</model>
+		<model name='ANH-1E'>
+			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:4+,MERC.WD:7+,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:3</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -982,21 +982,21 @@
 		<model name='ANV-5M'>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
-		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>FWL:3,WOB:3</availability>
 		</model>
+		<model name='ANV-3M'>
+			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:4,LA:3,FWL:8,SIC:4,MERC:4,FS:3,DC:6</availability>
-		<model name='APL-3T'>
+		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
-		<model name='APL-1R'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1018,48 +1018,48 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:6,HL:4,FRR:6,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,LA:8,FWL:8,NIOPS:4-,DC:7</availability>
-		<model name='ARC-2S'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>CWIE:3</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:4,DC:6</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>FRR:6+,MERC:3+,DC:3+</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:6+,FS:4+</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:3,LA:5,FRR:5,IS:5,Periphery.Deep:8,BAN:2,DC:5,Periphery:5</availability>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='ARC-5W'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:6+,LA:3+,MERC:3+</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2W'>
 			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
+			<availability>MERC.WD:5</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:4,CW:3,LA:2+,CSV:4,CFM:4,FS:2+,CGS:4,CWIE:3,DC:2+</availability>
 		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:6+,FS:4+</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>CWIE:3</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:6+,MERC:3+,DC:3+</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:3,LA:5,FRR:5,IS:5,Periphery.Deep:8,BAN:2,DC:5,Periphery:5</availability>
+		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CS:6+,CC:3+,LA:3+,PIR:2+,FWL:7+,WOB:6,SIC:3+,MERC:3+,FS:3+,DC:3+</availability>
 		</model>
-		<model name='ARC-2W'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>MERC.WD:5</availability>
+			<availability>FRR:4,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -1079,37 +1079,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1119,17 +1099,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -1167,20 +1167,35 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,FRR:5,CLAN:3,IS:3,WOB:4-,SIC:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,LA:4,FWL:4,NIOPS:4-,DC:8</availability>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4+,IS:3+,DC:4+</availability>
+		<model name='AS7-K'>
+			<availability>CC:2+,CS:3+,FRR:4+,FWL:4+,WOB:2,SIC:2+,MERC:4+,DC:6+</availability>
+		</model>
+		<model name='AS7-D-DC'>
+			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:2,CLAN:8,FS:2,DC:2</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4+,IS:3+,DC:4+</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>FRR:2+,MERC:2+,DC:2+</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
@@ -1189,32 +1204,17 @@
 		<model name='AS7-S'>
 			<availability>LA:5+,FS:4,MERC:3+</availability>
 		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2+,MERC:2+,DC:2+</availability>
-		</model>
-		<model name='AS7-D'>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1,MERC:0,DC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>CC:2+,CS:3+,FRR:4+,FWL:4+,WOB:2,SIC:2+,MERC:4+,DC:6+</availability>
-		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:4,CCC:4,CSR:4,CW:5,CLAN:4,CNC:5,BAN:5,CWIE:5</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
@@ -1241,13 +1241,13 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:3,OA:2,LA:4,IS:2,FWL:1,SIC:3,FS:4,CIR:2,TC:2,Periphery:1,DC:1</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8+,FS:8+</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>LA:5,General:5,FS:5</availability>
+		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8+,FS:8+</availability>
 		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
@@ -1255,11 +1255,11 @@
 		<model name='AWS-8R'>
 			<availability>IS:2,FWL:4</availability>
 		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
-		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -1267,11 +1267,11 @@
 		<model name='AWS-9M'>
 			<availability>FWL:6+,IS:5+</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>LA:4,FWL:4,FS:4</availability>
-		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:2+,FWL:4+,IS:2+,MH:2+,TC:2+,Periphery:2+</availability>
+		</model>
+		<model name='AWS-9Ma'>
+			<availability>LA:4,FWL:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -1285,12 +1285,12 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>LA:5+,FRR:2+,FS:3+,MERC:2+</availability>
-		<model name='AXM-1N'>
-			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
-		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>LA:6,FS:4</availability>
+		</model>
+		<model name='AXM-1N'>
+			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
@@ -1306,6 +1306,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -1314,14 +1322,6 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:4,MERC:5</availability>
@@ -1329,7 +1329,7 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1341,7 +1341,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1358,19 +1358,7 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:3,CHH:4,CLAN:2</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1378,12 +1366,28 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:6</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -1393,27 +1397,23 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:6</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='G'>
+		<model name='H'>
 			<roles>apc</roles>
-			<availability>General:5</availability>
+			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1423,8 +1423,8 @@
 		<model name='BNC-3MC'>
 			<availability>MOC:9</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
+		<model name='BNC-3M'>
+			<availability>FWL:2</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:3</availability>
@@ -1432,42 +1432,42 @@
 		<model name='BNC-3E'>
 			<availability>HL:3,General:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
 		</model>
+		<model name='BNC-3S'>
+			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
+		</model>
 		<model name='BNC-5S'>
 			<availability>LA:7+,FRR:3+,FS:6+,MERC:3+</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -1486,14 +1486,17 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:2,DC:5</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>CS:5+,CC:4+,PIR:2+,FWL:6+,IS:2+,WOB:5+,MH:2+,SIC:4+,MERC:4+</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1,WOB:1</availability>
@@ -1501,20 +1504,17 @@
 		<model name='BLR-1S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
 		<model name='BLR-3S'>
 			<availability>LA:6+,FS:4+</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,FS:3,BAN:8,Periphery:6</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
+		<model name='BLR-3M'>
+			<availability>CS:5+,CC:4+,PIR:2+,FWL:6+,IS:2+,WOB:5+,MH:2+,SIC:4+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1530,15 +1530,15 @@
 			<roles>interceptor</roles>
 			<availability>CHH:7,CIH:7,CNC:9,General:8,CGS:7</availability>
 		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CFM:6,CGS:8,CJF:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -1550,17 +1550,17 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:2,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
+		<model name='6'>
+			<availability>General:1</availability>
 		</model>
 		<model name='4'>
 			<availability>General:2</availability>
 		</model>
-		<model name='6'>
-			<availability>General:1</availability>
-		</model>
 		<model name='5'>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
@@ -1568,12 +1568,12 @@
 		<model name='(Armor)'>
 			<availability>IS:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1585,11 +1585,11 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>LA:4,FRR:2,FS:2</availability>
-		<model name='BRZ-B3'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BRZ-A3'>
 			<availability>LA:8,FRR:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='BRZ-B3'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
@@ -1597,18 +1597,15 @@
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CSJ:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:4</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -1616,47 +1613,50 @@
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>LA:4+,FRR:4+,SIC:2+,FS:2+,DC:5+</availability>
-		<model name='BHKU-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
 		</model>
-		<model name='BHKU-OD'>
+		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OA'>
+		<model name='BHKU-OC'>
 			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:7,FRR:3,CLAN:8,CFM:7,FS:1,CWIE:9,DC.GHO:3,OA:1,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,TC:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
-		<model name='BL-6-KNT'>
-			<availability>DC.GHO:4,CS:4,OA:2+,FRR:4+,CLAN:6,FWL:3+,NIOPS:4,WOB:4,MERC.SI:5,BAN:6,TC:2,DC:4+</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:6,CLAN:5,FWL:5+,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-9-KNT'>
+			<availability>CS:6+,WOB:6+</availability>
+		</model>
+		<model name='BL-6-KNT'>
+			<availability>DC.GHO:4,CS:4,OA:2+,FRR:4+,CLAN:6,FWL:3+,NIOPS:4,WOB:4,MERC.SI:5,BAN:6,TC:2,DC:4+</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:7,FRR:7,FWL:3,MERC:7,FS:7,DC:7</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>CS:6+,WOB:6+</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -1668,13 +1668,13 @@
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -1693,26 +1693,32 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:5-,MOC:4,OA:4,HL:3,IS:2,SIC:6,FS:7,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:2+,SIC:5+,FS:2+,MERC:2+</availability>
-		</model>
 		<model name='BJ-1DC'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='BJ-2'>
-			<availability>CC:3+,CS:3+,LA:3+,WOB:3+,SIC:4,FS:6+,MERC:3+</availability>
+		<model name='BJ-3'>
+			<availability>CC:2+,SIC:5+,FS:2+,MERC:2+</availability>
 		</model>
 		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
 		</model>
+		<model name='BJ-2'>
+			<availability>CC:3+,CS:3+,LA:3+,WOB:3+,SIC:4,FS:6+,MERC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CS:2+,FWL:2+,IS:2+,WOB:2+,FS:2+,DC:5+</availability>
-		<model name='BJ2-O'>
-			<availability>General:8</availability>
+		<model name='BJ2-OE'>
+			<availability>General:5,FWL:6</availability>
+		</model>
+		<model name='BJ2-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,DC:1+</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:7</availability>
@@ -1720,17 +1726,11 @@
 		<model name='BJ2-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BJ2-OE'>
-			<availability>General:5,FWL:6</availability>
-		</model>
 		<model name='BJ2-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,DC:1+</availability>
+		<model name='BJ2-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
@@ -1761,13 +1761,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,OA:1-,CDS:5,CLAN:4,IS:2-,NIOPS:5,FWL:2-,WOB:5,DC:2-,Periphery:1</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:6,FRR:3+,CLAN:8,NIOPS:6,WOB:6,MERC.SI:8,BAN:8</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -1783,13 +1783,13 @@
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -1807,6 +1807,9 @@
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -1815,9 +1818,6 @@
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -1835,13 +1835,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -1853,11 +1853,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -1904,13 +1904,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -1922,73 +1922,66 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:8,LA:3,SIC:5,FS:5,MERC:3</availability>
-		<model name='CTF-1X'>
-			<availability>General:6,Periphery:6</availability>
-		</model>
 		<model name='CTF-2X'>
 			<availability>CC:6,SIC:2,FS:1,MERC:1</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>LA:4+,FS:4+</availability>
 		</model>
+		<model name='CTF-3L'>
+			<availability>CC:7+</availability>
+		</model>
 		<model name='CTF-4X'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='CTF-3L'>
-			<availability>CC:7+</availability>
+		<model name='CTF-1X'>
+			<availability>General:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,CIR:2,FS:1,Periphery:2,TC:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
-		<model name='CPLT-K3'>
+		<model name='CPLT-C4C'>
 			<roles>fire_support</roles>
-			<availability>DC:5+</availability>
+			<availability>CC:2+,FS:2+,MERC:2+</availability>
+		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:3,DC:5</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:5,HL:3,CLAN:4,IS:1,Periphery.Deep:8,MERC:5,BAN:6,Periphery:5</availability>
+		</model>
+		<model name='CPLT-C4'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,OA:3,SIC:2</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4+,CS:2,WOB:2,FS:3+,DC:3+</availability>
 		</model>
-		<model name='CPLT-C1'>
+		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
-			<availability>CC:5,HL:3,CLAN:4,IS:1,Periphery.Deep:8,MERC:5,BAN:6,Periphery:5</availability>
+			<availability>CLAN:6</availability>
 		</model>
-		<model name='CPLT-K5'>
+		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
-			<availability>DC:4</availability>
+			<availability>DC:5+</availability>
 		</model>
 		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
 			<availability>CC:3,SIC:3</availability>
 		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:3,DC:5</availability>
-		</model>
-		<model name='CPLT-C1b'>
-			<roles>fire_support</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='CPLT-C4'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,OA:3,SIC:2</availability>
-		</model>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:2+,FS:2+,MERC:2+</availability>
-		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:4,CCC:4,CSR:4,CDS:4,CW:4,CLAN:2,CSJ:6,CGS:4,CJF:4,CGB:4</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -1997,21 +1990,28 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:4,IS:3,CM:4,FS:6,MERC:4</availability>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek'>
@@ -2042,26 +2042,26 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-D3'>
-			<availability>FS:2,MERC:2+</availability>
-		</model>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>IS:1,FS:3,MERC:3,Periphery:2</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:4+,IS:3+,FS:5+</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>LA:3+,FRR:3+,FWL:3+,SIC:3+,FS:8+,MERC:3+,CIR:3+,Periphery:2+</availability>
+			<availability>LA:2,IS:1,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:4,LA:4-,FRR:4-,General:4-,FWL:4-,Periphery.Deep:6,FS:5-,MERC:5-,Periphery:6</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-D'>
+			<availability>LA:3+,FRR:3+,FWL:3+,SIC:3+,FS:8+,MERC:3+,CIR:3+,Periphery:2+</availability>
+		</model>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:2,IS:1,FS:4,MERC:4,Periphery:2</availability>
+			<availability>IS:1,FS:3,MERC:3,Periphery:2</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FS:2,MERC:2+</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:4+,IS:3+,FS:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -2108,43 +2108,43 @@
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:2-,CC:3-,OA:2-,LA:3-,IS:2-,FWL:3-,FS:3-,Periphery:2-,TC:2-,DC:3-</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:4-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>IS:4,Periphery:2</availability>
-		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:4,IS:3,FS:4</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:3,IS:2,FS:3</availability>
 		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:4-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:4,IS:3,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:5,CHH:3,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:6,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+		<model name='CHP-3P'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='CHP-2N'>
+			<availability>IS:6,NIOPS:0</availability>
+		</model>
 		<model name='CHP-3N'>
 			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4+,CS:4,LA:4+,IS:4+,MERC:4+</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CHH:3,WOB:6,SIC:4,FS:4,MERC:4,BAN:4,DC.GHO:5,CS:6,LA:4,NIOPS:6,MERC.SI:6,DC:4,CGB:3</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:6,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4+,CS:4,LA:4+,IS:4+,MERC:4+</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
-		</model>
-		<model name='CHP-3P'>
-			<availability>CS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -2159,8 +2159,8 @@
 		<model name='CGR-3K'>
 			<availability>CC:4,FRR:5,MERC:4,DC:5</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>CC:5,HL:2,SIC:5,Periphery:4</availability>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>FRR:5,DC:5</availability>
@@ -2175,21 +2175,14 @@
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:3,MERC:4</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>CC:5,HL:2,SIC:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-11'>
-			<availability>FRR:4,FWL:6+,WOB:6,MERC:4</availability>
-		</model>
-		<model name='F-14-S'>
-			<availability>FWL:7+</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		<model name='F-12-S'>
+			<availability>FWL:4,WOB:4</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
@@ -2199,16 +2192,19 @@
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:4,WOB:4</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='F-11'>
+			<availability>FRR:4,FWL:6+,WOB:6,MERC:4</availability>
+		</model>
+		<model name='F-14-S'>
+			<availability>FWL:7+</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:6,NIOPS:6,WOB:6,DC:2+</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
@@ -2216,6 +2212,10 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Speed)'>
+			<roles>recon</roles>
+			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -2226,8 +2226,8 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:6+,FRR:4+,CLAN:6,WOB:6,SIC:4+,FS:4+,MERC:4+,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
@@ -2235,23 +2235,15 @@
 		<model name='CHP-W5b'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
+		<model name='CHP-W7'>
+			<availability>LA:6+,FRR:4+,CLAN:6,WOB:6,SIC:4+,FS:4+,MERC:4+,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,OA:1,LA:3,IS:3,FWL:6,WOB:4-,FS:2,MERC:3,Periphery:1,DC:4</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:1,SIC:1</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='CDA-3C'>
-			<roles>training</roles>
-			<availability>IS:2</availability>
 		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
@@ -2260,6 +2252,14 @@
 		<model name='CDA-3M'>
 			<roles>recon</roles>
 			<availability>FWL:7+,IS:4+,MERC:5+</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:1,SIC:1</availability>
+		</model>
+		<model name='CDA-3C'>
+			<roles>training</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
@@ -2287,20 +2287,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -2320,14 +2320,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -2335,29 +2332,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -2368,8 +2368,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -2377,18 +2380,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -2397,27 +2406,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -2425,8 +2425,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -2451,29 +2451,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,CS:2-,LA:3,FRR:3,IS:3,FWL:3,NIOPS:2-,WOB:2-,SIC:4,FS:4,MERC:3,DC:3</availability>
-		<model name='CLNT-2-3T'>
-			<availability>IS:6,Periphery.Deep:8,NIOPS:8</availability>
-		</model>
 		<model name='CLNT-2-4T'>
 			<availability>CC:3,SIC:3,FS:3</availability>
 		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:5+,CS:4,LA:3+,General:4+</availability>
 		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:6,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,WOB:6</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,NIOPS:4,WOB:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,NIOPS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Combat Engineer' unitType='Infantry'>
@@ -2498,18 +2498,18 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
-		<model name='COM-1B'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>LA:2</availability>
+			<availability>LA:8+,FRR:5+,MERC:5+,FS:4+</availability>
 		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
 		</model>
-		<model name='COM-5S'>
+		<model name='COM-1B'>
 			<roles>recon</roles>
-			<availability>LA:8+,FRR:5+,MERC:5+,FS:4+</availability>
+			<availability>LA:2</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
@@ -2523,17 +2523,17 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>MOC:3,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:3,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8,SIC:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>SIC:5,FS:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8,SIC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -2556,24 +2556,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:2</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,MERC.WD:1,CSR:1,CW:1,CSV:1,NIOPS:2,CSJ:3,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -2585,17 +2585,17 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Copperhead' unitType='Mek'>
@@ -2606,8 +2606,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V14'>
+			<availability>LA:5+,FRR:4+,FS:5+,MERC:4+</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>LA:2,FS.AH:4,Periphery:2</availability>
@@ -2615,11 +2618,8 @@
 		<model name='CSR-V12'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
 		</model>
-		<model name='CSR-V14'>
-			<availability>LA:5+,FRR:4+,FS:5+,MERC:4+</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:2</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -2630,11 +2630,11 @@
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -2643,28 +2643,28 @@
 			<roles>raider</roles>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:6,CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8+</availability>
-		</model>
-		<model name='CRB-C'>
-			<availability>DC:5+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:3,Periphery.Deep:8,NIOPS:0,Periphery:3</availability>
 		</model>
+		<model name='CRB-C'>
+			<availability>DC:5+</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:6,CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8+</availability>
+		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:8,CSR:6,FRR:2,CSV:6,CLAN:7,CFM:6,WOB:8,CGS:6,CWIE:7,DC.GHO:4,CS:9,CDS:6,CW:8,CBS:8,NIOPS:9,CJF:6,CGB:8</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:7,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:6,FRR:4,CLAN:6,NIOPS:6,WOB:6,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -2678,20 +2678,30 @@
 		<model name='A'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,WOB:5-,Periphery:5</availability>
-		<model name='CRD-4D'>
-			<availability>FS:6+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:8,SIC:7</availability>
 		</model>
-		<model name='CRD-2R'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		<model name='CRD-3R'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:3,Periphery:5</availability>
+		</model>
+		<model name='CRD-5M'>
+			<availability>CC:2+,CS:2,FWL:6+,IS:2+,WOB:4,FS:2+,MERC:2+,DC:2+</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>LA:4+,FRR:6+,MERC:4+,FS:4+,DC:6+</availability>
 		</model>
 		<model name='CRD-4BR'>
 			<availability>MERC:5</availability>
@@ -2699,31 +2709,36 @@
 		<model name='CRD-5S'>
 			<availability>LA:6+,FS:4+,MERC:4+</availability>
 		</model>
-		<model name='CRD-3R'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:3,Periphery:5</availability>
-		</model>
 		<model name='CRD-4L'>
 			<availability>CC:5+</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:4,DC:4</availability>
-		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:8,SIC:7</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:2+,CS:2,FWL:6+,IS:2+,WOB:4,FS:2+,MERC:2+,DC:2+</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='CRD-4K'>
-			<availability>LA:4+,FRR:6+,MERC:4+,FS:4+,DC:6+</availability>
+		<model name='CRD-4D'>
+			<availability>FS:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+		<model name='CP-11-G'>
+			<availability>CS:4+,FRR:4+,MERC:4+</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>CC:2+,CS:3,MOC:3+,LA:2+,FWL:3+,IS:2+,WOB:3,FS:4+,DC:4+,TC:3+</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:6,General:6,IS:6,FS:6,MERC:6,DC:6,TC:6</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
+		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
 			<availability>DC:3+</availability>
@@ -2731,34 +2746,19 @@
 		<model name='CP-11-H'>
 			<availability>PIR:3+,MH:3+,CIR:3+,TC:3+</availability>
 		</model>
-		<model name='CP-10-Z'>
-			<availability>OA:6,General:6,IS:6,FS:6,MERC:6,DC:6,TC:6</availability>
-		</model>
-		<model name='CP-11-A'>
-			<availability>CC:2+,CS:3,MOC:3+,LA:2+,FWL:3+,IS:2+,WOB:3,FS:4+,DC:4+,TC:3+</availability>
-		</model>
-		<model name='CP-11-G'>
-			<availability>CS:4+,FRR:4+,MERC:4+</availability>
-		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CS:6,CHH:4,CSR:4,CLAN:2,NIOPS:6,WOB:5,CJF:4</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CS:8,General:8,NIOPS:8,WOB:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
@@ -2780,36 +2780,36 @@
 		<model name='DMO-4K'>
 			<availability>FRR:2,DC:4</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='DMO-2K'>
 			<availability>FRR:2,DC:3</availability>
+		</model>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:4,CDS:5,CW:6,CBS:4,CNC:4,CLAN:4,CSJ:8,CJF:5,BAN:2,CWIE:6,CGB:5,CB:4</availability>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:4</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGS:5,CCO:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -2831,18 +2831,15 @@
 		<model name='DRT-3S'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='DRT-4S'>
-			<availability>LA:3,FS:5,MERC:2,CIR:2</availability>
-		</model>
 		<model name='DRT-6S'>
 			<availability>LA:6,FS:5</availability>
+		</model>
+		<model name='DRT-4S'>
+			<availability>LA:3,FS:5,MERC:2,CIR:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:5,FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
@@ -2850,6 +2847,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -2859,9 +2860,8 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:3</availability>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
@@ -2889,17 +2889,17 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,FWL:8,NIOPS:6,DC:7</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:5+,CS:5,LA:5+,FRR:4+,FWL:5+,IS:4+,WOB:5,SIC:4+,FS:5+,DC:5+,CWIE:4</availability>
 		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -2928,11 +2928,11 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:4,CC:3,HL:3,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:6,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
-		<model name='DV-7D'>
-			<availability>LA:4+,FS:6+,MERC:4+,TC:4+</availability>
-		</model>
 		<model name='DV-6M'>
 			<availability>HL:6,CLAN:4,IS:6-,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='DV-7D'>
+			<availability>LA:4+,FS:6+,MERC:4+,TC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -2943,69 +2943,69 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:2+,LA:3+,FS:3+,MERC:2+,TC:3</availability>
-		<model name='DVS-1D'>
-			<availability>LA:4,FS:4,TC:8</availability>
-		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='DVS-1D'>
+			<availability>LA:4,FS:4,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CIH:4,CGS:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,FRR:9,MERC:3,DC:8</availability>
+		<model name='DRG-1N'>
+			<availability>FRR:5,MERC:4,DC:4,Periphery:5</availability>
+		</model>
 		<model name='DRG-5N'>
 			<availability>FRR:5+,MERC:5+,DC:6+</availability>
 		</model>
 		<model name='DRG-1C'>
 			<availability>FRR:1,DC:1</availability>
 		</model>
-		<model name='DRG-1N'>
-			<availability>FRR:5,MERC:4,DC:4,Periphery:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:5,CHH:6,CIH:7,CDS:4,CSV:5,CLAN:5,CFM:5,CSJ:5,CJF:4,CGB:9,CB:7</availability>
-		<model name='D'>
-			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:7</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CWIE:6,CGB:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
+		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7,CB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
-		<model name='(SRM)'>
-			<availability>CC:8,General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:7</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>LA:7+,WOB:4,FS:4+</availability>
+		<model name='(SRM)'>
+			<availability>CC:8,General:4</availability>
 		</model>
 		<model name='(ERLL)'>
 			<availability>LA:1+,FS:1+</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:7+,WOB:4,FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -3017,9 +3017,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:2,General:8,FS:2</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:3,FS:3</availability>
 		</model>
@@ -3030,31 +3027,34 @@
 			<roles>ground_support</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:2,General:8,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,MERC.WD:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -3072,11 +3072,11 @@
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>LA:5,MH:2,SIC:3,FS:9,MERC:5,TC:2,DC:3</availability>
-		<model name='ENF-4R'>
-			<availability>LA:4,General:6,FS:6,TC:6</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>LA:4+,FS:6+,MERC:2+,TC:2+</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>LA:4,General:6,FS:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -3096,46 +3096,46 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:3+,CIH:3+,CGS:3+,CB:2+</availability>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='A'>
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CS:5,CIH:1,CDS:2,CSV:1,WOB:2,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>FS:2</availability>
-		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -3166,11 +3166,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:2,FWL:1,NIOPS:4,WOB:4,DC:1</availability>
-		<model name='EXT-4A'>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:2,DC:8</availability>
+		</model>
+		<model name='EXT-4A'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -3181,12 +3181,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -3206,11 +3206,11 @@
 		<model name='FLC-4P'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
@@ -3228,8 +3228,17 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:6,CHH:5,CIH:7,CDS:5,CW:8,CSV:5,CNC:4,CLAN:4,CSJ:4,CJF:6,CWIE:8,CGB:5</availability>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
+		</model>
 		<model name='B'>
 			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CCO:5</availability>
@@ -3237,22 +3246,9 @@
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4,CWIE:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
-		</model>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:5,LA:6,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:8</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
 			<availability>LA:3,FWL:2,FS:5</availability>
@@ -3260,6 +3256,10 @@
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -3279,9 +3279,13 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(UAC2)'>
+		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
-			<availability>IS:6</availability>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
 		</model>
 		<model name='(AC20)'>
 			<roles>field_gun</roles>
@@ -3291,59 +3295,55 @@
 			<roles>field_gun</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(UAC20)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(AC2)'>
 			<roles>field_gun</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Gauss)'>
+		<model name='(AC5)'>
 			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CFM:2,CJF:4</availability>
-		<model name='Prime'>
+		<model name='B'>
+			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
+		<model name='A'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -3355,13 +3355,13 @@
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>LA:5+,FS:5+,MERC:3+</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:5,MERC:5,FS:5</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>LA:6,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:5,MERC:5,FS:5</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -3370,14 +3370,14 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:6,MERC.WD:3,CIH:5,CLAN:3,WOB:5,BAN:2,CB:4</availability>
-		<model name='C'>
-			<availability>MERC.WD:6,CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:6+</availability>
 		</model>
 		<model name='FFL-4A'>
 			<availability>:0,MERC.WD:2-</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:6,CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FFL-4C'>
 			<availability>CS:6,WOB:6</availability>
@@ -3385,6 +3385,10 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1,LA.SR:2</availability>
+		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
@@ -3394,10 +3398,6 @@
 			<roles>recon</roles>
 			<availability>CC:3+,CS:3+,MOC:4+,LA:5+,FRR:4+,General:3+,FS:4+,TC:3+</availability>
 		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
-		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
 			<availability>LA:5+,General:2+,FS:4+</availability>
@@ -3405,6 +3405,12 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:4+,CC:3+,LA:4+,IS:3+,WOB:4+,FS:4+,MERC:3+,DC:6+</availability>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='FS9-OE'>
 			<availability>General:6</availability>
 		</model>
@@ -3412,57 +3418,51 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='FS9-OC'>
 			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OA'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:4,CSV:6,FRR:2,CLAN:5,CFM:6,WOB:5,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4,DC:2</availability>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:5,LA:5</availability>
+		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:8,CS:6,LA:2,CLAN:8,NIOPS:6,WOB:6,MERC.SI:8,BAN:8</availability>
 		</model>
 		<model name='FLS-C'>
 			<availability>DC:4+</availability>
 		</model>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:5,LA:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -3485,17 +3485,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -3503,9 +3501,11 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
@@ -3545,11 +3545,11 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CS:4,CHH:5,CW:4,CLAN:2,CJF:4,CGB:5</availability>
-		<model name='CX-17'>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
@@ -3572,15 +3572,19 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:5,CW:5,CLAN:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:6,CCO:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:3,Periphery:2,CS:5,LA:5,FWL:7,DC:3</availability>
+		</model>
 		<model name='GAL-200'>
 			<availability>MOC:3,LA:3,FRR:3,IS:1,DC:3,Periphery:3</availability>
 		</model>
@@ -3588,21 +3592,17 @@
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:6</availability>
 		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:3,Periphery:2,CS:5,LA:5,FWL:7,DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>CC:2+,MOC:2+,MERC.WD:6,IS:4+,FWL:2+,MH:4,MERC:6,TC:2+</availability>
 		<model name='GAL-2GLS'>
 			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -3618,20 +3618,20 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,MERC.WD:3,CDS:5,CSR:3,CNC:5,CLAN:5,CSJ:7,CJF:6,BAN:3,CGB:9,CB:6,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>CW:7,CSV:7,General:8,CSJ:7,CJF:9,CWIE:7,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,CW:6,CNC:6,General:3,CSJ:3,CJF:4,CWIE:6,CGB:5</availability>
+		<model name='H'>
+			<availability>CSA:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CW:7,CSV:7,General:8,CSJ:7,CJF:9,CWIE:7,CGB:8</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:4</availability>
+		<model name='D'>
+			<availability>CDS:4,CW:6,CNC:6,General:3,CSJ:3,CJF:4,CWIE:6,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>CSV:5,General:7,CSJ:5,CGB:4</availability>
@@ -3697,20 +3697,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:5,CLAN:2</availability>
-		<model name='(Standard)'>
-			<availability>CSV:8,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:6,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:4,HL:3,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:5,BAN:2,Periphery:5</availability>
-		</model>
 		<model name='GTHA-500b'>
 			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:4,HL:3,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:5,BAN:2,Periphery:5</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
@@ -3727,26 +3727,26 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,DC:8</availability>
-		<model name='DRG-C'>
-			<availability>FRR:6+,DC:6+</availability>
-		</model>
 		<model name='DRG-1G'>
 			<availability>FRR:6,DC:6</availability>
-		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
 		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:4+,DC:6+</availability>
 		</model>
+		<model name='DRG-C'>
+			<availability>FRR:6+,DC:6+</availability>
+		</model>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>CS:3,CC:3+,MOC:3+,FWL:6+,IS:3+,MH:3+,WOB:5,FWL.KIS:7+,SIC:3+,FS:3+,MERC:3+,DC:3+</availability>
-		<model name='T-IT-N10M'>
-			<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='T-IT-N11M'>
 			<availability>FWL:5,WOB:5</availability>
+		</model>
+		<model name='T-IT-N10M'>
+			<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -3757,11 +3757,11 @@
 		<model name='GHR-5H'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='GHR-C'>
-			<availability>IS:2+,DC:3+</availability>
-		</model>
 		<model name='GHR-5N'>
 			<availability>General:2</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:2+,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -3776,14 +3776,14 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
@@ -3797,14 +3797,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:4</availability>
@@ -3812,29 +3812,29 @@
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:4,MERC.WD:5,CIH:6,CDS:4,CW:5,CNC:6,CLAN:4,CCO:4,CJF:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CLAN:5,CNC:5</availability>
-		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CIH:8,CNC:8,CLAN:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CLAN:5,CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,CNC:2,NIOPS:3,DC:8</availability>
-		<model name='GRF-3M'>
-			<availability>LA:6+,FWL:6+,IS:4+,FS:4+,DC:3+</availability>
+		<model name='GRF-1S'>
+			<availability>LA:5,FRR:3,MERC:4</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:5,FRR:3,MERC:4</availability>
+		<model name='GRF-3M'>
+			<availability>LA:6+,FWL:6+,IS:4+,FS:4+,DC:3+</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>LA:4+,FRR:4+,FS:5+,MERC:4+,DC:5+</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
@@ -3851,12 +3851,12 @@
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:1,IS:1,FWL:1,SIC:3,MERC:1,TC:1,Periphery:1</availability>
-		<model name='B'>
-			<availability>CC:2,IS:2,FWL:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CC:2,IS:2,FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
@@ -3867,21 +3867,21 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8,DC:8</availability>
+			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,NIOPS:0,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:1,Periphery.ME:1,FWL:1,NIOPS:0,MERC:1</availability>
 		</model>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,NIOPS:0,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:6+,FWL:6+,WOB:4,FS:6+</availability>
+		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
@@ -3926,11 +3926,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:4,CNC:5,NIOPS:7,WOB:7,DC:3</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:2</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:2</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:6,CLAN:5,BAN:2</availability>
@@ -3938,23 +3938,23 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CDS:4,CSV:5,CNC:5,CLAN:2,CSJ:6,CJF:4,CCO:2,CGB:2</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -3973,16 +3973,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 		<model name='&apos;Mini-Peggy&apos;'>
 			<roles>recon</roles>
@@ -3991,11 +3991,11 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:5,MERC:3+,DC:8</availability>
-		<model name='HTM-27T'>
-			<availability>FRR:6+,MERC:3+,DC:5+</availability>
-		</model>
 		<model name='HTM-26T'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>FRR:6+,MERC:3+,DC:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -4031,11 +4031,11 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>Periphery.R:3,MERC.KH:4,LA:6,TC.PL:3,FRR:3,Periphery.MW:3,FS:5,MERC:3,DC:4</availability>
-		<model name='HCT-5S'>
-			<availability>LA:5+,FRR:2+,FS:5+,MERC:2+</availability>
-		</model>
 		<model name='HCT-3NH'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='HCT-5S'>
+			<availability>LA:5+,FRR:2+,FS:5+,MERC:2+</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
@@ -4057,6 +4057,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -4064,14 +4072,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -4082,25 +4082,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -4109,6 +4105,10 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -4116,6 +4116,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -4123,14 +4131,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8,WOB:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -4148,18 +4148,18 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:3-,OA:3-,HL:2,LA:4-,Periphery.Deep:2-,FS:3-,MERC:4-,Periphery:3-,TC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:3,FS:4</availability>
+		<model name='HCT-213S'>
+			<availability>LA:4,FS:3</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:4,FS:3</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:3,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
@@ -4190,73 +4190,73 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
 			<roles>recon</roles>
-			<availability>FWL:1</availability>
+			<availability>FWL:2,WOB:2</availability>
 		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 		<model name='HER-5S'>
 			<roles>recon</roles>
 			<availability>MOC:4+,CC:4+,LA:4+,FWL:7+,WOB:8,FS:4+,MERC:4+,DC:4+</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:2,WOB:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:3,FRR:2,FWL:5,NIOPS:3,WOB:3,CGB:3,CB:1</availability>
-		<model name='HER-1B'>
-			<roles>recon</roles>
-			<availability>:0,FWL:1</availability>
-		</model>
 		<model name='HER-3S2'>
 			<roles>recon,spotter</roles>
 			<availability>FWL:3+,WOB:4</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:5+,WOB:4</availability>
-		</model>
-		<model name='HER-3S'>
-			<roles>recon</roles>
-			<availability>FWL:6+,WOB:6+</availability>
-		</model>
-		<model name='HER-1A'>
-			<roles>recon</roles>
-			<availability>:0,FWL:2</availability>
 		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>DC.GHO:6,CS:6,CLAN:6,NIOPS:6,BAN:8</availability>
 		</model>
+		<model name='HER-3S'>
+			<roles>recon</roles>
+			<availability>FWL:6+,WOB:6+</availability>
+		</model>
+		<model name='HER-1B'>
+			<roles>recon</roles>
+			<availability>:0,FWL:1</availability>
+		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>CS:1,FRR:1,FWL:2,WOB:1</availability>
 		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:5+,WOB:4</availability>
+		</model>
+		<model name='HER-1A'>
+			<roles>recon</roles>
+			<availability>:0,FWL:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:3-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:3-,SIC:8,MERC:4,Periphery:4,CWIE:3</availability>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC10)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:3,IS:3,Periphery:3</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -4275,20 +4275,20 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:5,CLAN:7,NIOPS:9,CFM:8,WOB:9,SIC:1,MERC:2,FS:3,CJF:8,DC:2</availability>
+		<model name='HGN-733C'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
+		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
-		<model name='HGN-733C'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
+		<model name='HGN-733'>
+			<availability>CC:4,:0,LA:4,SIC:4,DC:4</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>MOC:4+,DC.GHO:8,CS:5,LA:4+,CLAN:6,IS:4+,NIOPS:5,WOB:5,MERC.SI:8,MERC:4+,FS:4+,BAN:8</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:4,:0,LA:4,SIC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hitman' unitType='Mek'>
@@ -4313,20 +4313,20 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:2,MERC.WD:2,CLAN:2,CGS:3</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='HOP-4B'>
+			<availability>MERC.WD:3</availability>
+		</model>
+		<model name='HOP-4D'>
+			<availability>MERC.WD:8</availability>
+		</model>
 		<model name='C'>
 			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:6,CLAN:1</availability>
-		</model>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='HOP-4D'>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='HOP-4B'>
-			<availability>MERC.WD:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -4334,16 +4334,16 @@
 		<model name='HNT-161'>
 			<availability>MERC.WD:5-</availability>
 		</model>
+		<model name='HNT-152'>
+			<roles>recon,urban</roles>
+			<availability>IS:2</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FS:5+,MERC:5+</availability>
-		</model>
-		<model name='HNT-152'>
-			<roles>recon,urban</roles>
-			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -4373,32 +4373,32 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
-		<model name='HBK-4N'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		<model name='HBK-4G'>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4H'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:3,MERC:3,DC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-5M'>
-			<availability>CS:4+,CC:3+,FRR:3+,FWL:5+,WOB:4+,MERC:4+</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='HBK-5N'>
+			<availability>MOC:3+,CC:3+,CS:3+,FRR:3+,FWL:4+,WOB:3+,MERC:3+,TC:3+</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
+		<model name='HBK-5M'>
+			<availability>CS:4+,CC:3+,FRR:3+,FWL:5+,WOB:4+,MERC:4+</availability>
+		</model>
 		<model name='HBK-5S'>
 			<availability>LA:3,FRR:2,MERC:2</availability>
 		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:3+,CC:3+,CS:3+,FRR:3+,FWL:4+,WOB:3+,MERC:3+,TC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -4412,53 +4412,53 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LRM10)'>
-			<roles>fire_support</roles>
-			<availability>General:3</availability>
 		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
 			<availability>LA:7+,FS:5+</availability>
 		</model>
+		<model name='(LRM10)'>
+			<roles>fire_support</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='(LRM15)'>
+			<roles>fire_support</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:6,FWL:5,WOB:3,MERC:2</availability>
-		<model name='HUR-WO-R4M'>
-			<availability>CC:3,MOC:3,FWL:4</availability>
-		</model>
 		<model name='HUR-WO-R4L'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HUR-WO-R4M'>
+			<availability>CC:3,MOC:3,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:6,CIH:6,LA:3,CSV:6,FRR:3,CLAN:5,NIOPS:4,WOB:4,MERC:3,DC:2</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:6,General:6,CLAN:6,NIOPS:6,MERC.SI:6,WOB:6,BAN:8</availability>
 		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -4469,28 +4469,28 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,LA:8,FWL:8,IS:8,WOB:8,FS:8,DC:8</availability>
-		<model name='(Level I) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
 		<model name='(Level I) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 	</chassis>
@@ -4512,11 +4512,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
-			<availability>MERC.WD:5</availability>
-		</model>
 		<model name='IMP-2E'>
 			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='IMP-3E'>
+			<availability>MERC.WD:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
@@ -4545,16 +4545,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:1</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:1</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:1</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -4587,15 +4587,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>LA:2,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -4612,29 +4612,29 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,FRR:5,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,CIR:5,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>IS:6</availability>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4,TC:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Kurita)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>DC:7,TC:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Kurita)'>
-			<roles>recon,raider</roles>
-			<availability>DC:7,TC:4</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>recon,raider</roles>
 			<availability>HL:5,General:4,Periphery.Deep:7,Periphery:7</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
@@ -4654,58 +4654,58 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,CS:3,LA:5,FRR:5,IS:3,FWL:3,NIOPS:3,WOB:3,SIC:7,MERC:3,FS:8,DC:3</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>OA:6+,LA:6+,FRR:6+,FS:6+,MERC:6+,DC:6+</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>CC:6,FRR:6,IS:6,SIC:8,FS:6</availability>
 		</model>
-		<model name='JM6-A'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:3+</availability>
 		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
+		<model name='JM6-A'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>OA:6+,LA:6+,FRR:6+,FS:6+,MERC:6+,DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+		<model name='JVN-10P'>
+			<roles>recon</roles>
+			<availability>LA:5+,FS:6+,MERC:4+</availability>
+		</model>
 		<model name='JVN-10F &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
 			<availability>MOC:2,IS:1,FS:4,MERC:2,TC:2,Periphery:1</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>LA:4+,FS:4+,MERC:4+</availability>
 		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
-			<availability>LA:5+,FS:6+,MERC:4+</availability>
+			<availability>LA:4+,FS:4+,MERC:4+</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -4714,9 +4714,6 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:5,CWIE:7,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
@@ -4726,32 +4723,35 @@
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:4,CW:4,CSV:6,CNC:8,CLAN:4,CSJ:6,CGS:4,CCO:5,CB:6</availability>
-		<model name='2'>
-			<availability>CCC:6,CSV:6,CNC:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:7,CLAN:6,CNC:7</availability>
 		</model>
+		<model name='2'>
+			<availability>CCC:6,CSV:6,CNC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
-		<model name='JR7-K'>
+		<model name='JR7-F'>
 			<roles>raider</roles>
-			<availability>MOC:3+,OA:3+,FRR:5+,MERC:3+,DC:3+,TC:3+</availability>
+			<availability>FS.DMM:1,DC:2</availability>
 		</model>
 		<model name='JR7-D'>
 			<roles>raider</roles>
 			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='JR7-F'>
+		<model name='JR7-K'>
 			<roles>raider</roles>
-			<availability>FS.DMM:1,DC:2</availability>
+			<availability>MOC:3+,OA:3+,FRR:5+,MERC:3+,DC:3+,TC:3+</availability>
 		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
@@ -4767,17 +4767,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -4794,17 +4794,9 @@
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>DC:5</availability>
-		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
@@ -4814,14 +4806,22 @@
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CS:2,NIOPS:2</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -4846,12 +4846,12 @@
 		<model name='CRK-5003-2'>
 			<availability>FRR:8,DC:8</availability>
 		</model>
+		<model name='CRK-5003-C'>
+			<availability>DC:2+</availability>
+		</model>
 		<model name='CRK-5003-CM'>
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
-		</model>
-		<model name='CRK-5003-C'>
-			<availability>DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
@@ -4860,21 +4860,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
@@ -4912,11 +4912,11 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:7,CHH:3,CDS:3,CSV:3,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:5,MERC:4,DC:5</availability>
+		<model name='KTO-C'>
+			<availability>MERC:5,DC:6+</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:6,CS:6,DC.SL:4,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,FS:6+,MERC:6+,BAN:7</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:6,MERC:6,DC:4</availability>
@@ -4924,23 +4924,23 @@
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:2,WOB:4,MERC:5,DC:8</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:5,DC:6+</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -4976,17 +4976,17 @@
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:1,CSV:1</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8,CB:5</availability>
 		</model>
-		<model name='D'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSA:4,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
-		</model>
-		<model name='E'>
-			<roles>recon</roles>
-			<availability>CLAN:4,IS:2,CCO:6</availability>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
@@ -4996,13 +4996,13 @@
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,CDS:6,CW:6,General:5,CSJ:4,CGS:6,CCO:4,CWIE:5,CGB:5</availability>
 		</model>
-		<model name='Prime'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
+			<availability>CSA:4,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
-		<model name='H'>
+		<model name='E'>
 			<roles>recon</roles>
-			<availability>CSA:4,CCC:1,CSV:1</availability>
+			<availability>CLAN:4,IS:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
@@ -5013,14 +5013,14 @@
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:5,CLAN:3,CJF:5</availability>
-		<model name='2'>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
+			<availability>CJF:5</availability>
+		</model>
+		<model name='2'>
 			<availability>CJF:5</availability>
 		</model>
 	</chassis>
@@ -5063,6 +5063,9 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:4,CLAN:4,NIOPS:6,CFM:5,WOB:6,CGS:5,BAN:7,DC:5</availability>
+		<model name='LNC25-04'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
 		<model name='LNC25-02'>
 			<roles>fire_support</roles>
 			<availability>:0,FRR:5,DC:5</availability>
@@ -5070,16 +5073,13 @@
 		<model name='LNC25-03'>
 			<availability>DC:7</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,FRR:5+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:5+</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4,WOB:4</availability>
 		</model>
-		<model name='LNC25-04'>
-			<availability>CS:6,WOB:6</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,FRR:5+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -5091,13 +5091,13 @@
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
@@ -5127,15 +5127,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,HL:4,LA:5</availability>
@@ -5156,11 +5156,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
-		<model name='LTN-G15b'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LTN-G15b'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
@@ -5168,17 +5168,17 @@
 		<model name='B'>
 			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:4,CIH:5,CW:5,CBS:4,CSV:5,CNC:3,General:3,CSJ:4,CJF:2,CWIE:5,CGB:5,CB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -5198,22 +5198,18 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:7,CLAN:4,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:5-,HL:5,CLAN:1-,IS:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,Periphery:6</availability>
-		<model name='LCT-3M'>
-			<roles>recon</roles>
-			<availability>MOC:3+,FWL:6+,IS:3+,MERC:4+</availability>
-		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
 			<availability>CC:2,SIC:2</availability>
@@ -5222,17 +5218,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:3,General:5,FS:5</availability>
-		</model>
 		<model name='LCT-3V'>
 			<roles>recon</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>FS:6+,MERC:4+</availability>
+			<availability>LA:3,General:5,FS:5</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -5242,18 +5234,23 @@
 			<roles>recon</roles>
 			<availability>LA:6+,FRR:4+,MERC:4+</availability>
 		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:3+,FWL:6+,IS:3+,MERC:4+</availability>
+		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:6,MERC:4</availability>
 		</model>
+		<model name='LCT-3D'>
+			<roles>recon</roles>
+			<availability>FS:6+,MERC:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSV:6,CLAN:5,CFM:6,BAN:6,CWIE:6,CDS:6,CW:6,CBS:6,CSJ:6,CJF:6,CGB:5,CB:7</availability>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
@@ -5264,8 +5261,11 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -5281,13 +5281,13 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,FS:7,Periphery:7,TC:7,CS:3,OA:7,LA:7,FWL:9,NIOPS:3,DC:6</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='LGB-7V'>
 			<roles>fire_support</roles>
 			<availability>MOC:3+,FWL:4+,IS:3+</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
@@ -5296,8 +5296,8 @@
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:6</availability>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -5305,8 +5305,14 @@
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Laser] (WoB)' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[Flamer] (WoB)' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 		<model name='[David] (WoB)' mechanized='true'>
 			<availability>CS:5,WOB:5</availability>
@@ -5314,40 +5320,30 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Laser] (WoB)' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[Flamer] (WoB)' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
-		<model name='LCF-R16K'>
-			<availability>General:6</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>FRR:5+,MERC:2+,DC:5+</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
+		<model name='LCF-R16'>
+			<availability>LA:6+,FS:4+,MERC:3+</availability>
+		</model>
 		<model name='LCF-R15'>
 			<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='LCF-R16'>
-			<availability>LA:6+,FS:4+,MERC:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -5355,6 +5351,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -5405,8 +5405,8 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CIH:4,CLAN:5,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:8,CDS:6,CW:9,CBS:4,CSJ:6,CJF:6,CB:4</availability>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -5416,20 +5416,20 @@
 			<roles>spotter</roles>
 			<availability>CHH:4,CIH:4,CLAN:5,CFM:4,CCO:6,CWIE:4,CW:4,CBS:4,CNC:4,General:5,CSJ:4,CJF:4,CB:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -5466,14 +5466,14 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
@@ -5508,32 +5508,26 @@
 		<model name='MAD-5A'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:2</availability>
-		</model>
 		<model name='MAD-4A'>
 			<availability>MERC:6</availability>
+		</model>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,FWL:3,NIOPS:7,DC:5,CGB:2</availability>
+		<model name='MAD-3D'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='MAD-5D'>
 			<availability>LA:5+,FRR:5+,WOB:3+,FS:5+,MERC:3+,DC:7+</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:2+,FS:2+,DC:2+</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>LA:4+,FRR:2+,FS:4+,MERC:2+</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:4,Periphery.ME:4,FWL:4,MH:4,MERC:4</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>CS:4+,FWL:5+,IS:3+,WOB:5+,MERC:3+</availability>
 		</model>
-		<model name='MAD-3D'>
-			<availability>FS:5</availability>
+		<model name='C'>
+			<availability>LA:2+,FS:2+,DC:2+</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:3-,HL:6,IS:5,Periphery.Deep:7,WOB:3-,Periphery:8,TC:8</availability>
@@ -5547,6 +5541,12 @@
 		<model name='MAD-1R'>
 			<availability>CS:5,CLAN:1,NIOPS:5,WOB:5,MERC:0,BAN:2</availability>
 		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:4,Periphery.ME:4,FWL:4,MH:4,MERC:4</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>LA:4+,FRR:2+,FS:4+,MERC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
@@ -5556,33 +5556,33 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:3,CWIE:4,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:6,CB:4</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:4</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:4</availability>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
@@ -5605,6 +5605,10 @@
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CHH:5,CLAN:3,FS:4,TC:6</availability>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:6</availability>
+		</model>
 		<model name='(Intermediate)'>
 			<roles>apc</roles>
 			<availability>TC:4</availability>
@@ -5612,10 +5616,6 @@
 		<model name='(Basic)'>
 			<roles>apc</roles>
 			<availability>FS:8,TC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -5632,33 +5632,9 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>DC:3+</availability>
-		</model>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>LA:3,FRR:3,IS:2,FS:3,DC:4</availability>
-		</model>
-		<model name='(BA Factory Upgrade)'>
-			<roles>apc</roles>
-			<availability>FRR:6+,FWL:5+,IS:4+,DC:6+</availability>
-		</model>
 		<model name='(SRM2)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Anti-Infantry)'>
-			<roles>apc,spotter,anti_infantry</roles>
-			<availability>IS:2,DC:4</availability>
-		</model>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
@@ -5666,6 +5642,30 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
+		</model>
+		<model name='(BA Field Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>DC:3+</availability>
+		</model>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
+			<roles>apc</roles>
+			<availability>FRR:6+,FWL:5+,IS:4+,DC:6+</availability>
+		</model>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>LA:3,FRR:3,IS:2,FS:3,DC:4</availability>
+		</model>
+		<model name='(Anti-Infantry)'>
+			<roles>apc,spotter,anti_infantry</roles>
+			<availability>IS:2,DC:4</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -5706,17 +5706,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -5724,31 +5724,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -5757,11 +5757,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -5842,25 +5842,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:4+,MERC:1+,DC:4+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>General:1,MERC:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:1,MERC:6,DC:1</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:1,MERC:6,DC:1</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>General:1,MERC:8</availability>
+			<availability>CC:1,MERC:6,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -5897,14 +5897,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:1,CHH:3,CLAN:4,WOB:3,MERC:1,Periphery:1,TC:1,CS:4,DC.GHO:4,OA:1,CDS:3,CBS:4,NIOPS:4,CJF:4,CGB:3,DC:1</availability>
-		<model name='MON-68'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
@@ -5912,6 +5904,14 @@
 		<model name='MON-67'>
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
+		</model>
+		<model name='MON-68'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -5924,9 +5924,6 @@
 		<availability>CLAN:2,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
@@ -5946,6 +5943,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -5954,12 +5957,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -5985,21 +5982,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
@@ -6021,11 +6018,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
@@ -6036,31 +6033,31 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CSJ:3,CJF:4</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>CW:4,LA:4+,CLAN:4,FS:3+,CGS:5,CGB:4</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightlord Battleship' unitType='Warship'>
@@ -6075,12 +6072,12 @@
 		<model name='(Standard)'>
 			<availability>General:8,WOB:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
@@ -6100,8 +6097,7 @@
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CNC:7</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -6111,7 +6107,8 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -6144,18 +6141,18 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:6,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,CDS:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4,DC:4</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>IS:6</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3,LA:3,FWL:3,SIC:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
+		</model>
+		<model name='(3053 Upgrade)'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -6169,29 +6166,29 @@
 		<model name='ON1-MA'>
 			<availability>MOC:2+,FWL:4+,IS:2+,MH:2+</availability>
 		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2+,MOC:2+,FWL:4+,WOB:4+,FS:2+,MERC:2+,DC:2+</availability>
+		<model name='ON1-MC'>
+			<availability>FRR:3+,FS:2+,MERC:2+,DC:4+</availability>
+		</model>
+		<model name='ON1-V'>
+			<availability>IS:2,MH:2,TC:2</availability>
 		</model>
 		<model name='ON1-V-DC'>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='ON1-MC'>
-			<availability>FRR:3+,FS:2+,MERC:2+,DC:4+</availability>
+		<model name='ON1-MB'>
+			<availability>CC:2+,MOC:2+,FWL:4+,WOB:4+,FS:2+,MERC:2+,DC:2+</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:4,General:6,CLAN:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='ON1-M'>
 			<availability>CS:4+,MOC:3+,Periphery.MW:2+,PIR:2+,Periphery.ME:2+,FWL:6+,IS:3+,WOB:5+,MH:2+,DC:4+</availability>
-		</model>
-		<model name='ON1-V'>
-			<availability>IS:2,MH:2,TC:2</availability>
 		</model>
 		<model name='ON1-VA'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:2+,DC:4+</availability>
-		</model>
-		<model name='ON1-K'>
-			<availability>HL:4,General:6,CLAN:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -6202,6 +6199,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:3,MOC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,Periphery:3,TC:3,CS:4-,LA:4,NIOPS:4-,DC:5</availability>
+		<model name='OSR-3C'>
+			<availability>IS:3,Periphery.Deep:4,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,MERC:6,BAN:2,Periphery:6</availability>
@@ -6209,9 +6209,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>IS:3,Periphery.Deep:4,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:3</availability>
@@ -6225,29 +6222,29 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:3,LA:2,FWL:4,NIOPS:3,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='OTT-7K'>
+			<roles>recon,spotter</roles>
+			<availability>DC:5+</availability>
 		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,BAN:2</availability>
 		</model>
-		<model name='OTT-7K'>
-			<roles>recon,spotter</roles>
-			<availability>DC:5+</availability>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:2,IS:3,FWL:5,NIOPS:6,WOB:6,FS:5,MERC:5,Periphery:3</availability>
+		<model name='OTL-4D'>
+			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
 		<model name='OTL-5M'>
 			<availability>CS:3+,FWL:6+,WOB:5+,MERC:3+</availability>
 		</model>
 		<model name='OTL-4F'>
 			<availability>FS:3</availability>
-		</model>
-		<model name='OTL-4D'>
-			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -6259,10 +6256,6 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:3,FS:3</availability>
@@ -6271,17 +6264,13 @@
 			<roles>assault</roles>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CS:2+,DC:3+</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -6290,21 +6279,25 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='OW-1R'>
 			<roles>recon,spotter</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='OW-1A'>
+		<model name='OW-1B'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,FWL:6,NIOPS:6,DC:6</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,SIC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -6312,6 +6305,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:2,MERC.KH:2,HL:2,FRR:3,IS:2,Periphery.Deep:6,SIC:3,MERC:2,FS:2,Periphery:4,PIR:2,General:2,FWL:2,DC:2</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,SIC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -6335,21 +6332,21 @@
 			<roles>fire_support</roles>
 			<availability>FS.RR:2+,FRR:2+,FS.DMM:2+,MERC:2+,DC:2+</availability>
 		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4+,FRR:6+,FS.DMM:4+,MERC:4+,DC:8+</availability>
-		</model>
 		<model name='PNT-CA'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:2+,FRR:2+,FS.DMM:2+,MERC:2+,DC:2+</availability>
 		</model>
-		<model name='PNT-C'>
+		<model name='PNT-10K'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
+			<availability>FS.RR:4+,FRR:6+,FS.DMM:4+,MERC:4+,DC:8+</availability>
 		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:5,IS:7,Periphery.Deep:7,MERC:7,Periphery:7,DC:7</availability>
+		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -6361,13 +6358,13 @@
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,LA:8,FWL:7,DC:6</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
@@ -6388,10 +6385,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:4,CC:5,HL:3,FRR:5,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,CIR:4,Periphery:4,TC:4,CWIE:4,CS:5-,OA:4,LA:7,FWL:5,DC:7</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -6399,6 +6392,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -6411,17 +6408,17 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>LA:4,FS:4</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
@@ -6436,11 +6433,11 @@
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:3-,LA:2-,FRR:2-,FWL:2-,IS:2-,SIC:2-,FS:2-,MERC:2-,DC:2-</availability>
-		<model name='(Cargo)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,DC:2</availability>
@@ -6448,23 +6445,23 @@
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CIH:4,CW:8,CCO:4,CJF:7,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CIH:7,General:8,CCO:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:4,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:4,CIH:6,General:5,CCO:4,CGB:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CIH:7,General:8,CCO:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CSA:7,General:6,CCO:7,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:4,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -6478,41 +6475,29 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2+</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2+</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:6,HL:3,CLAN:2,IS:9,FWL:10,NIOPS:6,Periphery.Deep:4,WOB:5,Periphery:4,CGB:2</availability>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
-		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>FS:4,MERC:4</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:5,BAN:6,Periphery:5</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FS:6+,MERC:5+</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>FWL:7+,IS:3+</availability>
+			<availability>CLAN:5,BAN:1</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
@@ -6522,25 +6507,37 @@
 			<roles>recon</roles>
 			<availability>FRR:6+,DC:6+</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,BAN:1</availability>
-		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:7+,MERC:4+</availability>
 		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>FWL:7+,IS:3+</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:5,BAN:6,Periphery:5</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FS:6+,MERC:5+</availability>
+		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:6,CC:3,CHH:5,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CIR:4,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:4,CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
-		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -6554,13 +6551,13 @@
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4+,FS:6+</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -6607,26 +6604,26 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CCC:2,CHH:1,CSR:5,CIH:1,CSV:2,CFM:1,CCO:2,CGS:4,CWIE:1,CS:1,CSA:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CW:8,CNC:4,CGS:7,CCO:6,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:7,CGB:8</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:3,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:7,CGB:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,CIH:6,General:5,CSJ:6</availability>
@@ -6665,10 +6662,6 @@
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8,General:5</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:3+</availability>
@@ -6676,6 +6669,10 @@
 		<model name='(Sealed)'>
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
@@ -6687,12 +6684,12 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:8</availability>
@@ -6715,41 +6712,41 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
-		<model name='QKD-4H'>
-			<availability>General:3</availability>
-		</model>
-		<model name='QKD-5A'>
-			<availability>General:2,MERC:4,DC:4,Periphery:4</availability>
+		<model name='QKD-5K2'>
+			<availability>MERC:1,DC:1</availability>
 		</model>
 		<model name='QKD-5K'>
 			<availability>FRR:4+,MERC:4+,DC:6+</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:3+,FWL:6+,IS:3+,MH:3+,TC:3+</availability>
-		</model>
-		<model name='QKD-5K2'>
-			<availability>MERC:1,DC:1</availability>
-		</model>
-		<model name='QKD-4G'>
-			<availability>MOC:5,OA:5,HL:3,Periphery.Deep:8,FWL:5,IS:5,Periphery:5,DC:5,TC:5</availability>
+		<model name='QKD-5A'>
+			<availability>General:2,MERC:4,DC:4,Periphery:4</availability>
 		</model>
 		<model name='QKD-C'>
 			<availability>FRR:4,MERC:4,DC:6+</availability>
 		</model>
+		<model name='QKD-4G'>
+			<availability>MOC:5,OA:5,HL:3,Periphery.Deep:8,FWL:5,IS:5,Periphery:5,DC:5,TC:5</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:3</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:3+,FWL:6+,IS:3+,MH:3+,TC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:6</availability>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
@@ -6760,21 +6757,15 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:3,FS:4</availability>
-		<model name='MDG-1A'>
-			<availability>LA:8,FS:8,MERC:8</availability>
-		</model>
 		<model name='MDG-1B'>
 			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='MDG-1A'>
+			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,LA:3,CLAN:3,NIOPS:8,WOB:8</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
@@ -6785,14 +6776,26 @@
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2,CNC:2</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:2+,FS:2+,DC:4+</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
@@ -6804,15 +6807,16 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,FWL:5,SIC:3,FS:4,MERC:4,DC:3</availability>
+		<model name='RVN-4X'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>CC:3,FWL:4,FS:2,MERC:3,DC:2</availability>
+		</model>
 		<model name='RVN-1X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:3,SIC:2,FS:2</availability>
@@ -6821,19 +6825,12 @@
 			<roles>spotter</roles>
 			<availability>CC:5,FWL:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='RVN-2X'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>CC:3,FWL:4,FS:2,MERC:3,DC:2</availability>
-		</model>
 		<model name='RVN-3X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='RVN-4X'>
-			<availability>CC:8</availability>
+		<model name='RVN-2X'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
@@ -6844,52 +6841,52 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:9,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,WOB:8,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CNC:3</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+		<model name='F-700a'>
+			<availability>CC:4+,FWL:4+,WOB:4+,FS:2+,MERC:4+</availability>
+		</model>
+		<model name='F-100b'>
+			<availability>FRR:7,DC:7</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,SIC:5,MERC:5,DC:1</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:6+,FWL:6+,WOB:8,MERC:6+</availability>
 		</model>
-		<model name='F-100b'>
-			<availability>FRR:7,DC:7</availability>
-		</model>
 		<model name='F-100'>
 			<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
-		</model>
-		<model name='F-700a'>
-			<availability>CC:4+,FWL:4+,WOB:4+,FS:2+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:4,CNC:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:6,CNC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:6,CLAN:5,CNC:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -6901,18 +6898,9 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:7-,CCC:4,HL:4,FRR:8-,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,FWL:8-,NIOPS:6-,CB:4</availability>
-		<model name='C'>
-			<availability>LA:2,CLAN:8,FS:2,BAN:4,DC:2</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>LA:6+,FS:6+,MERC:4+</availability>
-		</model>
 		<model name='RFL-3C'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FS:3</availability>
-		</model>
-		<model name='RFL-5M'>
-			<availability>CC:4+,MOC:4+,FWL:5+,IS:4+,MERC:4+,DC:4+</availability>
 		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
@@ -6922,46 +6910,55 @@
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>HL:4,General:6,Periphery.Deep:6,BAN:1,Periphery:6</availability>
 		</model>
+		<model name='RFL-5D'>
+			<availability>LA:6+,FS:6+,MERC:4+</availability>
+		</model>
+		<model name='RFL-5M'>
+			<availability>CC:4+,MOC:4+,FWL:5+,IS:4+,MERC:4+,DC:4+</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:2,CLAN:8,FS:2,BAN:4,DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:4+,CS:5,CHH:4,CSR:2,LA:4+,FRR:4+,CLAN:2,NIOPS:5,WOB:5,FS:4+,CJF:1,DC:4+</availability>
-		<model name='(ERML)'>
-			<roles>apc</roles>
-			<availability>CC:6,LA:6,FS:6,DC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8,BAN:2</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>CC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(ERML)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,FS:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:5</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:6,General:8,NIOPS:6,WOB:6</availability>
 		</model>
 		<model name='RGU-133L'>
 			<availability>CS:2,General:4,NIOPS:2,WOB:2</availability>
 		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:5</availability>
+		</model>
 		<model name='RGU-133F'>
 			<availability>CS:4,General:6,NIOPS:4,WOB:4</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:6,General:8,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
@@ -6990,23 +6987,23 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,MERC.WD:7,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8,CWIE:8</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
+		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:5</availability>
-		</model>
-		<model name='I'>
-			<availability>CLAN:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
+		<model name='H'>
+			<availability>CSA:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='I'>
+			<availability>CLAN:3</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CSR:6,CDS:5,CNC:4,General:5,CFM:4,CSJ:4,CCO:7,CJF:4,CWIE:6,CB:4</availability>
@@ -7043,20 +7040,20 @@
 		<model name='SB-27'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -7071,34 +7068,34 @@
 		<model name='S-4X'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='S-3'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='S-4C'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='S-3'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
+		<model name='(Standard)'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Clan Cargo)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>IS:8,Periphery:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:5,FS:4</availability>
-		<model name='PPR-5S'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='PPR-5T'>
 			<roles>fire_support</roles>
 			<availability>LA:4,MERC:2,FS:2</availability>
+		</model>
+		<model name='PPR-5S'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
@@ -7107,13 +7104,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>OA:2,FRR:1,DC:1</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,FRR:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -7141,13 +7138,13 @@
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>CS:4,LA:4,FS:5,MERC:4</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>LA:6,FS:4,MERC:4</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>LA:6,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek AC Carrier' unitType='Tank'>
@@ -7182,16 +7179,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:7,HL:7,LA:7,FRR:9,FWL:7,IS:8,Periphery.Deep:8,SIC:7,FS:7,CJF:3,DC:7,Periphery:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -7222,11 +7219,11 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -7257,19 +7254,19 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:3,CLAN:4,CFM:5,WOB:4,MERC:3,FS:3,CGS:3,CWIE:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:4,NIOPS:4,CJF:5,CGB:5,DC:2</availability>
-		<model name='STN-3KB'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
-		<model name='STN-3M'>
-			<availability>DC.GHO:7,DC:3+</availability>
 		</model>
 		<model name='STN-3K'>
 			<availability>LA:4,DC:4</availability>
 		</model>
 		<model name='STN-3KA'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='STN-3M'>
+			<availability>DC.GHO:7,DC:3+</availability>
+		</model>
+		<model name='STN-3KB'>
 			<availability>LA:2</availability>
 		</model>
 	</chassis>
@@ -7281,25 +7278,25 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2,DC:3</availability>
-		<model name='SYD-21'>
+		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
-			<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>OA:4,FRR:4,FWL:4,TC:4,DC:4</availability>
-		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:3,FS:2</availability>
+			<availability>HL:3,LA:5,Periphery.Deep:8,FS:5,Periphery:5</availability>
 		</model>
 		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
 			<availability>LA:6+,FRR:4+,FS:6+,MERC:4+</availability>
 		</model>
-		<model name='SYD-Z2'>
+		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
-			<availability>HL:3,LA:5,Periphery.Deep:8,FS:5,Periphery:5</availability>
+			<availability>OA:4,FRR:4,FWL:4,TC:4,DC:4</availability>
+		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
+		</model>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:3,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
@@ -7308,46 +7305,46 @@
 			<roles>recon</roles>
 			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:6,CWIE:7,CGB:7</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5,CGB:1</availability>
+		<model name='SHD-2K'>
+			<availability>FRR:5,MERC:3,DC:6</availability>
+		</model>
 		<model name='SHD-2D2'>
 			<availability>LA:4+,FS:6+</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:6</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>FRR:5,MERC:3,DC:6</availability>
+		<model name='SHD-2H'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:8,CCC:8,LA:2,CSV:8,CFM:8,FS:2,CGS:8,DC:2</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>CC:4+,FRR:4+,FWL:7+,IS:4+,WOB:6,MERC:4+,DC:4+</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:8,CCC:8,LA:2,CSV:8,CFM:8,FS:2,CGS:8,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -7370,14 +7367,14 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:2,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:3</availability>
+		</model>
 		<model name='C'>
 			<availability>MERC.WD:4+,CLAN:8</availability>
 		</model>
 		<model name='SHG-2F'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -7396,37 +7393,43 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:7</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,DC:1</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>OA:3+,FRR:5+,FS:3+,MERC:3+,DC:6+</availability>
-		</model>
-		<model name='SL-15'>
-			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>FRR:1,MERC:1,DC:1</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,DC:1</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -7450,12 +7453,12 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6</availability>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -7463,10 +7466,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -7491,9 +7490,8 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>LA:6,FS.CMM:2</availability>
+		<model name='SPR-6D'>
+			<availability>FRR:4+,FS:6+,MERC:4+</availability>
 		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -7503,8 +7501,9 @@
 			<roles>interceptor</roles>
 			<availability>OA:3,FRR:6,DC:6</availability>
 		</model>
-		<model name='SPR-6D'>
-			<availability>FRR:4+,FS:6+,MERC:4+</availability>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>LA:6,FS.CMM:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -7530,22 +7529,22 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:3,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:6</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>HL:3,FRR:1,IS:5,Periphery.Deep:8,FS:2,Periphery:5</availability>
-		</model>
-		<model name='SDR-7M'>
-			<availability>MOC:3+,CC:6+,FWL:6+,MH:2+,SIC:6+,MERC:3+,FS:6+,DC:5+</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>DC:3</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:5,DC:5</availability>
+		</model>
+		<model name='SDR-7M'>
+			<availability>MOC:3+,CC:6+,FWL:6+,MH:2+,SIC:6+,MERC:3+,FS:6+,DC:5+</availability>
+		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
@@ -7553,6 +7552,10 @@
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>FRR:5,IS:4,DC:6</availability>
+		</model>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
@@ -7562,18 +7565,14 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:5,OA:10,LA:9,FWL:10,NIOPS:5,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+		<model name='STK-5M'>
+			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,DC:5+,TC:3+</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1,OA:1,IS:1,Periphery:1,TC:1</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
@@ -7581,11 +7580,11 @@
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,DC:5+,TC:3+</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
+		<model name='STK-4N'>
+			<availability>MOC:1,OA:1,IS:1,Periphery:1,TC:1</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>LA:5+,CSV:2,MERC:2+,FS:4+,TC:2+</availability>
@@ -7629,19 +7628,15 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6,CGB:1-</availability>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,WOB:6,FS:3+,MERC:3+,DC:3+,TC:3+</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
@@ -7650,6 +7645,10 @@
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,WOB:6,FS:3+,MERC:3+,DC:3+,TC:3+</availability>
+		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
@@ -7657,15 +7656,15 @@
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='F-94'>
 			<availability>IS:4+</availability>
 		</model>
 		<model name='F-92'>
 			<availability>FWL:6+,IS:3+</availability>
-		</model>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:8</availability>
 		</model>
 		<model name='F-90'>
 			<availability>CS:6,LA:4,IS:6,FS:6,Periphery:6</availability>
@@ -7673,16 +7672,16 @@
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -7695,42 +7694,29 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:2+,FWL:2+,FS:2+,MERC:2+,DC:6+</availability>
-		<model name='SR1-OA'>
+		<model name='SR1-OD'>
 			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SR1-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-OD'>
+		<model name='SR1-OA'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
 		</model>
 		<model name='SR1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SR1-OB'>
-			<availability>General:7</availability>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:4,FRR:4,IS:5,WOB:4-,SIC:6,FS:9,MERC:3,CS:4-,CDS:3,LA:6,PIR:3,FWL:3,DC:3</availability>
-		<model name='(LRM)'>
-			<roles>fire_support</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>LA:5+,FS:6+,DC:4+</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='(Narc)'>
 			<availability>LA:2+,FS:2+,DC:1+</availability>
 		</model>
@@ -7738,17 +7724,30 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<roles>fire_support</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(3053 Upgrade)'>
+			<availability>LA:5+,FS:6+,DC:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:5,CS:4,MOC:3,MERC.WD:2-,LA:3,NIOPS:4,WOB:4,SIC:5</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>CC:6,General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:4+,MOC:4+</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -7756,14 +7755,14 @@
 		<model name='STU-K5'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:6,SIC:4</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,SIC:1,FS:1,TC:2,Periphery:1</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>LA:5+,FS:7+,MERC:5+</availability>
@@ -7771,21 +7770,21 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:4,HL:3,LA:7,FRR:2,SIC:2,MERC:3,FS:6</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8,WOB:0</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
@@ -7796,12 +7795,12 @@
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>LA:3+,FS:3+,DC:4+</availability>
+		<model name='SD1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='SD1-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='SD1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OA'>
 			<roles>fire_support</roles>
@@ -7830,10 +7829,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:2</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -7845,22 +7844,22 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:3</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:6,NIOPS:8,WOB:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:9,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:9,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -7878,57 +7877,57 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>FWL.MM:8+,FWL:6+,WOB:5,MERC:2+</availability>
-		<model name='TMP-3G'>
-			<availability>FWL:2,WOB:2,MERC:2</availability>
+		<model name='TMP-3M'>
+			<availability>FWL:8,WOB:8,MERC:8</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>FWL:8,WOB:8,MERC:8</availability>
+		<model name='TMP-3G'>
+			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CSR:5,CIH:4,CLAN:5,CCO:5,BAN:5,CWIE:6,CSA:5,MERC.WD:4,CDS:5,CW:5,CNC:6,CSJ:7,CJF:9,CGB:5,CB:5</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
-		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -7947,24 +7946,24 @@
 		<model name='THE-S'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='THE-N1'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
 		<model name='THE-T'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>CS:7,CLAN:6,NIOPS:7,BAN:6</availability>
 		</model>
+		<model name='THE-N1'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
@@ -7976,11 +7975,11 @@
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:5,CSV:7,FRR:3,CLAN:6,IS:2,CFM:8,WOB:7,FS:3,CWIE:7,CS:8,DC.GHO:5,CDS:5,CW:7,CBS:5,CNC:5,FWL:5,NIOPS:8,CJF:7,CGB:7</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>DC.GHO:8,CS:6,FRR:4+,CLAN:6,FWL:6+,NIOPS:6,WOB:6,FS:6+,BAN:8,DC:6+</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:8,MERC:8,DC:4</availability>
@@ -7995,11 +7994,11 @@
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>CS:2,LA:5,CLAN:2,NIOPS:2,MERC:2</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -8023,40 +8022,40 @@
 			<roles>escort,ground_support</roles>
 			<availability>MOC:3+,LA:5+,FRR:4+,MH:3+,MERC:4+</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:7,HL:3,CLAN:2,IS:8,Periphery.Deep:6,WOB:3-,FS:7,MERC:8,Periphery:4,TC:4,CS:4-,LA:8,NIOPS:4-,MH:4,DC:8</availability>
-		<model name='TDR-5Sb'>
-			<availability>CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,CNC:2,CJF:2,CWIE:2,CGB:2</availability>
+		<model name='TDR-9SE'>
+			<availability>LA:3+,MERC.ELH:7+,MERC:3+,FS:3+</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>LA:6+,FS:5+,MERC:2+</availability>
 		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:6,MERC:3</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:4,MERC:1</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:6,HL:4,LA:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='TDR-9SE'>
-			<availability>LA:3+,MERC.ELH:7+,MERC:3+,FS:3+</availability>
+		<model name='TDR-7M'>
+			<availability>CS:4+,CC:2+,FWL:7+,IS:2+,WOB:4+,MERC:2+</availability>
 		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:4,MERC:1</availability>
+		<model name='TDR-5SS'>
+			<availability>LA:6,MERC:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:4,CCC:4,LA:2,CSV:4,CFM:4,FS:2,CGS:4,DC:2,CB:4</availability>
 		</model>
-		<model name='TDR-7M'>
-			<availability>CS:4+,CC:2+,FWL:7+,IS:2+,WOB:4+,MERC:2+</availability>
+		<model name='TDR-5Sb'>
+			<availability>CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,CNC:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -8067,25 +8066,25 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:4,CLAN:4,NIOPS:3,WOB:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>FRR:6,DC:8</availability>
-		<model name='TKG-150'>
-			<availability>FRR:5,DC:4</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='TKG-150'>
+			<availability>FRR:5,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
@@ -8094,26 +8093,26 @@
 			<roles>escort</roles>
 			<availability>CS:3,NIOPS:3,WOB:3</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:3,BAN:2</availability>
-		</model>
-		<model name='&apos;C&apos;'>
-			<availability>CW:4,CLAN:3</availability>
-		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='&apos;C&apos;'>
+			<availability>CW:4,CLAN:3</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:3,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>CS:2,WOB:2</availability>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8,WOB:8</availability>
-		</model>
 		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
 			<roles>specops</roles>
 			<availability>CS:8</availability>
+		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toyama' unitType='Mek'>
@@ -8130,42 +8129,41 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:3,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:3</availability>
+		<model name='TR-13A'>
+			<availability>CC:6+,MOC:3+,General:3+</availability>
+		</model>
 		<model name='TR-14 &apos;AC&apos;'>
 			<availability>General:4,FWL:8</availability>
-		</model>
-		<model name='TR-16'>
-			<availability>MOC:4,CC:3,SIC:2,MERC:3,TC:3</availability>
 		</model>
 		<model name='TR-13'>
 			<availability>CC:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='TR-13A'>
-			<availability>CC:6+,MOC:3+,General:3+</availability>
+		<model name='TR-16'>
+			<availability>MOC:4,CC:3,SIC:2,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:4-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:3</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:5,CS:2,MOC:6,LA:5,FWL:4,IS:6,NIOPS:2,WOB:2,FS:5,MERC:6,DC:5,Periphery:6</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
 		</model>
 		<model name='TBT-7M'>
 			<roles>fire_support</roles>
@@ -8175,13 +8173,11 @@
 			<roles>fire_support</roles>
 			<availability>FRR:1,DC:3</availability>
 		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
+		<model name='TBT-5J'>
+			<availability>FWL:3</availability>
 		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:5,CS:2,MOC:6,LA:5,FWL:4,IS:6,NIOPS:2,WOB:2,FS:5,MERC:6,DC:5,Periphery:6</availability>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -8222,8 +8218,8 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CWIE:4,CGB:6</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8231,8 +8227,8 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
@@ -8240,14 +8236,14 @@
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CGS:7,CJF:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CJF:7,CGS:7</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:9,General:7,CGB:9</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -8259,27 +8255,25 @@
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:4,CDS:4,CSV:4,CLAN:4,IS:2,CB:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
 			<availability>CW:8,CSV:3,General:2,CWIE:6,CGB:2,CB:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
@@ -8288,16 +8282,18 @@
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CWIE:4,CGB:1</availability>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CWIE:4,CGB:1</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:4,CDS:4,CSV:4,CLAN:4,IS:2,CB:4</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
@@ -8313,13 +8309,13 @@
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech IIC' unitType='Mek'>
@@ -8335,21 +8331,17 @@
 			<roles>urban</roles>
 			<availability>CC:5,SIC:5</availability>
 		</model>
-		<model name='UM-R63'>
-			<roles>urban</roles>
-			<availability>CC:6+,CS:5,MERC:3+</availability>
-		</model>
 		<model name='UM-R60'>
 			<roles>urban</roles>
 			<availability>CC:6,HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
+		<model name='UM-R63'>
+			<roles>urban</roles>
+			<availability>CC:6+,CS:5,MERC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:5,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:4,FS:6,MERC:6,TC:6</availability>
-		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:3,FS:3,MERC:3</availability>
@@ -8358,9 +8350,20 @@
 			<roles>recon,fire_support</roles>
 			<availability>LA:6+,FS:6+,MERC:4+</availability>
 		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:4,FS:6,MERC:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
@@ -8369,16 +8372,12 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:6-,HL:9,IS:10,Periphery.Deep:8,WOB:6-,Periphery:10,CGB:5</availability>
+		<model name='(NETC)'>
+			<availability>IS:3+</availability>
+		</model>
 		<model name='(Liao)'>
 			<availability>CC:8,SIC:8</availability>
 		</model>
@@ -8391,19 +8390,16 @@
 		<model name='(Standard)'>
 			<availability>CC:5,General:7,SIC:5</availability>
 		</model>
-		<model name='(NETC)'>
-			<availability>IS:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
-		<model name='(3056)'>
-			<roles>asf_carrier</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(2682)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>asf_carrier</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -8411,38 +8407,38 @@
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:4-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
-		<model name='VTR-C'>
-			<availability>CC:2,FRR:3,MERC:2,DC:3</availability>
-		</model>
 		<model name='VTR-9B'>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-9D'>
-			<availability>CC:3+,LA:5+,SIC:5+,FS:6+</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
-		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
 		</model>
 		<model name='VTR-9K'>
 			<availability>MOC:3+,FRR:6+,FWL:3+,MH:3+,FS:3+,MERC:3+,TC:3+,Periphery:2+,DC:6+</availability>
 		</model>
+		<model name='VTR-C'>
+			<availability>CC:2,FRR:3,MERC:2,DC:3</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
+		</model>
 		<model name='VTR-9S'>
 			<availability>LA:3,CIR:3</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
+		</model>
+		<model name='VTR-9D'>
+			<availability>CC:3+,LA:5+,SIC:5+,FS:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -8458,17 +8454,17 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10,FRR:2,MH:3,SIC:10,MERC:5,TC:4</availability>
-		<model name='VND-1SIC'>
-			<availability>SIC:2</availability>
-		</model>
-		<model name='VND-3L'>
-			<availability>CC:7+,General:2+</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>FRR:8</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>FRR:8</availability>
+		<model name='VND-3L'>
+			<availability>CC:7+,General:2+</availability>
+		</model>
+		<model name='VND-1SIC'>
+			<availability>SIC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -8482,9 +8478,6 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
@@ -8494,17 +8487,20 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:4,CGS:6,CJF:6</availability>
+		<model name='2'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -8517,30 +8513,26 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,CS:6,LA:4,FRR:4,IS:1,FWL:3,WOB:6,FS:3,DC:4</availability>
-		<model name='VNL-K70'>
-			<availability>FRR:3,DC:3</availability>
-		</model>
 		<model name='VNL-K100'>
 			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
+		<model name='VNL-K70'>
+			<availability>FRR:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>MERC:4,TC:3</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:5+</availability>
-		</model>
 		<model name='VLC-5N'>
 			<availability>General:6</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
@@ -8549,13 +8541,13 @@
 			<roles>anti_infantry</roles>
 			<availability>General:7,FS:4</availability>
 		</model>
-		<model name='VT-5M'>
-			<roles>anti_infantry</roles>
-			<availability>FRR:2+,FWL:6+,WOB:3+,MERC:2+,DC:2+</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:5,CIR:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='VT-5M'>
+			<roles>anti_infantry</roles>
+			<availability>FRR:2+,FWL:6+,WOB:3+,MERC:2+,DC:2+</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -8564,20 +8556,20 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:4,CW:6,CNC:8,CJF:7,CGB:9,CB:7</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CSR:4,CDS:5,General:4,CGS:4,CCO:6,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:4,CDS:5,General:4,CGS:4,CCO:6,CGB:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:4</availability>
@@ -8585,10 +8577,6 @@
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
 		<availability>MERC:2,Periphery:1</availability>
-		<model name='(2312)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2312)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
@@ -8608,6 +8596,12 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='10'>
+			<availability>CSJ:6</availability>
+		</model>
 		<model name='12'>
 			<availability>CSJ:5</availability>
 		</model>
@@ -8618,21 +8612,9 @@
 		<model name='11'>
 			<availability>CSJ:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='10'>
-			<availability>CSJ:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:5-,HL:5,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:3+,FS:3+,DC:3+</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:3,SIC:3</availability>
 		</model>
@@ -8640,14 +8622,8 @@
 			<roles>spotter</roles>
 			<availability>DC:6+</availability>
 		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='WHM-7S'>
-			<availability>LA:6+,FS:4+,MERC:3+</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:4+,CC:3+,FRR:3+,FWL:7+,WOB:6+,MERC:2+,DC:3+,Periphery:3+</availability>
+		<model name='WHM-6R'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FRR:2,FS.DMM:2,FS:1,DC:3</availability>
@@ -8655,14 +8631,23 @@
 		<model name='WHM-6D'>
 			<availability>FS:3</availability>
 		</model>
+		<model name='WHM-7M'>
+			<availability>CS:4+,CC:3+,FRR:3+,FWL:7+,WOB:6+,MERC:2+,DC:3+,Periphery:3+</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>LA:6+,FS:4+,MERC:3+</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:3+,FS:3+,DC:3+</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
 		<model name='H-7'>
 			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
-		</model>
-		<model name='H-7C'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 		<model name='H-8'>
 			<availability>HL:2,LA:6,FS.CH:6,FRR:4,FS:6,MERC:4,Periphery:4</availability>
@@ -8670,61 +8655,64 @@
 		<model name='H-7A'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
+		<model name='H-7C'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2+</availability>
 		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:3-,HL:5,IS:9,NIOPS:3-,Periphery.Deep:5,WOB:3-,CIR:2,Periphery:6</availability>
-		<model name='WSP-1A'>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:3</availability>
+			<availability>MERC.WD:7+</availability>
 		</model>
 		<model name='WSP-1W'>
 			<roles>recon</roles>
 			<availability>MERC.WD:5</availability>
 		</model>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>FRR:3,DC:3</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>LA:7+,FS:5+,MERC:3+</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:7+</availability>
-		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:3,SIC:3</availability>
 		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:4+,MOC:4+,FWL:7+,WOB:6,MH:4+,MERC:4+,DC:4+</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1L'>
 			<roles>recon</roles>
-			<availability>FRR:3,DC:3</availability>
+			<availability>CC:3,SIC:3</availability>
+		</model>
+		<model name='WSP-1D'>
+			<roles>recon</roles>
+			<availability>FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
@@ -8750,13 +8738,13 @@
 			<roles>fire_support</roles>
 			<availability>HL:4,General:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='WTH-2'>
-			<roles>fire_support</roles>
-			<availability>CS:6,OA:4+,FS:4+,DC:4+,TC:4+</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>FRR:1,DC:1</availability>
+		</model>
+		<model name='WTH-2'>
+			<roles>fire_support</roles>
+			<availability>CS:6,OA:4+,FS:4+,DC:4+,TC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
@@ -8767,33 +8755,21 @@
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MERC.KH:6,MERC.WD:4,LA:7,FRR:5,FS:5,MERC:3</availability>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='WLF-1A'>
-			<availability>MERC.KH:1,LA:1</availability>
-		</model>
 		<model name='WLF-1'>
 			<availability>MERC.KH:5,MERC.WD:2,LA:6,FS:7,MERC:6</availability>
 		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='WLF-1B'>
+			<availability>MERC.KH:1,LA:1</availability>
+		</model>
+		<model name='WLF-1A'>
 			<availability>MERC.KH:1,LA:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:6,HL:4,FRR:7,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,TC:5,CS:4-,LA:7,FWL:10,NIOPS:4-,MH:4,DC:7</availability>
-		<model name='WVR-6R'>
-			<roles>recon</roles>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>LA:4+,FS:6+</availability>
-		</model>
-		<model name='WVR-6K'>
-			<roles>recon</roles>
-			<availability>FRR:2,DC:2</availability>
-		</model>
 		<model name='WVR-7M'>
 			<roles>recon</roles>
 			<availability>CC:2+,FWL:6+,WOB:5,MERC:4+,DC:2+</availability>
@@ -8806,14 +8782,26 @@
 			<roles>recon</roles>
 			<availability>Periphery.MW:4,Periphery.ME:4,FWL:8</availability>
 		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>LA:4+,FS:6+</availability>
+		</model>
+		<model name='WVR-6K'>
+			<roles>recon</roles>
+			<availability>FRR:2,DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -8834,17 +8822,17 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,CIH:2,FRR:5,CLAN:3,IS:4,CFM:4,WOB:5,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
-		<model name='WVE-9N'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CS:8,WOB:8</availability>
+			<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:1,CFM:2,CGS:2</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-9N'>
 			<roles>urban</roles>
-			<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -8893,11 +8881,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-115'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:5-,CLAN:2,NIOPS:5-,WOB:5-</availability>
+		</model>
+		<model name='ZRO-115'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
@@ -8908,20 +8896,20 @@
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:5,LA:10,FRR:4,IS:3,FS:7-,MERC:5</availability>
-		<model name='ZEU-6S'>
-			<availability>HL:6,General:4,Periphery.Deep:6,FS:4,Periphery:8</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>LA:6+,FRR:4+,FS:5+,MERC:3+</availability>
 		</model>
-		<model name='ZEU-9S2'>
-			<availability>LA:3+,FS:3+,MERC:2+</availability>
+		<model name='ZEU-6T'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:1+</availability>
 		</model>
-		<model name='ZEU-6T'>
-			<availability>LA:4,FS:4</availability>
+		<model name='ZEU-9S2'>
+			<availability>LA:3+,FS:3+,MERC:2+</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:6,General:4,Periphery.Deep:6,FS:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>
@@ -8932,11 +8920,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3058.xml
+++ b/megamek/data/forcegenerator/3058.xml
@@ -917,15 +917,15 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1000,20 +1000,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:3,CLAN:1,MERC:3,CCO:2,CWIE:2,BAN:2,CGB:2</availability>
-		<model name='ANH-1E'>
-			<availability>MERC.WD:4</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>MERC.KH:1,CLAN:2-,MERC:4</availability>
+		</model>
+		<model name='ANH-1E'>
+			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:4+,MERC.WD:7+,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:3</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1028,21 +1028,21 @@
 		<model name='ANV-5M'>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
-		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>FWL:3,WOB:3</availability>
 		</model>
+		<model name='ANV-3M'>
+			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:4,LA:3,FWL:8,SIC:4,MERC:4,FS:3,DC:6</availability>
-		<model name='APL-3T'>
+		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
-		<model name='APL-1R'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1064,60 +1064,54 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:6,HL:4,FRR:6,CLAN:1,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,LA:8,FWL:8,NIOPS:4-,DC:7,CGB:1</availability>
-		<model name='ARC-2S'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>LA:6</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:2,MERC.WD:2,CWIE:3</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:4,DC:6</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>FRR:6+,MERC:3+,DC:3+</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:6+,FS:4+</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:3,LA:5,FRR:5,IS:5,Periphery.Deep:8,BAN:2,DC:5,Periphery:5</availability>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='ARC-5W'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:6+,LA:3+,MERC:3+</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2W'>
 			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
+			<availability>MERC.WD:5</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:4,CW:3,LA:2+,CSV:4,CFM:4,FS:2+,CGS:4,CWIE:3,DC:2+</availability>
 		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:6+,FS:4+</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:2,MERC.WD:2,CWIE:3</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:6+,MERC:3+,DC:3+</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:3,LA:5,FRR:5,IS:5,Periphery.Deep:8,BAN:2,DC:5,Periphery:5</availability>
+		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CS:6+,CC:3+,LA:3+,PIR:2+,FWL:7+,WOB:6,SIC:3+,MERC:3+,FS:3+,DC:3+</availability>
 		</model>
-		<model name='ARC-2W'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>MERC.WD:5</availability>
+			<availability>FRR:4,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,MERC:1,CWIE:2-</availability>
-		<model name='AF1A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AF1C'>
 			<availability>General:7</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
@@ -1125,6 +1119,12 @@
 		</model>
 		<model name='AF1B'>
 			<availability>General:5</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
@@ -1150,37 +1150,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1190,17 +1170,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
@@ -1238,57 +1238,57 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:2</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:3,FRR:5,CLAN:3,IS:3,WOB:4-,SIC:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,LA:4,FWL:4,NIOPS:4-,DC:8</availability>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4+,IS:3+,DC:4+</availability>
+		<model name='AS7-K'>
+			<availability>CC:2+,CS:3+,MOC:1,FRR:4+,CNC:2,FWL:4+,WOB:2,SIC:2+,MERC:4+,DC:6+,TC:1</availability>
+		</model>
+		<model name='AS7-D-DC'>
+			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:2,CLAN:8,FS:2,DC:2</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4+,IS:3+,DC:4+</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>FRR:2+,MERC:2+,DC:2+</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>FRR:3+,MERC:3+,DC:4+</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:1,OA:1,LA:5+,PIR:1,FS:4,MERC:3+,TC:1</availability>
-		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2+,MERC:2+,DC:2+</availability>
-		</model>
 		<model name='AS7-S2'>
 			<availability>LA:5</availability>
 		</model>
-		<model name='AS7-D'>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1,MERC:0,DC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>CC:2+,CS:3+,MOC:1,FRR:4+,CNC:2,FWL:4+,WOB:2,SIC:2+,MERC:4+,DC:6+,TC:1</availability>
+		<model name='AS7-S'>
+			<availability>MOC:1,OA:1,LA:5+,PIR:1,FS:4,MERC:3+,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:4,CCC:4,CSR:4,CW:5,CLAN:4,CNC:5,BAN:5,CWIE:5</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
@@ -1318,13 +1318,13 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:3,FRR:1,IS:2,SIC:3,FS:4,CIR:2,TC:2,Periphery:1,OA:2,LA:4,FWL:1,DC:1</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8+,FS:8+</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>LA:5,General:5,FS:5</availability>
+		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8+,FS:8+</availability>
 		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
@@ -1332,11 +1332,11 @@
 		<model name='AWS-8R'>
 			<availability>IS:2,FWL:4</availability>
 		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
-		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -1344,11 +1344,11 @@
 		<model name='AWS-9M'>
 			<availability>MOC:2+,PIR:2+,FWL:6+,IS:5+,MH:2+,TC:2+</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>LA:4,FWL:4,FS:4</availability>
-		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:2+,FWL:4+,IS:2+,MH:2+,TC:2+,Periphery:2+</availability>
+		</model>
+		<model name='AWS-9Ma'>
+			<availability>LA:4,FWL:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -1362,12 +1362,12 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>LA:5+,FRR:2+,FS:3+,MERC:2+</availability>
-		<model name='AXM-1N'>
-			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
-		</model>
 		<model name='AXM-2N'>
 			<roles>fire_support</roles>
 			<availability>LA:6,FS:4</availability>
+		</model>
+		<model name='AXM-1N'>
+			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
@@ -1383,6 +1383,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -1391,26 +1399,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:4,MERC:5</availability>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
@@ -1422,13 +1418,17 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
@@ -1439,19 +1439,7 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:4,CHH:4,CLAN:2</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1459,12 +1447,28 @@
 			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5,MERC:3</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -1474,27 +1478,23 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='G'>
+		<model name='H'>
 			<roles>apc</roles>
-			<availability>General:4</availability>
+			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
@@ -1504,8 +1504,8 @@
 		<model name='BNC-3MC'>
 			<availability>MOC:9</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>OA:2,LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
+		<model name='BNC-3M'>
+			<availability>MOC:1,FWL:2,TC:1</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:3</availability>
@@ -1513,11 +1513,11 @@
 		<model name='BNC-3E'>
 			<availability>HL:3,General:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
 		</model>
+		<model name='BNC-3S'>
+			<availability>OA:2,LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
+		</model>
 		<model name='BNC-5S'>
 			<availability>LA:7+,FRR:3+,FS:6+,MERC:3+</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1,FWL:2,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
@@ -1528,33 +1528,33 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CGS:7,CCO:3,CB:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -1573,14 +1573,17 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:2,DC:5</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:2,MERC:0</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:2</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>CS:5+,CC:4+,PIR:2+,FWL:6+,IS:2+,WOB:5+,MH:2+,SIC:4+,MERC:4+</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1,WOB:1</availability>
@@ -1588,20 +1591,17 @@
 		<model name='BLR-1S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:2,MERC:0</availability>
+		</model>
 		<model name='BLR-3S'>
 			<availability>LA:6+,FS:4+</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,FS:3,BAN:8,Periphery:6</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:2</availability>
+		<model name='BLR-3M'>
+			<availability>CS:5+,CC:4+,PIR:2+,FWL:6+,IS:2+,WOB:5+,MH:2+,SIC:4+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMech Recovery Vehicle' unitType='Tank'>
@@ -1617,15 +1617,15 @@
 			<roles>interceptor</roles>
 			<availability>CHH:7,CIH:7,CNC:9,General:8,CGS:7</availability>
 		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
-		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CFM:6,CGS:8,CJF:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -1637,17 +1637,17 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:3,CSR:3,CLAN:2,CSJ:5,CGS:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:8,General:8</availability>
+		<model name='6'>
+			<availability>General:1</availability>
 		</model>
 		<model name='4'>
 			<availability>General:2</availability>
 		</model>
-		<model name='6'>
-			<availability>General:1</availability>
-		</model>
 		<model name='5'>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
@@ -1655,12 +1655,12 @@
 		<model name='(Armor)'>
 			<availability>IS:2,DC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1679,11 +1679,11 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>LA:4,FRR:2,FS:2,MERC:1</availability>
-		<model name='BRZ-B3'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BRZ-A3'>
 			<availability>LA:8,FRR:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='BRZ-B3'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
@@ -1691,18 +1691,15 @@
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:1,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CSJ:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:4,CCC:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -1710,20 +1707,26 @@
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:1,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:4,CCC:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:2+,LA:4+,FRR:4+,SIC:2+,FS:2+,MERC:2+,DC:5+</availability>
-		<model name='BHKU-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
+		</model>
+		<model name='BHKU-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OR'>
 			<availability>DC:1+</availability>
@@ -1731,29 +1734,26 @@
 		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OA'>
-			<availability>General:7</availability>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:6,FRR:3,CLAN:7,CFM:6,FS:1,CWIE:8,DC.GHO:3,OA:1,CDS:6,CBS:8,FWL:1,NIOPS:7,CGB:8,CSR:6,CSV:6,WOB:7,FWL.OH:1,MERC:2,CGS:8,Periphery:1,TC:1,CS:7,CW:8,LA:1,CNC:8,CJF:6,DC:2</availability>
-		<model name='BL-6-KNT'>
-			<availability>DC.GHO:4,CS:4,OA:2+,FRR:4,CLAN:6,FWL:3,NIOPS:4,WOB:4,MERC.SI:5,BAN:6,TC:2,DC:4</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>CS:6,CLAN:5,FWL:5+,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
 		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:8</availability>
+		<model name='BL-9-KNT'>
+			<availability>CS:6+,WOB:6+</availability>
+		</model>
+		<model name='BL-6-KNT'>
+			<availability>DC.GHO:4,CS:4,OA:2+,FRR:4,CLAN:6,FWL:3,NIOPS:4,WOB:4,MERC.SI:5,BAN:6,TC:2,DC:4</availability>
 		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:7,FRR:7,FWL:3,MERC:7,FS:7,DC:7</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>CS:6+,WOB:6+</availability>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -1765,13 +1765,13 @@
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -1790,26 +1790,32 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:5-,MOC:4,OA:4,HL:3,IS:2,SIC:6,FS:7,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:2+,SIC:5+,FS:2+,MERC:2+,Periphery:1</availability>
-		</model>
 		<model name='BJ-1DC'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='BJ-2'>
-			<availability>CC:3+,CS:3+,LA:3+,PIR:1+,WOB:3+,SIC:4,FS:6+,MERC:3+</availability>
+		<model name='BJ-3'>
+			<availability>CC:2+,SIC:5+,FS:2+,MERC:2+,Periphery:1</availability>
 		</model>
 		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
 		</model>
+		<model name='BJ-2'>
+			<availability>CC:3+,CS:3+,LA:3+,PIR:1+,WOB:3+,SIC:4,FS:6+,MERC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CS:2+,FWL:2+,IS:2+,WOB:2+,SIC:2+,FS:2+,MERC:2+,DC:5+</availability>
-		<model name='BJ2-O'>
-			<availability>General:8</availability>
+		<model name='BJ2-OE'>
+			<availability>General:5,FWL:6</availability>
+		</model>
+		<model name='BJ2-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,DC:1+</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:7</availability>
@@ -1817,17 +1823,11 @@
 		<model name='BJ2-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BJ2-OE'>
-			<availability>General:5,FWL:6</availability>
-		</model>
 		<model name='BJ2-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,DC:1+</availability>
+		<model name='BJ2-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
@@ -1858,13 +1858,13 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:5,OA:1-,CDS:5,CLAN:4,IS:2-,NIOPS:5,FWL:2-,WOB:5,DC:2-,Periphery:1</availability>
-		<model name='BMB-10D'>
-			<roles>fire_support</roles>
-			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
-		</model>
 		<model name='BMB-12D'>
 			<roles>fire_support</roles>
 			<availability>CS:6,OA:3+,FRR:3+,CLAN:8,NIOPS:6,WOB:6,MERC.SI:8,BAN:8</availability>
+		</model>
+		<model name='BMB-10D'>
+			<roles>fire_support</roles>
+			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -1880,13 +1880,13 @@
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -1904,6 +1904,9 @@
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -1912,9 +1915,6 @@
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -1932,13 +1932,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -1950,11 +1950,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -2007,13 +2007,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -2025,77 +2025,70 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:8,MOC:2,LA:3,Periphery.CM:2,Periphery.HR:2,Periphery.ME:2,MH:2,SIC:5,FS:5,MERC:3,TC:2,Periphery:1</availability>
-		<model name='CTF-1X'>
-			<availability>General:6,Periphery:6</availability>
-		</model>
 		<model name='CTF-2X'>
 			<availability>CC:6,MOC:2,SIC:2,FS:1,MERC:1,TC:2</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>LA:4+,FS:4+</availability>
 		</model>
+		<model name='CTF-3L'>
+			<availability>CC:7+,MOC:2,MERC:2,TC:2</availability>
+		</model>
 		<model name='CTF-4X'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='CTF-3L'>
-			<availability>CC:7+,MOC:2,MERC:2,TC:2</availability>
+		<model name='CTF-1X'>
+			<availability>General:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,CIR:2,FS:1,Periphery:2,TC:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
-		<model name='CPLT-K3'>
+		<model name='CPLT-C4C'>
 			<roles>fire_support</roles>
-			<availability>DC:5+</availability>
+			<availability>CC:2+,MOC:1,FS:2+,MERC:2+,TC:1</availability>
+		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:3,DC:5</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:5,HL:3,CLAN:4,IS:1,Periphery.Deep:8,MERC:5,BAN:6,Periphery:5</availability>
+		</model>
+		<model name='CPLT-C4'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,OA:3,SIC:2</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>FRR:2,DC:4</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4+,CS:2,MOC:2,WOB:2,FS:3+,DC:3+,TC:2</availability>
 		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:5,HL:3,CLAN:4,IS:1,Periphery.Deep:8,MERC:5,BAN:6,Periphery:5</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>FRR:2,DC:4</availability>
-		</model>
-		<model name='CPLT-A1'>
-			<roles>fire_support</roles>
-			<availability>CC:3,SIC:3</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:3,DC:5</availability>
-		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,OA:3,SIC:2</availability>
+			<availability>DC:5+</availability>
 		</model>
 		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
 			<availability>DC:1</availability>
 		</model>
-		<model name='CPLT-C4C'>
+		<model name='CPLT-A1'>
 			<roles>fire_support</roles>
-			<availability>CC:2+,MOC:1,FS:2+,MERC:2+,TC:1</availability>
+			<availability>CC:3,SIC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:4,CCC:4,CSR:4,CDS:4,CW:4,CLAN:4,CNC:3,CSJ:6,CGS:4,CJF:4,CGB:4</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -2104,20 +2097,27 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,FS:6</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
@@ -2125,15 +2125,15 @@
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(TAG)'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek'>
@@ -2164,26 +2164,26 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-D3'>
-			<availability>FS:2,MERC:2+</availability>
-		</model>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>IS:1,FS:3,MERC:3,Periphery:2</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:4+,IS:3+,FS:5+</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>LA:3+,FRR:3+,FWL:3+,SIC:3+,FS:8+,MERC:3+,CIR:3+,Periphery:2+</availability>
+			<availability>LA:2,IS:1,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:4,LA:4-,FRR:4-,General:4-,FWL:4-,Periphery.Deep:6,FS:5-,MERC:5-,Periphery:6</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-D'>
+			<availability>LA:3+,FRR:3+,FWL:3+,SIC:3+,FS:8+,MERC:3+,CIR:3+,Periphery:2+</availability>
+		</model>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:2,IS:1,FS:4,MERC:4,Periphery:2</availability>
+			<availability>IS:1,FS:3,MERC:3,Periphery:2</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FS:2,MERC:2+</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:4+,IS:3+,FS:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -2230,43 +2230,43 @@
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:3-,CC:3-,OA:3-,HL:2-,LA:3-,IS:2-,FWL:3-,FS:3-,Periphery:3-,TC:3-,DC:3-</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:4-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>IS:4,Periphery:2</availability>
-		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:4,IS:3,FS:4</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:3,IS:2,FS:3</availability>
 		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:4-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:4,IS:3,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:5,CHH:3,FRR:2,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:6,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+		<model name='CHP-3P'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='CHP-2N'>
+			<availability>IS:6,NIOPS:0</availability>
+		</model>
 		<model name='CHP-3N'>
 			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4+,CS:4,LA:4+,IS:4+,MERC:4+</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:2,CHH:3,WOB:6,SIC:4,FS:4,MERC:4,BAN:4,DC.GHO:5,CS:6,LA:4,NIOPS:6,MERC.SI:6,DC:4,CGB:3</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:6,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4+,CS:4,LA:4+,IS:4+,MERC:4+</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
-		</model>
-		<model name='CHP-3P'>
-			<availability>CS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -2281,8 +2281,8 @@
 		<model name='CGR-3K'>
 			<availability>CC:4,FRR:5,MERC:4,DC:5</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>CC:5,HL:2,SIC:5,Periphery:4</availability>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>OA:2,FRR:5,DC:5</availability>
@@ -2297,21 +2297,14 @@
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:3,MERC:4</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>CC:5,HL:2,SIC:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-11'>
-			<availability>FRR:4,FWL:6+,WOB:6,MERC:4</availability>
-		</model>
-		<model name='F-14-S'>
-			<availability>FWL:7+</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		<model name='F-12-S'>
+			<availability>FWL:4,WOB:4</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
@@ -2321,16 +2314,19 @@
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:4,WOB:4</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='F-11'>
+			<availability>FRR:4,FWL:6+,WOB:6,MERC:4</availability>
+		</model>
+		<model name='F-14-S'>
+			<availability>FWL:7+</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:6,NIOPS:6,WOB:6,DC:3+</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
@@ -2338,6 +2334,10 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Speed)'>
+			<roles>recon</roles>
+			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -2348,8 +2348,8 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:6+,FRR:4+,CLAN:6,WOB:6,SIC:4+,FS:4+,MERC:4+,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
@@ -2357,23 +2357,15 @@
 		<model name='CHP-W5b'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
+		<model name='CHP-W7'>
+			<availability>LA:6+,FRR:4+,CLAN:6,WOB:6,SIC:4+,FS:4+,MERC:4+,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,OA:1,LA:3,IS:3,FWL:6,WOB:4-,FS:2,MERC:3,Periphery:1,DC:4</availability>
-		<model name='CDA-2B'>
-			<roles>anti_infantry</roles>
-			<availability>CC:1,SIC:1</availability>
-		</model>
 		<model name='CDA-2A'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='CDA-3C'>
-			<roles>training</roles>
-			<availability>IS:2</availability>
 		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
@@ -2382,6 +2374,14 @@
 		<model name='CDA-3M'>
 			<roles>recon</roles>
 			<availability>FWL:7+,IS:4+,MERC:5+</availability>
+		</model>
+		<model name='CDA-2B'>
+			<roles>anti_infantry</roles>
+			<availability>CC:1,SIC:1</availability>
+		</model>
+		<model name='CDA-3C'>
+			<roles>training</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
@@ -2409,20 +2409,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -2442,14 +2442,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -2457,29 +2454,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -2490,8 +2490,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -2499,18 +2502,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -2519,27 +2528,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -2547,8 +2547,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -2573,29 +2573,29 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:3,IS:3,WOB:2-,SIC:4,FS:4,MERC:3,CS:2-,LA:3,FWL:3,NIOPS:2-,DC:3</availability>
-		<model name='CLNT-2-3T'>
-			<availability>IS:6,Periphery.Deep:8,NIOPS:8</availability>
-		</model>
 		<model name='CLNT-2-4T'>
 			<availability>CC:3,SIC:3,FS:3</availability>
 		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:5+,CS:4,LA:3+,General:4+</availability>
 		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:6,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:8,WOB:6</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,NIOPS:4,WOB:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,NIOPS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Combat Engineer' unitType='Infantry'>
@@ -2620,18 +2620,18 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
-		<model name='COM-1B'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>LA:2</availability>
+			<availability>LA:8+,FRR:5+,MERC:5+,FS:4+</availability>
 		</model>
 		<model name='COM-1D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>LA:1</availability>
 		</model>
-		<model name='COM-5S'>
+		<model name='COM-1B'>
 			<roles>recon</roles>
-			<availability>LA:8+,FRR:5+,MERC:5+,FS:4+</availability>
+			<availability>LA:2</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
@@ -2645,17 +2645,17 @@
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>MOC:3,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:3,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8,SIC:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>SIC:5,FS:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8,SIC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -2678,24 +2678,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:2</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,MERC.WD:1,CSR:1,CW:1,CSV:1,NIOPS:2,CSJ:3,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -2707,17 +2707,17 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Copperhead' unitType='Mek'>
@@ -2728,8 +2728,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:8</availability>
+		<model name='CSR-V14'>
+			<availability>LA:5+,FRR:4+,FS:5+,MERC:4+</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>LA:2,FS.AH:4,Periphery:2</availability>
@@ -2737,11 +2740,8 @@
 		<model name='CSR-V12'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
 		</model>
-		<model name='CSR-V14'>
-			<availability>LA:5+,FRR:4+,FS:5+,MERC:4+</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:2</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -2752,31 +2752,31 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
 		<availability>CSV:4,CSJ:4,CJF:4,CCO:4</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -2785,28 +2785,28 @@
 			<roles>raider</roles>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:6,CS:5,FRR:2,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8+</availability>
-		</model>
-		<model name='CRB-C'>
-			<availability>DC:5+</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:3,Periphery.Deep:8,NIOPS:0,Periphery:3</availability>
 		</model>
+		<model name='CRB-C'>
+			<availability>DC:5+</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:6,CS:5,FRR:2,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8+</availability>
+		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:7,CSR:5,FRR:3,CSV:6,CLAN:6,CFM:5,WOB:8,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:8,NIOPS:9,CJF:5,CGB:7</availability>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
+		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:7,NIOPS:0</availability>
 		</model>
 		<model name='CRK-5003-1'>
 			<availability>CS:6,FRR:4,CLAN:6,NIOPS:6,WOB:6,BAN:8</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
@@ -2820,20 +2820,30 @@
 		<model name='A'>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:4,CLAN:4,IS:8,NIOPS:6-,Periphery.Deep:5,WOB:5-,Periphery:5</availability>
-		<model name='CRD-4D'>
-			<availability>FS:6+</availability>
+		<model name='CRD-3L'>
+			<roles>raider</roles>
+			<availability>CC:8,SIC:7</availability>
 		</model>
-		<model name='CRD-2R'>
-			<availability>CLAN:5,CGS:7,BAN:2</availability>
+		<model name='CRD-3R'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:3,Periphery:5</availability>
+		</model>
+		<model name='CRD-5M'>
+			<availability>CC:2+,CS:2,FWL:6+,IS:2+,WOB:4,FS:2+,MERC:2+,DC:2+</availability>
+		</model>
+		<model name='CRD-3K'>
+			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='CRD-4K'>
+			<availability>LA:4+,FRR:6+,MERC:4+,FS:4+,DC:6+</availability>
 		</model>
 		<model name='CRD-4BR'>
 			<availability>MERC:5</availability>
@@ -2841,31 +2851,39 @@
 		<model name='CRD-5S'>
 			<availability>LA:6+,FS:4+,MERC:4+</availability>
 		</model>
-		<model name='CRD-3R'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:3,Periphery:5</availability>
-		</model>
 		<model name='CRD-4L'>
 			<availability>CC:5+</availability>
 		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:4,DC:4</availability>
-		</model>
-		<model name='CRD-3L'>
-			<roles>raider</roles>
-			<availability>CC:8,SIC:7</availability>
-		</model>
-		<model name='CRD-5M'>
-			<availability>CC:2+,CS:2,FWL:6+,IS:2+,WOB:4,FS:2+,MERC:2+,DC:2+</availability>
+		<model name='CRD-2R'>
+			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 		<model name='CRD-3D'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='CRD-4K'>
-			<availability>LA:4+,FRR:6+,MERC:4+,FS:4+,DC:6+</availability>
+		<model name='CRD-4D'>
+			<availability>FS:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
+		<model name='CP-11-G'>
+			<availability>CS:4+,FRR:4+,SL.2:4+,MERC:4+</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:2,DC:2</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>CC:2+,CS:3,MOC:3+,LA:2+,FWL:3+,IS:2+,WOB:3,FS:4+,DC:4+,TC:3+</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:6,General:6,IS:6,FS:6,MERC:6,DC:6,TC:6</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
+		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
 			<availability>CC:1,LA:1,FWL:2,IS:1,FS:2,DC:3+</availability>
@@ -2873,37 +2891,19 @@
 		<model name='CP-11-H'>
 			<availability>PIR:3+,MH:3+,CIR:3+,TC:3+</availability>
 		</model>
-		<model name='CP-10-Z'>
-			<availability>OA:6,General:6,IS:6,FS:6,MERC:6,DC:6,TC:6</availability>
-		</model>
-		<model name='CP-11-A'>
-			<availability>CC:2+,CS:3,MOC:3+,LA:2+,FWL:3+,IS:2+,WOB:3,FS:4+,DC:4+,TC:3+</availability>
-		</model>
-		<model name='CP-11-G'>
-			<availability>CS:4+,FRR:4+,SL.2:4+,MERC:4+</availability>
-		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CS:6,CHH:4,CSR:4,CLAN:2,NIOPS:6,WOB:5,CJF:4</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CS:8,General:8,NIOPS:8,WOB:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
@@ -2925,36 +2925,36 @@
 		<model name='DMO-4K'>
 			<availability>FRR:2,DC:4</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='DMO-2K'>
 			<availability>FRR:2,DC:3</availability>
+		</model>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,IS:1+,FS:1+,MERC:1+,BAN:2,CWIE:6,MERC.WD:4,CDS:5,CW:6,CBS:4,LA:1+,CNC:4,CSJ:8,CJF:5,CGB:5,CB:4,DC:1+</availability>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CHH:1,CW:2,CSV:3,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CLAN:2,General:1</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:4,General:4,CGS:5,CCO:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CLAN:2,General:1</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -2976,18 +2976,15 @@
 		<model name='DRT-3S'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='DRT-4S'>
-			<availability>LA:3,FS:5,MERC:2,CIR:2</availability>
-		</model>
 		<model name='DRT-6S'>
 			<availability>LA:6,FS:5</availability>
+		</model>
+		<model name='DRT-4S'>
+			<availability>LA:3,FS:5,MERC:2,CIR:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:5,FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
@@ -2995,6 +2992,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -3004,9 +3005,8 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:3</availability>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
@@ -3034,17 +3034,17 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,CNC:3,FWL:8,NIOPS:6,CJF:1,DC:7</availability>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:5+,CS:5,LA:5+,FRR:4+,FWL:5+,IS:4+,WOB:5,SIC:4+,FS:5+,DC:5+,CWIE:4</availability>
 		</model>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -3080,11 +3080,11 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:4,CC:3,HL:3,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:6,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
-		<model name='DV-7D'>
-			<availability>LA:4+,FS:6+,MERC:4+,TC:4+</availability>
-		</model>
 		<model name='DV-6M'>
 			<availability>HL:6,CLAN:4,IS:6-,Periphery.Deep:7,Periphery:8</availability>
+		</model>
+		<model name='DV-7D'>
+			<availability>LA:4+,FS:6+,MERC:4+,TC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -3095,24 +3095,24 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:2+,LA:3+,FS:3+,MERC:2+,TC:3</availability>
-		<model name='DVS-1D'>
-			<availability>LA:4,FS:4,TC:8</availability>
+		<model name='DVS-3'>
+			<availability>LA:2,FS:2</availability>
 		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='DVS-3'>
-			<availability>LA:2,FS:2</availability>
+		<model name='DVS-1D'>
+			<availability>LA:4,FS:4,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CIH:4,CGS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon Fire' unitType='Mek'>
@@ -3123,50 +3123,50 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,FRR:9,MERC:3,DC:8</availability>
+		<model name='DRG-1N'>
+			<availability>FRR:5,MERC:4,DC:4,Periphery:5</availability>
+		</model>
 		<model name='DRG-5N'>
 			<availability>FRR:5+,MERC:5+,DC:6+</availability>
 		</model>
 		<model name='DRG-1C'>
 			<availability>FRR:1,DC:1</availability>
 		</model>
-		<model name='DRG-1N'>
-			<availability>FRR:5,MERC:4,DC:4,Periphery:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CIH:7,CSV:5,CLAN:5,IS:1+,CFM:5,CSA:6,MERC.WD:5,CDS:4,CSJ:5,CJF:4,CGB:9,CB:7</availability>
-		<model name='D'>
-			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:7</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CWIE:6,CGB:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
+		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7,CB:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
-		<model name='(SRM)'>
-			<availability>CC:8,General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:7</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>LA:7+,WOB:4,FS:4+</availability>
+		<model name='(SRM)'>
+			<availability>CC:8,General:4</availability>
 		</model>
 		<model name='(ERLL)'>
 			<availability>LA:1+,FS:1+</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:7+,WOB:4,FS:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -3191,9 +3191,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
-		<model name='EGL-R6'>
-			<availability>LA:2,General:7,FS:2</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:3,FS:3</availability>
 		</model>
@@ -3204,41 +3201,44 @@
 			<roles>ground_support</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:2,General:7,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:2+,MOC:2+,FWL.MM:4,FWL:3+,FWL.FO:4+,MERC:2+</availability>
-		<model name='EGL-1M'>
-			<availability>CC:3,MOC:3,FWL:2</availability>
-		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='EGL-1M'>
+			<availability>CC:3,MOC:3,FWL:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:8,MERC.WD:8,CW:8,CLAN:8,CNC:8</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -3262,11 +3262,11 @@
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>OA:2,LA:5,Periphery.HR:2,MH:2,SIC:3,FS:9,MERC:5,Periphery.OS:2,TC:2,DC:3</availability>
-		<model name='ENF-4R'>
-			<availability>LA:4,General:6,FS:6,TC:6</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>LA:4+,FS:6+,MERC:2+,TC:2+</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>LA:4,General:6,FS:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -3286,46 +3286,46 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,CCC:3+,CIH:3+,CGS:3+,CB:2+</availability>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='A'>
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:1,CS:5,CIH:1,CDS:2,CSV:1,FWL:1,WOB:2,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CS:4,CLAN:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>FS:2,MERC:1</availability>
-		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -3356,11 +3356,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:2,FWL:1,NIOPS:4,WOB:4,DC:1</availability>
-		<model name='EXT-4A'>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:2,DC:8</availability>
+		</model>
+		<model name='EXT-4A'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -3371,12 +3371,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -3396,11 +3396,11 @@
 		<model name='FLC-4P'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
@@ -3425,8 +3425,17 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,MERC.KH:1+,CIH:7,CSV:5,CLAN:4,IS:1+,CWIE:8,MERC.WD:6,CDS:5,CW:8,CNC:4,CSJ:4,CJF:6,CGB:5</availability>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
+		</model>
 		<model name='B'>
 			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CB:9</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:3,CW:3,CBS:2,CLAN:2,General:1,CCO:5,CWIE:4</availability>
@@ -3434,22 +3443,9 @@
 		<model name='C'>
 			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4,CWIE:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CB:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
-		</model>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:5,LA:6,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:8</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
 			<availability>LA:3,FWL:2,FS:5</availability>
@@ -3457,6 +3453,10 @@
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:9</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -3483,65 +3483,65 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(LBX20)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(UAC20)'>
+		<model name='(LBX5)'>
 			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC20)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:7</availability>
 		</model>
-		<model name='(LBX5)'>
+		<model name='(RAC2)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>IS:3</availability>
 		</model>
 		<model name='(LBX2)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LBX10)'>
+		<model name='(AC10)'>
 			<roles>field_gun</roles>
-			<availability>IS:4</availability>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LBX10)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(UAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
@@ -3550,28 +3550,28 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CFM:2,CJF:4</availability>
-		<model name='Prime'>
+		<model name='B'>
+			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
+		<model name='A'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
@@ -3583,13 +3583,13 @@
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>LA:5+,FS:5+,MERC:3+</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:5,MERC:5,FS:5</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>LA:6,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:5,MERC:5,FS:5</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -3598,14 +3598,14 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:6,MERC.WD:3,CIH:5,CLAN:3,WOB:5,BAN:2,CB:4</availability>
-		<model name='C'>
-			<availability>MERC.WD:6,CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:6+</availability>
 		</model>
 		<model name='FFL-4A'>
 			<availability>:0,MERC.WD:2-</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:6,CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FFL-4C'>
 			<availability>CS:6,WOB:6</availability>
@@ -3613,6 +3613,10 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:8,IS:7,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
+		<model name='FS9-M &apos;Mirage&apos;'>
+			<roles>recon</roles>
+			<availability>LA:1,LA.SR:2</availability>
+		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
@@ -3622,10 +3626,6 @@
 			<roles>recon</roles>
 			<availability>CC:3+,CS:3+,MOC:4+,LA:5+,FRR:4+,General:3+,FS:4+,TC:3+</availability>
 		</model>
-		<model name='FS9-M &apos;Mirage&apos;'>
-			<roles>recon</roles>
-			<availability>LA:1,LA.SR:2</availability>
-		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
 			<availability>LA:5+,General:2+,FS:4+</availability>
@@ -3633,70 +3633,70 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:4+,CC:3+,LA:4+,IS:3+,WOB:4+,FS:4+,MERC:3+,DC:6+</availability>
-		<model name='FS9-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OX'>
-			<availability>General:1</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='FS9-OD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
+		<model name='FS9-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='FS9-OR'>
 			<availability>CLAN:4,IS:1+,DC:1+</availability>
 		</model>
+		<model name='FS9-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OX'>
+			<availability>General:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:3,CSV:5,FRR:2,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:4,Periphery.R:2,CDS:3,LA:6,CBS:3,NIOPS:5,CJF:5,CGB:3,DC:2</availability>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:5,LA:5</availability>
+		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:8,CS:6,LA:2,CLAN:8,NIOPS:6,WOB:6,MERC.SI:8,BAN:8</availability>
 		</model>
 		<model name='FLS-C'>
 			<availability>DC:4+</availability>
 		</model>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:5,LA:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -3719,17 +3719,15 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -3737,20 +3735,22 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
 		<availability>CS:4,CHH:1,LA:4,CBS:1,NIOPS:4,SIC:2,FS:4,Periphery:1</availability>
-		<model name='(2613)'>
-			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3058)'>
 			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
 			<availability>CS:4,LA:4,FS:4</availability>
+		</model>
+		<model name='(2613)'>
+			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -3783,11 +3783,11 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CS:4,CHH:5,CW:4,CLAN:2,CJF:4,CGB:5</availability>
-		<model name='CX-17'>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>CS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fury' unitType='Dropship'>
@@ -3810,15 +3810,19 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:5,CW:5,CLAN:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:2,CW:6,CCO:6,CGS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:4,Periphery:2,CS:5,OA:2,LA:5,FWL:7,DC:3</availability>
+		</model>
 		<model name='GAL-200'>
 			<availability>MOC:3,LA:3,FRR:3,IS:1,DC:3,Periphery:3</availability>
 		</model>
@@ -3826,21 +3830,17 @@
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:6</availability>
 		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:4,Periphery:2,CS:5,OA:2,LA:5,FWL:7,DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>CC:2+,MOC:2+,MERC.WD:6,IS:4+,FWL:2+,MH:4,MERC:6,TC:2+</availability>
 		<model name='GAL-2GLS'>
 			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
@@ -3865,20 +3865,20 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSR:3,CLAN:5,IS:1+,BAN:3,CWIE:4,CSA:5,MERC.WD:3,CDS:5,CNC:5,CSJ:7,CJF:6,CGB:9,CB:6</availability>
-		<model name='Prime'>
-			<availability>CW:7,CSV:7,General:8,CSJ:7,CJF:9,CWIE:7,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,CW:6,CNC:6,General:3,CSJ:3,CJF:4,CWIE:6,CGB:5</availability>
+		<model name='H'>
+			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CLAN:2,General:1</availability>
 		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CW:7,CSV:7,General:8,CSJ:7,CJF:9,CWIE:7,CGB:8</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CLAN:2,General:1</availability>
+		<model name='D'>
+			<availability>CDS:4,CW:6,CNC:6,General:3,CSJ:3,CJF:4,CWIE:6,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>CSV:5,General:7,CSJ:5,CGB:4</availability>
@@ -3950,20 +3950,20 @@
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:5,CLAN:2</availability>
-		<model name='(Standard)'>
-			<availability>CSV:8,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:6,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:8,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:4,HL:3,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:5,BAN:2,Periphery:5</availability>
-		</model>
 		<model name='GTHA-500b'>
 			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:4,HL:3,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:5,BAN:2,Periphery:5</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
@@ -3980,26 +3980,26 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,CNC:2,DC:8</availability>
-		<model name='DRG-C'>
-			<availability>FRR:6+,DC:6+</availability>
-		</model>
 		<model name='DRG-1G'>
 			<availability>FRR:6,DC:6</availability>
-		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
 		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:4+,CNC:5,DC:6+</availability>
 		</model>
+		<model name='DRG-C'>
+			<availability>FRR:6+,DC:6+</availability>
+		</model>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>CC:3+,MOC:3+,IS:3+,WOB:5,FWL.KIS:7+,SIC:3+,FS:3+,MERC:3+,CS:3,Periphery.MW:1,FWL:6+,MH:3+,DC:3+</availability>
-		<model name='T-IT-N10M'>
-			<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='T-IT-N11M'>
 			<availability>FWL:5,WOB:5,MERC:2</availability>
+		</model>
+		<model name='T-IT-N10M'>
+			<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -4010,11 +4010,11 @@
 		<model name='GHR-5H'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='GHR-C'>
-			<availability>IS:2+,DC:3+</availability>
-		</model>
 		<model name='GHR-5N'>
 			<availability>General:2</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:2+,DC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -4029,14 +4029,14 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
@@ -4050,14 +4050,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:4</availability>
@@ -4065,29 +4065,29 @@
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:4,MERC.WD:5,CIH:6,CDS:4,CW:5,CNC:6,CLAN:4,CCO:4,CJF:5,CGB:5,CWIE:2</availability>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CLAN:5,CNC:5</availability>
-		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CIH:8,CNC:8,CLAN:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CLAN:5,CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,CNC:2,NIOPS:3,DC:8</availability>
-		<model name='GRF-3M'>
-			<availability>LA:6+,FWL:6+,IS:4+,FS:4+,DC:3+</availability>
+		<model name='GRF-1S'>
+			<availability>LA:5,FRR:3,MERC:4</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:5,FRR:3,MERC:4</availability>
+		<model name='GRF-3M'>
+			<availability>LA:6+,FWL:6+,IS:4+,FS:4+,DC:3+</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>LA:4+,FRR:4+,FS:5+,MERC:4+,DC:5+</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
@@ -4104,15 +4104,15 @@
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:1,IS:1,FWL:1,SIC:3,MERC:1,TC:1,Periphery:1</availability>
-		<model name='B'>
-			<availability>CC:2,IS:2,FWL:2</availability>
+		<model name='(Standard)'>
+			<roles>ground_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CC:2,MOC:2,SIC:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>ground_support</roles>
-			<availability>General:6</availability>
+		<model name='B'>
+			<availability>CC:2,IS:2,FWL:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
@@ -4123,21 +4123,21 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
-		<model name='GLT-3N'>
+		<model name='GLT-4L'>
 			<roles>raider</roles>
-			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8,DC:8</availability>
+			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,NIOPS:0,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='GLT-4P'>
 			<roles>raider</roles>
 			<availability>Periphery.MW:1,Periphery.ME:1,FWL:1,NIOPS:0,MERC:1</availability>
 		</model>
-		<model name='GLT-4L'>
-			<roles>raider</roles>
-			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,NIOPS:0,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:6+,FWL:6+,WOB:4,FS:6+</availability>
+		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
@@ -4187,11 +4187,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:3,CNC:5,FWL:1,NIOPS:7,WOB:7,DC:3</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:2</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:2</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:6,CLAN:5,BAN:2</availability>
@@ -4199,23 +4199,23 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CDS:4,CIH:2,CSV:5,CNC:5,CLAN:2,CSJ:6,CJF:4,CCO:2,CGB:2</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -4234,16 +4234,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 		<model name='&apos;Mini-Peggy&apos;'>
 			<roles>recon</roles>
@@ -4258,14 +4258,14 @@
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:5,MERC:3+,DC:8</availability>
+		<model name='HTM-26T'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='HTM-28T'>
 			<availability>DC:3</availability>
 		</model>
 		<model name='HTM-27T'>
 			<availability>FRR:6+,MERC:3+,DC:5+</availability>
-		</model>
-		<model name='HTM-26T'>
-			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -4301,11 +4301,11 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>Periphery.R:3,MERC.KH:4,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,FS:5,MERC:3,Periphery:1,DC:4</availability>
-		<model name='HCT-5S'>
-			<availability>LA:5+,FRR:3+,FS:5+,MERC:2+,DC:1</availability>
-		</model>
 		<model name='HCT-3NH'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='HCT-5S'>
+			<availability>LA:5+,FRR:3+,FS:5+,MERC:2+,DC:1</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
@@ -4327,6 +4327,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -4334,14 +4342,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Jump Infantry' unitType='Infantry'>
@@ -4358,25 +4358,21 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		</model>
 		<model name='Inseki II'>
 			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:5,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -4385,6 +4381,10 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -4392,6 +4392,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -4399,14 +4407,6 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8,WOB:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
@@ -4430,18 +4430,18 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:3-,OA:3-,HL:2,LA:4-,Periphery.Deep:2-,FS:3-,MERC:4-,Periphery:3-,TC:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:3,FS:4</availability>
+		<model name='HCT-213S'>
+			<availability>LA:4,FS:3</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:4,FS:3</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:3,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
@@ -4458,15 +4458,15 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CIH:6,CDS:2,CCO:2</availability>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:3,General:6,CJF:3</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:8,General:7,CJF:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:4,General:8</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:3,General:6,CJF:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -4491,77 +4491,77 @@
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
 			<roles>recon</roles>
-			<availability>FWL:1</availability>
+			<availability>FWL:2,WOB:2</availability>
 		</model>
 		<model name='HER-2S'>
 			<roles>recon</roles>
 			<availability>HL:5,IS:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1</availability>
+		</model>
 		<model name='HER-5S'>
 			<roles>recon</roles>
 			<availability>MOC:4+,CC:4+,LA:4+,PIR:2,FWL:7+,WOB:8,FS:4+,MERC:4+,DC:4+</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:2,WOB:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:3,FRR:2,FWL:5,NIOPS:3,WOB:3,CGB:3,CB:1,DC:2</availability>
-		<model name='HER-1B'>
-			<roles>recon</roles>
-			<availability>:0,FWL:1</availability>
-		</model>
 		<model name='HER-3S2'>
 			<roles>recon,spotter</roles>
 			<availability>FWL:3+,WOB:4</availability>
-		</model>
-		<model name='HER-4K'>
-			<roles>recon</roles>
-			<availability>DC:3</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:5+,WOB:4</availability>
-		</model>
-		<model name='HER-3S'>
-			<roles>recon</roles>
-			<availability>FWL:6+,WOB:6+</availability>
-		</model>
-		<model name='HER-1A'>
-			<roles>recon</roles>
-			<availability>:0,FWL:2</availability>
 		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>DC.GHO:6,CS:6,CLAN:6,NIOPS:6,BAN:8</availability>
 		</model>
+		<model name='HER-3S'>
+			<roles>recon</roles>
+			<availability>FWL:6+,WOB:6+</availability>
+		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>DC:3</availability>
+		</model>
+		<model name='HER-1B'>
+			<roles>recon</roles>
+			<availability>:0,FWL:1</availability>
+		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>CS:2,FRR:2,FWL:3,WOB:2</availability>
 		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:5+,WOB:4</availability>
+		</model>
+		<model name='HER-1A'>
+			<roles>recon</roles>
+			<availability>:0,FWL:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:3-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:3-,SIC:8,MERC:4,Periphery:4,CWIE:3</availability>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC10)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:3,IS:3,Periphery:3</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -4580,20 +4580,20 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:5,CLAN:6,NIOPS:9,CFM:7,WOB:9,SIC:1,MERC:3,FS:4,CJF:7,DC:2</availability>
+		<model name='HGN-733C'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
+		</model>
 		<model name='HGN-732b'>
 			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
-		<model name='HGN-733C'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
+		<model name='HGN-733'>
+			<availability>CC:4,:0,LA:4,SIC:4,DC:4</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>MOC:4+,DC.GHO:8,CS:5,LA:4+,CLAN:6,IS:4+,NIOPS:5,WOB:5,MERC.SI:8,MERC:4+,FS:4+,BAN:8</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:4,:0,LA:4,SIC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hitman' unitType='Mek'>
@@ -4624,20 +4624,20 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:2,MERC.WD:2,CLAN:2,CGS:3</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='HOP-4B'>
+			<availability>MERC.WD:3</availability>
+		</model>
+		<model name='HOP-4D'>
+			<availability>MERC.WD:8</availability>
+		</model>
 		<model name='C'>
 			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:6,CLAN:1</availability>
-		</model>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='HOP-4D'>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='HOP-4B'>
-			<availability>MERC.WD:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -4645,16 +4645,16 @@
 		<model name='HNT-161'>
 			<availability>MERC.WD:5-</availability>
 		</model>
+		<model name='HNT-152'>
+			<roles>recon,urban</roles>
+			<availability>IS:2</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FS:5+,MERC:5+</availability>
-		</model>
-		<model name='HNT-152'>
-			<roles>recon,urban</roles>
-			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -4684,35 +4684,35 @@
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:5,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
-		<model name='HBK-4N'>
-			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		<model name='HBK-4G'>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:3,IS:2,FWL:3,MERC:3,Periphery:3</availability>
 		</model>
+		<model name='HBK-4H'>
+			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='HBK-4SP'>
 			<availability>IS:2,FWL:3,MERC:3,DC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-5M'>
-			<availability>CS:4+,CC:3+,MOC:1,FRR:3+,FWL:5+,WOB:4+,MERC:4+,TC:1</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		<model name='HBK-5N'>
+			<availability>MOC:3+,CC:3+,CS:3+,FRR:3+,FWL:4+,WOB:3+,MERC:3+,TC:3+</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
+		<model name='HBK-5M'>
+			<availability>CS:4+,CC:3+,MOC:1,FRR:3+,FWL:5+,WOB:4+,MERC:4+,TC:1</availability>
+		</model>
 		<model name='HBK-5S'>
 			<availability>LA:3,FRR:2,MERC:2</availability>
 		</model>
-		<model name='HBK-6N'>
-			<availability>FWL:4,WOB:4,MERC:2</availability>
-		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:3+,CC:3+,CS:3+,FRR:3+,FWL:4+,WOB:3+,MERC:3+,TC:3+</availability>
+		<model name='HBK-6N'>
+			<availability>FWL:4,WOB:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -4726,56 +4726,56 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3</availability>
+		<model name='(ERLL)'>
+			<availability>LA:2,FS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:2,FS:2</availability>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>LA:7+,FS:5+</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
+		<model name='(LRM15)'>
 			<roles>fire_support</roles>
-			<availability>LA:7+,FS:5+</availability>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:6,MOC:4,FWL:5,WOB:3,MERC:2,TC:4</availability>
-		<model name='HUR-WO-R4M'>
-			<availability>CC:3,MOC:3,FWL:4</availability>
-		</model>
 		<model name='HUR-WO-R4L'>
 			<availability>General:8</availability>
+		</model>
+		<model name='HUR-WO-R4M'>
+			<availability>CC:3,MOC:3,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:6,CIH:6,LA:3,CSV:6,FRR:3,CLAN:5,NIOPS:4,WOB:4,MERC:3,DC:2</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:6,General:6,CLAN:6,NIOPS:6,MERC.SI:6,WOB:6,BAN:8</availability>
 		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -4792,28 +4792,28 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,MOC:8,LA:8,FWL:8,IS:8,WOB:8,MH:8,FS:8,DC:8,TC:8</availability>
-		<model name='(Level I) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
 		<model name='(Level I) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 	</chassis>
@@ -4835,11 +4835,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
-			<availability>MERC.WD:5</availability>
-		</model>
 		<model name='IMP-2E'>
 			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='IMP-3E'>
+			<availability>MERC.WD:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -4888,16 +4888,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6,CLAN:1</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6,CLAN:1</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6,CLAN:1</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -4930,15 +4930,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>LA:2,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1+</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -4955,29 +4955,29 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,FRR:5,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,CIR:5,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>IS:6</availability>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4,TC:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Kurita)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>DC:7,TC:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Kurita)'>
-			<roles>recon,raider</roles>
-			<availability>DC:7,TC:4</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>recon,raider</roles>
 			<availability>HL:5,General:4,Periphery.Deep:7,Periphery:7</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
@@ -4997,17 +4997,17 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -5018,47 +5018,47 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:6,MOC:2,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,FS:8,Periphery.OS:1,CIR:2,TC:2,CS:3,OA:1,LA:6,Periphery.CM:1,Periphery.HR:2,Periphery.ME:1,FWL:3,NIOPS:3,MH:2,DC:3</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>OA:6+,LA:6+,FRR:6+,FS:6+,MERC:6+,DC:6+</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>CC:6,FRR:6,IS:6,SIC:6,FS:6</availability>
 		</model>
-		<model name='JM6-DGr'>
-			<roles>anti_aircraft</roles>
-			<availability>LA:2,FRR:2,FS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='JM6-A'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:3+,MERC:3</availability>
 		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
+		<model name='JM6-A'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DGr'>
+			<roles>anti_aircraft</roles>
+			<availability>LA:2,FRR:2,FS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>OA:6+,LA:6+,FRR:6+,FS:6+,MERC:6+,DC:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+		<model name='JVN-10P'>
+			<roles>recon</roles>
+			<availability>LA:5+,FS:6+,MERC:4+</availability>
+		</model>
 		<model name='JVN-10F &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
 			<availability>MOC:2,IS:1,FS:4,MERC:2,TC:2,Periphery:1</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>LA:4+,FS:4+,MERC:4+</availability>
 		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
-			<availability>LA:5+,FS:6+,MERC:4+</availability>
+			<availability>LA:4+,FS:4+,MERC:4+</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -5067,9 +5067,6 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:5,CWIE:7,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
@@ -5079,32 +5076,35 @@
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:4,CW:4,CSV:6,CNC:8,CLAN:4,CSJ:6,CGS:4,CCO:5,CB:6</availability>
-		<model name='2'>
-			<availability>CCC:6,CSV:6,CNC:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:7,CLAN:6,CNC:7</availability>
 		</model>
+		<model name='2'>
+			<availability>CCC:6,CSV:6,CNC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
-		<model name='JR7-K'>
+		<model name='JR7-F'>
 			<roles>raider</roles>
-			<availability>MOC:3+,OA:3+,FRR:5+,MERC:3+,DC:3+,TC:3+</availability>
+			<availability>FS.DMM:1,DC:2</availability>
 		</model>
 		<model name='JR7-D'>
 			<roles>raider</roles>
 			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 		</model>
-		<model name='JR7-F'>
+		<model name='JR7-K'>
 			<roles>raider</roles>
-			<availability>FS.DMM:1,DC:2</availability>
+			<availability>MOC:3+,OA:3+,FRR:5+,MERC:3+,DC:3+,TC:3+</availability>
 		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
@@ -5120,17 +5120,17 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -5153,21 +5153,9 @@
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>MERC:1,DC:5</availability>
-		</model>
-		<model name='(DEST)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>DC:2</availability>
-		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
@@ -5177,28 +5165,40 @@
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(DEST)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:1,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.SL:6,General:6</availability>
 		</model>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kanga Medium Hovertank' unitType='Tank'>
 		<availability>CS:2,NIOPS:2</availability>
-		<model name='(AC)'>
-			<availability>BAN:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC)'>
+			<availability>BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -5223,12 +5223,12 @@
 		<model name='CRK-5003-2'>
 			<availability>FRR:8,DC:8</availability>
 		</model>
+		<model name='CRK-5003-C'>
+			<availability>DC:2+</availability>
+		</model>
 		<model name='CRK-5003-CM'>
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
-		</model>
-		<model name='CRK-5003-C'>
-			<availability>DC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
@@ -5237,21 +5237,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
@@ -5289,14 +5289,11 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:7,CHH:3,CDS:3,CSV:3,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:5,MERC:4,DC:5</availability>
+		<model name='KTO-C'>
+			<availability>MERC:5,DC:6+</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:6,CS:6,DC.SL:4,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,FS:6+,MERC:6+,BAN:7</availability>
-		</model>
-		<model name='KTO-21'>
-			<availability>CS:3,WOB:3</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:5,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:6,MERC:6,DC:4</availability>
@@ -5307,23 +5304,26 @@
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:2,WOB:4,MERC:5,DC:8</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:5,DC:6+</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:5,CGS:6,BAN:2</availability>
+		</model>
+		<model name='KTO-21'>
+			<availability>CS:3,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kiso ConstructionMech' unitType='Mek'>
@@ -5359,17 +5359,17 @@
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,IS:1+,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:1,CSV:1,CNC:2,General:1</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8,CB:5</availability>
 		</model>
-		<model name='D'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CSA:4,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
-		</model>
-		<model name='E'>
-			<roles>recon</roles>
-			<availability>CLAN:4,IS:2,CCO:6</availability>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
@@ -5379,13 +5379,13 @@
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,CDS:6,CW:6,General:5,CSJ:4,CGS:6,CCO:4,CWIE:5,CGB:5</availability>
 		</model>
-		<model name='Prime'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
+			<availability>CSA:4,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
-		<model name='H'>
+		<model name='E'>
 			<roles>recon</roles>
-			<availability>CSA:4,CCC:1,CSV:1,CNC:2,General:1</availability>
+			<availability>CLAN:4,IS:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
@@ -5396,14 +5396,14 @@
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:5,CLAN:3,CJF:5</availability>
-		<model name='2'>
-			<availability>CSV:2,CJF:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
+			<availability>CSV:2,CJF:5</availability>
+		</model>
+		<model name='2'>
 			<availability>CSV:2,CJF:5</availability>
 		</model>
 	</chassis>
@@ -5446,6 +5446,9 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:4,CLAN:4,NIOPS:6,CFM:5,WOB:6,CGS:5,BAN:7,DC:5</availability>
+		<model name='LNC25-04'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
 		<model name='LNC25-02'>
 			<roles>fire_support</roles>
 			<availability>:0,FRR:5,DC:5</availability>
@@ -5453,16 +5456,13 @@
 		<model name='LNC25-03'>
 			<availability>DC:7</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:8,FRR:5+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:5+</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:4,NIOPS:4,WOB:4</availability>
 		</model>
-		<model name='LNC25-04'>
-			<availability>CS:6,WOB:6</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:8,FRR:5+,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:6,DC:5+</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -5474,13 +5474,13 @@
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>CC:4,LA:4,FWL:6,WOB:4,FS:4</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>CC:4,LA:4,FWL:6,WOB:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
@@ -5516,15 +5516,15 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,HL:4,LA:5</availability>
@@ -5545,11 +5545,11 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
-		<model name='LTN-G15b'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LTN-G15b'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
@@ -5557,17 +5557,17 @@
 		<model name='B'>
 			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:4,CIH:5,CW:5,CBS:4,CSV:5,CNC:3,General:3,CSJ:4,CJF:2,CWIE:5,CGB:5,CB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lineholder' unitType='Mek'>
@@ -5602,22 +5602,18 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CS:1,CHH:6,CW:7,LA:1,CLAN:4,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:8,General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CIH:4,CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:5-,HL:5,CLAN:1-,IS:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,Periphery:6</availability>
-		<model name='LCT-3M'>
-			<roles>recon</roles>
-			<availability>MOC:3+,FWL:6+,IS:3+,MERC:4+</availability>
-		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
 			<availability>CC:2,SIC:2</availability>
@@ -5626,17 +5622,13 @@
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:3,General:5,FS:5</availability>
-		</model>
 		<model name='LCT-3V'>
 			<roles>recon</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-1V'>
 			<roles>recon</roles>
-			<availability>FS:6+,MERC:4+</availability>
+			<availability>LA:3,General:5,FS:5</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -5646,18 +5638,23 @@
 			<roles>recon</roles>
 			<availability>LA:6+,FRR:4+,MERC:4+</availability>
 		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:3+,FWL:6+,IS:3+,MERC:4+</availability>
+		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:6,MERC:4</availability>
 		</model>
+		<model name='LCT-3D'>
+			<roles>recon</roles>
+			<availability>FS:6+,MERC:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSV:6,CLAN:5,IS:1+,CFM:6,BAN:6,CWIE:6,CDS:6,CW:6,CBS:6,CSJ:6,CJF:6,CGB:5,CB:7</availability>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
@@ -5668,8 +5665,11 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -5685,13 +5685,13 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,FS:7,Periphery:7,TC:7,CS:3,OA:7,LA:7,FWL:9,NIOPS:3,DC:6</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='LGB-7V'>
 			<roles>fire_support</roles>
 			<availability>MOC:3+,FWL:4+,IS:3+</availability>
+		</model>
+		<model name='LGB-0W'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
@@ -5700,8 +5700,8 @@
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:6,WOB:5</availability>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -5709,8 +5709,14 @@
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Laser] (WoB)' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[Flamer] (WoB)' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 		<model name='[David] (WoB)' mechanized='true'>
 			<availability>CS:5,WOB:5</availability>
@@ -5718,40 +5724,30 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Laser] (WoB)' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[Flamer] (WoB)' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
-		<model name='LCF-R16K'>
-			<availability>General:6</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>FRR:5+,MERC:2+,DC:5+</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
+		<model name='LCF-R16'>
+			<availability>LA:6+,FS:4+,MERC:4+</availability>
+		</model>
 		<model name='LCF-R15'>
 			<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:6,FS:6</availability>
 		</model>
-		<model name='LCF-R16'>
-			<availability>LA:6+,FS:4+,MERC:4+</availability>
-		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -5759,6 +5755,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -5809,8 +5809,8 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CIH:4,CLAN:5,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:8,CDS:6,CW:9,CBS:4,CSJ:6,CJF:6,CB:4</availability>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -5820,20 +5820,20 @@
 			<roles>spotter</roles>
 			<availability>CHH:4,CIH:4,CLAN:5,CFM:4,CCO:6,CWIE:4,CW:4,CBS:4,CNC:4,General:5,CSJ:4,CJF:4,CB:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:4,CCC:3,CDS:3,CSV:3,CNC:3,CLAN:2,General:1</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
@@ -5870,14 +5870,14 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
@@ -5912,32 +5912,26 @@
 		<model name='MAD-5A'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:2</availability>
-		</model>
 		<model name='MAD-4A'>
 			<availability>MERC:6</availability>
+		</model>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,FWL:3,NIOPS:7,DC:5,CGB:2</availability>
+		<model name='MAD-3D'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='MAD-5D'>
 			<availability>LA:5+,FRR:5+,WOB:3+,FS:5+,MERC:3+,DC:7+</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>LA:4+,FRR:2+,FS:4+,MERC:2+</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:4,Periphery.MW:2,PIR:2,Periphery.ME:4,FWL:4,MH:4,MERC:4</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>CS:4+,FWL:5+,IS:3+,WOB:5+,MERC:3+</availability>
 		</model>
-		<model name='MAD-3D'>
-			<availability>FS:5</availability>
+		<model name='C'>
+			<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:3-,HL:6,IS:5,Periphery.Deep:7,WOB:3-,Periphery:8,TC:8</availability>
@@ -5950,6 +5944,12 @@
 		</model>
 		<model name='MAD-1R'>
 			<availability>CS:5,CLAN:1,NIOPS:5,WOB:5,MERC:0,BAN:2</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:4,Periphery.MW:2,PIR:2,Periphery.ME:4,FWL:4,MH:4,MERC:4</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>LA:4+,FRR:2+,FS:4+,MERC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
@@ -5969,33 +5969,33 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:3,CLAN:4,IS:1+,CFM:4,MERC:1+,CGS:4,BAN:3,CWIE:4,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:6,CB:4</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:4,CCC:3,CDS:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:4,CCC:3,CDS:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
@@ -6018,6 +6018,10 @@
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:3,MOC:3,CHH:4,CLAN:2,MH:2,FS:4,TC:6</availability>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
+		</model>
 		<model name='(Intermediate)'>
 			<roles>apc</roles>
 			<availability>TC:4</availability>
@@ -6025,10 +6029,6 @@
 		<model name='(Basic)'>
 			<roles>apc</roles>
 			<availability>FS:8,TC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -6045,33 +6045,9 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>FRR:2,IS:1,SIC:1,MERC:2,DC:3+</availability>
-		</model>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>LA:3,FRR:3,IS:2,FS:3,DC:4</availability>
-		</model>
-		<model name='(BA Factory Upgrade)'>
-			<roles>apc</roles>
-			<availability>CC:3,FRR:6+,FWL:5+,IS:4+,SIC:3,DC:6+</availability>
-		</model>
 		<model name='(SRM2)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Anti-Infantry)'>
-			<roles>apc,spotter,anti_infantry</roles>
-			<availability>IS:2,DC:4</availability>
-		</model>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
@@ -6079,6 +6055,30 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
+		</model>
+		<model name='(BA Field Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>FRR:2,IS:1,SIC:1,MERC:2,DC:3+</availability>
+		</model>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
+			<roles>apc</roles>
+			<availability>CC:3,FRR:6+,FWL:5+,IS:4+,SIC:3,DC:6+</availability>
+		</model>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>LA:3,FRR:3,IS:2,FS:3,DC:4</availability>
+		</model>
+		<model name='(Anti-Infantry)'>
+			<roles>apc,spotter,anti_infantry</roles>
+			<availability>IS:2,DC:4</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -6119,17 +6119,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -6137,31 +6137,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -6170,11 +6170,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -6261,25 +6261,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:4+,MERC:1+,DC:4+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>General:1,MERC:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>CC:1,MERC:6,DC:1</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:1,MERC:6,DC:1</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>General:1,MERC:8</availability>
+			<availability>CC:1,MERC:6,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -6316,14 +6316,6 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>MOC:1,CHH:3,CLAN:4,WOB:3,MERC:1,Periphery:1,TC:1,CS:4,DC.GHO:2,OA:1,CDS:3,CBS:4,NIOPS:4,CJF:4,CGB:3,DC:1</availability>
-		<model name='MON-68'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
@@ -6331,6 +6323,14 @@
 		<model name='MON-67'>
 			<roles>recon</roles>
 			<availability>NIOPS:0,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
+		</model>
+		<model name='MON-68'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -6343,9 +6343,6 @@
 		<availability>CLAN:2,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
@@ -6365,6 +6362,12 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
@@ -6373,12 +6376,6 @@
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -6411,21 +6408,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
@@ -6447,11 +6444,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
@@ -6462,31 +6459,31 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CSJ:3,CJF:4</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>OA:2,CW:4,LA:4+,CLAN:4,FWL:2+,MERC:2+,FS:3+,CGS:5,CGB:4</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightlord Battleship' unitType='Warship'>
@@ -6501,21 +6498,21 @@
 		<model name='(Standard)'>
 			<availability>General:8,WOB:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>LA:5,FS:5,MERC:1</availability>
-		<model name='NGS-4T'>
-			<availability>LA:2,FS:2,MERC:2</availability>
-		</model>
 		<model name='NGS-4S'>
 			<availability>:0,HL:6,LA:8,General:8,Periphery.Deep:6,FS:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='NGS-4T'>
+			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='NGS-5T'>
 			<availability>LA:2,FS:2,MERC:2</availability>
@@ -6544,8 +6541,7 @@
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CDS:2,CNC:7,CFM:2</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -6555,7 +6551,8 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -6568,6 +6565,15 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CIH:2,CDS:3,CNC:6,CLAN:2,CSJ:4,CWIE:2</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -6575,15 +6581,6 @@
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
@@ -6615,18 +6612,18 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>CC:6,MOC:2,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:2,CDS:4,LA:7,PIR:4,Periphery.ME:4,CNC:2,FWL:9,MH:4,DC:4</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:5,CNC:5,IS:6</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:3,LA:3,FWL:3,SIC:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
+		</model>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:5,CNC:5,IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Orion IIC' unitType='Mek'>
@@ -6640,29 +6637,29 @@
 		<model name='ON1-MA'>
 			<availability>MOC:2+,FWL:4+,IS:2+,MH:2+</availability>
 		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2+,MOC:2+,FWL:4+,WOB:4+,FS:2+,MERC:2+,DC:2+</availability>
+		<model name='ON1-MC'>
+			<availability>FRR:3+,FS:2+,MERC:2+,DC:4+</availability>
+		</model>
+		<model name='ON1-V'>
+			<availability>IS:2,MH:2,TC:2</availability>
 		</model>
 		<model name='ON1-V-DC'>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='ON1-MC'>
-			<availability>FRR:3+,FS:2+,MERC:2+,DC:4+</availability>
+		<model name='ON1-MB'>
+			<availability>CC:2+,MOC:2+,FWL:4+,WOB:4+,FS:2+,MERC:2+,DC:2+</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:4,General:6,CLAN:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 		<model name='ON1-M'>
 			<availability>CS:4+,MOC:3+,Periphery.MW:2+,PIR:2+,Periphery.ME:2+,FWL:6+,IS:3+,WOB:5+,MH:2+,DC:4+</availability>
-		</model>
-		<model name='ON1-V'>
-			<availability>IS:2,MH:2,TC:2</availability>
 		</model>
 		<model name='ON1-VA'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:2+,DC:4+</availability>
-		</model>
-		<model name='ON1-K'>
-			<availability>HL:4,General:6,CLAN:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -6673,6 +6670,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>CC:3,MOC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,Periphery:3,TC:3,CS:4-,LA:4,NIOPS:4-,DC:5</availability>
+		<model name='OSR-3C'>
+			<availability>IS:3,Periphery.Deep:4,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,MERC:6,BAN:2,Periphery:6</availability>
@@ -6680,9 +6680,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>IS:3,Periphery.Deep:4,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:3</availability>
@@ -6696,29 +6693,29 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:3,LA:2,FWL:4,NIOPS:3,DC:4</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='OTT-7K'>
+			<roles>recon,spotter</roles>
+			<availability>DC:6+</availability>
 		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
 			<availability>General:8,BAN:2</availability>
 		</model>
-		<model name='OTT-7K'>
-			<roles>recon,spotter</roles>
-			<availability>DC:6+</availability>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
 		<availability>CS:6,HL:2,IS:3,FWL:5,NIOPS:6,WOB:6,FS:5,MERC:5,Periphery:3</availability>
+		<model name='OTL-4D'>
+			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
 		<model name='OTL-5M'>
 			<availability>CS:3+,FWL:6+,WOB:5+,MERC:3+</availability>
 		</model>
 		<model name='OTL-4F'>
 			<availability>FS:3</availability>
-		</model>
-		<model name='OTL-4D'>
-			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -6730,10 +6727,6 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:3,FS:3</availability>
@@ -6742,17 +6735,13 @@
 			<roles>assault</roles>
 			<availability>FS:2</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CS:2+,CC:1+,FWL:1+,WOB:1+,SIC:1+,FS:1+,MERC:1+,DC:3+</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
@@ -6761,11 +6750,19 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='OW-1R'>
 			<roles>recon,spotter</roles>
 			<availability>General:1+,CLAN:6</availability>
 		</model>
-		<model name='OW-1A'>
+		<model name='OW-1B'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -6778,10 +6775,6 @@
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:5,CC:6,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,FWL:6,NIOPS:6,DC:6</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,SIC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -6789,6 +6782,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:2,MERC.KH:2,HL:2,FRR:3,IS:2,Periphery.Deep:6,SIC:3,MERC:2,FS:2,Periphery:4,PIR:2,General:2,FWL:2,DC:2</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,SIC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -6812,21 +6809,21 @@
 			<roles>fire_support</roles>
 			<availability>FS.RR:2+,FRR:2+,CNC:5,FS.DMM:2+,MERC:2+,DC:2+</availability>
 		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4+,FRR:6+,CNC:2,FS.DMM:4+,MERC:4+,DC:8+</availability>
-		</model>
 		<model name='PNT-CA'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:2+,FRR:2+,FS.DMM:2+,MERC:2+,DC:2+</availability>
 		</model>
-		<model name='PNT-C'>
+		<model name='PNT-10K'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
+			<availability>FS.RR:4+,FRR:6+,CNC:2,FS.DMM:4+,MERC:4+,DC:8+</availability>
 		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:5,IS:7,Periphery.Deep:7,MERC:7,Periphery:7,DC:7</availability>
+		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -6842,10 +6839,6 @@
 			<roles>spotter,anti_aircraft</roles>
 			<availability>WOB:4,FS:5</availability>
 		</model>
-		<model name='(Company Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:2,FS:2</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>WOB:4,FS:4</availability>
@@ -6854,16 +6847,20 @@
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:2,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,CDS:2,LA:8,FWL:7,DC:6</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
@@ -6884,10 +6881,6 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:4,CC:5,HL:3,FRR:5,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,CIR:4,Periphery:4,TC:4,CWIE:4,CS:5-,OA:4,LA:7,FWL:5,DC:7</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
@@ -6895,6 +6888,10 @@
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -6907,17 +6904,17 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>LA:4,FS:4,MERC:1</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
@@ -6932,11 +6929,11 @@
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:3-,LA:2-,FRR:2-,FWL:2-,IS:2-,SIC:2-,FS:2-,MERC:2-,DC:2-</availability>
-		<model name='(Cargo)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,DC:2</availability>
@@ -6947,39 +6944,39 @@
 		<model name='P1D'>
 			<availability>General:7</availability>
 		</model>
+		<model name='P1A'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1'>
 			<availability>General:8</availability>
 		</model>
 		<model name='P1C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='P1B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1A'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CCC:4,CIH:4,CSR:4,CW:8,CCO:4,CJF:7,CGS:2,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CIH:7,General:8,CCO:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:6,CIH:6,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:4,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:4,CIH:6,General:5,CCO:4,CGB:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CIH:7,General:8,CCO:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CSA:7,General:6,CCO:7,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:4,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -6993,41 +6990,29 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:6,HL:3,CLAN:2,IS:9,FWL:10,NIOPS:6,Periphery.Deep:4,WOB:5,Periphery:4,CGB:2</availability>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
-		</model>
 		<model name='PXH-1D'>
 			<roles>recon</roles>
 			<availability>PIR:2,FS:4,MERC:4</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:5,BAN:6,Periphery:5</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FS:6+,MERC:5+</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>FWL:7+,IS:3+</availability>
+			<availability>CLAN:5,BAN:1</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
@@ -7037,25 +7022,37 @@
 			<roles>recon</roles>
 			<availability>FRR:6+,DC:6+</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,BAN:1</availability>
-		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:7+,MERC:4+</availability>
 		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>FWL:7+,IS:3+</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:5,BAN:6,Periphery:5</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FS:6+,MERC:5+</availability>
+		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:6,CC:3,CHH:5,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CIR:4,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:5,CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
-		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -7069,13 +7066,13 @@
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4+,FS:6+</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinto Attack VTOL' unitType='VTOL'>
@@ -7125,26 +7122,26 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CCC:2,CHH:1,CSR:5,CIH:1,CSV:2,CFM:1,CCO:2,CGS:4,CWIE:1,CS:1,CSA:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CHH:2,CW:8,CNC:4,CGS:7,CCO:6,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:7,CGB:8</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:3,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:8,CSV:6,General:8,CSJ:7,CJF:7,CGB:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,CIH:6,General:5,CSJ:6</availability>
@@ -7183,10 +7180,6 @@
 			<roles>support</roles>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8,General:6</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4+</availability>
@@ -7195,9 +7188,16 @@
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8,General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:8,CLAN:8,IS:1+,CFM:8,MERC:1+,CCO:7,BAN:7,CWIE:8,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+		<model name='H'>
+			<availability>CHH:4,CCC:3,CW:4,CBS:4,CLAN:2,General:1,CFM:4,CSJ:4,CJF:4</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CSJ:3,CGB:3</availability>
 		</model>
@@ -7205,18 +7205,15 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CDS:6,CW:8,CBS:8,CSV:6,CNC:7,General:8,CFM:8,CSJ:7,CJF:9,CGB:8</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:4,CCC:3,CW:4,CBS:4,CLAN:2,General:1,CFM:4,CSJ:4,CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -7236,26 +7233,26 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
-		<model name='QKD-4H'>
-			<availability>General:3</availability>
-		</model>
-		<model name='QKD-5A'>
-			<availability>General:2,MERC:4,DC:4,Periphery:4</availability>
+		<model name='QKD-5K2'>
+			<availability>MERC:1,DC:1</availability>
 		</model>
 		<model name='QKD-5K'>
 			<availability>FRR:4+,MERC:4+,DC:6+</availability>
 		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:3+,FWL:6+,IS:3+,MH:3+,TC:3+</availability>
+		<model name='QKD-5A'>
+			<availability>General:2,MERC:4,DC:4,Periphery:4</availability>
 		</model>
-		<model name='QKD-5K2'>
-			<availability>MERC:1,DC:1</availability>
+		<model name='QKD-C'>
+			<availability>FRR:4,MERC:4,DC:6+</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:5,OA:5,HL:3,Periphery.Deep:8,FWL:5,IS:5,Periphery:5,DC:5,TC:5</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>FRR:4,MERC:4,DC:6+</availability>
+		<model name='QKD-4H'>
+			<availability>General:3</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:3+,FWL:6+,IS:3+,MH:3+,TC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
@@ -7267,21 +7264,21 @@
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:7</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
@@ -7292,21 +7289,15 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:3,FS:4,MERC:2</availability>
-		<model name='MDG-1A'>
-			<availability>LA:8,FS:8,MERC:8</availability>
-		</model>
 		<model name='MDG-1B'>
 			<availability>LA:4,FS:4,MERC:3</availability>
+		</model>
+		<model name='MDG-1A'>
+			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,LA:3,CLAN:3,NIOPS:8,WOB:8</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
@@ -7317,14 +7308,26 @@
 		<model name='RPR-200'>
 			<availability>CCC:2,CSR:2,CBS:2,CNC:2</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:2+,FS:2+,DC:4+</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:1+</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
@@ -7336,15 +7339,16 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,MOC:2,FWL:5,SIC:3,FS:4,MERC:4,DC:3,TC:2</availability>
+		<model name='RVN-4X'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='RVN-3M'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:1,FWL:4,FS:2,MERC:3,DC:2,TC:1</availability>
+		</model>
 		<model name='RVN-1X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:3,SIC:2,FS:2</availability>
@@ -7353,19 +7357,12 @@
 			<roles>spotter</roles>
 			<availability>CC:5,MOC:2,FWL:3,MERC:3,FS:2,DC:3,TC:2</availability>
 		</model>
-		<model name='RVN-2X'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RVN-3M'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:1,FWL:4,FS:2,MERC:3,DC:2,TC:1</availability>
-		</model>
 		<model name='RVN-3X'>
 			<roles>recon,ew_support</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='RVN-4X'>
-			<availability>CC:8</availability>
+		<model name='RVN-2X'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
@@ -7376,52 +7373,52 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:8,HL:9,FRR:7,CLAN:6,Periphery.Deep:9,IS:7,WOB:8,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8,DC:7</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:3,CW:3,General:8,CNC:3</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+		<model name='F-700a'>
+			<availability>CC:4+,FWL:4+,WOB:4+,FS:2+,MERC:4+</availability>
+		</model>
+		<model name='F-100b'>
+			<availability>FRR:7,DC:7</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,SIC:5,MERC:5,DC:1</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:6+,FWL:6+,WOB:8,MERC:6+</availability>
 		</model>
-		<model name='F-100b'>
-			<availability>FRR:7,DC:7</availability>
-		</model>
 		<model name='F-100'>
 			<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
-		</model>
-		<model name='F-700a'>
-			<availability>CC:4+,FWL:4+,WOB:4+,FS:2+,MERC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:4,CNC:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:6,CNC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:6,CLAN:5,CNC:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6,CNC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -7433,18 +7430,9 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:7-,CCC:4,HL:4,FRR:8-,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,FWL:8-,NIOPS:6-,CB:4</availability>
-		<model name='C'>
-			<availability>LA:2,CLAN:8,FS:2,BAN:4,DC:2</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>LA:6+,FS:6+,MERC:4+</availability>
-		</model>
 		<model name='RFL-3C'>
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>FS:3</availability>
-		</model>
-		<model name='RFL-5M'>
-			<availability>CC:4+,MOC:4+,FWL:5+,IS:4+,MERC:4+,DC:4+</availability>
 		</model>
 		<model name='RFL-4D'>
 			<roles>fire_support,anti_aircraft</roles>
@@ -7454,28 +7442,37 @@
 			<roles>fire_support,anti_aircraft</roles>
 			<availability>HL:4,General:6,Periphery.Deep:6,BAN:1,Periphery:6</availability>
 		</model>
+		<model name='RFL-5D'>
+			<availability>LA:6+,FS:6+,MERC:4+</availability>
+		</model>
+		<model name='RFL-5M'>
+			<availability>CC:4+,MOC:4+,FWL:5+,IS:4+,MERC:4+,DC:4+</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:2,CLAN:8,FS:2,BAN:4,DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:4+,CS:5,CHH:4,CSR:2,LA:4+,FRR:4+,CLAN:2,NIOPS:5,WOB:5,FS:4+,CJF:1,DC:4+</availability>
-		<model name='(SPL)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>IS:2</availability>
+			<availability>General:8,BAN:2</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>apc</roles>
+			<availability>CHH:8,CLAN:6</availability>
 		</model>
 		<model name='(ERML)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>CC:6,LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(SPL)'>
 			<roles>apc</roles>
-			<availability>CHH:8,CLAN:6</availability>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
@@ -7486,24 +7483,24 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:5</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:6,General:8,NIOPS:6,WOB:6</availability>
 		</model>
 		<model name='RGU-133L'>
 			<availability>CS:2,General:4,NIOPS:2,WOB:2</availability>
 		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:5</availability>
+		</model>
 		<model name='RGU-133F'>
 			<availability>CS:4,General:6,NIOPS:4,WOB:4</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:2</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:6,General:8,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
@@ -7532,23 +7529,23 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:7,CDS:9,CBS:9,CNC:8,CSJ:9,CJF:9,DC:1+</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
+		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:5,CCC:3,CBS:2,CSV:3,CLAN:2,General:1</availability>
-		</model>
-		<model name='I'>
-			<availability>CLAN:3,General:1</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
+		<model name='H'>
+			<availability>CSA:5,CCC:3,CBS:2,CSV:3,CLAN:2,General:1</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='I'>
+			<availability>CLAN:3,General:1</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CSR:6,CDS:5,CNC:4,General:5,CFM:4,CSJ:4,CCO:7,CJF:4,CWIE:6,CB:4</availability>
@@ -7585,20 +7582,20 @@
 		<model name='SB-27'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -7613,23 +7610,23 @@
 		<model name='S-4X'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='S-3'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='S-4C'>
 			<availability>CLAN:8,DC:1</availability>
+		</model>
+		<model name='S-3'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:7,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
+		<model name='(Standard)'>
+			<availability>IS:8,Periphery:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Clan Cargo)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
@@ -7640,13 +7637,13 @@
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>CS:2,LA:5,FS:4,MERC:2</availability>
-		<model name='PPR-5S'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='PPR-5T'>
 			<roles>fire_support</roles>
 			<availability>LA:4,MERC:2,FS:2</availability>
+		</model>
+		<model name='PPR-5S'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
@@ -7655,13 +7652,13 @@
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>OA:2,FRR:1,DC:1</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,FRR:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -7685,14 +7682,14 @@
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CW:2,CCO:5</availability>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:3,General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
@@ -7714,13 +7711,13 @@
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>CS:4,LA:4,FS:5,MERC:4</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>LA:6,FS:4,MERC:4</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>LA:6,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
@@ -7729,13 +7726,13 @@
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
@@ -7774,16 +7771,16 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:7,HL:7,LA:7,FRR:9,FWL:7,IS:8,Periphery.Deep:8,SIC:7,FS:7,CJF:3,DC:7,Periphery:8</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -7814,11 +7811,11 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -7849,19 +7846,19 @@
 	</chassis>
 	<chassis name='Sentinel' unitType='Mek'>
 		<availability>CSV:2,CLAN:3,CFM:4,WOB:4,MERC:3,FS:3,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,CBS:2,LA:4,NIOPS:4,CJF:4,CGB:4,DC:2</availability>
-		<model name='STN-3KB'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='STN-3L'>
 			<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
-		</model>
-		<model name='STN-3M'>
-			<availability>DC.GHO:7,DC:3+</availability>
 		</model>
 		<model name='STN-3K'>
 			<availability>LA:4,DC:4</availability>
 		</model>
 		<model name='STN-3KA'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='STN-3M'>
+			<availability>DC.GHO:7,DC:3+</availability>
+		</model>
+		<model name='STN-3KB'>
 			<availability>LA:2</availability>
 		</model>
 	</chassis>
@@ -7873,25 +7870,25 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,FWL:1,MH:2,DC:3</availability>
-		<model name='SYD-21'>
+		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
-			<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>OA:4,HL:3,FRR:4,FWL:4,TC:4,Periphery:5,DC:4</availability>
-		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:3,FS:2</availability>
+			<availability>HL:3,LA:5,Periphery.Deep:8,FS:5,Periphery:5</availability>
 		</model>
 		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
 			<availability>LA:6+,FRR:4+,FS:6+,MERC:4+</availability>
 		</model>
-		<model name='SYD-Z2'>
+		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
-			<availability>HL:3,LA:5,Periphery.Deep:8,FS:5,Periphery:5</availability>
+			<availability>OA:4,HL:3,FRR:4,FWL:4,TC:4,Periphery:5,DC:4</availability>
+		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
+		</model>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:3,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
@@ -7900,46 +7897,46 @@
 			<roles>recon</roles>
 			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:7,CDS:7,CLAN:7,CNC:7,CJF:6,CWIE:7,CGB:7</availability>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5,CGB:1</availability>
+		<model name='SHD-2K'>
+			<availability>FRR:5,MERC:3,DC:6</availability>
+		</model>
 		<model name='SHD-2D2'>
 			<availability>LA:4+,FS:6+</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:6</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>FRR:5,MERC:3,DC:6</availability>
+		<model name='SHD-2H'>
+			<availability>HL:4,General:6,Periphery.Deep:6,BAN:2,Periphery:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:8,CCC:8,LA:3,CSV:8,CFM:8,FS:3,CGS:8,DC:3</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>CC:4+,FRR:4+,FWL:7+,IS:4+,WOB:6,MERC:4+,DC:4+</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:8,CCC:8,LA:3,CSV:8,CFM:8,FS:3,CGS:8,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -7962,14 +7959,14 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:3,MERC.WD:2,CIH:3,CBS:1,CLAN:1,CCO:3,CB:1</availability>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:3</availability>
+		</model>
 		<model name='C'>
 			<availability>MERC.WD:6+,CLAN:8</availability>
 		</model>
 		<model name='SHG-2F'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -7988,6 +7985,18 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverback Coastal Cutter' unitType='Naval'>
+		<availability>LA:7</availability>
+		<model name='(Standard)'>
+			<availability>LA:7</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:2,CSJ:4</availability>
 		<model name='(Standard)'>
@@ -7996,35 +8005,35 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:7</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,DC:1</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>OA:3+,FRR:5+,FS:3+,MERC:3+,DC:6+,TC:2</availability>
-		</model>
-		<model name='SL-15'>
-			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>FRR:1,MERC:1,DC:1</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,DC:1</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -8048,12 +8057,12 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6</availability>
+		<model name='(Standard)'>
+			<availability>CIH:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -8061,10 +8070,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -8089,9 +8094,8 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>LA:6,FS.CMM:2</availability>
+		<model name='SPR-6D'>
+			<availability>FRR:4+,FS:6+,MERC:4+</availability>
 		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -8101,8 +8105,9 @@
 			<roles>interceptor</roles>
 			<availability>OA:3,FRR:6,DC:6</availability>
 		</model>
-		<model name='SPR-6D'>
-			<availability>FRR:4+,FS:6+,MERC:4+</availability>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>LA:6,FS.CMM:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -8128,22 +8133,22 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:3,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:6</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>HL:3,FRR:1,IS:5,Periphery.Deep:8,FS:2,Periphery:5</availability>
-		</model>
-		<model name='SDR-7M'>
-			<availability>MOC:3+,CC:6+,FWL:6+,MH:2+,SIC:6+,MERC:3+,FS:6+,DC:5+</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:2,FWL:2,FS:2,MERC:2,DC:3</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:5,DC:5</availability>
+		</model>
+		<model name='SDR-7M'>
+			<availability>MOC:3+,CC:6+,FWL:6+,MH:2+,SIC:6+,MERC:3+,FS:6+,DC:5+</availability>
+		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:6</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:2,FWL:2,FS:2,MERC:2,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
@@ -8151,6 +8156,10 @@
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>FRR:5,IS:4,DC:6</availability>
+		</model>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
@@ -8160,18 +8169,14 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:10,CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:5,OA:10,LA:9,FWL:10,NIOPS:5,DC:7</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+		<model name='STK-5M'>
+			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,CIR:1+,DC:5+,TC:3+</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1,OA:1,IS:1,Periphery:1,TC:1</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
@@ -8179,11 +8184,11 @@
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,CIR:1+,DC:5+,TC:3+</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
+		<model name='STK-4N'>
+			<availability>MOC:1,OA:1,IS:1,Periphery:1,TC:1</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:2,LA:5+,CSV:2,MERC:2+,FS:4+,CJF:2,TC:2+</availability>
@@ -8233,19 +8238,15 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6,CGB:1-</availability>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,WOB:6,FS:3+,MERC:3+,DC:3+,TC:3+</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
@@ -8254,6 +8255,10 @@
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,WOB:6,FS:3+,MERC:3+,DC:3+,TC:3+</availability>
+		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
@@ -8261,15 +8266,15 @@
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='F-94'>
 			<availability>IS:4+</availability>
 		</model>
 		<model name='F-92'>
 			<availability>FWL:6+,IS:3+</availability>
-		</model>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:8</availability>
 		</model>
 		<model name='F-90'>
 			<availability>CS:5,LA:4,IS:5,FS:5,Periphery:5</availability>
@@ -8277,16 +8282,16 @@
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3,CB:3</availability>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -8299,22 +8304,9 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:2+,FWL:2+,FS:2+,MERC:2+,DC:6+</availability>
-		<model name='SR1-OA'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SR1-OD'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='SR1-OR'>
 			<availability>CLAN:6</availability>
@@ -8322,22 +8314,22 @@
 		<model name='SR1-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:4,FRR:4,IS:5,WOB:4-,SIC:6,FS:9,MERC:3,CS:4-,CDS:3,LA:6,PIR:3,FWL:3,DC:3</availability>
-		<model name='(LRM)'>
-			<roles>fire_support</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>LA:5+,FS:6+,DC:4+</availability>
-		</model>
-		<model name='(Ammo)'>
-			<availability>General:2</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='(Narc)'>
 			<availability>LA:2+,FS:2+,DC:1+</availability>
 		</model>
@@ -8345,17 +8337,30 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<roles>fire_support</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(3053 Upgrade)'>
+			<availability>LA:5+,FS:6+,DC:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:5,CS:4,MOC:4,MERC.WD:2-,LA:3,NIOPS:4,WOB:4,SIC:5</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>CC:6,General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:4+,MOC:4+</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -8363,14 +8368,14 @@
 		<model name='STU-K5'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:8,Periphery:6</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:6,SIC:4</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,SIC:1,FS:1,TC:2,Periphery:1</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>LA:5+,FS:7+,MERC:5+</availability>
@@ -8378,21 +8383,21 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:4,CDS:2,HL:3,LA:7,FRR:2,CNC:2,SIC:2,MERC:3,FS:6,CWIE:2</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8,WOB:0</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
-		<model name='C'>
-			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CBS:2,General:2,CGB:6,CB:2</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:2,General:2,CJF:6,CGB:6,CB:2</availability>
@@ -8403,12 +8408,12 @@
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:2+,LA:3+,SIC:2+,FS:3+,MERC:2+,DC:4+</availability>
+		<model name='SD1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='SD1-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='SD1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OR'>
 			<availability>CLAN:6,General:1+,DC:2+</availability>
@@ -8440,10 +8445,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:2,MOC:1,TC:1</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -8455,22 +8460,22 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:3</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:6,NIOPS:8,WOB:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:9,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:9,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Talon' unitType='Mek'>
@@ -8495,57 +8500,57 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>FWL.MM:8+,FWL:6+,WOB:5,MERC:2+</availability>
-		<model name='TMP-3G'>
-			<availability>FWL:2,WOB:2,MERC:2</availability>
+		<model name='TMP-3M'>
+			<availability>FWL:8,WOB:8,MERC:8</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>FWL:8,WOB:8,MERC:8</availability>
+		<model name='TMP-3G'>
+			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CSJ:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CSR:5,CIH:4,CLAN:5,IS:1+,CCO:5,BAN:5,CWIE:6,CSA:5,MERC.WD:4,CDS:5,CW:5,CNC:6,CSJ:7,CJF:9,CGB:5,CB:5</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:4,CCC:3,CBS:3,CSV:3,CLAN:2,General:1</availability>
 		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
-		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -8564,43 +8569,43 @@
 		<model name='THE-S'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='THE-N1'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
 		<model name='THE-T'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>CS:7,CLAN:6,NIOPS:7,BAN:6</availability>
 		</model>
+		<model name='THE-N1'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:3,CSR:3,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
-		<model name='TR-7p'>
-			<availability>SIC:1</availability>
-		</model>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
 			<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
+		<model name='TR-7p'>
+			<availability>SIC:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:4,FRR:3,CSV:6,CLAN:5,IS:2,CFM:7,WOB:7,SIC:2,FS:3,CWIE:6,DC.GHO:5,CS:8,OA:2,CDS:4,CW:6,CBS:4,LA:2,CNC:4,FWL:5,NIOPS:8,CJF:6,CGB:6</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>DC.GHO:8,CS:6,FRR:4+,CLAN:6,FWL:6+,IS:2,NIOPS:6,WOB:6,FS:6+,BAN:8,DC:6+</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:5,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:8,MERC:8,DC:4</availability>
@@ -8615,15 +8620,15 @@
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>CS:2,LA:5,CLAN:2,NIOPS:2,MERC:3</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:4</availability>
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -8647,40 +8652,40 @@
 			<roles>escort,ground_support</roles>
 			<availability>MOC:4,LA:5,FRR:4,MH:4,MERC:4</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:7,HL:3,CLAN:2,IS:8,Periphery.Deep:6,WOB:3-,FS:7,MERC:8,Periphery:4,TC:4,CS:4-,LA:8,NIOPS:4-,MH:4,DC:8</availability>
-		<model name='TDR-5Sb'>
-			<availability>CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,CNC:2,CJF:2,CWIE:2,CGB:2</availability>
+		<model name='TDR-9SE'>
+			<availability>LA:3+,MERC.ELH:7+,MERC:3+,FS:3+</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>LA:6+,FS:5+,MERC:2+</availability>
 		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:6,MERC:3</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:4,MERC:1</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:6,HL:4,LA:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='TDR-9SE'>
-			<availability>LA:3+,MERC.ELH:7+,MERC:3+,FS:3+</availability>
+		<model name='TDR-7M'>
+			<availability>CS:4+,CC:2+,FWL:7+,IS:2+,WOB:4+,MERC:2+</availability>
 		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:4,MERC:1</availability>
+		<model name='TDR-5SS'>
+			<availability>LA:6,MERC:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:4,CCC:4,LA:2,CSV:4,CFM:4,FS:2,CGS:4,DC:2,CB:4</availability>
 		</model>
-		<model name='TDR-7M'>
-			<availability>CS:4+,CC:2+,FWL:7+,IS:2+,WOB:4+,MERC:2+</availability>
+		<model name='TDR-5Sb'>
+			<availability>CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,CNC:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
@@ -8698,25 +8703,25 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:4,CLAN:4,NIOPS:3,WOB:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>FRR:6,DC:8</availability>
-		<model name='TKG-150'>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>FRR:8,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='TKG-150'>
+			<availability>FRR:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
@@ -8725,15 +8730,15 @@
 			<roles>escort</roles>
 			<availability>CS:3,NIOPS:3,WOB:3</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:3,BAN:2</availability>
+		<model name='THK-63'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='&apos;C&apos;'>
 			<availability>CW:5,CLAN:4</availability>
 		</model>
-		<model name='THK-63'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
+		<model name='THK-63b'>
+			<availability>CLAN:3,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tonbo Superheavy Transport' unitType='VTOL'>
@@ -8745,13 +8750,13 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>CS:2,FWL:1,WOB:2</availability>
-		<model name='G12' mechanized='true'>
-			<roles>specops</roles>
-			<availability>FWL:8,WOB:8</availability>
-		</model>
 		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
 			<roles>specops</roles>
 			<availability>CS:8</availability>
+		</model>
+		<model name='G12' mechanized='true'>
+			<roles>specops</roles>
+			<availability>FWL:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Toyama' unitType='Mek'>
@@ -8768,62 +8773,59 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:9,MOC:3,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:3</availability>
+		<model name='TR-13A'>
+			<availability>CC:6+,MOC:3+,General:3+</availability>
+		</model>
 		<model name='TR-14 &apos;AC&apos;'>
 			<availability>General:4,FWL:8</availability>
-		</model>
-		<model name='TR-16'>
-			<availability>MOC:4,CC:3,SIC:2,MERC:3,TC:3</availability>
 		</model>
 		<model name='TR-13'>
 			<availability>CC:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='TR-13A'>
-			<availability>CC:6+,MOC:3+,General:3+</availability>
+		<model name='TR-16'>
+			<availability>MOC:4,CC:3,SIC:2,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:8,MOC:8,General:8,TC:8</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TR-10'>
+			<availability>CC:8,MOC:8,General:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:4-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:3</availability>
-		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
-		</model>
-		<model name='TBT-7M'>
+		<model name='TBT-5N'>
 			<roles>fire_support</roles>
-			<availability>CC:4+,LA:3+,FRR:4+,FWL:6+,WOB:4,MH:3+,FS:4+,MERC:4+,TC:3+,DC:4+</availability>
-		</model>
-		<model name='TBT-9K'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
-		</model>
-		<model name='TBT-7K'>
-			<roles>fire_support</roles>
-			<availability>FRR:1,DC:3</availability>
+			<availability>CC:5,CS:2,MOC:6,LA:5,FWL:4,IS:6,NIOPS:2,WOB:2,FS:5,MERC:6,DC:5,Periphery:6</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
 		</model>
-		<model name='TBT-5N'>
+		<model name='TBT-7M'>
 			<roles>fire_support</roles>
-			<availability>CC:5,CS:2,MOC:6,LA:5,FWL:4,IS:6,NIOPS:2,WOB:2,FS:5,MERC:6,DC:5,Periphery:6</availability>
+			<availability>CC:4+,LA:3+,FRR:4+,FWL:6+,WOB:4,MH:3+,FS:4+,MERC:4+,TC:3+,DC:4+</availability>
+		</model>
+		<model name='TBT-7K'>
+			<roles>fire_support</roles>
+			<availability>FRR:1,DC:3</availability>
+		</model>
+		<model name='TBT-9K'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='TBT-5J'>
+			<availability>FWL:3</availability>
+		</model>
+		<model name='TBT-5S'>
+			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -8868,8 +8870,8 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CWIE:4,CGB:6</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8877,8 +8879,8 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
@@ -8886,14 +8888,14 @@
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CGS:7,CJF:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CHH:7,CW:7,CNC:7,CSJ:7,CFM:7,CJF:7,CGS:7</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:9,General:7,CGB:9</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
@@ -8905,27 +8907,25 @@
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
-		<model name='B'>
-			<availability>CSA:5,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:4,CDS:4,CSV:4,CLAN:4,IS:2,CB:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
 			<availability>CW:8,CSV:3,General:2,CWIE:6,CGB:2,CB:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
@@ -8934,16 +8934,18 @@
 			<roles>fire_support</roles>
 			<availability>CSA:4,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CWIE:4,CGB:1</availability>
+		<model name='B'>
+			<availability>CSA:5,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CWIE:4,CGB:1</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:4,CDS:4,CSV:4,CLAN:4,IS:2,CB:4</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
@@ -8965,13 +8967,13 @@
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>CS:4,LA:2,IS:2,WOB:4,FS:4</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech IIC' unitType='Mek'>
@@ -8987,13 +8989,13 @@
 			<roles>urban</roles>
 			<availability>CC:5,SIC:5,Periphery:2</availability>
 		</model>
-		<model name='UM-R63'>
-			<roles>urban</roles>
-			<availability>CC:6+,CS:5,MOC:2+,MERC:3+,TC:2+</availability>
-		</model>
 		<model name='UM-R60'>
 			<roles>urban</roles>
 			<availability>CC:6,HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='UM-R63'>
+			<roles>urban</roles>
+			<availability>CC:6+,CS:5,MOC:2+,MERC:3+,TC:2+</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
@@ -9005,10 +9007,6 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:5,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:4,FS:6,MERC:6,TC:6</availability>
-		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:3,FS:3,MERC:3</availability>
@@ -9017,9 +9015,20 @@
 			<roles>recon,fire_support</roles>
 			<availability>LA:6+,FS:6+,MERC:4+</availability>
 		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:4,FS:6,MERC:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<roles>bomber</roles>
 			<availability>General:6</availability>
@@ -9028,16 +9037,12 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:6-,HL:9,IS:10,Periphery.Deep:8,WOB:6-,Periphery:10,CGB:5</availability>
+		<model name='(NETC)'>
+			<availability>IS:3+</availability>
+		</model>
 		<model name='(Liao)'>
 			<availability>CC:8,SIC:8</availability>
 		</model>
@@ -9050,19 +9055,16 @@
 		<model name='(Standard)'>
 			<availability>CC:5,General:7,SIC:5</availability>
 		</model>
-		<model name='(NETC)'>
-			<availability>IS:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
-		<model name='(3056)'>
-			<roles>asf_carrier</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(2682)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>asf_carrier</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -9070,38 +9072,38 @@
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:4-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
-		<model name='VTR-C'>
-			<availability>CC:2,FRR:3,MERC:2,FS:2,DC:3</availability>
-		</model>
 		<model name='VTR-9B'>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-9D'>
-			<availability>CC:3+,LA:5+,SIC:5+,FS:6+</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
 		</model>
 		<model name='VTR-9K'>
 			<availability>MOC:3+,FRR:6+,FWL:3+,MH:3+,FS:3+,MERC:3+,TC:3+,Periphery:2+,DC:6+</availability>
 		</model>
+		<model name='VTR-C'>
+			<availability>CC:2,FRR:3,MERC:2,FS:2,DC:3</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1,Periphery:1</availability>
+		</model>
 		<model name='VTR-9S'>
 			<availability>LA:3,CIR:3</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
+		</model>
+		<model name='VTR-9D'>
+			<availability>CC:3+,LA:5+,SIC:5+,FS:6+</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
@@ -9124,17 +9126,17 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:10,FRR:2,MH:3,SIC:10,MERC:5,TC:4</availability>
-		<model name='VND-1SIC'>
-			<availability>SIC:2</availability>
-		</model>
-		<model name='VND-3L'>
-			<availability>CC:7+,MOC:2,General:2+,TC:2</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>FRR:8,TC:2</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>FRR:8,TC:2</availability>
+		<model name='VND-3L'>
+			<availability>CC:7+,MOC:2,General:2+,TC:2</availability>
+		</model>
+		<model name='VND-1SIC'>
+			<availability>SIC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -9148,9 +9150,6 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
@@ -9160,17 +9159,20 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:4,CGS:6,CJF:6</availability>
+		<model name='2'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -9183,30 +9185,26 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CC:1,CS:6,LA:4,FRR:4,IS:1,FWL:3,WOB:6,FS:3,MERC:1,DC:4</availability>
-		<model name='VNL-K70'>
-			<availability>FRR:3,DC:3</availability>
-		</model>
 		<model name='VNL-K100'>
 			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:8</availability>
 		</model>
+		<model name='VNL-K70'>
+			<availability>FRR:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>MERC:4,TC:3</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='VLC-5N'>
 			<availability>General:5</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
@@ -9215,13 +9213,13 @@
 			<roles>anti_infantry</roles>
 			<availability>General:7,FS:4</availability>
 		</model>
-		<model name='VT-5M'>
-			<roles>anti_infantry</roles>
-			<availability>FRR:2+,FWL:6+,WOB:3+,MERC:2+,DC:2+</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:5,CIR:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='VT-5M'>
+			<roles>anti_infantry</roles>
+			<availability>FRR:2+,FWL:6+,WOB:3+,MERC:2+,DC:2+</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -9230,20 +9228,20 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:4,CW:6,CNC:8,CJF:7,CGB:9,CB:7,DC:1+</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CSR:4,CDS:5,General:4,CGS:4,CCO:6,CGB:4</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:4,CDS:5,General:4,CGS:4,CCO:6,CGB:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:4,CCC:3,CDS:3,CBS:3,CSV:3,CNC:3,CLAN:2,General:1</availability>
@@ -9251,10 +9249,6 @@
 	</chassis>
 	<chassis name='Vulture' unitType='Dropship'>
 		<availability>MERC:2,Periphery:1</availability>
-		<model name='(2312)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2312)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
@@ -9274,6 +9268,12 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='10'>
+			<availability>CSJ:6</availability>
+		</model>
 		<model name='12'>
 			<availability>CSJ:5</availability>
 		</model>
@@ -9284,21 +9284,9 @@
 		<model name='11'>
 			<availability>CSJ:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='10'>
-			<availability>CSJ:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:5-,HL:5,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:3+,FS:3+,DC:3+</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:3,SIC:3</availability>
 		</model>
@@ -9306,14 +9294,8 @@
 			<roles>spotter</roles>
 			<availability>DC:6+</availability>
 		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='WHM-7S'>
-			<availability>LA:6+,FS:4+,MERC:3+</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:4+,CC:3+,FRR:3+,FWL:7+,WOB:6+,MERC:2+,DC:3+,Periphery:3+</availability>
+		<model name='WHM-6R'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:2,FRR:2,FS.DMM:2,FS:1,DC:3</availability>
@@ -9321,14 +9303,23 @@
 		<model name='WHM-6D'>
 			<availability>FS:3</availability>
 		</model>
+		<model name='WHM-7M'>
+			<availability>CS:4+,CC:3+,FRR:3+,FWL:7+,WOB:6+,MERC:2+,DC:3+,Periphery:3+</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>LA:6+,FS:4+,MERC:3+</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:3+,FS:3+,DC:3+</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
 		<model name='H-7'>
 			<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
-		</model>
-		<model name='H-7C'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 		<model name='H-8'>
 			<availability>HL:2,LA:6,FS.CH:6,FRR:4,FS:6,MERC:4,Periphery:4</availability>
@@ -9336,61 +9327,64 @@
 		<model name='H-7A'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
+		<model name='H-7C'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:3-,HL:5,IS:9,NIOPS:3-,Periphery.Deep:5,WOB:3-,CIR:2,Periphery:6</availability>
-		<model name='WSP-1A'>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:3</availability>
+			<availability>MERC.WD:7+</availability>
 		</model>
 		<model name='WSP-1W'>
 			<roles>recon</roles>
 			<availability>MERC.WD:5</availability>
 		</model>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>FRR:3,DC:3</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>LA:7+,FS:5+,MERC:3+</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:7+</availability>
-		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:3,SIC:3</availability>
 		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:4+,MOC:4+,FWL:7+,WOB:6,MH:4+,MERC:4+,DC:4+</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1L'>
 			<roles>recon</roles>
-			<availability>FRR:3,DC:3</availability>
+			<availability>CC:3,SIC:3</availability>
+		</model>
+		<model name='WSP-1D'>
+			<roles>recon</roles>
+			<availability>FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
@@ -9416,13 +9410,13 @@
 			<roles>fire_support</roles>
 			<availability>HL:4,General:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='WTH-2'>
-			<roles>fire_support</roles>
-			<availability>CS:6,OA:4+,MH:2,FS:4+,DC:4+,TC:4+</availability>
-		</model>
 		<model name='WTH-1S'>
 			<roles>fire_support</roles>
 			<availability>FRR:1,DC:1</availability>
+		</model>
+		<model name='WTH-2'>
+			<roles>fire_support</roles>
+			<availability>CS:6,OA:4+,MH:2,FS:4+,DC:4+,TC:4+</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -9440,33 +9434,21 @@
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:2,MERC.KH:6,MERC.WD:4,LA:7,FRR:5,MH:2,FS:5,MERC:3,CIR:2</availability>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='WLF-1A'>
-			<availability>MERC.KH:1,LA:1</availability>
-		</model>
 		<model name='WLF-1'>
 			<availability>MERC.KH:5,MERC.WD:2,HL:3,LA:6,FS:7,MERC:6,Periphery:5</availability>
 		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='WLF-1B'>
+			<availability>MERC.KH:1,LA:1</availability>
+		</model>
+		<model name='WLF-1A'>
 			<availability>MERC.KH:1,LA:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:6,HL:4,FRR:7,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,TC:5,CS:4-,LA:7,CNC:1,FWL:10,NIOPS:4-,MH:4,DC:7</availability>
-		<model name='WVR-6R'>
-			<roles>recon</roles>
-			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>LA:4+,FS:6+</availability>
-		</model>
-		<model name='WVR-6K'>
-			<roles>recon</roles>
-			<availability>FRR:2,DC:2</availability>
-		</model>
 		<model name='WVR-7M'>
 			<roles>recon</roles>
 			<availability>CC:2+,FWL:6+,WOB:5,MERC:4+,DC:2+</availability>
@@ -9479,14 +9461,26 @@
 			<roles>recon</roles>
 			<availability>Periphery.MW:4,PIR:2,Periphery.ME:4,FWL:8,MH:2</availability>
 		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>LA:4+,FS:6+</availability>
+		</model>
+		<model name='WVR-6K'>
+			<roles>recon</roles>
+			<availability>FRR:2,DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -9507,17 +9501,17 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,CIH:2,FRR:5,CLAN:3,IS:4,CFM:4,WOB:5,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
-		<model name='WVE-9N'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CS:8,WOB:8</availability>
+			<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>
 		</model>
 		<model name='WVE-5Nb'>
 			<roles>urban</roles>
 			<availability>CLAN:1,CFM:2,CGS:2</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-9N'>
 			<roles>urban</roles>
-			<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -9589,11 +9583,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-115'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:5-,CLAN:2,NIOPS:5-,WOB:5-</availability>
+		</model>
+		<model name='ZRO-115'>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
@@ -9604,20 +9598,20 @@
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:5,LA:10,FRR:4,IS:3,FS:7-,MERC:5,Periphery:2</availability>
-		<model name='ZEU-6S'>
-			<availability>HL:6,General:4,Periphery.Deep:6,FS:4,Periphery:8</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>LA:6+,FRR:4+,PIR:2+,FS:5+,MERC:3+,TC:2+</availability>
 		</model>
-		<model name='ZEU-9S2'>
-			<availability>LA:3+,FS:3+,MERC:3+</availability>
+		<model name='ZEU-6T'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:2+</availability>
 		</model>
-		<model name='ZEU-6T'>
-			<availability>LA:4,FS:4</availability>
+		<model name='ZEU-9S2'>
+			<availability>LA:3+,FS:3+,MERC:3+</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:6,General:4,Periphery.Deep:6,FS:4,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>
@@ -9628,11 +9622,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:9,CBS:10,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3060.xml
+++ b/megamek/data/forcegenerator/3060.xml
@@ -968,15 +968,6 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(WoB) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(WoB) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
@@ -984,21 +975,30 @@
 			<roles>spotter</roles>
 			<availability>CS:5,WOB:5</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='(WoB) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(WoB) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
 		<model name='(WoB)' mechanized='true'>
 			<availability>CS:4,WOB:4</availability>
 		</model>
 		<model name='(WoB) [David]' mechanized='true'>
 			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(WoB) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1032,14 +1032,14 @@
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
 		<availability>CS:7,CLAN:1,FWL:5,NIOPS:7,WOB:7,DC:3</availability>
-		<model name='AHB-MD'>
-			<availability>WOB:3</availability>
-		</model>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='AHB-443b'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='AHB-MD'>
+			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ailette Zero-G Engineering Exoskeleton' unitType='BattleArmor'>
@@ -1051,33 +1051,33 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>CS:3,FS:4</availability>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>CNC:2,DC:5</availability>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,DC:5</availability>
-		</model>
 		<model name='AKU-1X'>
 			<availability>DC:7</availability>
+		</model>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:3,CS:7,CDS:3,LA:5,CNC:3,NIOPS:7,WOB:7,FS:4,MERC:3,CWIE:4,DC:3</availability>
-		<model name='Mk VII'>
-			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk VII'>
+			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
@@ -1104,20 +1104,20 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:4,CLAN:1,MERC:3,CCO:2,CWIE:3,BAN:2,CGB:2</availability>
-		<model name='ANH-1E'>
-			<availability>MERC.WD:2</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>CLAN:1-,MERC:3</availability>
+		</model>
+		<model name='ANH-1E'>
+			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8,BAN:3</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1146,28 +1146,28 @@
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>CC:4,FWL:6,WOB:2,MERC:2</availability>
-		<model name='ANV-5M'>
-			<availability>FWL:6,WOB:6</availability>
-		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
+		<model name='ANV-5M'>
+			<availability>FWL:6,WOB:6</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
+		<model name='ANV-3M'>
+			<availability>CC:8,FWL:6,WOB:6,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,LA:3,FWL:8,SIC:4,MERC:4,FS:3,DC:6</availability>
-		<model name='APL-3T'>
+		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
-		<model name='APL-1R'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1205,60 +1205,54 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:5,HL:4,FRR:5,CLAN:1,IS:7,Periphery.Deep:5,WOB:2-,SIC:6,FS:6,Periphery:5,CS:4-,LA:7,FWL:7,NIOPS:4-,DC:6,CGB:1</availability>
-		<model name='ARC-2S'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>LA:5</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:4,MERC.WD:4,CWIE:4</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:3,DC:5</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>FRR:8,MERC:4,DC:4</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:8,FS:4</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:2,LA:4,FRR:4,IS:4,Periphery.Deep:8,BAN:2,DC:4-,Periphery:4</availability>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='ARC-5W'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8,LA:4,MERC:4</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2W'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:5</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:5,CCC:5,CW:4,LA:3+,CSV:5,CFM:5,FS:3+,CGS:5,CWIE:4,DC:3+</availability>
 		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:8,FS:4</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:4,MERC.WD:4,CWIE:4</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:8,MERC:4,DC:4</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:2,LA:4,FRR:4,IS:4,Periphery.Deep:8,BAN:2,DC:4-,Periphery:4</availability>
+		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CS:6,CC:5,LA:4,PIR:3,FWL:8,WOB:6,SIC:5,MERC:5,FS:4,DC:5</availability>
 		</model>
-		<model name='ARC-2W'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>MERC.WD:4</availability>
+			<availability>FRR:3,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AF1C'>
 			<availability>General:7</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
@@ -1266,6 +1260,12 @@
 		</model>
 		<model name='AF1B'>
 			<availability>General:5</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
@@ -1294,46 +1294,26 @@
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
 		<availability>FS:4+</availability>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AGS-4D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1343,27 +1323,47 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
 		<availability>MOC:4-,CC:4-,FRR:1,IS:1,WOB:2-,MERC:1,FS:1,Periphery:2,TC:4-,CS:3-,OA:1,LA:1,FS.CMM:2-</availability>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:4,MH:4,MERC:4,FS:4,TC:4</availability>
+		</model>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
 		</model>
 		<model name='ASN-21'>
 			<availability>General:2</availability>
@@ -1398,39 +1398,17 @@
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>CLAN:1</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
 		<availability>MOC:1,CC:2,FRR:6,CLAN:4,IS:3,WOB:4-,SIC:3,FS:4,Periphery:1,TC:1,CS:4-,OA:1,LA:3,FWL:3,NIOPS:4-,DC:9</availability>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4,IS:4,DC:4</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:3,CLAN:8,FS:3,DC:3</availability>
-		</model>
-		<model name='AS7-CM'>
-			<roles>spotter</roles>
-			<availability>FRR:4,MERC:4,DC:6</availability>
-		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,OA:2,LA:4,PIR:2,FS:3,MERC:3,TC:2</availability>
-		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='AS7-S2'>
-			<availability>LA:5</availability>
-		</model>
-		<model name='AS7-D'>
-			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='AS7-K'>
+			<availability>CC:3,MOC:2,CS:3,OA:2,FRR:5,CNC:3,FWL:3,WOB:3,SIC:2,MERC:4,TC:2,DC:8</availability>
 		</model>
 		<model name='AS7-S3'>
 			<availability>LA:3,MERC:2</availability>
@@ -1438,26 +1416,36 @@
 		<model name='AS7-D-DC'>
 			<availability>IS:1,MERC:0,DC:2</availability>
 		</model>
-		<model name='AS7-K'>
-			<availability>CC:3,MOC:2,CS:3,OA:2,FRR:5,CNC:3,FWL:3,WOB:3,SIC:2,MERC:4,TC:2,DC:8</availability>
+		<model name='C'>
+			<availability>LA:3,CLAN:8,FS:3,DC:3</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>FRR:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='AS7-CM'>
+			<roles>spotter</roles>
+			<availability>FRR:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:5</availability>
+		</model>
+		<model name='AS7-S'>
+			<availability>MOC:2,OA:2,LA:4,PIR:2,FS:3,MERC:3,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:3,FS:3</availability>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(CV)'>
@@ -1468,6 +1456,14 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Gunship)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
@@ -1475,6 +1471,10 @@
 		<model name='(Tanker)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1486,24 +1486,24 @@
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CW:5,CLAN:3,CNC:5,BAN:5,CWIE:5</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
@@ -1514,24 +1514,24 @@
 		<model name='AV1-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
+		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OE'>
-			<availability>General:6</availability>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AV1-OR'>
 			<availability>CLAN:6,DC:1+</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
@@ -1539,13 +1539,13 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:2,FRR:2,IS:2,SIC:2,FS:4,CIR:2,Periphery:1,TC:2,OA:2,LA:4,FWL:2,DC:3</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>LA:4,General:4,FS:4</availability>
+		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
@@ -1553,11 +1553,11 @@
 		<model name='AWS-8R'>
 			<availability>IS:2,FWL:3</availability>
 		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2,CIR:4</availability>
-		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='AWS-8T'>
+			<availability>IS:2,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
@@ -1565,11 +1565,11 @@
 		<model name='AWS-9M'>
 			<availability>MOC:3+,PIR:3+,FWL:8,IS:6,MH:3+,TC:3+</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>LA:4,FWL:4,FS:4</availability>
-		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:3,FWL:6,IS:3,MH:3,TC:3,Periphery:3</availability>
+		</model>
+		<model name='AWS-9Ma'>
+			<availability>LA:4,FWL:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank' unitType='Tank'>
@@ -1583,9 +1583,6 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>LA:5,FRR:2,FS:3,MERC:2</availability>
-		<model name='AXM-1N'>
-			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
-		</model>
 		<model name='AXM-3S'>
 			<availability>LA:3,FS:2,MERC:2</availability>
 		</model>
@@ -1593,21 +1590,40 @@
 			<roles>fire_support</roles>
 			<availability>LA:5,FS:3</availability>
 		</model>
+		<model name='AXM-1N'>
+			<availability>LA:8,FRR:8,MERC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:5,CSR:4,CSV:6,CJF:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>CSV:6,CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CSR:2,CSV:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>CSV:6,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:3,MERC.WD:2,CW:2,CLAN:1</availability>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:5,CLAN:4</availability>
+		</model>
 		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1619,34 +1635,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:5,CLAN:4</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:4</availability>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
@@ -1658,13 +1654,17 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
@@ -1678,15 +1678,19 @@
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:3,CLAN:1</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:4,General:2,CCO:5</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1698,20 +1702,20 @@
 			<roles>apc</roles>
 			<availability>CSA:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:5,MERC:5</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -1721,7 +1725,7 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
@@ -1729,21 +1733,17 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
@@ -1751,11 +1751,11 @@
 		<model name='BNC-3MC'>
 			<availability>MOC:9</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>OA:3,LA:4,IS:1,FS:2,MERC:2,CIR:3,TC:3</availability>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
-		<model name='BNC-6S'>
-			<availability>LA:3</availability>
+		<model name='BNC-3M'>
+			<availability>MOC:2,FWL:2,TC:2</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:2</availability>
@@ -1763,60 +1763,60 @@
 		<model name='BNC-3E'>
 			<availability>HL:2,General:4,Periphery.Deep:8,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
+		<model name='BNC-3S'>
+			<availability>OA:3,LA:4,IS:1,FS:2,MERC:2,CIR:3,TC:3</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:7,FRR:3,FS:6,MERC:5</availability>
 		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:2,FWL:2,TC:2</availability>
+		<model name='BNC-6S'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:4,FRR:3,MERC:3</availability>
-		<model name='BGS-2T'>
-			<availability>LA:5,MERC:5</availability>
-		</model>
 		<model name='BGS-1T'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BGS-2T'>
+			<availability>LA:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:6,CLAN:5,CSJ:7,BAN:5</availability>
-		<model name='D'>
-			<availability>CSR:6,CNC:3,CLAN:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='D'>
+			<availability>CSR:6,CNC:3,CLAN:2</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
 		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CCC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CSV:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CLAN.IS:3,CGS:7,CCO:3,CJF:4</availability>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='C'>
+			<availability>General:5,CCO:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CBS:8,General:6</availability>
+		<model name='H'>
+			<availability>CSA:6,General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -1824,22 +1824,15 @@
 		<model name='F'>
 			<availability>General:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,General:5</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5,CCO:6</availability>
+		<model name='B'>
+			<availability>CBS:8,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='IS'>
 		<availability>CS:4</availability>
-		<model name='BTL-C-2O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='BTL-C-2OB'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='BTL-C-2OA'>
 			<roles>ew_support,spotter</roles>
 			<availability>General:5</availability>
@@ -1847,6 +1840,13 @@
 		<model name='BTL-C-2OC'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='BTL-C-2OB'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='BTL-C-2O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -1865,17 +1865,20 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:1,DC:5</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1,MERC:0</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:1</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>CS:6,CC:5,PIR:3,FWL:8,IS:3,WOB:7,MH:3,SIC:5,MERC:5</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:4,FRR:3,MERC:2,CJF:3</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='BLR-1D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='BLR-4S'>
+			<availability>LA:4,FRR:3,MERC:2,CJF:3</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1,WOB:1</availability>
@@ -1883,24 +1886,21 @@
 		<model name='BLR-1S'>
 			<availability>LA:3</availability>
 		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1,MERC:0</availability>
+		</model>
 		<model name='BLR-3S'>
 			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='BLR-1G'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,FS:2,BAN:8,Periphery:5</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:1</availability>
-		</model>
 		<model name='BLR-CM'>
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
+		</model>
+		<model name='BLR-3M'>
+			<availability>CS:6,CC:5,PIR:3,FWL:8,IS:3,WOB:7,MH:3,SIC:5,MERC:5</availability>
 		</model>
 		<model name='BLR-K3'>
 			<roles>spotter</roles>
@@ -1916,22 +1916,22 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,DC:3+</availability>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CIH:7,CNC:9,General:8,CGS:7</availability>
-		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CFM:6,CGS:8,CJF:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -1943,8 +1943,8 @@
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:5,CSR:3,CLAN:1,CSJ:5,CGS:5</availability>
-		<model name='(Standard)'>
-			<availability>CSR:6,General:6</availability>
+		<model name='6'>
+			<availability>General:1</availability>
 		</model>
 		<model name='4'>
 			<availability>General:1</availability>
@@ -1952,27 +1952,27 @@
 		<model name='2'>
 			<availability>CHH:5,CGS:6</availability>
 		</model>
-		<model name='6'>
-			<availability>General:1</availability>
-		</model>
 		<model name='5'>
 			<availability>General:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:6,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:5,HL:4,FRR:6,IS:5,WOB:5-,SIC:6,MERC:5,FS:8,Periphery:5,CS:5-,OA:6,CDS:3,LA:6,PIR:5,DC:7</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:3,IS:3,DC:6</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2,DC:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
 		</model>
-		<model name='(Kurita)'>
-			<availability>CLAN:3,IS:3,DC:6</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -1991,11 +1991,11 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>LA:5,FRR:3,FS:4,MERC:1</availability>
-		<model name='BRZ-B3'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BRZ-A3'>
 			<availability>LA:8,FRR:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='BRZ-B3'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2013,18 +2013,15 @@
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CSJ:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -2032,20 +2029,29 @@
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:4+,LA:6+,FRR:6+,SIC:4+,FS:4+,MERC:4+,DC:7+</availability>
-		<model name='BHKU-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
+		</model>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BHKU-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OR'>
 			<availability>General:1+,DC:1+</availability>
@@ -2053,35 +2059,29 @@
 		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OA'>
-			<availability>General:7</availability>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:6,FRR:3,CLAN:7,CFM:6,FS:3,CWIE:8,DC.GHO:3,OA:2,CDS:6,CBS:8,FWL:2,NIOPS:7,CGB:8,CSR:6,CSV:6,WOB:7,FWL.OH:2,MERC:3,CGS:8,Periphery:2,TC:3,CS:7,CW:8,LA:2,CNC:8,CJF:6,DC:3</availability>
-		<model name='BL-12-KNT'>
-			<availability>FS:2</availability>
+		<model name='BL-6b-KNT'>
+			<availability>CS:6,CLAN:5,FWL:6,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
+		</model>
+		<model name='BL-9-KNT'>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='BL-6-KNT'>
 			<availability>CS:4,DC.GHO:4,OA:3,FRR:5,CLAN:6,FWL:4,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,TC:3,DC:4</availability>
 		</model>
-		<model name='BL-6b-KNT'>
-			<availability>CS:6,CLAN:5,FWL:6,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:6</availability>
-		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:6,FRR:6,FWL:2,MERC:6,FS:6,DC:6</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -2089,16 +2089,12 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,CLAN:5</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:5</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:5,CCO:6</availability>
@@ -2106,6 +2102,10 @@
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -2130,26 +2130,35 @@
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:5-,MOC:4,OA:4,HL:3,IS:1,SIC:6,FS:7,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:2,SIC:5,FS:4,MERC:4,Periphery:2</availability>
-		</model>
 		<model name='BJ-1DC'>
 			<availability>FS:1</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:2,General:4,Periphery.Deep:8,Periphery:4</availability>
 		</model>
-		<model name='BJ-2'>
-			<availability>CC:3,CS:3,LA:3,PIR:2+,WOB:3,SIC:4,FS:8,MERC:3</availability>
+		<model name='BJ-3'>
+			<availability>CC:2,SIC:5,FS:4,MERC:4,Periphery:2</availability>
 		</model>
 		<model name='BJ-1DB'>
 			<availability>FS:1</availability>
 		</model>
+		<model name='BJ-2'>
+			<availability>CC:3,CS:3,LA:3,PIR:2+,WOB:3,SIC:4,FS:8,MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CS:3+,MOC:3+,FWL:3+,IS:3+,WOB:3+,SIC:3+,FS:3+,MERC:3+,DC:6+</availability>
-		<model name='BJ2-O'>
-			<availability>General:8</availability>
+		<model name='BJ2-OE'>
+			<availability>General:6,FWL:6</availability>
+		</model>
+		<model name='BJ2-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:1+,DC:2+</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:4</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:7</availability>
@@ -2157,20 +2166,11 @@
 		<model name='BJ2-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BJ2-OE'>
-			<availability>General:6,FWL:6</availability>
-		</model>
 		<model name='BJ2-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:4</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:1+,DC:2+</availability>
+		<model name='BJ2-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
@@ -2181,37 +2181,37 @@
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,CM:5,WOB:5,MERC:5,TC:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Black Blizzard&apos;'>
 			<availability>CC:4,WOB:3</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:3,CCC:2,CBS:2</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:7,General:5</availability>
@@ -2250,17 +2250,17 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:4,OA:1-,CDS:5,CLAN:4,IS:1-,NIOPS:4,FWL:1-,WOB:5,DC:1-</availability>
-		<model name='BMB-14C'>
+		<model name='BMB-12D'>
 			<roles>fire_support</roles>
-			<availability>CS:6,WOB:6</availability>
+			<availability>CS:5,OA:4,FRR:4,CLAN:8,NIOPS:5,WOB:5,MERC.SI:8,BAN:8</availability>
 		</model>
 		<model name='BMB-10D'>
 			<roles>fire_support</roles>
 			<availability>HL:4-,IS:6-,Periphery.Deep:6-,Periphery:6-</availability>
 		</model>
-		<model name='BMB-12D'>
+		<model name='BMB-14C'>
 			<roles>fire_support</roles>
-			<availability>CS:5,OA:4,FRR:4,CLAN:8,NIOPS:5,WOB:5,MERC.SI:8,BAN:8</availability>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -2276,13 +2276,13 @@
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -2297,10 +2297,10 @@
 		<model name='LDT-1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='LDT-X1'>
+		<model name='LDT-X2'>
 			<availability>General:4</availability>
 		</model>
-		<model name='LDT-X2'>
+		<model name='LDT-X1'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -2312,6 +2312,9 @@
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -2320,9 +2323,6 @@
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -2340,13 +2340,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -2358,11 +2358,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:6,General:8,FS:6,MERC:6,DC:6</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:6,General:8,FS:6,MERC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
@@ -2427,13 +2427,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -2445,93 +2445,86 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:8,MOC:4,LA:3,Periphery.CM:3,Periphery.HR:3,Periphery.ME:3,MH:3,SIC:5,FS:5,MERC:4,TC:4,Periphery:2</availability>
-		<model name='CTF-1X'>
-			<availability>General:5,Periphery:6</availability>
-		</model>
 		<model name='CTF-2X'>
 			<availability>CC:4,MOC:4,SIC:2,FS:1,MERC:1,TC:4</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>LA:6,FS:6</availability>
 		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
 		<model name='CTF-4X'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		<model name='CTF-1X'>
+			<availability>General:5,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,FRR:5,IS:1,SIC:2,MERC:2,CIR:4,FS:1,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:4,DC:6</availability>
-		<model name='CPLT-K3'>
+		<model name='CPLT-C4C'>
 			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+			<availability>CC:2,MOC:2,FS:2,MERC:2,TC:2</availability>
+		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:2,DC:4</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>HL:2,PIR:4,MH:6,Periphery:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:4,HL:2,CLAN:3,IS:1,Periphery.Deep:8,MERC:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:3,MOC:3,TC:3</availability>
+		</model>
+		<model name='CPLT-C4'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:2,OA:2,SIC:2,TC:2</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>FRR:4,DC:6</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:5,CS:3,MOC:3,WOB:3,FS:4,TC:3,DC:4</availability>
 		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:4,HL:2,CLAN:3,IS:1,Periphery.Deep:8,MERC:4,BAN:6,Periphery:4</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>HL:2,PIR:4,MH:6,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>FRR:4,DC:6</availability>
-		</model>
-		<model name='CPLT-A1'>
-			<roles>fire_support</roles>
-			<availability>CC:2,SIC:2</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:2,DC:4</availability>
-		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
-			<availability>CC:2,MOC:2,OA:2,SIC:2,TC:2</availability>
+			<availability>DC:2</availability>
 		</model>
 		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
 			<availability>DC:2</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:3,MOC:3,TC:3</availability>
-		</model>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:2,FS:2,MERC:2,TC:2</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:2,MOC:2</availability>
 		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:2,SIC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CCC:4,CSR:4,CLAN:3,CGS:4,CSA:4,CDS:4,CW:3,CNC:4,CSJ:6,CJF:3,CGB:3,DC:2+</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CLAN:5,IS:2</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -2540,26 +2533,39 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>LA:3,FS:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:4,IS:3,CM:4,FS:6,MERC:4</availability>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
@@ -2568,12 +2574,6 @@
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Celerity' unitType='Mek'>
@@ -2585,11 +2585,11 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:4,CSR:3,CBS:3,CNC:4,CFM:3,CSJ:5,CJF:5</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,CSR:8,CNC:8,CFM:8,CSJ:8,CJF:8</availability>
-		</model>
 		<model name='3'>
 			<availability>CSR:4,CBS:4,CFM:4,CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8,CSR:8,CNC:8,CFM:8,CSJ:8,CJF:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:4,CSR:4,CBS:4,CNC:4,CFM:6,CJF:4</availability>
@@ -2597,13 +2597,13 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:6,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Aero'>
@@ -2620,35 +2620,35 @@
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-D3'>
-			<availability>FS:3,MERC:3</availability>
-		</model>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>FS:2,MERC:2,Periphery:1</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:6,IS:4,FS:6</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>LA:3,FRR:3,FWL:3,SIC:4,FS:8,MERC:4,CIR:3,Periphery:3</availability>
+			<availability>LA:1,FS:3,MERC:3,Periphery:1</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>HL:3,LA:2-,FRR:2-,FWL:2-,Periphery.Deep:8,FS:4-,MERC:4-,Periphery:5</availability>
 		</model>
+		<model name='CN9-D'>
+			<availability>LA:3,FRR:3,FWL:3,SIC:4,FS:8,MERC:4,CIR:3,Periphery:3</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='CN9-D3D'>
 			<availability>FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>LA:1,FS:3,MERC:3,Periphery:1</availability>
+			<availability>FS:2,MERC:2,Periphery:1</availability>
 		</model>
 		<model name='CN9-D4D'>
 			<availability>FWL:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FS:3,MERC:3</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:6,IS:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -2656,11 +2656,11 @@
 		<model name='MR-5M'>
 			<availability>CC:4,FWL:6,WOB:6</availability>
 		</model>
-		<model name='MR-V3'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='MR-V2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MR-V3'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -2705,43 +2705,43 @@
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:5,CC:5,OA:5,HL:3,LA:5,IS:4,FWL:5,FS:5,TC:5,Periphery:4,DC:4</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:3-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:2,IS:6,Periphery:4</availability>
-		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:4,IS:3,FS:4</availability>
 		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:3-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:6,CHH:3,FRR:4,CLAN:3,IS:4,WOB:5,SIC:3,MERC:2,FS:4,CS:5,DC.GHO:6,LA:5,FWL:4,NIOPS:5,CGB:3,DC:5</availability>
+		<model name='CHP-3P'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='CHP-2N'>
+			<availability>IS:5,NIOPS:0</availability>
+		</model>
 		<model name='CHP-3N'>
 			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,CS:4,LA:4,IS:4,MERC:4</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:3,CHH:2,WOB:5,SIC:5,FS:4,MERC:5,BAN:4,DC.GHO:4,CS:5,LA:5,NIOPS:5,MERC.SI:5,DC:4,CGB:2</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:5,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,CS:4,LA:4,IS:4,MERC:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
-		</model>
-		<model name='CHP-3P'>
-			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -2761,11 +2761,18 @@
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:4-,MOC:2-,OA:2-,LA:3-,FRR:5-,FWL:2-,SIC:3-,MERC:3-,TC:2-,Periphery:2,DC:5-</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:4,OA:10,PIR:4,MH:4</availability>
+		</model>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>MERC:4,DC:4</availability>
+		</model>
 		<model name='CGR-3K'>
 			<availability>CC:3-,FRR:4-,MERC:3-,DC:4-</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>CC:4,HL:3,SIC:4,Periphery:5</availability>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>OA:4,FRR:3-,DC:3-</availability>
@@ -2777,31 +2784,17 @@
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,SIC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-2A2'>
-			<availability>MOC:4,OA:10,PIR:4,MH:4</availability>
-		</model>
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:3,MERC:4</availability>
 		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>CC:4,HL:3,SIC:4,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
-		<model name='F-11'>
-			<availability>FRR:5,FWL:8,WOB:8,MERC:5</availability>
-		</model>
-		<model name='F-14-S'>
-			<availability>FWL:8</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:5,HL:3,General:5,FWL:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
+		<model name='F-12-S'>
+			<availability>FWL:3,WOB:3</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
@@ -2811,16 +2804,19 @@
 			<roles>recon</roles>
 			<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:3,WOB:3</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:5,HL:3,General:5,FWL:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
+		</model>
+		<model name='F-11'>
+			<availability>FRR:5,FWL:8,WOB:8,MERC:5</availability>
+		</model>
+		<model name='F-14-S'>
+			<availability>FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:5,NIOPS:5,WOB:5,DC:3</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
@@ -2828,6 +2824,10 @@
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Speed)'>
+			<roles>recon</roles>
+			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -2847,8 +2847,8 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
-		<model name='CHP-W7'>
-			<availability>LA:7,FRR:6,CLAN:6,WOB:6,SIC:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:2,LA:4,IS:4,Periphery.Deep:8,MERC:4,BAN:3,Periphery:4</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:6,FS:5,TC:4,Periphery:4</availability>
@@ -2856,8 +2856,8 @@
 		<model name='CHP-W5b'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:2,LA:4,IS:4,Periphery.Deep:8,MERC:4,BAN:3,Periphery:4</availability>
+		<model name='CHP-W7'>
+			<availability>LA:7,FRR:6,CLAN:6,WOB:6,SIC:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
@@ -2866,10 +2866,6 @@
 			<roles>recon</roles>
 			<availability>General:4-</availability>
 		</model>
-		<model name='CDA-3C'>
-			<roles>training</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
 			<availability>CC:4,FRR:4,FWL:5,WOB:5,MERC:4,DC:4</availability>
@@ -2877,6 +2873,10 @@
 		<model name='CDA-3M'>
 			<roles>recon</roles>
 			<availability>FWL:8,IS:6,MERC:6</availability>
+		</model>
+		<model name='CDA-3C'>
+			<roles>training</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
@@ -2904,20 +2904,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -2937,14 +2937,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -2952,29 +2949,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -2985,8 +2985,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -2994,18 +2997,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -3014,27 +3023,18 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -3042,8 +3042,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -3068,6 +3068,12 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,FRR:3,IS:2,WOB:1-,SIC:3,FS:3,MERC:2,CS:2-,LA:2,FWL:2,NIOPS:2-,DC:2</availability>
+		<model name='CLNT-2-4T'>
+			<availability>CC:2,SIC:2,FS:2</availability>
+		</model>
+		<model name='CLNT-2-3U'>
+			<availability>CC:8,CS:6,LA:4,General:6</availability>
+		</model>
 		<model name='CLNT-5U'>
 			<roles>spotter</roles>
 			<availability>LA:6,MERC:6</availability>
@@ -3075,26 +3081,20 @@
 		<model name='CLNT-2-3T'>
 			<availability>IS:4,Periphery.Deep:8,NIOPS:8</availability>
 		</model>
-		<model name='CLNT-2-4T'>
-			<availability>CC:2,SIC:2,FS:2</availability>
-		</model>
-		<model name='CLNT-2-3U'>
-			<availability>CC:8,CS:6,LA:4,General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:7,WOB:6</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,NIOPS:4,WOB:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,NIOPS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra' unitType='Mek'>
@@ -3126,51 +3126,51 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
-		<model name='COM-1B'>
-			<roles>recon</roles>
-			<availability>LA:1</availability>
-		</model>
-		<model name='COM-7S'>
-			<roles>recon</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='COM-5S'>
 			<roles>recon</roles>
 			<availability>LA:8,FRR:6,FS:4,MERC:5</availability>
 		</model>
-		<model name='COM-3A'>
-			<roles>recon</roles>
-			<availability>LA:3,MERC:2</availability>
-		</model>
 		<model name='COM-4H'>
 			<roles>recon</roles>
 			<availability>PIR:6,MH:10</availability>
+		</model>
+		<model name='COM-1B'>
+			<roles>recon</roles>
+			<availability>LA:1</availability>
+		</model>
+		<model name='COM-3A'>
+			<roles>recon</roles>
+			<availability>LA:3,MERC:2</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>HL:6,LA:5,General:6,Periphery.Deep:7,TC:7,Periphery:8</availability>
 		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>MOC:2,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8,SIC:5</availability>
-		</model>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6,General:7,FS:6,Periphery:7</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>SIC:5,FS:6</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,SIC:2,FS:2</availability>
+		</model>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>LA:5,IS:3</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8,SIC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -3193,24 +3193,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,MERC.WD:1,CSR:1,CW:1,CSV:1,NIOPS:2,CSJ:3,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -3232,17 +3232,17 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Copperhead' unitType='Mek'>
@@ -3259,8 +3259,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:1,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:6</availability>
+		<model name='CSR-V14'>
+			<availability>LA:6,FRR:5,FS:6,MERC:5</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>LA:2,FS.AH:3,Periphery:2</availability>
@@ -3268,11 +3271,8 @@
 		<model name='CSR-V12'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:4,Periphery:5</availability>
 		</model>
-		<model name='CSR-V14'>
-			<availability>LA:6,FRR:5,FS:6,MERC:5</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,BAN:2</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -3290,37 +3290,37 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
 		<availability>CSV:4,CSJ:4,CJF:5,CCO:5</availability>
-		<model name='H'>
-			<availability>CSA:5,General:4</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:5,General:4</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -3329,30 +3329,30 @@
 			<roles>raider</roles>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
-		<model name='CRB-27'>
-			<roles>raider</roles>
-			<availability>DC.GHO:5,CS:4,FRR:3,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
-		</model>
-		<model name='CRB-C'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='CRB-30'>
-			<availability>CS:6,FRR:3,WOB:5</availability>
-		</model>
 		<model name='CRB-20'>
 			<roles>raider</roles>
 			<availability>IS:1,Periphery.Deep:8,NIOPS:0,Periphery:1</availability>
 		</model>
+		<model name='CRB-C'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:5,CS:4,FRR:3,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
+		</model>
+		<model name='CRB-30'>
+			<availability>CS:6,FRR:3,WOB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CCC:2,CFM.MiKr:5,CBS:4,CFM:3</availability>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='A'>
@@ -3361,8 +3361,11 @@
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:7,CSR:5,FRR:5,CSV:5,CLAN:6,CFM:5,WOB:8,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:8,NIOPS:9,CJF:5,CGB:7</availability>
-		<model name='CRK-5003-3'>
-			<availability>CS:6,FRR:3</availability>
+		<model name='CRK-5004-1'>
+			<availability>CS:5,FRR:3</availability>
+		</model>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
 		<model name='CRK-5003-0'>
 			<availability>IS:5,NIOPS:0</availability>
@@ -3370,69 +3373,42 @@
 		<model name='CRK-5003-1'>
 			<availability>CS:5,FRR:4,CLAN:6,NIOPS:5,WOB:5,BAN:8</availability>
 		</model>
-		<model name='CRK-5004-1'>
-			<availability>CS:5,FRR:3</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		<model name='CRK-5003-3'>
+			<availability>CS:6,FRR:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
 		<availability>HL:2,Periphery.MW:4,Periphery.ME:4,FWL:2,MERC:3,Periphery:3</availability>
-		<model name='CNS-5M'>
-			<availability>CS:0,PIR:3,IS:6</availability>
-		</model>
 		<model name='CNS-3M'>
 			<availability>General:6</availability>
+		</model>
+		<model name='CNS-5M'>
+			<availability>CS:0,PIR:3,IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CSR:3,CDS:3,CW:3,CBS:5,CSV:8,CNC:3,CCO:3,CJF:3,CWIE:3,CGB:3</availability>
-		<model name='D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='A'>
 			<availability>General:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:5,IS:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:5,IS:2</availability>
+		</model>
 		<model name='H'>
 			<availability>CLAN:4,IS:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:5,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:5,WOB:4-,Periphery:6</availability>
-		<model name='CRD-4D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='CRD-2R'>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>FRR:4,MERC:3,DC:4</availability>
-		</model>
-		<model name='CRD-5S'>
-			<availability>LA:8,FS:4,MERC:4</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>HL:2,General:4,Periphery.Deep:8,BAN:2,Periphery:4</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:2,DC:3</availability>
-		</model>
 		<model name='CRD-8S'>
 			<availability>LA:4</availability>
 		</model>
@@ -3440,18 +3416,60 @@
 			<roles>raider</roles>
 			<availability>CC:6,SIC:6</availability>
 		</model>
+		<model name='CRD-3R'>
+			<availability>HL:2,General:4,Periphery.Deep:8,BAN:2,Periphery:4</availability>
+		</model>
 		<model name='CRD-5M'>
 			<availability>CC:4,CS:3,FWL:8,IS:4,WOB:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FS:3</availability>
+		<model name='CRD-3K'>
+			<availability>FRR:2,DC:3</availability>
 		</model>
 		<model name='CRD-4K'>
 			<availability>LA:4,FRR:8,MERC:4,FS:4,DC:8</availability>
 		</model>
+		<model name='CRD-4BR'>
+			<availability>MERC:6</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>FRR:4,MERC:3,DC:4</availability>
+		</model>
+		<model name='CRD-2R'>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		</model>
+		<model name='CRD-3D'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='CRD-4D'>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
+		<model name='CP-11-G'>
+			<availability>CS:5,FRR:5,SL.2:5,MERC:4</availability>
+		</model>
+		<model name='CP-10-Q'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:4,DC:4</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>CC:4,CS:4,MOC:4,LA:4,FWL:5,IS:4,WOB:5,FS:6,DC:4,TC:4</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:5,General:5,IS:5,FS:5,MERC:5,DC:5,TC:5</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
+		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
 			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,DC:5</availability>
@@ -3459,37 +3477,19 @@
 		<model name='CP-11-H'>
 			<availability>PIR:5,MH:5,CIR:5,TC:5</availability>
 		</model>
-		<model name='CP-10-Z'>
-			<availability>OA:5,General:5,IS:5,FS:5,MERC:5,DC:5,TC:5</availability>
-		</model>
-		<model name='CP-11-A'>
-			<availability>CC:4,CS:4,MOC:4,LA:4,FWL:5,IS:4,WOB:5,FS:6,DC:4,TC:4</availability>
-		</model>
-		<model name='CP-11-G'>
-			<availability>CS:5,FRR:5,SL.2:5,MERC:4</availability>
-		</model>
-		<model name='CP-10-Q'>
-			<availability>IS:2</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
 		<availability>CS:6,CHH:3,CSR:3,CLAN:1,NIOPS:6,WOB:5,CJF:3</availability>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,escort</roles>
 			<availability>CS:8,General:8,NIOPS:8,WOB:8</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
@@ -3527,39 +3527,39 @@
 		<model name='DMO-4K'>
 			<availability>FRR:3,DC:5</availability>
 		</model>
-		<model name='DMO-1K'>
-			<availability>General:8,DC:8</availability>
-		</model>
 		<model name='DMO-2K'>
 			<availability>FRR:3,DC:4</availability>
+		</model>
+		<model name='DMO-1K'>
+			<availability>General:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,IS:2+,FS:2+,MERC:2+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:2+,CNC:5,CSJ:8,CJF:5,CGB:5,DC:2+</availability>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CHH:1,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CSJ:3,CJF:2,CGB:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4,CGS:5,CCO:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danais' unitType='Dropship'>
@@ -3581,18 +3581,15 @@
 		<model name='DRT-3S'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='DRT-4S'>
-			<availability>LA:4,FS:6,MERC:3,CIR:3</availability>
-		</model>
 		<model name='DRT-6S'>
 			<availability>LA:6,FS:5</availability>
+		</model>
+		<model name='DRT-4S'>
+			<availability>LA:4,FS:6,MERC:3,CIR:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>LA:5,FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
@@ -3600,6 +3597,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -3609,13 +3610,15 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
+		<model name='(SRM-2)'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CHH:7,CCC:5,MERC.WD:5,CIH:5,CDS:5,CLAN:4,IS:2+,CCO:3,CJF:4,BAN:4,CGB:8</availability>
+		<model name='H'>
+			<availability>CSA:6,CIH:3,CDS:3,CBS:2,General:4,CWIE:5,CGB:5</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:3,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -3626,9 +3629,6 @@
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:5,CHH:8,CIH:6,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CIH:3,CDS:3,CBS:2,General:4,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CIH:7,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
@@ -3648,24 +3648,24 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,TC:9,Periphery:10,CS:6,OA:9,LA:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,MOC:4,CS:4,LA:4,FRR:4,IS:2,FWL:4,WOB:4,SIC:4,FS:4,TC:4,DC:4</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:8,CS:8,LA:8,FRR:6,FWL:8,IS:4,WOB:8,SIC:7,FS:8,DC:8,CWIE:4</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>DC:4</availability>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,MOC:4,CS:4,LA:4,FRR:4,IS:2,FWL:4,WOB:4,SIC:4,FS:4,TC:4,DC:4</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -3704,11 +3704,11 @@
 		<model name='DV-8D'>
 			<availability>FS:3,MERC:3</availability>
 		</model>
-		<model name='DV-7D'>
-			<availability>LA:5,FS:8,MERC:4,TC:4</availability>
-		</model>
 		<model name='DV-6M'>
 			<availability>HL:5,CLAN:4,IS:5-,Periphery.Deep:7,Periphery:7</availability>
+		</model>
+		<model name='DV-7D'>
+			<availability>LA:5,FS:8,MERC:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -3719,24 +3719,24 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:3,LA:5,FS:4,MERC:3,TC:3</availability>
-		<model name='DVS-1D'>
-			<availability>LA:3,FS:3,TC:8</availability>
+		<model name='DVS-3'>
+			<availability>LA:3,FS:3</availability>
 		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='DVS-3'>
-			<availability>LA:3,FS:3</availability>
+		<model name='DVS-1D'>
+			<availability>LA:3,FS:3,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CIH:4,CGS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau Assault Interceptor' unitType='Dropship'>
@@ -3760,26 +3760,23 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,LA:2,FRR:8,MERC:3,DC:7</availability>
-		<model name='DRG-5N'>
-			<availability>FRR:6,MERC:6,DC:6</availability>
-		</model>
 		<model name='DRG-7N'>
 			<availability>LA:4,MERC:3,DC:3</availability>
 		</model>
 		<model name='DRG-1N'>
 			<availability>FRR:3,MERC:2,DC:3,Periphery:4</availability>
 		</model>
+		<model name='DRG-5N'>
+			<availability>FRR:6,MERC:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,MERC.WD:5,CHH:5,CIH:7,CDS:3,CSV:4,CLAN:4,IS:1+,CFM:4,CSJ:4,CJF:3,CGB:8</availability>
-		<model name='D'>
-			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CWIE:6,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
@@ -3787,26 +3784,29 @@
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:1</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,MERC:3,FS:6,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,CC.MAC:4,DC:3</availability>
-		<model name='(SRM)'>
-			<availability>CC:7,General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:5,General:6</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>LA:7,WOB:5,FS:5</availability>
+		<model name='(SRM)'>
+			<availability>CC:7,General:3</availability>
 		</model>
 		<model name='(ERLL)'>
 			<availability>LA:1,FS:1</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:7,WOB:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -3831,9 +3831,6 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:3,IS:3,WOB:3-,SIC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:4</availability>
-		<model name='EGL-R6'>
-			<availability>LA:1,General:7,FS:1</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:2,FS:2</availability>
 		</model>
@@ -3844,15 +3841,18 @@
 			<roles>ground_support</roles>
 			<availability>LA:2,FS:2</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>LA:1,General:7,FS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,FWL.MM:6,FWL:5,MH:3,FWL.FO:6,MERC:4</availability>
-		<model name='EGL-1M'>
-			<availability>CC:3,MOC:3,FWL:2,MH:2</availability>
-		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='EGL-1M'>
+			<availability>CC:3,MOC:3,FWL:2,MH:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -3863,49 +3863,49 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:2+</availability>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='EST-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='EST-OA'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:7,MERC.WD:7,CW:7,CLAN:7,CNC:7+</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='[MicroPL]' mechanized='true'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='[MicroPL]' mechanized='true'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
@@ -3927,6 +3927,9 @@
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FS:5,MERC:3</availability>
+		<model name='ENF-6M'>
+			<availability>FS:8,MERC:8</availability>
+		</model>
 		<model name='ENF-6H'>
 			<availability>FS:4</availability>
 		</model>
@@ -3936,17 +3939,14 @@
 		<model name='ENF-6G'>
 			<availability>FS:3,MERC:3</availability>
 		</model>
-		<model name='ENF-6M'>
-			<availability>FS:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>OA:3,LA:5,Periphery.HR:3,MH:2,SIC:3,FS:9,MERC:5,Periphery.OS:3,TC:3,DC:3,Periphery:2</availability>
-		<model name='ENF-4R'>
-			<availability>LA:2,General:5,FS:5,TC:5</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>LA:4,FS:8,MERC:5,TC:5</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>LA:2,General:5,FS:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -3972,46 +3972,46 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CIH:3+,CDS:4+,CW:4+,CNC:3+,CGS:3+,CGB:3+,CWIE:4+</availability>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='A'>
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CS:4,CIH:1,CDS:2,CSV:1,FWL:2,WOB:2,CSJ:1,CGS:1,CCO:1,CGB:2</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CS:4,CLAN:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:6,FS:5</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>FS:2,MERC:2</availability>
-		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -4042,11 +4042,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:1,NIOPS:4,WOB:4,DC:1</availability>
-		<model name='EXT-4A'>
-			<availability>FWL:8</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:6,CLAN:6,NIOPS:6,WOB:6,BAN:2,DC:8</availability>
+		</model>
+		<model name='EXT-4A'>
+			<availability>FWL:8</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -4057,21 +4057,21 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6</availability>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CC:5</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>CC:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>CC:7</availability>
 		</model>
 		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -4088,12 +4088,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -4116,11 +4116,11 @@
 		<model name='FLC-6C'>
 			<availability>MERC.WD:4+</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
@@ -4145,58 +4145,54 @@
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SRM]' mechanized='false'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[SL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SL]' mechanized='false'>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[SRM]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:2+,CHH:5,CIH:7,CSV:5,CLAN:3,IS:2+,CWIE:8,MERC.WD:7,CDS:4,CW:8,CNC:3,CSJ:4,CJF:6,CGB:5</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4,CWIE:3</availability>
-		</model>
-		<model name='H'>
-			<availability>General:2,CWIE:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
+		<model name='D'>
+			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 		</model>
-		<model name='D'>
-			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CSJ:6,CJF:6,CGB:6</availability>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>General:2,CWIE:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CSJ:3,CGS:4,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:5,HL:5,LA:5,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:7</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
 			<availability>LA:3,FWL:2,FS:5</availability>
@@ -4204,6 +4200,10 @@
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -4230,55 +4230,51 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(LBX20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(UAC20)'>
+		<model name='(LBX5)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(UAC5)'>
+		<model name='(AC20)'>
 			<roles>field_gun</roles>
-			<availability>IS:7</availability>
+			<availability>General:7</availability>
 		</model>
-		<model name='(LBX5)'>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(LBX2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(LBX2)'>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(UAC10)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -4286,9 +4282,13 @@
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(UAC10)'>
+		<model name='(UAC2)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
@@ -4297,58 +4297,58 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CIH:3,CNC:2,CFM:4,CJF:5,CLAN.HW:3</availability>
-		<model name='Prime'>
+		<model name='B'>
+			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:4,IS:2,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>CSA:5,CLAN:4,IS:2</availability>
+			<availability>General:9</availability>
 		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
+		<model name='A'>
 			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:8</availability>
+			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CSA:5,CLAN:4,IS:2</availability>
+		</model>
+		<model name='E'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:4,IS:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
 		<availability>CGS:8</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>CLAN:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>LA:6,FS:6,MERC:4</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:6,MERC:6,FS:6</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>LA:6,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -4364,11 +4364,11 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:6,MERC.WD:2,CIH:4,CLAN:2,WOB:5,BAN:1</availability>
-		<model name='C'>
-			<availability>MERC.WD:5,CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:5,CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FFL-4C'>
 			<availability>CS:8,WOB:8</availability>
@@ -4376,15 +4376,6 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:7,IS:6,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:4,CS:4,MOC:5,LA:7,FRR:5,General:4,FS:5,TC:4</availability>
-		</model>
 		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
 			<availability>LA:1,LA.SR:2</availability>
@@ -4392,8 +4383,17 @@
 		<model name='FS9-C'>
 			<availability>MOC:4,PIR:5,MH:5,CIR:7,Periphery:3,TC:3</availability>
 		</model>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		</model>
 		<model name='FS9-P'>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:4,CS:4,MOC:5,LA:7,FRR:5,General:4,FS:5,TC:4</availability>
 		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
@@ -4402,79 +4402,79 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:5+,CC:4+,LA:5+,IS:4+,WOB:5+,FS:5+,MERC:4+,DC:7+</availability>
+		<model name='FS9-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='FS9-OE'>
 			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:1+,DC:1+</availability>
 		</model>
 		<model name='FS9-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='FS9-OX'>
-			<availability>General:1</availability>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
 		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
+		<model name='FS9-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OF'>
 			<availability>General:6</availability>
 		</model>
-		<model name='FS9-OD'>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:1+,DC:1+</availability>
+		<model name='FS9-OX'>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:3,CSV:5,FRR:4,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:5,Periphery.R:2,CDS:3,LA:6,CBS:3,NIOPS:5,CJF:5,CGB:3,DC:4</availability>
-		<model name='FLS-8K'>
-			<availability>DC.GHO:6,CS:5,LA:4,CLAN:8,NIOPS:5,WOB:5,MERC.SI:6,BAN:8</availability>
-		</model>
-		<model name='FLS-C'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='FLS-9C'>
 			<availability>CS:4</availability>
 		</model>
 		<model name='FLS-7K'>
 			<availability>:0,MERC.KH:4,LA:4</availability>
 		</model>
+		<model name='FLS-8K'>
+			<availability>DC.GHO:6,CS:5,LA:4,CLAN:8,NIOPS:5,WOB:5,MERC.SI:6,BAN:8</availability>
+		</model>
+		<model name='FLS-C'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
@@ -4482,12 +4482,12 @@
 		<model name='FLE-15'>
 			<availability>MERC.WD:1,FWL:1</availability>
 		</model>
-		<model name='FLE-17'>
-			<availability>CC:8,FWL:3,WOB:3,MERC:3,Periphery:3</availability>
-		</model>
 		<model name='&apos;Fire Ant&apos;'>
 			<roles>urban</roles>
 			<availability>CC:2,CM:4</availability>
+		</model>
+		<model name='FLE-17'>
+			<availability>CC:8,FWL:3,WOB:3,MERC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -4498,20 +4498,18 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -4519,20 +4517,22 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
 		<availability>CS:4,CHH:1,LA:4,CBS:1,NIOPS:4,SIC:2,FS:4,Periphery:1</availability>
-		<model name='(2613)'>
-			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3058)'>
 			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
 			<availability>CS:6,LA:6,FS:6</availability>
+		</model>
+		<model name='(2613)'>
+			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -4565,11 +4565,11 @@
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CS:5,CHH:4,CW:3,CLAN:1,FS:3,CJF:3,CGB:4</availability>
-		<model name='CX-17'>
-			<availability>CS:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='CX-17'>
+			<availability>CS:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -4596,18 +4596,22 @@
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:4,CW:4,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CSA:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:4,CW:6,CGS:4,CCO:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:3,CS:5,OA:3,LA:5,FWL:7,DC:3</availability>
+		</model>
 		<model name='GAL-200'>
 			<availability>MOC:2,LA:2,FRR:2,IS:1,DC:2,Periphery:2</availability>
 		</model>
@@ -4615,39 +4619,35 @@
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:5</availability>
 		</model>
-		<model name='GAL-102'>
-			<roles>recon</roles>
-			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:3,CS:5,OA:3,LA:5,FWL:7,DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>CC:4,MOC:4,MERC.WD:8,IS:6,FWL:4,MH:4,MERC:6,TC:4</availability>
-		<model name='GAL-2GLS'>
-			<availability>HL:2,IS:4,Periphery:4</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:5,MERC:3</availability>
 		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:5,MERC:3</availability>
+		<model name='GAL-2GLS'>
+			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:5,MERC:3</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FS:3,MERC:4,TC:4</availability>
+		<model name='GRM-01C'>
+			<availability>FS:4,MERC:4</availability>
+		</model>
 		<model name='GRM-01B'>
 			<availability>IS:7,CDP:7</availability>
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
-		</model>
-		<model name='GRM-01C'>
-			<availability>FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -4663,26 +4663,26 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:3,CDS:5,CSR:3,CNC:5,CLAN:5,IS:1+,CSJ:7,CJF:5,BAN:4,CGB:9,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>CW:7,CSV:7,General:8,CSJ:7,CJF:9,CWIE:7,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:3,CW:5,CNC:5,General:3,CSJ:3,CJF:3,CWIE:5,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CW:7,CSV:7,General:8,CSJ:7,CJF:9,CWIE:7,CGB:8</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CGB:5</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:3,CW:5,CNC:5,General:3,CSJ:3,CJF:3,CWIE:5,CGB:4</availability>
 		</model>
 		<model name='B'>
 			<availability>CSV:5,General:7,CSJ:5,CGB:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -4745,34 +4745,34 @@
 			<roles>fire_support</roles>
 			<availability>CC:8,FWL:8,WOB:8,MERC:6</availability>
 		</model>
-		<model name='GOL-3S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,MERC:3</availability>
-		</model>
 		<model name='GOL-1H'>
 			<roles>fire_support</roles>
 			<availability>CC:4,HL:2,LA:6,General:4,FWL:4,Periphery.Deep:8,MERC:4,Periphery:4</availability>
 		</model>
+		<model name='GOL-3S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CSA:5,CSR:4,CIH:3,CBS:3,CNC:3,CFM:3,CSJ:5,CJF:6,CCO:3</availability>
-		<model name='(Standard)'>
-			<availability>CSA:6,CSR:6,CBS:6,CNC:6,CFM:6,CSJ:8,CJF:6</availability>
+		<model name='2'>
+			<availability>CSA:6,CIH:6,CFM:6,CJF:6,CCO:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:4,CSR:4,CBS:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:6,CIH:6,CFM:6,CJF:6,CCO:6</availability>
+		<model name='(Standard)'>
+			<availability>CSA:6,CSR:6,CBS:6,CNC:6,CFM:6,CSJ:8,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:5,CLAN:1</availability>
-		<model name='(Standard)'>
-			<availability>CSV:6,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:5,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:6,General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSV:8</availability>
@@ -4780,11 +4780,11 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6</availability>
-		<model name='GTHA-500'>
-			<availability>CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
-		</model>
 		<model name='GTHA-500b'>
 			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='GTHA-500'>
+			<availability>CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:6,FWL:6,MH:6,MERC:6</availability>
@@ -4792,11 +4792,11 @@
 	</chassis>
 	<chassis name='Grand Crusader II' unitType='Mek'>
 		<availability>WOB:3</availability>
-		<model name='GRN-D-03'>
-			<availability>General:6</availability>
-		</model>
 		<model name='GRN-D-04'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GRN-D-03'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Crusader' unitType='Mek'>
@@ -4810,29 +4810,29 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,CNC:4,DC:8</availability>
-		<model name='DRG-C'>
-			<availability>FRR:7,DC:7</availability>
-		</model>
-		<model name='DRG-7K'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='DRG-1G'>
 			<availability>FRR:5,DC:5</availability>
-		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
 		</model>
 		<model name='DRG-5K'>
 			<availability>FRR:6,CNC:8,DC:8</availability>
 		</model>
+		<model name='DRG-C'>
+			<availability>FRR:7,DC:7</availability>
+		</model>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
+		</model>
+		<model name='DRG-7K'>
+			<availability>DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>CC:4,MOC:4,IS:3,WOB:5,FWL.KIS:8,SIC:3,FS:4,MERC:4,CS:3,Periphery.MW:2,FWL:7,MH:2,DC:4</availability>
-		<model name='T-IT-N10M'>
-			<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='T-IT-N11M'>
 			<availability>FWL:6,WOB:6,MERC:4</availability>
+		</model>
+		<model name='T-IT-N10M'>
+			<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
@@ -4840,17 +4840,17 @@
 		<model name='GHR-5J'>
 			<availability>CS:3,IS:3,WOB:3,Periphery:3</availability>
 		</model>
+		<model name='GHR-6K'>
+			<availability>FRR:5,MERC:2,FS:2,DC:6</availability>
+		</model>
 		<model name='GHR-5H'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
-		</model>
-		<model name='GHR-C'>
-			<availability>IS:3,DC:4</availability>
 		</model>
 		<model name='GHR-5N'>
 			<availability>General:2</availability>
 		</model>
-		<model name='GHR-6K'>
-			<availability>FRR:5,MERC:2,FS:2,DC:6</availability>
+		<model name='GHR-C'>
+			<availability>IS:3,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -4865,14 +4865,14 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
@@ -4883,18 +4883,18 @@
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:2</availability>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[TAG]' mechanized='false'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
 		</model>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[TAG]' mechanized='false'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
@@ -4903,6 +4903,9 @@
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:4,CHH:5,CDS:6,CSR:4,CSV:6,CFM:4,CCO:6,CJF:6</availability>
 		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 		<model name='C'>
@@ -4917,9 +4920,6 @@
 		<model name='E'>
 			<availability>CLAN:4,IS:2,CCO:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:4</availability>
 		</model>
@@ -4929,23 +4929,20 @@
 		<model name='4'>
 			<availability>CSA:5,CDS:5,CNC:6,CLAN:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CLAN:4,CNC:4</availability>
+		<model name='3'>
+			<availability>CDS:6,CNC:4,CLAN:4,CCO:6</availability>
 		</model>
 		<model name='2'>
 			<availability>MERC.WD:8,CIH:6,CNC:6,CLAN:6</availability>
 		</model>
-		<model name='3'>
-			<availability>CDS:6,CNC:4,CLAN:4,CCO:6</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CLAN:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:3,CC:6,HL:4,CLAN:1,IS:7,Periphery.Deep:6,WOB:2,SIC:6,MERC:8,TC:6,Periphery:5,CS:2,OA:2,LA:7,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-3M'>
-			<availability>LA:7,FWL:8,IS:6,FS:6,DC:4</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:4,FRR:3,FS:3,MERC:3,DC:3</availability>
+		<model name='GRF-1S'>
+			<availability>LA:4,FRR:2,MERC:4</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CLAN:6,BAN:4</availability>
@@ -4953,53 +4950,56 @@
 		<model name='GRF-5M'>
 			<availability>FWL:4,WOB:4,MERC:3</availability>
 		</model>
-		<model name='GRF-1N'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:2,Periphery:5</availability>
-		</model>
-		<model name='GRF-1S'>
-			<availability>LA:4,FRR:2,MERC:4</availability>
+		<model name='GRF-3M'>
+			<availability>LA:7,FWL:8,IS:6,FS:6,DC:4</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>LA:5,FRR:5,FS:7,MERC:5,DC:6</availability>
 		</model>
+		<model name='GRF-1N'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:2,Periphery:5</availability>
+		</model>
+		<model name='GRF-6S'>
+			<availability>LA:4,FRR:3,FS:3,MERC:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>CS:5,WOB:4,MERC:4,DC:4</availability>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>WOB:5+,MERC:4</availability>
+		</model>
 		<model name='GRM-R-PR30'>
 			<availability>WOB:4+,MERC:2</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>CS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>WOB:5+,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
 		<availability>CSA:4,CHH:4,CCC:4,CIH:4,CSR:4,CBS:4,CSV:4,CLAN:3,CCO:4,CGB:5</availability>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>CGB:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:2,IS:1,FWL:2,SIC:3,MERC:1,TC:2,Periphery:1</availability>
-		<model name='D'>
-			<availability>CC:3,MOC:3,SIC:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CC:2,IS:1,FWL:2</availability>
+		<model name='(Standard)'>
+			<roles>ground_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CC:4,MOC:4,SIC:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>ground_support</roles>
-			<availability>General:5</availability>
+		<model name='B'>
+			<availability>CC:2,IS:1,FWL:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CC:3,MOC:3,SIC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
@@ -5010,10 +5010,6 @@
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:5,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
-		<model name='GLT-3N'>
-			<roles>raider</roles>
-			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:6,MERC.SI:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='GLT-4L'>
 			<roles>raider</roles>
 			<availability>HL:3,IS:5,FWL:5,Periphery.Deep:8,NIOPS:0,MERC:5,Periphery:5</availability>
@@ -5025,6 +5021,10 @@
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,FWL:8,WOB:4,FS:6</availability>
+		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:6,MERC.SI:8,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
@@ -5057,13 +5057,13 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CDS:4,CBS:2,LA:3,CNC:3,CFM:2,DC:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='HKO-1C'>
 			<roles>fire_support</roles>
 			<availability>LA:8,DC:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
@@ -5104,11 +5104,11 @@
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:2,NIOPS:7,WOB:7,DC:4</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:3</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,NIOPS:8,WOB:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:3</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
@@ -5116,26 +5116,26 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CIH:3,CDS:4,CSV:5,CNC:5,CLAN:2,IS:2+,CSJ:6,CJF:4,CCO:3,CGB:3</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CLAN:5,IS:1</availability>
 		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -5154,16 +5154,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:4,WOB:5,MERC:5,Periphery:5,CS:5,FWL.pm:7,LA:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,FWL:7,MH:5,DC:5</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 		<model name='&apos;Mini-Peggy&apos;'>
 			<roles>recon</roles>
@@ -5175,23 +5175,23 @@
 		<model name='(Standard)'>
 			<availability>CSA:6,CHH:6,CBS:6,CFM:6,CSJ:8,CJF:6</availability>
 		</model>
-		<model name='3'>
-			<availability>CSA:4,CHH:3,CFM:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:6,CBS:6,CFM:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:4,CHH:3,CFM:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:5,MERC:4,DC:8</availability>
+		<model name='HTM-26T'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='HTM-28T'>
 			<availability>DC:5</availability>
 		</model>
 		<model name='HTM-27T'>
 			<availability>FRR:8,MERC:6,DC:7</availability>
-		</model>
-		<model name='HTM-26T'>
-			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -5227,42 +5227,42 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>Periphery.R:3,MERC.KH:4,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,FS:5,MERC:3,Periphery:2,DC:4</availability>
-		<model name='HCT-5DD'>
-			<availability>FS:2,MERC:2</availability>
+		<model name='HCT-6S'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
+		<model name='HCT-3NH'>
+			<availability>DC:3</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>FS:2,MERC:2</availability>
 		</model>
-		<model name='HCT-6D'>
-			<availability>FS:6,MERC:4</availability>
-		</model>
 		<model name='HCT-5S'>
 			<availability>LA:6,FRR:4,FS:6,MERC:4,DC:2</availability>
 		</model>
-		<model name='HCT-3NH'>
-			<availability>DC:3</availability>
+		<model name='HCT-5DD'>
+			<availability>FS:2,MERC:2</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>LA:4,TC.PL:6,MERC:4,FS:4,Periphery:4</availability>
 		</model>
-		<model name='HCT-6S'>
-			<availability>LA:4,MERC:4</availability>
+		<model name='HCT-6D'>
+			<availability>FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:3+</availability>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='HA1-OC'>
 			<availability>General:6</availability>
-		</model>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
@@ -5289,6 +5289,14 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
+		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
@@ -5296,14 +5304,6 @@
 		<model name='(MG)'>
 			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -5330,8 +5330,8 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:4,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
@@ -5339,14 +5339,14 @@
 		<model name='Meteor-U'>
 			<availability>FS:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:5,CC:4,OA:5,LA:2,General:4,FWL:4,MH:5,SIC:4,MERC:4,FS:3,CIR:4,TC:1</availability>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,TC:5</availability>
 		</model>
 		<model name='Meteor-G'>
 			<availability>General:2,FWL:3</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -5357,10 +5357,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -5368,6 +5364,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -5376,6 +5376,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -5384,35 +5392,27 @@
 			<roles>apc,support</roles>
 			<availability>General:8,WOB:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CSV:2,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
 		<availability>CS:4,MOC:3,CC:3,SIC:5,FS:3,MERC:3,DC:2,TC:3</availability>
-		<model name='HEL-3D'>
-			<availability>CC:8,CS:8,MOC:8,SIC:8,FS:8,MERC:8,TC:8</availability>
+		<model name='HEL-4A'>
+			<availability>CC:5,MOC:5,SIC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
 		<model name='HEL-C'>
 			<availability>CC:5,MOC:5,SIC:5,MERC:5,DC:8</availability>
 		</model>
-		<model name='HEL-4A'>
-			<availability>CC:5,MOC:5,SIC:5,MERC:5,DC:5,TC:5</availability>
+		<model name='HEL-3D'>
+			<availability>CC:8,CS:8,MOC:8,SIC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -5430,18 +5430,18 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,OA:3-,HL:2,LA:3-,Periphery.Deep:1-,FS:3-,MERC:3-,Periphery:3-,TC:2-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:2,FS:3</availability>
+		<model name='HCT-213S'>
+			<availability>LA:3,FS:2</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:3,FS:2</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
+		</model>
+		<model name='HCT-213D'>
+			<availability>LA:2,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
@@ -5452,11 +5452,11 @@
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:2,CHH:4,CIH:4,CDS:3,DC.AL:2,CLAN:2,CNC:4,CJF:4</availability>
-		<model name='2'>
-			<availability>CDS:6,CNC:8,CCO:4,CWIE:4,DC:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CNC:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:6,CNC:8,CCO:4,CWIE:4,DC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CLAN:6,CJF:8</availability>
@@ -5464,18 +5464,18 @@
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CHH:2,CIH:8,CDS:3,CNC:3,CLAN:3,CFM:3,CCO:3</availability>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>CSA:3,General:6,CJF:3</availability>
-		</model>
 		<model name='B'>
 			<availability>CSA:8,General:7,CJF:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:4,General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:3,General:7,CJF:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>CSA:4,General:8</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>CSA:3,General:6,CJF:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
@@ -5487,6 +5487,14 @@
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:3+,CHH:3+</availability>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>recon,apc,fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -5494,14 +5502,6 @@
 		<model name='Prime'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon,apc,fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -5526,13 +5526,13 @@
 			<roles>recon</roles>
 			<availability>FWL:3</availability>
 		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:3,WOB:3</availability>
+		</model>
 		<model name='HER-6D'>
 			<roles>recon</roles>
 			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1-</availability>
 		</model>
 		<model name='HER-5C'>
 			<roles>recon</roles>
@@ -5542,13 +5542,13 @@
 			<roles>recon</roles>
 			<availability>HL:4,IS:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1-</availability>
+		</model>
 		<model name='HER-5S'>
 			<roles>recon</roles>
 			<availability>MOC:5,CC:5,LA:5,PIR:4,FWL:8,WOB:8,FS:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:3,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
@@ -5557,41 +5557,41 @@
 			<roles>recon,spotter</roles>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
-		<model name='HER-4K'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>DC:5</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:6,WOB:5</availability>
+			<availability>DC.GHO:5,CS:5,CLAN:6,NIOPS:5,BAN:8</availability>
 		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:8,WOB:8</availability>
 		</model>
-		<model name='HER-1S'>
+		<model name='HER-4M'>
 			<roles>recon</roles>
-			<availability>DC.GHO:5,CS:5,CLAN:6,NIOPS:5,BAN:8</availability>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>DC:5</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>CS:2,FRR:2,FWL:4,WOB:2</availability>
 		</model>
-		<model name='HER-4M'>
+		<model name='HER-3S1'>
 			<roles>recon</roles>
-			<availability>FWL:4,WOB:4</availability>
+			<availability>FWL:6,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,SIC:8,MERC:3,Periphery:3,CWIE:3</availability>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(AC10)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
@@ -5599,11 +5599,11 @@
 		<model name='(LB-X)'>
 			<availability>CC:4,MOC:2,TC:3</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:3,IS:3,Periphery:3</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -5622,6 +5622,12 @@
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:6,CLAN:6,NIOPS:9,CFM:7,WOB:9,SIC:1,MERC:4,FS:5,CJF:7,DC:1</availability>
+		<model name='HGN-733C'>
+			<availability>CC:1,:0,LA:1,SIC:1</availability>
+		</model>
+		<model name='HGN-734'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
 		<model name='HGN-736'>
 			<availability>CS:6,WOB:4</availability>
 		</model>
@@ -5634,17 +5640,11 @@
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1,SIC:1</availability>
 		</model>
-		<model name='HGN-734'>
-			<availability>LA:4,MERC:4</availability>
-		</model>
-		<model name='HGN-733C'>
-			<availability>CC:1,:0,LA:1,SIC:1</availability>
+		<model name='HGN-733'>
+			<availability>CC:3,:0,LA:3,SIC:3,DC:3</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>MOC:6,DC.GHO:8,CS:4,LA:6,CLAN:6,IS:6,NIOPS:4,WOB:4,MERC.SI:8,MERC:6,FS:6,BAN:8</availability>
-		</model>
-		<model name='HGN-733'>
-			<availability>CC:3,:0,LA:3,SIC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hitman' unitType='Mek'>
@@ -5660,11 +5660,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:5,MERC:4,FS:4</availability>
-		<model name='BZK-F5'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BZK-F7'>
 			<availability>General:5</availability>
+		</model>
+		<model name='BZK-F5'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -5678,20 +5678,20 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:2,MERC.WD:2,CLAN:1,CGS:2</availability>
+		<model name='HOP-4Bb'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='HOP-4B'>
+			<availability>MERC.WD:2</availability>
+		</model>
+		<model name='HOP-4D'>
+			<availability>MERC.WD:8</availability>
+		</model>
 		<model name='C'>
 			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='HOP-4Cb'>
 			<availability>CHH:5,CLAN:1</availability>
-		</model>
-		<model name='HOP-4Bb'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='HOP-4D'>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='HOP-4B'>
-			<availability>MERC.WD:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -5699,16 +5699,16 @@
 		<model name='HNT-161'>
 			<availability>MERC.WD:4-</availability>
 		</model>
+		<model name='HNT-152'>
+			<roles>recon,urban</roles>
+			<availability>IS:2</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FS:6,MERC:6</availability>
-		</model>
-		<model name='HNT-152'>
-			<roles>recon,urban</roles>
-			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -5732,44 +5732,26 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:6,CDS:7,CSR:6,CW:6,CSV:5,CLAN:2,IS:3,CSJ:5,CJF:6,CGB:6,CWIE:5</availability>
-		<model name='3'>
-			<availability>CSR:6,CCO:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:6,CBS:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:6,General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CSR:6,CCO:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:4,FRR:6,IS:4,Periphery.Deep:5,WOB:3-,SIC:5,FS:4,CIR:5,Periphery:5,TC:4,CS:4-,OA:4,LA:4,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
-		<model name='HBK-6S'>
-			<availability>LA:2,MERC:1</availability>
-		</model>
-		<model name='HBK-4N'>
-			<availability>IS:2,FWL:2,FS:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='HBK-4J'>
-			<availability>CC:2,IS:2,FWL:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='HBK-4SP'>
-			<availability>IS:1,FWL:2,MERC:2,DC:2,Periphery:2</availability>
-		</model>
-		<model name='HBK-5M'>
-			<availability>CS:4,CC:3,MOC:2,FRR:3,FWL:4,WOB:4,MERC:3,TC:2</availability>
-		</model>
 		<model name='HBK-4G'>
 			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='HBK-4P'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='HBK-6S'>
+			<availability>LA:2,MERC:1</availability>
 		</model>
-		<model name='HBK-5S'>
-			<availability>LA:4,FRR:3,MERC:3</availability>
-		</model>
-		<model name='HBK-6N'>
-			<availability>FWL:6,WOB:6,MERC:4</availability>
+		<model name='HBK-4J'>
+			<availability>CC:2,IS:2,FWL:2,MERC:2,Periphery:2</availability>
 		</model>
 		<model name='HBK-4H'>
 			<availability>IS:2,FWL:2,FS:2,MERC:2,Periphery:2</availability>
@@ -5777,8 +5759,26 @@
 		<model name='HBK-5H'>
 			<availability>MH:4,Periphery:2</availability>
 		</model>
+		<model name='HBK-4SP'>
+			<availability>IS:1,FWL:2,MERC:2,DC:2,Periphery:2</availability>
+		</model>
 		<model name='HBK-5N'>
 			<availability>MOC:5,CC:5,CS:5,FRR:5,FWL:6,WOB:5,MERC:5,TC:5</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='HBK-5M'>
+			<availability>CS:4,CC:3,MOC:2,FRR:3,FWL:4,WOB:4,MERC:3,TC:2</availability>
+		</model>
+		<model name='HBK-5S'>
+			<availability>LA:4,FRR:3,MERC:3</availability>
+		</model>
+		<model name='HBK-4N'>
+			<availability>IS:2,FWL:2,FS:2,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='HBK-6N'>
+			<availability>FWL:6,WOB:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -5792,38 +5792,41 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='&apos;Assault Hunter&apos;'>
-			<availability>LA:2,FS:2</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:3</availability>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>LA:8,FS:5</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
+		<model name='(LRM15)'>
 			<roles>fire_support</roles>
-			<availability>LA:8,FS:5</availability>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='&apos;Assault Hunter&apos;'>
+			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,WOB:3,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:4,MOC:4,FWL:5</availability>
 		</model>
@@ -5831,19 +5834,16 @@
 			<roles>fire_support</roles>
 			<availability>CC:5</availability>
 		</model>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>CS:2+,FRR:4+</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HSCL-1-OA'>
+		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OB'>
+		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OC'>
@@ -5852,24 +5852,24 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:6,CIH:6,LA:3,CSV:6,FRR:3,CLAN:5,NIOPS:4,WOB:4,MERC:3,DC:2</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
+		<model name='HSR-500-D'>
+			<availability>CS:4,WOB:8</availability>
 		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:5,General:8,CLAN:6,NIOPS:5,MERC.SI:5,WOB:5,BAN:8</availability>
 		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:2</availability>
+		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='HSR-500-D'>
-			<availability>CS:4,WOB:8</availability>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
@@ -5883,11 +5883,11 @@
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
 		<availability>CHH:3,CBS:1,CFM:4,CSJ:5</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,CBS:8,CFM:8,CSJ:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8,CBS:8,CFM:8,CSJ:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hyena' unitType='Mek'>
@@ -5899,35 +5899,35 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,MOC:8,LA:5,FWL:5,IS:8,WOB:5,MH:8,FS:4,DC:5,TC:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [LRR]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [SRM]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -5948,14 +5948,14 @@
 		<model name='C'>
 			<availability>MERC.WD:4,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
-			<availability>MERC.WD:6</availability>
+		<model name='IMP-4E'>
+			<availability>MERC.WD:5</availability>
 		</model>
 		<model name='IMP-2E'>
 			<availability>MERC.WD:2</availability>
 		</model>
-		<model name='IMP-4E'>
-			<availability>MERC.WD:5</availability>
+		<model name='IMP-3E'>
+			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -5991,11 +5991,11 @@
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>FS:3,TC:2</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='&apos;Puma&apos;' mechanized='true'>
 			<availability>FS:8,TC:8</availability>
+		</model>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Initiate' unitType='Mek'>
@@ -6017,16 +6017,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,SIC:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -6062,15 +6062,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>LA:2,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -6087,29 +6087,29 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:5,MOC:4,CC:2,DC.LV:6,HL:3,FRR:4,DC.GR:6,FS.AH:5,IS:4,Periphery.Deep:5,WOB:4-,SIC:2,FS:3,CIR:4,Periphery:4,TC:6,CS:3-,OA:4,LA:5,FWL:2,NIOPS:3-,DC:4</availability>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4,TC:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Kurita)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>DC:8,TC:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Kurita)'>
-			<roles>recon,raider</roles>
-			<availability>DC:8,TC:4</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>recon,raider</roles>
 			<availability>HL:4,General:4,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jackal' unitType='Mek'>
@@ -6132,20 +6132,20 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
 			<availability>CSR:4,CW:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -6156,59 +6156,59 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,OA:2,LA:5,Periphery.CM:2,Periphery.HR:3,PIR:2,Periphery.ME:2,FWL:3,NIOPS:3,MH:4,DC:3</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>OA:8,LA:8,FRR:8,FS:8,MERC:8,DC:8</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>CC:5,FRR:4,IS:5,SIC:5,FS:5,Periphery:8</availability>
 		</model>
-		<model name='JM6-DGr'>
-			<roles>anti_aircraft</roles>
-			<availability>LA:3,FRR:3,FS:3,MERC:3,DC:3</availability>
-		</model>
-		<model name='JM6-A'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2-</availability>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:6,MERC:5</availability>
 		</model>
-		<model name='JM7-F'>
+		<model name='JM6-A'>
 			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
+			<availability>FS:2-</availability>
 		</model>
 		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
 			<availability>PIR:2,MH:4</availability>
 		</model>
+		<model name='JM7-F'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM6-DGr'>
+			<roles>anti_aircraft</roles>
+			<availability>LA:3,FRR:3,FS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>OA:8,LA:8,FRR:8,FS:8,MERC:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+		<model name='JVN-10P'>
+			<roles>recon</roles>
+			<availability>LA:6,FS:6,MERC:6</availability>
+		</model>
 		<model name='JVN-10F &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
 			<availability>MOC:2,IS:1,FS:2,MERC:2,TC:2,Periphery:1</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
-			<availability>LA:6,FS:6,MERC:6</availability>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -6217,14 +6217,14 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:5,CWIE:7,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:5,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>CSR:5,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -6232,38 +6232,38 @@
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CSR:5,CJF:5</availability>
+		<model name='B'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:5,CW:5,CSV:6,CNC:8,CLAN:3,CSJ:6,CGS:5,CCO:5,DC:1</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
-		<model name='3'>
+		<model name='(Standard)'>
+			<availability>CW:6,CLAN:5,CNC:6</availability>
+		</model>
+		<model name='2'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:4,CNC:6,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CW:6,CLAN:5,CNC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
-		<model name='JR7-K'>
+		<model name='JR7-F'>
 			<roles>raider</roles>
-			<availability>MOC:4,OA:4,FRR:6,MERC:4,DC:3,TC:4</availability>
+			<availability>FS.DMM:1,DC:2</availability>
 		</model>
 		<model name='JR7-D'>
 			<roles>raider</roles>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 		</model>
-		<model name='JR7-F'>
+		<model name='JR7-K'>
 			<roles>raider</roles>
-			<availability>FS.DMM:1,DC:2</availability>
+			<availability>MOC:4,OA:4,FRR:6,MERC:4,DC:3,TC:4</availability>
 		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
@@ -6285,11 +6285,11 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
@@ -6297,8 +6297,8 @@
 		<model name='(Gauss)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -6321,21 +6321,9 @@
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
-		</model>
-		<model name='(DEST)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
@@ -6345,19 +6333,31 @@
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(DEST)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[Industrial Drill]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Salvage Arm]' mechanized='false'>
 			<roles>support</roles>
 			<availability>DC.SL:6,General:6</availability>
 		</model>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[Industrial Drill]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -6372,19 +6372,19 @@
 			<roles>cargo</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='(AC)'>
+			<availability>MH:3,MERC:3</availability>
+		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:4,OA:4,HL:2,PIR:5,MH:4,CIR:4,Periphery:4,TC:4</availability>
+		</model>
 		<model name='(3055 Upgrade)'>
 			<roles>cargo</roles>
 			<availability>IS:4,Periphery:2</availability>
 		</model>
-		<model name='(AC)'>
-			<availability>MH:3,MERC:3</availability>
-		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>CS:4,FWL:5,IS:5,WOB:4</availability>
-		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:4,OA:4,HL:2,PIR:5,MH:4,CIR:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
@@ -6392,11 +6392,11 @@
 		<model name='CRK-5003-2'>
 			<availability>FRR:8,DC:7</availability>
 		</model>
-		<model name='CRK-5003-CM'>
-			<roles>spotter</roles>
+		<model name='CRK-5003-C'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='CRK-5003-C'>
+		<model name='CRK-5003-CM'>
+			<roles>spotter</roles>
 			<availability>DC:3</availability>
 		</model>
 	</chassis>
@@ -6406,30 +6406,27 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
 		<availability>CC:1,FRR:3,CLAN:3,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:4,DC:1</availability>
 		<model name='KGC-001'>
 			<availability>CS:8,LA:5,IS:5,WOB:5</availability>
-		</model>
-		<model name='KGC-005'>
-			<availability>CS:4,WOB:3</availability>
 		</model>
 		<model name='KGC-000b'>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
@@ -6440,23 +6437,23 @@
 		<model name='KGC-000'>
 			<availability>CS:5,FRR:8,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8</availability>
 		</model>
+		<model name='KGC-005'>
+			<availability>CS:4,WOB:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>CDS:3,CSR:3,CLAN:3,CNC:3,IS:2+,CSJ:5,CGB:6</availability>
 		<model name='C'>
 			<availability>General:5,CGB:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6,CGB:5</availability>
-		</model>
 		<model name='E'>
 			<availability>CLAN:5,IS:2</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6,CGB:5</availability>
+		</model>
 		<model name='B'>
 			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:5,IS:2</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -6464,17 +6461,17 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='H'>
+			<availability>CLAN:5,IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:7,CHH:2,CDS:2,CSV:2,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:4,MERC:5,DC:5</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:8</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:6,CS:5,DC.SL:4,CLAN:6,NIOPS:5,WOB:5,MERC.SI:6,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-21'>
-			<availability>CS:5,WOB:5</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:5,MERC:5,DC:4</availability>
@@ -6485,23 +6482,26 @@
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:4,WOB:4,MERC:6,DC:6</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:8</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		</model>
+		<model name='KTO-21'>
+			<availability>CS:5,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -6524,13 +6524,13 @@
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:4,CCC:3,CIH:5,CSR:6,CNC:3,CLAN:3,CGS:4,CCO:3,CGB:8</availability>
+		<model name='5'>
+			<availability>CGB:4</availability>
+		</model>
 		<model name='2'>
 			<availability>CGB:4</availability>
 		</model>
 		<model name='4'>
-			<availability>CGB:4</availability>
-		</model>
-		<model name='5'>
 			<availability>CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -6543,9 +6543,6 @@
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='KIM-2'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>General:8,DC:7</availability>
@@ -6554,12 +6551,39 @@
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
+		<model name='KIM-2C'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:8,CLAN:4,IS:2+,CCO:4,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:6,CLAN:5,IS:2</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<roles>recon</roles>
+			<availability>CSA:6,CIH:6,CDS:6,CW:6,General:5,CSJ:4,CGS:6,CCO:4,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<roles>recon</roles>
@@ -6568,30 +6592,6 @@
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:5,IS:2,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:6,CLAN:5,IS:2</availability>
-		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CSA:6,CIH:6,CDS:6,CW:6,General:5,CSJ:4,CGS:6,CCO:4,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
@@ -6605,9 +6605,6 @@
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:4,CLAN:2,CJF:4</availability>
-		<model name='2'>
-			<availability>CSV:3,CJF:5</availability>
-		</model>
 		<model name='4'>
 			<availability>CJF:4</availability>
 		</model>
@@ -6616,6 +6613,9 @@
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
+			<availability>CSV:3,CJF:5</availability>
+		</model>
+		<model name='2'>
 			<availability>CSV:3,CJF:5</availability>
 		</model>
 	</chassis>
@@ -6662,6 +6662,9 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:4,CLAN:4,NIOPS:6,CFM:5,WOB:6,CGS:5,BAN:7,DC:6</availability>
+		<model name='LNC25-04'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
 		<model name='LNC25-02'>
 			<roles>fire_support</roles>
 			<availability>:0,FRR:4,DC:4</availability>
@@ -6669,34 +6672,31 @@
 		<model name='LNC25-03'>
 			<availability>DC:6-</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:6,FRR:6,CLAN:8,NIOPS:6,WOB:6,MERC.SI:6,BAN:6,DC:6</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:3,NIOPS:3,WOB:3</availability>
 		</model>
-		<model name='LNC25-04'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:6,FRR:6,CLAN:8,NIOPS:6,WOB:6,MERC.SI:6,BAN:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>FWL:3,WOB:2</availability>
-		<model name='LX-2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LX-2A'>
 			<availability>FWL:5</availability>
+		</model>
+		<model name='LX-2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:5,MOC:3,TC:3</availability>
-		<model name='LHU-3C'>
-			<availability>CC:4+,MOC:4+</availability>
-		</model>
 		<model name='LHU-2B'>
 			<availability>MOC:8,CC:8,TC:8</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4+,MOC:4+</availability>
 		</model>
 		<model name='LHU-3B'>
 			<roles>spotter</roles>
@@ -6722,13 +6722,13 @@
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>CC:6,LA:6,FWL:8,WOB:6,FS:6</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>CC:6,LA:6,FWL:8,WOB:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
@@ -6764,30 +6764,30 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FS:5,MERC:1</availability>
-		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>FWL:3</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:3</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:5,SIC:2,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='Andurien'>
-			<availability>FWL:2</availability>
+		<model name='Comet'>
+			<availability>FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:5,HL:4,LA:5</availability>
 		</model>
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
+		</model>
+		<model name='Andurien'>
+			<availability>FWL:2</availability>
+		</model>
+		<model name='Angel (Upgrade)'>
+			<availability>FWL:3</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
@@ -6802,22 +6802,22 @@
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:6,CC:5,HL:3,FRR:5,CLAN:2,IS:4,WOB:3-,SIC:7,FS:4,Periphery:4,TC:4,CS:3-,OA:6,LA:4,FWL:2,NIOPS:3-,DC:6</availability>
-		<model name='LTN-G15b'>
-			<availability>CLAN:3</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
+		</model>
+		<model name='LTN-G15b'>
+			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightray' unitType='Mek'>
 		<availability>WOB:5</availability>
-		<model name='LGH-4Y'>
-			<roles>recon</roles>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='LGH-5W'>
 			<roles>recon</roles>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='LGH-4Y'>
+			<roles>recon</roles>
+			<availability>WOB:5</availability>
 		</model>
 		<model name='LGH-4W'>
 			<roles>recon</roles>
@@ -6829,38 +6829,38 @@
 		<model name='B'>
 			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,CCO:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:4,CIH:5,CW:5,CBS:4,CSV:5,CNC:3,General:3,CSJ:5,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:4,CSV:5,CLAN:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:4,CIH:5,CW:5,CBS:4,CSV:5,CNC:3,General:3,CSJ:5,CJF:2,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Lineholder' unitType='Mek'>
 		<availability>CC:4,FWL:4,IS:3,CM:8,WOB:5,FS:5,CIR:6,TC:6</availability>
-		<model name='KW2-LHW'>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='KW1-LH3'>
 			<availability>General:2,CM:6,WOB:3,FS:3</availability>
 		</model>
 		<model name='KW1-LH2'>
 			<availability>General:8,WOB:2,FS:2</availability>
+		</model>
+		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='KW2-LHW'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -6886,51 +6886,47 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CS:2,CHH:6,CW:7,LA:2,CLAN:3,CJF:6,CGB:6</availability>
+		<model name='3'>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:6,General:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CSA:3,CS:6,CHH:3,CW:3,LA:6,CJF:4</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:4,CW:4,CCO:2,CGB:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:3,CIH:3,CJF:3</availability>
 		</model>
-		<model name='3'>
-			<availability>General:2</availability>
+		<model name='5'>
+			<availability>CHH:4,CW:4,CCO:2,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:4-,HL:5,CLAN:2-,IS:8,NIOPS:4-,Periphery.Deep:5,WOB:4-,Periphery:5</availability>
-		<model name='LCT-3M'>
-			<roles>recon</roles>
-			<availability>MOC:4,FWL:8,IS:4,MERC:5</availability>
-		</model>
 		<model name='LCT-1L'>
 			<roles>recon</roles>
 			<availability>CC:1,SIC:1</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>PIR:3,FWL:4,WOB:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:3,General:4,FS:4</availability>
-		</model>
 		<model name='LCT-3V'>
 			<roles>recon</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='LCT-3D'>
+		<model name='LCT-5M'>
 			<roles>recon</roles>
-			<availability>FS:8,MERC:5</availability>
+			<availability>PIR:3,FWL:4,WOB:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='LCT-1V2'>
+			<roles>recon</roles>
+			<availability>PIR:4,MH:4</availability>
+		</model>
+		<model name='LCT-1V'>
+			<roles>recon</roles>
+			<availability>LA:3,General:4,FS:4</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -6940,22 +6936,23 @@
 			<roles>recon</roles>
 			<availability>LA:8,FRR:6,MERC:6</availability>
 		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:4,FWL:8,IS:4,MERC:5</availability>
+		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:5,MERC:4</availability>
 		</model>
-		<model name='LCT-1V2'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>PIR:4,MH:4</availability>
+			<availability>FS:8,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CSV:5,CLAN:4,IS:2+,CFM:5,BAN:6,CWIE:6,CDS:4,CW:5,CBS:5,CSJ:5,CJF:5,CGB:4</availability>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
@@ -6966,8 +6963,11 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -6983,27 +6983,27 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:5,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,SIC:5,FS:6,Periphery:7,TC:6,CS:3,OA:6,LA:6,FWL:8,NIOPS:3,DC:6</availability>
-		<model name='LGB-0W'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='LGB-7V'>
 			<roles>fire_support</roles>
 			<availability>MOC:4,FWL:6,IS:4</availability>
 		</model>
-		<model name='LGB-12C'>
+		<model name='LGB-0W'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:3,LA:2,FWL:2,SIC:2,FS:2,MERC:2</availability>
+			<availability>General:5</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:4,OA:4,General:4,TC:4,Periphery:4</availability>
 		</model>
+		<model name='LGB-12C'>
+			<roles>fire_support</roles>
+			<availability>CC:4,MOC:3,LA:2,FWL:2,SIC:2,FS:2,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:8,WOB:8,MH:3</availability>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -7011,8 +7011,14 @@
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Laser] (WoB)' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[Flamer] (WoB)' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 		<model name='[David] (WoB)' mechanized='true'>
 			<availability>CS:5,WOB:5</availability>
@@ -7020,40 +7026,30 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Laser] (WoB)' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[Flamer] (WoB)' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>FRR:5,MERC:3,DC:5</availability>
-		<model name='LCF-R16K'>
-			<availability>General:5</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>FRR:5,MERC:2,DC:6</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:4,FRR:4,SIC:4,FS:5,MERC:4,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:9,Periphery.MW:3</availability>
+		<model name='LCF-R16'>
+			<availability>LA:8,FS:6,MERC:5</availability>
+		</model>
 		<model name='LCF-R15'>
 			<availability>LA:2,General:2,Periphery.Deep:4,MERC:8,Periphery:2</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='LCF-R16'>
-			<availability>LA:8,FS:6,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:1</availability>
@@ -7061,6 +7057,10 @@
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -7117,8 +7117,8 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CIH:4,CLAN:5,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:9,CDS:6,CW:9,CBS:4,CSJ:6,CJF:6</availability>
-		<model name='Prime'>
-			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -7128,20 +7128,20 @@
 			<roles>spotter</roles>
 			<availability>CHH:4,CIH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CFM:4,CSJ:4,CCO:6,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4,CSJ:3</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4,CSJ:3</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
@@ -7152,17 +7152,17 @@
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
 		<availability>LA:4,FS:3,MERC:3,DC:5</availability>
-		<model name='MTR-6E'>
-			<roles>recon,spotter</roles>
-			<availability>DC:2</availability>
+		<model name='MTR-5K'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:4</availability>
 		</model>
-		<model name='MTR-5K'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='MTR-6E'>
+			<roles>recon,spotter</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Magellan Jumpship' unitType='Jumpship'>
@@ -7179,14 +7179,14 @@
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>FWL:6</availability>
-		<model name='(C3)'>
-			<availability>IS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(XL)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mammoth' unitType='Dropship'>
@@ -7198,23 +7198,23 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CIH:9,CSV:8,CLAN:5,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:6,CSJ:7,CJF:9,CGB:5</availability>
-		<model name='E'>
-			<availability>CLAN:6,General:2,CCO:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:2,CCO:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CSJ:4,CJF:2,CGB:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
@@ -7231,30 +7231,30 @@
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,FS:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
-		<model name='(C3S)'>
-			<availability>FS:5,DC:7</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>FS:2,DC:4</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>LA:4,WOB:4,FS:4</availability>
+		</model>
+		<model name='(C3S)'>
+			<availability>FS:5,DC:7</availability>
 		</model>
 		<model name='(3055 Upgrade)'>
 			<availability>LA:6,FS:6,MERC:4+</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,LA:4,General:6,Periphery.Deep:5,FS:4,DC:4,Periphery:6</availability>
+		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>FS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
@@ -7265,11 +7265,11 @@
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:7,MERC.WD:6,CSR:6,CW:6,CLAN:5,CNC:6,CJF:7,CWIE:6,CGB:7</availability>
-		<model name='3'>
-			<availability>CSA:5,CLAN:3,CJF:4,CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:8,CLAN:5,CJF:6,CGB:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:5,CLAN:3,CJF:4,CGB:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:4,CCC:2,CDS:2,CSR:2,CBS:2,CGS:2,CJF:2,CWIE:2,CGB:2</availability>
@@ -7283,38 +7283,32 @@
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:2</availability>
-		</model>
 		<model name='MAD-4S'>
 			<availability>CS:8,LA:8,FRR:8,CNC:8,FWL:8,SL.2:8,FS:8,MERC:3,DC:8</availability>
-		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='MAD-4A'>
 			<availability>MERC:5</availability>
 		</model>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:2</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:1,FRR:4,CLAN:1,IS:3,WOB:7,SIC:4,FS:6,TC:3,Periphery:1,CS:6,LA:5,FWL:3,NIOPS:6,DC:4,CGB:2</availability>
+		<model name='MAD-3D'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='MAD-5D'>
 			<availability>LA:3,FRR:6,WOB:4,FS:6,MERC:4,DC:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:4</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>LA:6,FRR:3,FS:5,MERC:3</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:4,Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:3,MH:4,MERC:4</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>CS:6,FWL:8,IS:3,WOB:7,MERC:4</availability>
 		</model>
-		<model name='MAD-3D'>
-			<availability>FS:4</availability>
+		<model name='C'>
+			<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:4</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:2-,HL:4,IS:4,Periphery.Deep:6,WOB:2-,Periphery:6,TC:6</availability>
@@ -7328,17 +7322,23 @@
 		<model name='MAD-1R'>
 			<availability>CS:4,CLAN:1,NIOPS:4,WOB:4,MERC:0,BAN:1</availability>
 		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:4,Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:3,MH:4,MERC:4</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>LA:6,FRR:3,FS:5,MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
-		<model name='(ATM)'>
-			<availability>General:4,CCO:6,CJF:2</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CHH:4,CCC:3,CIH:3,CGS:3,CCO:3,CGB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ATM)'>
+			<availability>General:4,CCO:6,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Marshal' unitType='Mek'>
@@ -7352,33 +7352,33 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:2,CLAN:3,IS:1+,CFM:6,MERC:1+,CGS:4,BAN:3,CWIE:3,CSA:4,MERC.WD:3,CDS:4,CW:3,CBS:4,CNC:3,CSJ:8,CJF:4,CGB:5</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
+		<model name='A'>
+			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:8,CSV:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
@@ -7407,6 +7407,10 @@
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:5,MOC:5,CHH:4,CLAN:2,MH:3,FS:3,TC:6</availability>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
+		</model>
 		<model name='(Intermediate)'>
 			<roles>apc</roles>
 			<availability>TC:2</availability>
@@ -7414,10 +7418,6 @@
 		<model name='(Basic)'>
 			<roles>apc</roles>
 			<availability>FS:8,TC:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -7441,33 +7441,9 @@
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:4,CC:5,HL:3,FRR:6,CLAN:4,IS:4,Periphery.Deep:5,WOB:5-,SIC:5,MERC:4,FS:3,CIR:4,Periphery:4,TC:4,CS:5-,OA:4,LA:6,FWL:5,NIOPS:5-,DC:5</availability>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>FRR:3,IS:2,SIC:2,MERC:3,DC:4</availability>
-		</model>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>LA:2,FRR:2,IS:2,FS:2,DC:3</availability>
-		</model>
-		<model name='(BA Factory Upgrade)'>
-			<roles>apc</roles>
-			<availability>CC:5,FRR:5,FWL:5,IS:4,SIC:5,DC:5</availability>
-		</model>
 		<model name='(SRM2)'>
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Anti-Infantry)'>
-			<roles>apc,spotter,anti_infantry</roles>
-			<availability>IS:2,DC:3</availability>
-		</model>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
@@ -7475,6 +7451,30 @@
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(BA Field Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>FRR:3,IS:2,SIC:2,MERC:3,DC:4</availability>
+		</model>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
+			<roles>apc</roles>
+			<availability>CC:5,FRR:5,FWL:5,IS:4,SIC:5,DC:5</availability>
+		</model>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>LA:2,FRR:2,IS:2,FS:2,DC:3</availability>
+		</model>
+		<model name='(Anti-Infantry)'>
+			<roles>apc,spotter,anti_infantry</roles>
+			<availability>IS:2,DC:3</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -7498,12 +7498,12 @@
 			<roles>interceptor</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Laser)'>
 			<roles>interceptor</roles>
 			<availability>FRR:1,MERC:1,Periphery:1,DC:1</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Assault XCT' unitType='Infantry'>
@@ -7525,17 +7525,17 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -7543,31 +7543,31 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -7576,11 +7576,11 @@
 		<model name='(MG)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -7619,11 +7619,11 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OB'>
+		<model name='MS1-OC'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -7694,12 +7694,12 @@
 		<model name='(Standard)'>
 			<availability>CLAN:6,CSJ:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CCC:4,CGS:4</availability>
-		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CCC:4,CGS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -7731,25 +7731,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:4+,MERC:2+,DC:4+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>General:1,MERC:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>CC:1,MERC:6,DC:1</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
-			<availability>General:1,MERC:6</availability>
+			<availability>MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -7786,17 +7786,17 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>CS:3,CHH:2,CDS:2,CBS:3,CLAN:3,NIOPS:3,WOB:3,CJF:3,CGB:2</availability>
-		<model name='MON-68'>
+		<model name='MON-66b'>
 			<roles>recon</roles>
-			<availability>DC:2</availability>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
 		<model name='MON-66'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
-		<model name='MON-66b'>
+		<model name='MON-68'>
 			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -7809,9 +7809,6 @@
 		<availability>CLAN:2,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
@@ -7848,23 +7845,23 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
@@ -7910,21 +7907,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
@@ -7957,29 +7954,32 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
 		<availability>CS:6,WOB:6</availability>
-		<model name='NXS1-A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='NXS1-B'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='NXS1-A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CSJ:3,CJF:5,CGS:2</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CLAN:5,IS:2</availability>
@@ -7987,25 +7987,22 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:2</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>OA:3,CW:5,LA:5,CLAN:3,FWL:3,MERC:3,FS:3,CGS:4,CGB:5</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightlord Battleship' unitType='Warship'>
@@ -8020,21 +8017,21 @@
 		<model name='(Standard)'>
 			<availability>General:8,WOB:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>LA:6,FS:6,MERC:2</availability>
-		<model name='NGS-4T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-4S'>
 			<availability>:0,HL:6,LA:8,General:8,Periphery.Deep:6,FS:8,MERC:8,Periphery:8</availability>
+		</model>
+		<model name='NGS-4T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-5T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
@@ -8048,11 +8045,11 @@
 		<model name='NSR-9FC'>
 			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
-		<model name='NSR-9SS'>
-			<availability>LA:3,MERC:2,FS:3</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9SS'>
+			<availability>LA:3,MERC:2,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ninja-To' unitType='Mek'>
@@ -8063,25 +8060,27 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:5,DC.SL:2,FRR:3,MERC:2,DC:4</availability>
+		<model name='NDA-2KO'>
+			<availability>MERC:4,DC:4</availability>
+		</model>
 		<model name='NDA-2K'>
 			<availability>MERC:6,DC:6</availability>
 		</model>
 		<model name='NDA-1K'>
 			<availability>FRR:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='NDA-2KO'>
-			<availability>MERC:4,DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,CDS:4,CNC:8,CFM:4</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:4,CNC:4,CFM:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -8090,11 +8089,9 @@
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,CNC:4,CFM:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -8106,6 +8103,15 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CIH:4,CDS:5,CNC:7,CLAN:3,CSJ:4,CWIE:4</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -8113,15 +8119,6 @@
 		<model name='C'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
@@ -8157,8 +8154,8 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:4,CC:6,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:4,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:3,FWL:9,MH:4,DC:4</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:8,CNC:8,IS:8</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<availability>CC:5,MOC:4,IS:4,FWL:5</availability>
@@ -8167,11 +8164,11 @@
 			<roles>fire_support</roles>
 			<availability>CC:3,LA:3,FWL:3,SIC:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:2,LA:2,FWL:2,SIC:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:8,CNC:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
@@ -8188,38 +8185,38 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:4,CC:4,HL:3,FRR:4,CLAN:1,IS:4,Periphery.Deep:4,WOB:3-,SIC:4,FS:4,CIR:5,Periphery:4,TC:4,CWIE:2,CS:4-,OA:4,CW:2,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
-		<model name='ON1-MD'>
-			<availability>FWL:4,WOB:4,MERC:2,FS:2</availability>
-		</model>
 		<model name='ON1-MA'>
 			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2,MOC:2,FWL:4,WOB:4,FS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='ON2-M'>
-			<availability>FWL:4,WOB:4,MERC:3</availability>
-		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1</availability>
 		</model>
 		<model name='ON1-MC'>
 			<availability>FRR:4,FS:2,MERC:2,DC:4</availability>
 		</model>
+		<model name='ON1-V'>
+			<availability>IS:2,MH:2,TC:2</availability>
+		</model>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1</availability>
+		</model>
+		<model name='ON1-MB'>
+			<availability>CC:2,MOC:2,FWL:4,WOB:4,FS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:3,General:5,CLAN:5,Periphery.Deep:8,Periphery:5</availability>
+		</model>
 		<model name='ON1-M'>
 			<availability>CS:6,MOC:6,Periphery.MW:3+,PIR:3+,Periphery.ME:3+,FWL:8,IS:6,WOB:6,MH:3+,DC:6</availability>
 		</model>
-		<model name='ON1-V'>
-			<availability>IS:2,MH:2,TC:2</availability>
+		<model name='ON1-MD'>
+			<availability>FWL:4,WOB:4,MERC:2,FS:2</availability>
 		</model>
 		<model name='ON1-VA'>
 			<availability>IS:2</availability>
 		</model>
+		<model name='ON2-M'>
+			<availability>FWL:4,WOB:4,MERC:3</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:4,DC:6</availability>
-		</model>
-		<model name='ON1-K'>
-			<availability>HL:3,General:5,CLAN:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -8236,6 +8233,9 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:3,CC:3,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:3,SIC:3,TC:3,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
+		<model name='OSR-3C'>
+			<availability>IS:2,Periphery.Deep:4,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:8,MERC:5,BAN:1,Periphery:5</availability>
@@ -8243,9 +8243,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>IS:2,Periphery.Deep:4,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:2</availability>
@@ -8256,22 +8253,18 @@
 		<model name='OSR-4C'>
 			<availability>CIR:6,TC:4</availability>
 		</model>
-		<model name='OSR-4L'>
-			<availability>CC:4,MOC:3</availability>
-		</model>
 		<model name='OSR-2M'>
 			<availability>FWL:4</availability>
+		</model>
+		<model name='OSR-4L'>
+			<availability>CC:4,MOC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,FRR:3,CLAN:1-,IS:2,WOB:3,SIC:2,FS:2,MERC:3,CS:3,LA:2,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='OTT-9CS'>
+		<model name='OTT-7K'>
 			<roles>recon,spotter</roles>
-			<availability>CS:4,WOB:3</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
@@ -8281,9 +8274,13 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:4,MERC:2</availability>
 		</model>
-		<model name='OTT-7K'>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='OTT-9CS'>
 			<roles>recon,spotter</roles>
-			<availability>DC:6</availability>
+			<availability>CS:4,WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -8291,8 +8288,8 @@
 		<model name='OTL-7M'>
 			<availability>FWL:4,WOB:3,MERC:4</availability>
 		</model>
-		<model name='OTL-5D'>
-			<availability>FS:4</availability>
+		<model name='OTL-4D'>
+			<availability>HL:3,IS:5,FWL:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
 		</model>
 		<model name='OTL-6D'>
 			<availability>FS:3,MERC:2,DC:2</availability>
@@ -8303,11 +8300,11 @@
 		<model name='OTL-8M'>
 			<availability>FWL:4,WOB:3,MERC:2</availability>
 		</model>
+		<model name='OTL-5D'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='OTL-4F'>
 			<availability>FS:2</availability>
-		</model>
-		<model name='OTL-4D'>
-			<availability>HL:3,IS:5,FWL:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
@@ -8326,10 +8323,6 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:6,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:5,FS:5</availability>
@@ -8338,26 +8331,26 @@
 			<roles>assault</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:6,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:2+,CS:3+,FWL:2+,WOB:2+,SIC:2+,FS:2+,MERC:2+,DC:4+</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='OW-1C'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -8365,26 +8358,26 @@
 			<roles>recon,spotter</roles>
 			<availability>General:1+,CLAN:6</availability>
 		</model>
-		<model name='OW-1A'>
+		<model name='OW-1E'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='OW-1B'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:2,CHH:2,CCC:2,MERC.KH:1,CDS:3,CIH:2,CSR:4,CSV:2,CNC:3,CCO:2,CWIE:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CWIE:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:4,CC:5,HL:4,FRR:4,IS:5,Periphery.Deep:4,WOB:6,SIC:3,FS:7,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:5</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,SIC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -8392,6 +8385,10 @@
 		<model name='PKR-T5 (ICE)'>
 			<roles>recon,raider</roles>
 			<availability>CC:2,MERC.KH:2,FRR:2,IS:2,Periphery.Deep:6,SIC:2,MERC:2,FS:2,Periphery:3,PIR:2,General:2,FWL:2,DC:2</availability>
+		</model>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,SIC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
@@ -8415,25 +8412,25 @@
 			<roles>fire_support</roles>
 			<availability>FS.RR:3+,FRR:3+,CNC:8,FS.DMM:3+,MERC:3+,DC:3+</availability>
 		</model>
-		<model name='PNT-10K'>
+		<model name='PNT-12A'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:5,FRR:6,CNC:4,FS.DMM:5,MERC:5,DC:9</availability>
+			<availability>DC:5</availability>
 		</model>
 		<model name='PNT-CA'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:3+,FRR:3+,FS.DMM:3+,MERC:3+,DC:3+</availability>
 		</model>
-		<model name='PNT-12A'>
+		<model name='PNT-10K'>
 			<roles>fire_support</roles>
-			<availability>DC:5</availability>
-		</model>
-		<model name='PNT-C'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
+			<availability>FS.RR:5,FRR:6,CNC:4,FS.DMM:5,MERC:5,DC:9</availability>
 		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
+		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -8449,10 +8446,6 @@
 			<roles>spotter,anti_aircraft</roles>
 			<availability>WOB:4,FS:5</availability>
 		</model>
-		<model name='(Company Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:2,FS:2</availability>
-		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
 			<availability>WOB:6,FS:6</availability>
@@ -8461,23 +8454,27 @@
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:2,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:8,CC:5,HL:7,FRR:5,IS:6,Periphery.Deep:8,WOB:7,SIC:7,FS:7,CIR:5,Periphery:8,TC:8,CS:7-,OA:4,CDS:3,LA:6,FWL:6,DC:5</availability>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(C3)'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Patron LoaderMech' unitType='Mek'>
@@ -8489,26 +8486,30 @@
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
 		<availability>LA:7,FRR:5,FS:7,MERC:5,CWIE:3</availability>
-		<model name='(Standard)'>
-			<availability>HL:4,IS:5,Periphery.Deep:4,Periphery:6</availability>
-		</model>
 		<model name='(Ultra)'>
 			<availability>LA:6,General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:4,IS:5,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:8,WOB:5-,SIC:5,FS:6,CIR:3,Periphery:3,TC:3,CWIE:4,CS:5-,OA:3,LA:6,FWL:4,DC:6</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:2</availability>
-		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
 		</model>
+		<model name='(MRM)'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -8518,40 +8519,36 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:5,WOB:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(MRM)'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>LA:6,FS:6,MERC:2</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:2,CSJ:5,CGB:4</availability>
-		<model name='5'>
-			<availability>CGS:6</availability>
-		</model>
-		<model name='4'>
-			<availability>CSR:8,CBS:7,CGS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CGS:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='4'>
+			<availability>CSR:8,CBS:7,CGS:6</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_infantry</roles>
@@ -8560,11 +8557,11 @@
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:2-,LA:4-,FRR:1-,FWL:1-,IS:1-,SIC:1-,FS:4-,MERC:1-,DC:2-</availability>
-		<model name='(Cargo)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,DC:2</availability>
@@ -8575,17 +8572,17 @@
 		<model name='P1D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='P1'>
-			<availability>General:8</availability>
-		</model>
-		<model name='P1C'>
+		<model name='P1A'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='P1A'>
-			<roles>spotter</roles>
+		<model name='P1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='P1C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -8594,53 +8591,53 @@
 		<model name='(A)' mechanized='true'>
 			<availability>FWL:8</availability>
 		</model>
-		<model name='(B)' mechanized='true'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='(WoB-A)' mechanized='true'>
 			<availability>WOB:8</availability>
 		</model>
 		<model name='(WoB-B)' mechanized='true'>
 			<availability>WOB:3</availability>
 		</model>
+		<model name='(B)' mechanized='true'>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CIH:6,CSR:6,CW:8,CGS:4,CCO:4,CJF:7,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CIH:7,General:8,CCO:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:7,CIH:6,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:5,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:5,CIH:6,General:5,CCO:4,CGB:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:4,CSV:5,CLAN:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:5,CIH:6,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CIH:7,General:8,CCO:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='C'>
+			<availability>CSA:5,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CIH:5,CSR:5,CDS:5,CBS:3,CSV:5,CLAN:3,CFM:5,CCO:5</availability>
-		<model name='3'>
-			<availability>CDS:4,CLAN:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCC:6,CSR:6,CIH:6,CDS:6,CSV:6,CLAN:6,CNC:6,CFM:6,CCO:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:3,CSV:5,CLAN:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:4,CLAN:3</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
@@ -8648,26 +8645,22 @@
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:5,HL:4,CLAN:1,IS:9,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:4,Periphery:5,CGB:1</availability>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,CGS:5</availability>
-		</model>
 		<model name='PXH-4L'>
 			<availability>CC:4,MOC:3,MH:3,WOB:3,CIR:2,TC:3</availability>
 		</model>
@@ -8675,17 +8668,9 @@
 			<roles>recon</roles>
 			<availability>PIR:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='PXH-1'>
+		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
-			<availability>General:4,BAN:6,Periphery:4</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FS:8,MERC:6</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>FWL:8,IS:4</availability>
+			<availability>CLAN:5,BAN:1</availability>
 		</model>
 		<model name='PXH-1K'>
 			<roles>recon</roles>
@@ -8695,28 +8680,40 @@
 			<roles>recon</roles>
 			<availability>FRR:8,DC:8</availability>
 		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,BAN:1</availability>
-		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:8,MERC:5</availability>
 		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>FWL:8,IS:4</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,CGS:5</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FS:8,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:6,CC:3,CHH:5,HL:2,FRR:4,CLAN:5,IS:4,WOB:5-,SIC:3,FS:4,MERC:4,CIR:3,CWIE:6,TC:4,Periphery:3,CS:5-,OA:4,MERC.WD:5,CDS:6,LA:3,CNC:6,FWL:3,MH:5,DC:4</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:6,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(RAC) &apos;Assault Pike&apos;'>
 			<availability>FS:5,TC:6</availability>
 		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
+		<model name='(Standard)'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -8733,13 +8730,13 @@
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,FS:7</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -8799,35 +8796,35 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CWIE:1,CSA:1,CS:1,CDS:5,NIOPS:1,CSJ:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CGS:7,CCO:6,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:6,CSV:6,General:8,CSJ:5,CJF:7,CGB:8</availability>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,CSJ:3,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:6,CSV:6,General:8,CSJ:5,CJF:7,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:3,CIH:6,General:5,CSJ:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,CSJ:3,CGB:3</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
@@ -8848,11 +8845,11 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:3,CBS:2,CCO:4</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,CBS:8,CCO:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:3,CCO:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8,CBS:8,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -8878,10 +8875,6 @@
 			<roles>support</roles>
 			<availability>IS:6,Periphery:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8,General:7</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -8890,9 +8883,16 @@
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8,General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:8,CLAN:8,IS:1+,CFM:8,MERC:1+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:5,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CFM:6,CSJ:6,CJF:6</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CSJ:3,CGB:3</availability>
 		</model>
@@ -8900,21 +8900,18 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CSJ:4,CJF:4,CGB:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CBS:6,CSV:6,CNC:7,General:8,CFM:6,CSJ:5,CJF:7,CGB:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CFM:6,CSJ:6,CJF:6</availability>
+		<model name='E'>
+			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -8928,31 +8925,31 @@
 	</chassis>
 	<chassis name='Purifier Adaptive Battle Armor' unitType='BattleArmor'>
 		<availability>WOB:4,MH:3,CIR:3,TC:3</availability>
-		<model name='[Laser] (RAF)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CS:7,WOB:7,Periphery:7</availability>
+		<model name='[PPC] (RAF)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[PPC]' mechanized='true'>
 			<availability>CS:6,WOB:6,Periphery:6</availability>
-		</model>
-		<model name='[Narc]' mechanized='true'>
-			<availability>CS:4,WOB:4,Periphery:4</availability>
-		</model>
-		<model name='[PPC] (RAF)' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:5,WOB:5,Periphery:5</availability>
 		</model>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Laser] (RAF)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CS:7,WOB:7,Periphery:7</availability>
+		</model>
+		<model name='[Narc]' mechanized='true'>
+			<availability>CS:4,WOB:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
@@ -8963,8 +8960,11 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
-		<model name='QKD-4H'>
-			<availability>General:2</availability>
+		<model name='QKD-5K2'>
+			<availability>MERC:1,DC:1</availability>
+		</model>
+		<model name='QKD-5K'>
+			<availability>FRR:6,MERC:6,DC:8</availability>
 		</model>
 		<model name='QKD-5A'>
 			<availability>General:1,MERC:3,DC:3,Periphery:3</availability>
@@ -8972,20 +8972,17 @@
 		<model name='QKD-8K'>
 			<availability>FRR:3,MERC:2,DC:5</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>FRR:6,MERC:6,DC:8</availability>
-		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:4,FWL:8,IS:4,MH:4,TC:4</availability>
-		</model>
-		<model name='QKD-5K2'>
-			<availability>MERC:1,DC:1</availability>
+		<model name='QKD-C'>
+			<availability>FRR:6,MERC:5,DC:8</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:4,OA:4,HL:2,Periphery.Deep:8,FWL:4,IS:4,Periphery:4,DC:4,TC:4</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>FRR:6,MERC:5,DC:8</availability>
+		<model name='QKD-4H'>
+			<availability>General:2</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:4,FWL:8,IS:4,MH:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
@@ -9003,24 +9000,24 @@
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:8</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin' unitType='Mek'>
@@ -9034,24 +9031,18 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:4,FS:5,MERC:3</availability>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:8,LA:4,CLAN:3,NIOPS:8,WOB:8</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:5</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
@@ -9062,14 +9053,29 @@
 		<model name='RPR-200'>
 			<availability>CCC:1,CSR:1,CBS:1,CNC:2</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:5</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:3+,FS:3+,DC:6+</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:1+</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
@@ -9081,36 +9087,27 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,MOC:4,FWL:5,FS:4,MERC:4,DC:3,TC:4</availability>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:5,MOC:3,FWL:3,FS:3,MERC:3,DC:3,TC:3</availability>
+		<model name='RVN-4X'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='RVN-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:2,FWL:4,FS:2,MERC:3,DC:2,TC:2</availability>
 		</model>
-		<model name='RVN-4L'>
-			<roles>spotter</roles>
-			<availability>CC:7,MOC:7,TC:7</availability>
-		</model>
-		<model name='RVN-4X'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,TC:2</availability>
+		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:5,MOC:3,FWL:3,FS:3,MERC:3,DC:3,TC:3</availability>
+		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:7,MOC:7,TC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
@@ -9124,15 +9121,15 @@
 	</chassis>
 	<chassis name='Red Shift' unitType='Mek'>
 		<availability>WOB:5</availability>
-		<model name='RDS-2B'>
-			<roles>recon,spotter</roles>
-			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
-			<availability>General:5</availability>
-		</model>
 		<model name='RDS-2A'>
 			<roles>spotter</roles>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
 			<availability>General:8</availability>
+		</model>
+		<model name='RDS-2B'>
+			<roles>recon,spotter</roles>
+			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
@@ -9147,58 +9144,58 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,FRR:6,CLAN:6,Periphery.Deep:9,IS:6,WOB:7,SIC:6,FS:7,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:8,NIOPS:7,DC:6</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:2,CW:2,General:8,CNC:2</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:6,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+		<model name='F-700a'>
+			<availability>CC:7,FWL:7,WOB:7,FS:4,MERC:7</availability>
+		</model>
+		<model name='F-100b'>
+			<availability>FRR:6,DC:6</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>CC:5,FWL:5,SIC:5,MERC:5</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:8,FWL:8,WOB:8,MERC:8</availability>
 		</model>
-		<model name='F-100b'>
-			<availability>FRR:6,DC:6</availability>
-		</model>
 		<model name='F-100'>
 			<availability>CC:5,HL:3,LA:2,FRR:2,FWL:5,Periphery.Deep:8,SIC:5,MERC:5,DC:2,Periphery:5</availability>
-		</model>
-		<model name='F-700a'>
-			<availability>CC:7,FWL:7,WOB:7,FS:4,MERC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:3,CNC:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:5,CNC:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:4,CCC:5,CDS:4,CIH:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:5,CLAN:4,CNC:5</availability>
 		</model>
 		<model name='4'>
 			<availability>CSA:5,CCC:4,CDS:4,CBS:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:4,CCC:5,CDS:4,CIH:3</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:5,CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -9210,11 +9207,20 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,CCC:5,HL:3,FRR:7,CSV:5,IS:7,Periphery.Deep:5,WOB:5,CFM:5,SIC:7-,FS:8,CGS:5,Periphery:4,CS:5,CSA:5,FWL:7,NIOPS:5</availability>
-		<model name='C'>
-			<availability>LA:2,CLAN:8,FS:2,BAN:3,DC:2</availability>
-		</model>
 		<model name='RFL-7M'>
 			<availability>FWL:4,WOB:3</availability>
+		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RFL-4D'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:1,MERC:1</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
 		<model name='RFL-5D'>
 			<availability>LA:6,FS:6,MERC:5</availability>
@@ -9222,23 +9228,14 @@
 		<model name='RFL-8D'>
 			<availability>LA:3,FS:4</availability>
 		</model>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:2</availability>
+		<model name='RFL-6X'>
+			<availability>FS:2,MERC:2</availability>
 		</model>
 		<model name='RFL-5M'>
 			<availability>CC:5,MOC:5,FWL:5,IS:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='RFL-4D'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:1,MERC:1</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FS:2,MERC:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		<model name='C'>
+			<availability>LA:2,CLAN:8,FS:2,BAN:3,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Riot Police' unitType='Infantry'>
@@ -9250,59 +9247,59 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CS:6,CHH:4,CSR:1,LA:5,FRR:5,CLAN:2,NIOPS:6,WOB:6,FS:5,CJF:1,DC:5</availability>
-		<model name='(SPL)'>
-			<roles>apc</roles>
-			<availability>IS:3</availability>
-		</model>
-		<model name='(ERML)'>
-			<roles>apc</roles>
-			<availability>CC:6,LA:6,FS:6,DC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8,BAN:2</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>CC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(ERML)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(SPL)'>
+			<roles>apc</roles>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:2,CHH:4,CSR:5,CBS:5,CNC:6,CFM:3,CSJ:5,CGS:5,CCO:6,CWIE:6</availability>
-		<model name='3'>
-			<availability>CSR:4,CBS:4,CNC:3,CFM:4,CCO:3,CWIE:4</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:6,CSJ:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CCC:4,CSR:6,CBS:6,CNC:4,CFM:6,CCO:6,CGS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:6,CSJ:8</availability>
+		<model name='3'>
+			<availability>CSR:4,CBS:4,CNC:3,CFM:4,CCO:3,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:6</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:5,General:8,NIOPS:5,WOB:6</availability>
 		</model>
 		<model name='RGU-133L'>
 			<availability>CS:1,General:4,NIOPS:1,WOB:2</availability>
 		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:6</availability>
+		</model>
 		<model name='RGU-133F'>
 			<availability>CS:3,General:6,NIOPS:3,WOB:4</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:1</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:5,General:8,NIOPS:5,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
@@ -9338,23 +9335,23 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CBS:9,CNC:8,CSJ:9,CJF:9,DC:2+</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
+		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:5,CCC:5,CBS:4,CSV:5,CLAN:3,General:1</availability>
-		</model>
-		<model name='I'>
-			<availability>CLAN:3,General:1</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CSJ:6,CJF:4,CGB:3</availability>
+		<model name='H'>
+			<availability>CSA:5,CCC:5,CBS:4,CSV:5,CLAN:3,General:1</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CSJ:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='I'>
+			<availability>CLAN:3,General:1</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CSR:6,CDS:6,CNC:4,General:5,CFM:4,CSJ:4,CCO:7,CJF:4,CWIE:6</availability>
@@ -9369,13 +9366,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:5,LA:6,FWL:5,IS:4,FS:6,DC:5,Periphery:4</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:3,Periphery:2</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:5,LA:6,FWL:5,IS:4,FS:6,DC:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -9395,20 +9392,20 @@
 		<model name='SB-27'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9429,8 +9426,8 @@
 		<model name='S-4X'>
 			<availability>DC:1</availability>
 		</model>
-		<model name='S-7'>
-			<availability>CNC:3,DC:3</availability>
+		<model name='S-4C'>
+			<availability>CLAN:8,DC:2</availability>
 		</model>
 		<model name='S-3'>
 			<availability>DC:3</availability>
@@ -9438,25 +9435,25 @@
 		<model name='S-4'>
 			<availability>FRR:6,FS:5,DC:6</availability>
 		</model>
-		<model name='S-4C'>
-			<availability>CLAN:8,DC:2</availability>
+		<model name='S-7'>
+			<availability>CNC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:7,Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,SIC:7,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,LA:7,FWL:7,CJF:4,DC:9</availability>
-		<model name='(Armor)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Ultra)'>
+		<model name='(LB-X)'>
 			<availability>IS:3,DC:4</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:8,Periphery:8</availability>
 		</model>
-		<model name='(LB-X)'>
+		<model name='(Armor)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ultra)'>
 			<availability>IS:3,DC:4</availability>
 		</model>
 	</chassis>
@@ -9471,6 +9468,14 @@
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>CS:3,LA:7,FS:5,MERC:3</availability>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
+		</model>
+		<model name='PPR-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:4,MERC:2,FS:2</availability>
@@ -9479,28 +9484,20 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
-		<model name='PPR-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>OA:1,FRR:1,DC:1</availability>
-		<model name='SL-26'>
-			<roles>ground_support</roles>
-			<availability>CLAN:8,BAN:2</availability>
-		</model>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
 			<availability>OA:8,FRR:8,DC:8</availability>
+		</model>
+		<model name='SL-26'>
+			<roles>ground_support</roles>
+			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -9514,11 +9511,11 @@
 	</chassis>
 	<chassis name='Sasquatch' unitType='Mek'>
 		<availability>WOB:2</availability>
-		<model name='SQS-TH-001'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SQS-TH-002'>
 			<availability>General:4</availability>
+		</model>
+		<model name='SQS-TH-001'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sassanid' unitType='Dropship'>
@@ -9530,6 +9527,10 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:2,CSR:2,CIH:5,CBS:3,CNC:2,CSJ:5,CFM:2,CGS:5,CCO:5,CWIE:5</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:8</availability>
@@ -9538,24 +9539,20 @@
 			<roles>recon,raider</roles>
 			<availability>CIH:4,CGS:2,CWIE:2</availability>
 		</model>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:2,CW:4,CCO:6</availability>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:8,CLAN:6</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:3,General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
+		<model name='C'>
+			<availability>CSA:8,CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
@@ -9577,13 +9574,13 @@
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>CS:4,LA:5,FS:6,MERC:4</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>LA:6,FS:4,MERC:5</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>LA:6,FS:4,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
@@ -9596,13 +9593,13 @@
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<roles>missile_artillery,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
@@ -9641,20 +9638,20 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,HL:6,LA:6,FRR:9,FWL:6,IS:7,Periphery.Deep:7,SIC:6,FS:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(MRM)'>
-			<availability>IS:3,DC:4,Periphery:2</availability>
+		<model name='(LRM)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(ML)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>IS:3,DC:4,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -9662,11 +9659,11 @@
 		<model name='SCP-1N'>
 			<availability>HL:6,FRR:8,General:2,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 		</model>
-		<model name='SCP-12S'>
-			<availability>LA:4,MERC:2</availability>
-		</model>
 		<model name='SCP-1O'>
 			<availability>IS:6</availability>
+		</model>
+		<model name='SCP-12S'>
+			<availability>LA:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -9693,17 +9690,17 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
@@ -9752,34 +9749,34 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:4,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:2,MH:2,DC:4</availability>
-		<model name='SYD-21'>
+		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
-			<availability>MERC.KH:3,LA:3,Periphery.Deep:4,FS:2,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>OA:5,HL:6,FRR:5,Periphery.Deep:6,FWL:5,Periphery:8,TC:5,DC:5</availability>
-		</model>
-		<model name='SYD-Z4'>
-			<availability>OA:2,LA:4</availability>
-		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:2,FS:2</availability>
+			<availability>HL:2,LA:4,Periphery.Deep:8,FS:4,Periphery:4</availability>
 		</model>
 		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
 			<availability>LA:8,FRR:6,FS:8,MERC:6</availability>
 		</model>
-		<model name='SYD-Z2'>
+		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
-			<availability>HL:2,LA:4,Periphery.Deep:8,FS:4,Periphery:4</availability>
+			<availability>OA:5,HL:6,FRR:5,Periphery.Deep:6,FWL:5,Periphery:8,TC:5,DC:5</availability>
+		</model>
+		<model name='SYD-Z3A'>
+			<availability>LA:4,FRR:2,MERC:2</availability>
+		</model>
+		<model name='SYD-Z4'>
+			<availability>OA:2,LA:4</availability>
+		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>MERC.KH:3,LA:3,Periphery.Deep:4,FS:2,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='SYD-Z2B'>
 			<availability>OA:2,LA:4</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>LA:4,FRR:2,MERC:2</availability>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
@@ -9801,64 +9798,64 @@
 			<roles>recon</roles>
 			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:5,IS:2</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,CLAN:5,IS:2</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,CDS:6,CLAN:6,CNC:6,CJF:5,CWIE:6,CGB:6</availability>
-		<model name='2'>
-			<availability>CSA:5,CCC:5,CIH:5,CGB:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:4,CDS:4,CNC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:5,CCC:5,CIH:5,CGB:5</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:4,CNC:4</availability>
 		</model>
+		<model name='3'>
+			<availability>CSA:4,CDS:4,CNC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:4,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:1</availability>
+		<model name='SHD-2K'>
+			<availability>FRR:4,MERC:2,DC:5</availability>
+		</model>
 		<model name='SHD-2D2'>
 			<availability>LA:5,FS:8</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='SHD-7CS'>
-			<availability>CS:4,WOB:3</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:3,General:5,Periphery.Deep:8,BAN:1,Periphery:5</availability>
 		</model>
 		<model name='SHD-2D'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='SHD-2K'>
-			<availability>FRR:4,MERC:2,DC:5</availability>
+		<model name='SHD-2H'>
+			<availability>HL:3,General:5,Periphery.Deep:8,BAN:1,Periphery:5</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:8,CCC:8,LA:4,CSV:8,CFM:8,FS:4,CGS:8,DC:4</availability>
+		<model name='SHD-2Hb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='SHD-5M'>
 			<availability>CC:5,FRR:5,Periphery.MW:3,Periphery.ME:2,FWL:8,IS:4,WOB:6,MERC:5,DC:5</availability>
 		</model>
-		<model name='SHD-5D'>
-			<availability>LA:2,FS:4,MERC:2</availability>
+		<model name='C'>
+			<availability>CSA:8,CCC:8,LA:4,CSV:8,CFM:8,FS:4,CGS:8,DC:4</availability>
 		</model>
 		<model name='SHD-7M'>
 			<availability>CC:3,MOC:3,FWL:4,TC:3</availability>
+		</model>
+		<model name='SHD-7CS'>
+			<availability>CS:4,WOB:3</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:2,FS:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
@@ -9881,6 +9878,9 @@
 	</chassis>
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>FWL:3+,WOB:3+,FWL.KIS:4+,FWL.FWG:4+</availability>
+		<model name='SHV-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='SHV-OB'>
 			<availability>General:7</availability>
 		</model>
@@ -9888,9 +9888,6 @@
 			<availability>General:8</availability>
 		</model>
 		<model name='SHV-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -9902,14 +9899,14 @@
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
 		<availability>CSA:2,MERC.WD:2,CIH:2,CBS:2,CCO:2</availability>
+		<model name='SHG-2E'>
+			<availability>MERC.WD:2</availability>
+		</model>
 		<model name='C'>
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 		<model name='SHG-2F'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='SHG-2E'>
-			<availability>MERC.WD:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -9941,16 +9938,28 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverback Coastal Cutter' unitType='Naval'>
+		<availability>LA:7</availability>
+		<model name='(Standard)'>
+			<availability>LA:7</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:4,CCC:4,CIH:4,CSJ:5,CCO:4</availability>
+		<model name='2'>
+			<availability>CSA:6,CCC:6,CIH:6</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4,CIH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSA:6,CCC:6,CIH:6,CSJ:8,CCO:6</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:6,CCC:6,CIH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
@@ -9964,26 +9973,26 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:4,Periphery.DD:3,FRR:5,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:6</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:7</availability>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,DC:1</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>OA:6,FRR:8,FS:6,MERC:6,DC:8,TC:4</availability>
-		</model>
-		<model name='SL-15'>
-			<availability>HL:2,IS:4,Periphery.Deep:8,FS:0,Periphery:4</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>FRR:1,MERC:1,DC:1</availability>
@@ -9991,11 +10000,11 @@
 		<model name='SL-15K'>
 			<availability>FRR:2,DC:2</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:2,IS:4,Periphery.Deep:8,FS:0,Periphery:4</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,DC:1</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -10019,12 +10028,12 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6,CNC:4</availability>
+		<model name='(Standard)'>
+			<availability>CIH:8,CNC:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CIH:8,CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -10038,10 +10047,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -10066,23 +10071,23 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:3</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>LA:4,FS.CMM:1</availability>
+		<model name='SPR-6D'>
+			<availability>FRR:5,FS:8,MERC:5</availability>
 		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FRR:1,General:5,Periphery.Deep:8,FS:5,MERC:5,DC:1,TC:5</availability>
 		</model>
+		<model name='SPR-7D'>
+			<availability>FS:3,MERC:3</availability>
+		</model>
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:2,FRR:5,DC:5</availability>
 		</model>
-		<model name='SPR-7D'>
-			<availability>FS:3,MERC:3</availability>
-		</model>
-		<model name='SPR-6D'>
-			<availability>FRR:5,FS:8,MERC:5</availability>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>LA:4,FS.CMM:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -10112,25 +10117,25 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,SIC:4,MERC:3,FS:4,Periphery:2,TC:2,CS:3,OA:1,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:5</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>HL:2,IS:4,Periphery.Deep:8,FS:1,Periphery:4</availability>
-		</model>
-		<model name='SDR-7M'>
-			<availability>MOC:3,CC:8,FWL:8,MH:3,SIC:8,MERC:3,FS:8,DC:6</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>FWL:6,MERC:2</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:3,FWL:3,FS:3,MERC:3,DC:6</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:4,DC:4</availability>
+		</model>
+		<model name='SDR-7M'>
+			<availability>MOC:3,CC:8,FWL:8,MH:3,SIC:8,MERC:3,FS:8,DC:6</availability>
+		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:5</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:3,FWL:3,FS:3,MERC:3,DC:6</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>FWL:6,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
@@ -10145,6 +10150,10 @@
 			<roles>recon</roles>
 			<availability>FRR:5,IS:4,DC:6</availability>
 		</model>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
@@ -10153,21 +10162,20 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:9,CC:6,HL:9,FRR:6,CLAN:3,IS:8,Periphery.Deep:9,WOB:4,SIC:6,FS:6,CIR:9,Periphery:10,TC:9,CS:5,OA:9,LA:8,FWL:9,NIOPS:5,DC:6</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+		<model name='STK-8S'>
+			<availability>LA:3</availability>
+		</model>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:2+,DC:6,TC:3</availability>
+		</model>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-7D'>
 			<availability>FS:4</availability>
-		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1,OA:1,IS:1,Periphery:1,TC:1</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
@@ -10175,30 +10183,27 @@
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:2+,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:1,OA:1,IS:1,Periphery:1,TC:1</availability>
 		</model>
 		<model name='STK-6M'>
 			<availability>FWL:4,WOB:4,MERC:4</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
-		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,CSV:3,MERC:4,FS:5,CJF:3,TC:4</availability>
-		</model>
-		<model name='STK-8S'>
-			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:5+,CBS:2+</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -10234,22 +10239,22 @@
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>LA:2,FS:4,MERC:4</availability>
-		</model>
 		<model name='STH-2D'>
 			<roles>recon</roles>
 			<availability>LA:2,FS:6,MERC:4</availability>
 		</model>
+		<model name='STH-2D1'>
+			<roles>recon</roles>
+			<availability>LA:2,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Stiletto' unitType='Mek'>
 		<availability>LA:4,MERC:2</availability>
-		<model name='STO-4A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='STO-4B'>
 			<availability>General:4</availability>
+		</model>
+		<model name='STO-4A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -10260,19 +10265,15 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:5,CLAN:1-,IS:8,Periphery.Deep:5,WOB:3-,SIC:8,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FWL:8,IS:4,WOB:8,FS:4,MERC:4,DC:4,TC:4</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:8,BAN:8,Periphery:4</availability>
@@ -10281,6 +10282,10 @@
 			<roles>recon</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,FWL:8,IS:4,WOB:8,FS:4,MERC:4,DC:4,TC:4</availability>
+		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:2,Periphery.Deep:4,Periphery:2</availability>
@@ -10288,15 +10293,15 @@
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:7,NIOPS:3,MH:2,DC:4</availability>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:8</availability>
+		</model>
 		<model name='F-94'>
 			<availability>IS:6</availability>
 		</model>
 		<model name='F-92'>
 			<availability>FWL:7,IS:4</availability>
-		</model>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:8</availability>
 		</model>
 		<model name='F-90'>
 			<availability>CS:4,LA:3,IS:4,FS:4,Periphery:4</availability>
@@ -10304,23 +10309,23 @@
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3</availability>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>:0,CLAN:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>:0,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -10332,25 +10337,9 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:4+,FWL:4+,FS:4+,MERC:4+,DC:6+</availability>
-		<model name='SR1-OA'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SR1-OD'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='SR1-OR'>
 			<availability>CLAN:6,General:1+</availability>
@@ -10358,15 +10347,35 @@
 		<model name='SR1-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:4,FRR:4,IS:5,WOB:3-,SIC:6,FS:9,MERC:3,CS:3-,CDS:3,LA:6,PIR:3,FWL:3,DC:3</availability>
+		<model name='(Narc)'>
+			<availability>LA:2,FS:2,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>IS:5</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>LA:6,FS:7,DC:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2</availability>
@@ -10377,27 +10386,23 @@
 		<model name='(SRM)'>
 			<availability>IS:5</availability>
 		</model>
-		<model name='(Narc)'>
-			<availability>LA:2,FS:2,DC:1</availability>
-		</model>
 		<model name='(3061 Upgrade)'>
 			<availability>LA:4,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>LA:6,FS:7,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:5,CS:4,MOC:5,MERC.WD:2-,LA:3,NIOPS:4,WOB:4,SIC:5</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>CC:5,General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:6,MOC:6</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -10405,14 +10410,14 @@
 		<model name='STU-K5'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:8,Periphery:5</availability>
 		</model>
+		<model name='STU-K5b'>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:3,FS.DMM:5,SIC:4</availability>
 		</model>
 		<model name='STU-K15'>
 			<availability>OA:2,SIC:1,FS:1,TC:2,Periphery:1</availability>
-		</model>
-		<model name='STU-K5b'>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>LA:6,FS:8,MERC:6</availability>
@@ -10420,12 +10425,12 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:4,CDS:3,HL:3,LA:7,FRR:1,CNC:4,SIC:1,MERC:3,FS:5,CWIE:4</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8,WOB:0</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Heavy Gauss)'>
 			<availability>LA:5,CNC:5,CWIE:5</availability>
@@ -10433,13 +10438,13 @@
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:4</availability>
-		<model name='(Standard)'>
-			<roles>recon,fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Suffren Destroyer' unitType='Warship'>
@@ -10451,14 +10456,14 @@
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:6,CBS:4,General:2,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:4,General:2,CJF:6,CGB:6</availability>
@@ -10469,12 +10474,12 @@
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:3+,LA:5+,SIC:3+,FS:5+,MERC:3+,DC:6+</availability>
+		<model name='SD1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='SD1-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='SD1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OR'>
 			<availability>CLAN:6,General:1+,DC:2+</availability>
@@ -10515,10 +10520,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:2,MOC:2,CDP:2,TC:2</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -10530,22 +10535,22 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:3</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:5,NIOPS:8,WOB:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:9,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:9,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
@@ -10573,10 +10578,6 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>CS:3,MOC:3,CC:4,FWL:5,IS:3,WOB:4,MERC:4,DC:5</availability>
-		<model name='ZPH-3A'>
-			<roles>recon</roles>
-			<availability>FWL:3,IS:4,MERC:3,DC:3</availability>
-		</model>
 		<model name='ZPH-2A'>
 			<roles>recon</roles>
 			<availability>CC:6,FWL:6,IS:6,MERC:6,DC:6</availability>
@@ -10585,20 +10586,24 @@
 			<roles>recon</roles>
 			<availability>CC:6,MOC:6,General:6,FWL:6,MERC:6,DC:6</availability>
 		</model>
+		<model name='ZPH-3A'>
+			<roles>recon</roles>
+			<availability>FWL:3,IS:4,MERC:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>FRR:3+,DC:4+</availability>
-		<model name='MIK-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MIK-OC'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsumaki Destroyer' unitType='Warship'>
@@ -10610,14 +10615,14 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>FWL.MM:8,FWL:6,WOB:5,MERC:2</availability>
-		<model name='TMP-3G'>
-			<availability>FWL:2,WOB:2,MERC:2</availability>
+		<model name='TMP-3M'>
+			<availability>FWL:8,WOB:8,MERC:8</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>FWL:3,WOB:3,MERC:3</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>FWL:8,WOB:8,MERC:8</availability>
+		<model name='TMP-3G'>
+			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
@@ -10628,6 +10633,9 @@
 		<model name='TLR1-OB'>
 			<availability>General:4</availability>
 		</model>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='TLR1-OC'>
 			<availability>General:5</availability>
 		</model>
@@ -10637,9 +10645,6 @@
 		</model>
 		<model name='TLR1-OA'>
 			<availability>General:7</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
@@ -10655,22 +10660,22 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
 		<availability>LA:4,FS:4,MERC:3</availability>
-		<model name='TNS-4T'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TNS-4T'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thera Carrier' unitType='Warship'>
@@ -10682,34 +10687,34 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CSR:5,CIH:3,CLAN:5,IS:1+,CCO:5,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CDS:5,CW:5,CNC:5,CSJ:6,CJF:9,CGB:5</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CSJ:3,CGS:4,CWIE:6,CGB:8</availability>
-		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -10728,46 +10733,46 @@
 		<model name='THE-S'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='THE-N1'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
 		<model name='THE-T'>
 			<availability>DC:1</availability>
 		</model>
 		<model name='THE-N'>
 			<availability>CS:6,CLAN:6,NIOPS:6,BAN:6</availability>
 		</model>
+		<model name='THE-N1'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CSR:2,CLAN:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>MOC:4,CC:6,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+		</model>
 		<model name='TR-8'>
 			<availability>CC:4</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>SIC:2</availability>
 		</model>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:4,FRR:3,CSV:6,CLAN:5,IS:2,CFM:7,WOB:7,SIC:3,FS:4,CWIE:6,DC.GHO:6,CS:8,OA:3,CDS:4,CW:6,CBS:4,LA:3,CNC:4,FWL:6,NIOPS:8,CJF:6,CGB:6</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>DC.GHO:8,CS:5,FRR:6,CLAN:6,IS:4,FWL:8,NIOPS:5,WOB:5,FS:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='THG-11Eb'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:6,MERC:6,DC:2</availability>
@@ -10785,9 +10790,6 @@
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>CS:2,LA:6,CLAN:1,NIOPS:2,MERC:4</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:6</availability>
@@ -10797,6 +10799,9 @@
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -10810,11 +10815,11 @@
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,MERC:3,TC:4</availability>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-1L'>
 			<availability>General:8</availability>
+		</model>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
@@ -10823,40 +10828,40 @@
 			<roles>escort,ground_support</roles>
 			<availability>MOC:4,LA:6,FRR:5,MH:4,MERC:5</availability>
 		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='TRB-D36b'>
 			<roles>ground_support</roles>
 			<availability>CLAN:4</availability>
 		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:7,HL:3,CLAN:2,IS:7,Periphery.Deep:6,WOB:2-,FS:6,MERC:7,Periphery:4,TC:4,CS:3-,LA:7,NIOPS:3-,MH:4,DC:7</availability>
-		<model name='TDR-5Sb'>
-			<availability>CHH:1,CSR:1,CDS:1,CW:1,CLAN:2,CNC:1,CJF:1,CWIE:1,CGB:1</availability>
+		<model name='TDR-9SE'>
+			<availability>LA:3,MERC.ELH:8,MERC:3,FS:3</availability>
 		</model>
 		<model name='TDR-9S'>
 			<availability>LA:8,FS:6,MERC:3</availability>
 		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:5,MERC:2</availability>
+		<model name='TDR-5SE'>
+			<availability>MERC.ELH:2</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:5,HL:3,LA:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='TDR-9SE'>
-			<availability>LA:3,MERC.ELH:8,MERC:3,FS:3</availability>
+		<model name='TDR-7M'>
+			<availability>CS:6,CC:3,FWL:8,IS:3,WOB:6,MERC:3</availability>
 		</model>
-		<model name='TDR-5SE'>
-			<availability>MERC.ELH:2</availability>
+		<model name='TDR-5SS'>
+			<availability>LA:5,MERC:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:5,CCC:5,LA:2,CSV:5,CFM:5,FS:2,CGS:5,DC:2</availability>
 		</model>
-		<model name='TDR-7M'>
-			<availability>CS:6,CC:3,FWL:8,IS:3,WOB:6,MERC:3</availability>
+		<model name='TDR-5Sb'>
+			<availability>CHH:1,CSR:1,CDS:1,CW:1,CLAN:2,CNC:1,CJF:1,CWIE:1,CGB:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
@@ -10877,55 +10882,55 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:5,CLAN:4,NIOPS:3,WOB:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:2,FRR:6,CNC:4,DC:8</availability>
-		<model name='(C3)'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='TKG-150'>
-			<availability>FRR:3-,DC:3-</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>FRR:7,DC:7</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>CDS:8,CNC:8,DC:2</availability>
+		<model name='(C3)'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>CDS:8,CNC:8,DC:2</availability>
 		</model>
 		<model name='(MRM)'>
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
 		</model>
+		<model name='TKG-150'>
+			<availability>FRR:3-,DC:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:3</availability>
-		<model name='CH'>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:2,NIOPS:2,WOB:2</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:2,BAN:2</availability>
-		</model>
-		<model name='&apos;C&apos;'>
-			<availability>CW:6,CLAN:4</availability>
+		<model name='CH'>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='&apos;C&apos;'>
+			<availability>CW:6,CLAN:4</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:2,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
@@ -10936,10 +10941,10 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -10952,27 +10957,27 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>CS:2,FWL:2,WOB:2</availability>
-		<model name='G13 [Grenade Launcher]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
+		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
+			<roles>specops</roles>
+			<availability>CS:8</availability>
 		</model>
-		<model name='G13 [Machine Gun]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
 		<model name='G12' mechanized='true'>
 			<roles>specops</roles>
 			<availability>FWL:8,WOB:8</availability>
 		</model>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
+		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Machine Gun]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
-		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
-			<roles>specops</roles>
-			<availability>CS:8</availability>
-		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
 	</chassis>
@@ -10990,65 +10995,62 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:5</availability>
+		<model name='TR-13A'>
+			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
 		<model name='TR-14 &apos;AC&apos;'>
 			<availability>General:4,FWL:6</availability>
-		</model>
-		<model name='TR-16'>
-			<availability>CC:5,MOC:5,SIC:2,MERC:5,TC:5</availability>
 		</model>
 		<model name='TR-13'>
 			<availability>CC:5,HL:3,IS:5,MERC:5,Periphery:5</availability>
 		</model>
-		<model name='TR-13A'>
-			<availability>CC:8,MOC:7,General:5</availability>
+		<model name='TR-16'>
+			<availability>CC:5,MOC:5,SIC:2,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:7,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:7,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:7,MOC:7,General:7,TC:7</availability>
-		</model>
-		<model name='TR-12'>
-			<availability>CC:4</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='TR-12'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>CC:7,MOC:7,General:7,TC:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:4,CC:4,FRR:4,IS:4,WOB:3-,SIC:4,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3-,DC:4</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:3</availability>
-		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:3,IS:3,Periphery.Deep:4,FWL:3,MERC:3,Periphery:3,TC:3</availability>
-		</model>
-		<model name='TBT-7M'>
+		<model name='TBT-5N'>
 			<roles>fire_support</roles>
-			<availability>CC:4,LA:2,FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
-		</model>
-		<model name='TBT-9K'>
-			<roles>fire_support</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='TBT-7K'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+			<availability>CC:4,CS:2,MOC:6,LA:4,FWL:3,IS:6,NIOPS:2,WOB:2,FS:4,MERC:6,DC:4,Periphery:6</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
 		</model>
-		<model name='TBT-5N'>
+		<model name='TBT-7M'>
 			<roles>fire_support</roles>
-			<availability>CC:4,CS:2,MOC:6,LA:4,FWL:3,IS:6,NIOPS:2,WOB:2,FS:4,MERC:6,DC:4,Periphery:6</availability>
+			<availability>CC:4,LA:2,FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
+		</model>
+		<model name='TBT-7K'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='TBT-9K'>
+			<roles>fire_support</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='TBT-5J'>
+			<availability>FWL:3</availability>
+		</model>
+		<model name='TBT-5S'>
+			<availability>MOC:3,IS:3,Periphery.Deep:4,FWL:3,MERC:3,Periphery:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -11062,8 +11064,8 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:4,MOC:2,TC:2</availability>
-		<model name='(Asterion)[PPC]' mechanized='true'>
-			<availability>MH:6,TC:6</availability>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Asterion)[MRR]' mechanized='true'>
 			<availability>MH:6,TC:6</availability>
@@ -11071,8 +11073,8 @@
 		<model name='(Ying Long)(Plasma)' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
+		<model name='(Asterion)[PPC]' mechanized='true'>
+			<availability>MH:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -11088,11 +11090,11 @@
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
 		<availability>CC:2,MOC:2,TC:4</availability>
-		<model name='CMT-4U'>
-			<availability>General:5</availability>
-		</model>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
+		</model>
+		<model name='CMT-4U'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Trojan' unitType='Dropship'>
@@ -11104,11 +11106,11 @@
 	</chassis>
 	<chassis name='Tsunami' unitType='Mek'>
 		<availability>MERC:3</availability>
-		<model name='TS-P1D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='TS-P1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TS-P1D'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Turhan Urban Combat Vehicle' unitType='Tank'>
@@ -11120,8 +11122,8 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:4,CGB:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -11132,14 +11134,24 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CSR:2,CNC:4,CSJ:3,CLAN.HW:3,CJF:7</availability>
+		<model name='Z'>
+			<roles>spotter</roles>
+			<availability>CCO:4</availability>
+		</model>
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CFM:7,CGS:7,CJF:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CHH:8,CW:8,CNC:8,CFM:8,CJF:8,CCO:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:5,CW:5,CNC:5,CJF:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:7,CW:7,CNC:7,CFM:7,CJF:7,CGS:7</availability>
@@ -11150,19 +11162,13 @@
 		<model name='H'>
 			<availability>CHH:4,CW:5,CNC:4,CJF:4</availability>
 		</model>
-		<model name='Z'>
-			<roles>spotter</roles>
-			<availability>CCO:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CW:8,CNC:8,CFM:8,CJF:8,CCO:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:5,CW:5,CNC:5,CJF:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,FS:6,MERC:3</availability>
+		<model name='(RAC)'>
+			<roles>urban</roles>
+			<availability>General:4,FS:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
@@ -11170,10 +11176,6 @@
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>urban</roles>
-			<availability>General:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
@@ -11185,27 +11187,25 @@
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:3,CCO:3,CWIE:4,MERC.WD:4,CDS:4,CW:4,CBS:6,CNC:3,CSJ:4,CJF:7,CGB:3</availability>
-		<model name='B'>
-			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
 			<availability>CW:6,CSV:3,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
@@ -11214,16 +11214,18 @@
 			<roles>fire_support</roles>
 			<availability>CSA:5,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CWIE:4,CGB:1</availability>
+		<model name='B'>
+			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CSJ:2,CJF:2,CWIE:4,CGB:1</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
@@ -11252,13 +11254,13 @@
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:6,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>CS:6,LA:4,IS:4,WOB:6,FS:6</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:6,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech IIC' unitType='Mek'>
@@ -11282,13 +11284,13 @@
 			<roles>urban</roles>
 			<availability>CC:4,SIC:4,Periphery:3</availability>
 		</model>
-		<model name='UM-R63'>
-			<roles>urban</roles>
-			<availability>CC:8,CS:6,MOC:3+,MERC:4,TC:3+</availability>
-		</model>
 		<model name='UM-R60'>
 			<roles>urban</roles>
 			<availability>CC:5,HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='UM-R63'>
+			<roles>urban</roles>
+			<availability>CC:8,CS:6,MOC:3+,MERC:4,TC:3+</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
@@ -11310,10 +11312,6 @@
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>LA:5,FS:9,MERC:4,TC:2</availability>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:3,FS:5,MERC:5,TC:5</availability>
-		</model>
 		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:2,FS:2,MERC:2</availability>
@@ -11322,30 +11320,34 @@
 			<roles>recon,fire_support</roles>
 			<availability>LA:8,FS:8,MERC:6</availability>
 		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>LA:3,FS:5,MERC:5,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanquisher' unitType='Mek'>
@@ -11356,6 +11358,9 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:5-,HL:9,IS:10,Periphery.Deep:8,WOB:4-,Periphery:10,CGB:4</availability>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(Liao)'>
 			<availability>CC:7,SIC:7</availability>
 		</model>
@@ -11368,19 +11373,16 @@
 		<model name='(Standard)'>
 			<availability>CC:4,General:6,SIC:4</availability>
 		</model>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:3,FRR:3,IS:1,WOB:5,SIC:2,FS:3,Periphery:1,TC:1,CS:5,OA:1,LA:3,FWL:3,NIOPS:5,DC:3</availability>
-		<model name='(3056)'>
-			<roles>asf_carrier</roles>
-			<availability>FS:6</availability>
-		</model>
 		<model name='(2682)'>
 			<roles>asf_carrier</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(3056)'>
+			<roles>asf_carrier</roles>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
@@ -11388,11 +11390,11 @@
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
 		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
@@ -11404,23 +11406,26 @@
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:3,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:3-,CJF:2,DC:6</availability>
-		<model name='VTR-C'>
-			<availability>CC:3,FRR:6,MERC:3,FS:3,DC:6</availability>
+		<model name='VTR-9B'>
+			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FRR:8,FWL:4,MH:4,FS:2,MERC:4,TC:4,Periphery:3,DC:8</availability>
 		</model>
 		<model name='VTR-10S'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='VTR-9B'>
-			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-9D'>
-			<availability>CC:4,LA:5,SIC:5,FS:4</availability>
+		<model name='VTR-C'>
+			<availability>CC:3,FRR:6,MERC:3,FS:3,DC:6</availability>
 		</model>
 		<model name='VTR-9A1'>
 			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1,MERC:1,Periphery:1</availability>
+		</model>
+		<model name='VTR-9S'>
+			<availability>LA:2,CIR:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='VTR-10D'>
 			<availability>FS:4</availability>
@@ -11428,21 +11433,18 @@
 		<model name='VTR-9A'>
 			<availability>CC:1,CS:1,IS:1,SIC:1,FS:1</availability>
 		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FRR:8,FWL:4,MH:4,FS:2,MERC:4,TC:4,Periphery:3,DC:8</availability>
-		</model>
-		<model name='VTR-9S'>
-			<availability>LA:2,CIR:2</availability>
+		<model name='VTR-9D'>
+			<availability>CC:4,LA:5,SIC:5,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CS:5,FRR:5</availability>
+		<model name='VKG-2G'>
+			<availability>CS:4,FRR:5</availability>
+		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-2G'>
-			<availability>CS:4,FRR:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Vincent Corvette' unitType='Warship'>
@@ -11458,23 +11460,23 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:5,FRR:2,MH:2,SIC:9,MERC:4,TC:5</availability>
-		<model name='VND-1SIC'>
-			<availability>SIC:2</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:3,MOC:2,TC:2</availability>
-		</model>
-		<model name='VND-3L'>
-			<availability>CC:8,MOC:3,General:4,TC:3</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>FRR:8,TC:3</availability>
 		</model>
 		<model name='VND-5L'>
 			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
 		</model>
+		<model name='VND-4L'>
+			<availability>CC:3,MOC:2,TC:2</availability>
+		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>FRR:8,TC:3</availability>
+		<model name='VND-3L'>
+			<availability>CC:8,MOC:3,General:4,TC:3</availability>
+		</model>
+		<model name='VND-1SIC'>
+			<availability>SIC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -11491,37 +11493,37 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>CSR:6,CJF:6</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:3,CGS:6,CJF:6</availability>
+		<model name='2'>
+			<availability>CLAN:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5,CJF:8</availability>
+		</model>
+		<model name='4'>
+			<availability>CIH:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:2</availability>
 		</model>
 		<model name='5'>
-			<availability>CIH:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:3</availability>
-		</model>
-		<model name='4'>
 			<availability>CIH:4</availability>
 		</model>
 	</chassis>
@@ -11535,33 +11537,29 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CS:6,LA:3,FRR:4,FWL:2,WOB:6,MERC:2,FS:3,DC:5-</availability>
-		<model name='VNL-K70'>
-			<availability>FRR:3,DC:3</availability>
+		<model name='VNL-K100'>
+			<availability>LA:1,FS:3</availability>
 		</model>
 		<model name='VNL-K75N'>
 			<availability>LA:6,FRR:5,FWL:6,FS:6,DC:6</availability>
 		</model>
-		<model name='VNL-K100'>
-			<availability>LA:1,FS:3</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:6</availability>
+		</model>
+		<model name='VNL-K70'>
+			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>MERC:4,TC:2</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-5N'>
 			<availability>General:4</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
@@ -11570,13 +11568,13 @@
 			<roles>anti_infantry</roles>
 			<availability>General:6,FS:3</availability>
 		</model>
-		<model name='VT-5M'>
-			<roles>anti_infantry</roles>
-			<availability>FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='VL-5T'>
 			<roles>anti_infantry</roles>
 			<availability>MOC:2,PIR:2,IS:2,FS:5,CIR:2,Periphery:2,TC:2</availability>
+		</model>
+		<model name='VT-5M'>
+			<roles>anti_infantry</roles>
+			<availability>FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
@@ -11585,20 +11583,20 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:5,CW:5,CNC:6,CJF:7,CGB:9,DC:1+</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CSR:5,CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:6,CDS:7,CSV:8,CNC:7,General:6,CSJ:7,CGB:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:5,CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CNC:5,CLAN:4,General:1</availability>
@@ -11628,37 +11626,31 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:6</availability>
-		<model name='12'>
-			<availability>CSJ:5</availability>
-		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CCC:4,CDS:4,CLAN:4</availability>
-		</model>
-		<model name='11'>
-			<availability>CSJ:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='10'>
 			<availability>CSJ:6</availability>
 		</model>
+		<model name='12'>
+			<availability>CSJ:5</availability>
+		</model>
 		<model name='4'>
 			<availability>CSA:4,CDS:4,CNC:4,CCO:4,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CCC:4,CDS:4,CLAN:4</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='11'>
+			<availability>CSJ:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:4-,TC:7,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:2,General:4,Periphery.Deep:8,BAN:8,Periphery:4</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:3+,FS:3+,DC:3+</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:2,SIC:2</availability>
 		</model>
@@ -11666,17 +11658,11 @@
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:2,IS:3,FS:4,MERC:3,TC:2</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>LA:8,FS:6,MERC:4</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:6,CC:3,FRR:3,FWL:8,WOB:7,MERC:3,DC:3,Periphery:3</availability>
+		<model name='WHM-6R'>
+			<availability>HL:2,General:4,Periphery.Deep:8,BAN:8,Periphery:4</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:1,FRR:1,FS.DMM:1,FS:1,DC:2</availability>
@@ -11684,14 +11670,23 @@
 		<model name='WHM-6D'>
 			<availability>FS:2</availability>
 		</model>
+		<model name='WHM-7M'>
+			<availability>CS:6,CC:3,FRR:3,FWL:8,WOB:7,MERC:3,DC:3,Periphery:3</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>LA:8,FS:6,MERC:4</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:3+,FS:3+,DC:3+</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
 		<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
 		<model name='H-7'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='H-7C'>
-			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='H-8'>
 			<availability>HL:4,LA:7,FS.CH:8,FRR:6,Periphery.Deep:4,FS:8,MERC:6,Periphery:6</availability>
@@ -11699,61 +11694,64 @@
 		<model name='H-7A'>
 			<availability>HL:3,IS:5,Periphery:5</availability>
 		</model>
+		<model name='H-7C'>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:2-,HL:5,IS:8,NIOPS:2-,Periphery.Deep:5,WOB:2-,CIR:2,Periphery:6</availability>
-		<model name='WSP-1A'>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='WSP-1D'>
-			<roles>recon</roles>
-			<availability>FS:2</availability>
+			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='WSP-1W'>
 			<roles>recon</roles>
 			<availability>MERC.WD:4</availability>
 		</model>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>FRR:2,DC:2</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>LA:8,FS:6,MERC:4</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:2,SIC:2</availability>
 		</model>
 		<model name='WSP-3M'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:6,FWL:8,WOB:7,MH:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1L'>
 			<roles>recon</roles>
-			<availability>FRR:2,DC:2</availability>
+			<availability>CC:2,SIC:2</availability>
+		</model>
+		<model name='WSP-1D'>
+			<roles>recon</roles>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
@@ -11802,23 +11800,20 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>FRR:2,MERC:2,DC:4</availability>
-		<model name='WFT-C'>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='WFT-1'>
 			<availability>General:6</availability>
+		</model>
+		<model name='WFT-C'>
+			<availability>FRR:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:3,MERC.KH:6,MERC.WD:4,LA:7,FRR:5,MH:3,FS:4,CIR:3,MERC:4,CWIE:4</availability>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:6,FS:4,MERC:6</availability>
-		</model>
-		<model name='WLF-1A'>
-			<availability>MERC.KH:1,LA:1</availability>
-		</model>
 		<model name='WLF-1'>
 			<availability>MERC.KH:5,MERC.WD:2,HL:6,LA:5,Periphery.Deep:6,FS:4,MERC:5,Periphery:8</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:6,FS:4,MERC:6</availability>
 		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4,CWIE:6</availability>
@@ -11826,9 +11821,30 @@
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1,LA:1</availability>
 		</model>
+		<model name='WLF-1A'>
+			<availability>MERC.KH:1,LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:6,HL:4,FRR:6,IS:6,Periphery.Deep:5,WOB:3-,SIC:5,FS:7,Periphery:5,TC:5,CS:3-,LA:6,CNC:2,FWL:9,NIOPS:3-,MH:4,DC:6</availability>
+		<model name='WVR-7M'>
+			<roles>recon</roles>
+			<availability>CC:4,FWL:8,WOB:6,MERC:6,DC:4</availability>
+		</model>
+		<model name='WVR-8K'>
+			<availability>FRR:4,CNC:8,MERC:2,DC:4</availability>
+		</model>
+		<model name='WVR-7K'>
+			<roles>recon</roles>
+			<availability>FRR:8,MERC:5,DC:4</availability>
+		</model>
+		<model name='WVR-8D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='WVR-6M'>
+			<roles>recon</roles>
+			<availability>Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:6,MH:4</availability>
+		</model>
 		<model name='WVR-6R'>
 			<roles>recon</roles>
 			<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
@@ -11837,32 +11853,14 @@
 			<roles>recon</roles>
 			<availability>LA:5,FS:8</availability>
 		</model>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,FWL:8,WOB:6,MERC:6,DC:4</availability>
-		</model>
-		<model name='WVR-8D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='WVR-7K'>
-			<roles>recon</roles>
-			<availability>FRR:8,MERC:5,DC:4</availability>
-		</model>
-		<model name='WVR-6M'>
-			<roles>recon</roles>
-			<availability>Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:6,MH:4</availability>
-		</model>
-		<model name='WVR-8K'>
-			<availability>FRR:4,CNC:8,MERC:2,DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -11883,9 +11881,9 @@
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:4,CIH:2,FRR:5,CLAN:2,IS:4,CFM:3,WOB:4,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
-		<model name='WVE-9N'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CS:8,WOB:8</availability>
+			<availability>DC.GHO:5,CS:5,FRR:8,NIOPS:5,WOB:5,CFM:2,FS:8,MERC:8,BAN:3,DC:3</availability>
 		</model>
 		<model name='WVE-10N'>
 			<roles>urban</roles>
@@ -11895,9 +11893,9 @@
 			<roles>urban</roles>
 			<availability>CLAN:1,CFM:2,CGS:2</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-9N'>
 			<roles>urban</roles>
-			<availability>DC.GHO:5,CS:5,FRR:8,NIOPS:5,WOB:5,CFM:2,FS:8,MERC:8,BAN:3,DC:3</availability>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -11952,11 +11950,11 @@
 	</chassis>
 	<chassis name='Yu Huang' unitType='Mek'>
 		<availability>CC:5,MOC:4,TC:4</availability>
-		<model name='Y-H10G'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Y-H9G'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Y-H10G'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zechetinu Corvette' unitType='Warship'>
@@ -11988,11 +11986,11 @@
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-115'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-</availability>
+		</model>
+		<model name='ZRO-115'>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
@@ -12003,20 +12001,20 @@
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:5,LA:10,FRR:4,PIR:2,IS:3,MH:2,FS:7-,MERC:5,Periphery:4,TC:2</availability>
-		<model name='ZEU-6S'>
-			<availability>HL:6,General:3,Periphery.Deep:6,FS:2,Periphery:8</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>LA:8,FRR:6,PIR:4+,FS:4,MERC:4,TC:4+</availability>
 		</model>
-		<model name='ZEU-9S2'>
-			<availability>LA:3+,FS:3+,MERC:3+</availability>
+		<model name='ZEU-6T'>
+			<availability>LA:3,FS:4</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='ZEU-6T'>
-			<availability>LA:3,FS:4</availability>
+		<model name='ZEU-9S2'>
+			<availability>LA:3+,FS:3+,MERC:3+</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:6,General:3,Periphery.Deep:6,FS:2,Periphery:8</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:4,MERC:3</availability>
@@ -12030,11 +12028,11 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,CBS:8,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3067.xml
+++ b/megamek/data/forcegenerator/3067.xml
@@ -956,15 +956,6 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(WoB) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(WoB) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
@@ -972,21 +963,30 @@
 			<roles>spotter</roles>
 			<availability>CS:5,WOB:5</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='(WoB) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(WoB) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
 		<model name='(WoB)' mechanized='true'>
 			<availability>CS:4,WOB:4</availability>
 		</model>
 		<model name='(WoB) [David]' mechanized='true'>
 			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(WoB) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1024,14 +1024,14 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:3,CIH:6,CJF:3</availability>
-		<model name='(Jade Falcon)' mechanized='true'>
-			<availability>CJF:6</availability>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:6</availability>
+		<model name='(Jade Falcon)' mechanized='true'>
+			<availability>CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Agamemnon Heavy Cruiser' unitType='Warship'>
@@ -1043,9 +1043,6 @@
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
 		<availability>CS:7,CLAN:1,FWL:4,NIOPS:7,WOB:7,DC:3</availability>
-		<model name='AHB-MD'>
-			<availability>WOB:3</availability>
-		</model>
 		<model name='AHB-643'>
 			<availability>WOB:5</availability>
 		</model>
@@ -1054,6 +1051,9 @@
 		</model>
 		<model name='AHB-443b'>
 			<availability>CLAN:1,WOB:3</availability>
+		</model>
+		<model name='AHB-MD'>
+			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ailette Zero-G Engineering Exoskeleton' unitType='BattleArmor'>
@@ -1065,9 +1065,8 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>CS:3,FS:6</availability>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4</availability>
@@ -1075,29 +1074,30 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>CNC:3,WOB:3,DC:6</availability>
-		<model name='AKU-2X'>
-			<availability>DC:2</availability>
+		<model name='AKU-1X'>
+			<availability>WOB:6,DC:6</availability>
 		</model>
 		<model name='AKU-1XJ'>
 			<availability>CNC:5,WOB:4,DC:5</availability>
 		</model>
-		<model name='AKU-1X'>
-			<availability>WOB:6,DC:6</availability>
+		<model name='AKU-2X'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:3,CS:7,CDS:4,LA:6,CNC:4,NIOPS:7,WOB:7,FS:5,MERC:3,CWIE:5,DC:3</availability>
-		<model name='Mk VII'>
-			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk VII'>
+			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
@@ -1133,11 +1133,14 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:4,MERC.WD:8,CHH:2,CSR:2,LA:5,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CGB:2</availability>
-		<model name='ANH-4A'>
-			<availability>MERC.WD:5,CHH:5,MERC.KH:5,CWIE:5</availability>
+		<model name='C 2'>
+			<availability>CLAN:6,BAN:1</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>CLAN:1-,MERC:3-</availability>
+		</model>
+		<model name='ANH-4A'>
+			<availability>MERC.WD:5,CHH:5,MERC.KH:5,CWIE:5</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
@@ -1147,9 +1150,6 @@
 		</model>
 		<model name='ANH-3A'>
 			<availability>MERC.WD:5</availability>
-		</model>
-		<model name='C 2'>
-			<availability>CLAN:6,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1168,11 +1168,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:3,MOC:5,PIR:3,TC:3</availability>
-		<model name='ABS-3T'>
-			<availability>CC:5,MOC:5,TC:5</availability>
-		</model>
 		<model name='ABS-3R'>
 			<availability>General:4</availability>
+		</model>
+		<model name='ABS-3T'>
+			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
@@ -1181,18 +1181,12 @@
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>CC:4,FWL:6,WOB:2,MERC:2</availability>
-		<model name='ANV-5M'>
-			<availability>FWL:6,WOB:6</availability>
-		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>CC:8,FWL:5,WOB:5,MERC:5</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
+		<model name='ANV-5M'>
+			<availability>FWL:6,WOB:6</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
@@ -1201,14 +1195,20 @@
 		<model name='ANV-5Q'>
 			<availability>FWL:4,WOB:4</availability>
 		</model>
+		<model name='ANV-3R'>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>CC:8,FWL:5,WOB:5,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,LA:3,FWL:8,MERC:4,FS:3,DC:6</availability>
-		<model name='APL-3T'>
+		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
-		<model name='APL-1R'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1254,119 +1254,110 @@
 	</chassis>
 	<chassis name='Archangel' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:4</availability>
-		<model name='C-ANG-O Invictus'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C-ANG-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-ANG-OE Eminus'>
-			<roles>fire_support</roles>
+		<model name='C-ANG-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OS Caelestis'>
 			<availability>General:4</availability>
 		</model>
-		<model name='C-ANG-OD Luminos'>
+		<model name='C-ANG-OC Comminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-ANG-O Invictus'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C-ANG-OE Eminus'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-ANG-OC Comminus'>
+		<model name='C-ANG-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,HL:4,FRR:4,CLAN:1,IS:5-,Periphery.Deep:5,WOB:2-,FS:5-,Periphery:5,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
-		<model name='ARC-6W'>
-			<roles>fire_support</roles>
-			<availability>FVC:2,TC:3,Periphery:2</availability>
-		</model>
-		<model name='ARC-6S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,FRR:3,MERC:3</availability>
-		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:4-</availability>
-		</model>
-		<model name='ARC-8M'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:3,FRR:2,PIR:2,FWL:4,WOB:3,MERC:2,DC:2</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:5,MERC.WD:5,CWIE:4</availability>
-		</model>
 		<model name='ARC-7L'>
 			<roles>fire_support</roles>
 			<availability>CC:5</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:3-,DC:5-</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:3,WOB:3</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>FRR:8,MERC:4,DC:3</availability>
-		</model>
-		<model name='ARC-9K'>
-			<roles>fire_support</roles>
-			<availability>CNC:4,DC:3</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:8,FS:3</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:2-,LA:4-,FRR:4-,IS:4-,Periphery.Deep:8,BAN:2,DC:4-,Periphery:4-</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:4,MERC:4</availability>
 		</model>
 		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
 			<availability>CLAN:4,FWL:3,BAN:2</availability>
 		</model>
-		<model name='C'>
+		<model name='ARC-5W'>
 			<roles>fire_support</roles>
-			<availability>CSA:6,CCC:6,CW:3,LA:3+,CSV:6,CFM:6,FS:3+,CGS:6,CWIE:3,CB:6,DC:3+</availability>
-		</model>
-		<model name='ARC-4M'>
-			<roles>fire_support</roles>
-			<availability>CS:6,CC:5,FVC:3,LA:3,PIR:4,FWL:8,WOB:6,MERC:5,FS:3,DC:5</availability>
+			<availability>MERC.WD:8,LA:4,MERC:4</availability>
 		</model>
 		<model name='ARC-2W'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:4-</availability>
 		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,FRR:3,MERC:3</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:3,WOB:3</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:4-</availability>
+		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:2,TC:3,Periphery:2</availability>
+		</model>
+		<model name='ARC-9K'>
+			<roles>fire_support</roles>
+			<availability>CNC:4,DC:3</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:6,CCC:6,CW:3,LA:3+,CSV:6,CFM:6,FS:3+,CGS:6,CWIE:3,CB:6,DC:3+</availability>
+		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:8,FS:3</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:5,MERC.WD:5,CWIE:4</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:8,MERC:4,DC:3</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:2-,LA:4-,FRR:4-,IS:4-,Periphery.Deep:8,BAN:2,DC:4-,Periphery:4-</availability>
+		</model>
+		<model name='ARC-4M'>
+			<roles>fire_support</roles>
+			<availability>CS:6,CC:5,FVC:3,LA:3,PIR:4,FWL:8,WOB:6,MERC:5,FS:3,DC:5</availability>
+		</model>
+		<model name='ARC-2K'>
+			<roles>fire_support</roles>
+			<availability>FRR:3-,DC:5-</availability>
+		</model>
+		<model name='ARC-8M'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:3,FRR:2,PIR:2,FWL:4,WOB:3,MERC:2,DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1E'>
-			<availability>General:6</availability>
+		<model name='AF1C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
@@ -1374,6 +1365,15 @@
 		</model>
 		<model name='AF1B'>
 			<availability>General:5</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
@@ -1414,52 +1414,32 @@
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
 		<availability>FS:5+</availability>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
 		<model name='AGS-4D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1469,34 +1449,54 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
 		<availability>MOC:4-,CC:4-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:4-,CS:3-,OA:1-,FVC:1,LA:1,FS.CMM:1-</availability>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
+		<model name='ASN-99'>
+			<roles>spotter</roles>
+			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:5,FVC:4,MH:4,MERC:4,FS:4,CDP:6,TC:5</availability>
 		</model>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
 		<model name='ASN-21'>
 			<availability>General:2-</availability>
-		</model>
-		<model name='ASN-99'>
-			<roles>spotter</roles>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -1539,20 +1539,20 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,CCC:4,CSR:5,CDS:5,CW:5,CSV:5,CFM:3,CGS:5,CJF:3,CCO:3,CGB:6</availability>
-		<model name='(HAG)'>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>LA:2,CLAN:1,WOB:3</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -1560,30 +1560,8 @@
 		<model name='AS7-Dr'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4,IS:4,DC:4</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:3,CLAN:8,FS:3,DC:3</availability>
-		</model>
-		<model name='AS7-CM'>
-			<roles>spotter</roles>
-			<availability>FRR:5,MERC:5,DC:6</availability>
-		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
-		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='AS7-S2'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='AS7-D'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:2-,Periphery:2-</availability>
+		<model name='AS7-K'>
+			<availability>CC:3,MOC:3,CS:3,OA:3,FRR:5,CNC:4,FWL:3,WOB:3,MERC:4,CDP:3,TC:3,DC:8</availability>
 		</model>
 		<model name='AS7-S3'>
 			<availability>LA:4,MERC:2</availability>
@@ -1591,26 +1569,36 @@
 		<model name='AS7-D-DC'>
 			<availability>IS:1-,MERC:0,DC:2-</availability>
 		</model>
-		<model name='AS7-K'>
-			<availability>CC:3,MOC:3,CS:3,OA:3,FRR:5,CNC:4,FWL:3,WOB:3,MERC:4,CDP:3,TC:3,DC:8</availability>
+		<model name='C'>
+			<availability>LA:3,CLAN:8,FS:3,DC:3</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>FRR:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='AS7-CM'>
+			<roles>spotter</roles>
+			<availability>FRR:5,MERC:5,DC:6</availability>
+		</model>
+		<model name='AS7-S2'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:5,FS:5</availability>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(CV)'>
@@ -1621,6 +1609,14 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Gunship)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
@@ -1628,6 +1624,10 @@
 		<model name='(Tanker)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1639,24 +1639,24 @@
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CW:5,CLAN:3,CNC:5,BAN:5,CWIE:5</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
@@ -1667,27 +1667,27 @@
 		<model name='AV1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='AV1-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-OH'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AV1-OE'>
+		<model name='AV1-OD'>
 			<availability>General:6</availability>
+		</model>
+		<model name='AV1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AV1-OR'>
 			<availability>General:1+,CLAN:6,DC:2+</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
@@ -1695,13 +1695,13 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:2,OA:2,LA:4,FRR:2,IS:2,FWL:3,FS:4,CIR:2,TC:2,Periphery:1,DC:3</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>LA:4-,General:4,FS:4-</availability>
+		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
@@ -1709,26 +1709,26 @@
 		<model name='AWS-8R'>
 			<availability>IS:2-,FWL:2-</availability>
 		</model>
-		<model name='AWS-8T'>
-			<availability>IS:2-,CIR:4</availability>
-		</model>
 		<model name='AWS-8V'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='AWS-8Q'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
 		<model name='AWS-10KM'>
 			<availability>FWL:3+,WOB:3,DC:3+</availability>
 		</model>
+		<model name='AWS-8T'>
+			<availability>IS:2-,CIR:4</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:4,PIR:4,FWL:8,IS:6,MH:4,TC:4</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:4,LA:4,FWL:4,FS:4</availability>
-		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:3,FWL:6,IS:3,MH:3,TC:3,Periphery:3</availability>
+		</model>
+		<model name='AWS-9Ma'>
+			<availability>DTA:4,LA:4,FWL:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
@@ -1751,8 +1751,15 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:3,LA:4,FRR:2,FS:3,MERC:2</availability>
+		<model name='AXM-3S'>
+			<availability>LA:4,FS:3,MERC:3</availability>
+		</model>
 		<model name='AXM-4D'>
 			<availability>FS:3</availability>
+		</model>
+		<model name='AXM-2N'>
+			<roles>fire_support</roles>
+			<availability>FVC:2,LA:4,FS:2</availability>
 		</model>
 		<model name='AXM-1N'>
 			<availability>FVC:7,LA:7,FRR:7,MERC:7,FS:7</availability>
@@ -1760,16 +1767,13 @@
 		<model name='AXM-3Sr'>
 			<availability>LA:3,FS:4</availability>
 		</model>
-		<model name='AXM-3S'>
-			<availability>LA:4,FS:3,MERC:3</availability>
-		</model>
-		<model name='AXM-2N'>
-			<roles>fire_support</roles>
-			<availability>FVC:2,LA:4,FS:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:5,CSR:5,CSV:6,CJF:5,CB:4</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CSR:4,CSV:8</availability>
+		</model>
 		<model name='3 &apos;Devil&apos;'>
 			<availability>CSR:5</availability>
 		</model>
@@ -1777,14 +1781,30 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CSR:4,CSV:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:3,MERC.WD:2,CW:2,CLAN:1</availability>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:6,CLAN:5,General:2</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:6,General:2</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -1796,38 +1816,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>CLAN:6,General:2</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:2</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:4</availability>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
@@ -1843,44 +1839,56 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:3,FWL:3,WOB:3,FS:2,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:3</availability>
+		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
 		<model name='BNDR-01B'>
 			<availability>General:4,MERC:8</availability>
 		</model>
-		<model name='BNDR-01Ar'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:3,CLAN:1</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3,CCO:6</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
@@ -1890,24 +1898,20 @@
 			<roles>apc</roles>
 			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:4,MERC:5</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -1917,7 +1921,7 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
@@ -1929,36 +1933,38 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='Prime'>
+		<model name='H'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:7-,CC:3-,HL:8-,FRR:4-,IS:3-,Periphery.Deep:9-,FS:4-,CIR:7-,MERC:4-,Periphery:9-,TC:7-,OA:7-,LA:6-,FWL:3-,MH:7-,DC:3-</availability>
+		<model name='BNC-3Mr'>
+			<availability>MOC:3,FWL:3,WOB:4,CDP:3,TC:3</availability>
+		</model>
 		<model name='BNC-3MC'>
 			<availability>MOC:8-</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>OA:3-,LA:4-,IS:1-,FS:2-,MERC:2-,CIR:3,CDP:3,TC:3-</availability>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
-		<model name='BNC-6S'>
-			<availability>LA:4</availability>
+		<model name='BNC-9S'>
+			<availability>LA:2</availability>
 		</model>
-		<model name='BNC-3Mr'>
-			<availability>MOC:3,FWL:3,WOB:4,CDP:3,TC:3</availability>
+		<model name='BNC-8S'>
+			<availability>LA:4,WOB:9</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:2-,FWL:2-,CDP:2-,TC:2-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:2-</availability>
@@ -1966,24 +1972,24 @@
 		<model name='BNC-3E'>
 			<availability>HL:2-,General:3-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
 		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:4,WOB:9</availability>
+		<model name='BNC-3S'>
+			<availability>OA:3-,LA:4-,IS:1-,FS:2-,MERC:2-,CIR:3,CDP:3,TC:3-</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:7,FRR:3,FS:6,MERC:5</availability>
 		</model>
-		<model name='BNC-9S'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:2-,FWL:2-,CDP:2-,TC:2-</availability>
+		<model name='BNC-6S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,FRR:4,MERC:4</availability>
+		<model name='BGS-1T'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BGS-3T'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
 		<model name='BGS-2T'>
 			<availability>LA:5,MERC:5</availability>
 		</model>
@@ -1991,33 +1997,27 @@
 			<roles>fire_support</roles>
 			<availability>LA:3</availability>
 		</model>
-		<model name='BGS-1T'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BGS-3T'>
-			<availability>LA:4,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:8,CNC:6,CLAN:5,BAN:5</availability>
-		<model name='D'>
-			<availability>CSR:6,CNC:3,CLAN:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Z'>
 			<availability>SOC:10,CCO:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:6,CNC:3,CLAN:2</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
@@ -2026,67 +2026,67 @@
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CSA:3,CCC:5,SOC:4,CSV:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CSV:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4,SOC:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:3,CDS:3,CBS:7,CSV:9,CNC:3,CLAN.IS:3,CGS:7,CCO:3,CJF:5</availability>
+		<model name='C'>
+			<availability>General:6,CCO:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='F'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='F'>
-			<availability>General:5</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:6,CCO:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='IS'>
 		<availability>CS:5</availability>
-		<model name='BTL-C-2O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTL-C-2OE'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='BTL-C-2OB'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='BTL-C-2OF'>
-			<roles>anti_infantry</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='BTL-C-2OA'>
 			<roles>ew_support,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='BTL-C-2OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BTL-C-2OC'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='BTL-C-2OB'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='BTL-C-2O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BTL-C-2OF'>
+			<roles>anti_infantry</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='BTL-C-2OD'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2112,48 +2112,41 @@
 		<model name='BKX-7K'>
 			<availability>FS:6-,MERC:6-</availability>
 		</model>
-		<model name='BKX-1X'>
-			<availability>LA:8-,FS:6-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>FS:6</availability>
+		</model>
+		<model name='BKX-1X'>
+			<availability>LA:8-,FS:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:6,LA:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1-,MERC:0</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:1,WOB:2</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>CS:6,CC:6,FVC:5,PIR:4,FWL:6,IS:3,WOB:7,MH:4,MERC:6</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:5,FRR:3,WOB:4,MERC:3,CJF:3</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,WOB:4,BAN:2</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:1,WOB:1</availability>
 		</model>
-		<model name='BLR-10S'>
-			<availability>LA:4,FS:2</availability>
+		<model name='BLR-1D'>
+			<availability>FVC:4-,FS:5-</availability>
 		</model>
-		<model name='BLR-10S2'>
-			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:5</availability>
+		<model name='BLR-4S'>
+			<availability>LA:5,FRR:3,WOB:4,MERC:3,CJF:3</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>DC.GHO:1,CS:1,WOB:1</availability>
 		</model>
-		<model name='BLR-M3'>
-			<roles>spotter</roles>
-			<availability>FWL:2,WOB:3</availability>
-		</model>
-		<model name='BLR-K4'>
-			<availability>FRR:3,WOB:2,DC:3</availability>
-		</model>
 		<model name='BLR-1S'>
 			<availability>LA:3-</availability>
+		</model>
+		<model name='BLR-10S'>
+			<availability>LA:4,FS:2</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1-,MERC:0</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:5,FS:3</availability>
@@ -2161,21 +2154,28 @@
 		<model name='BLR-1G'>
 			<availability>HL:3-,IS:5-,Periphery.Deep:8,FS:2-,BAN:8,Periphery:5-</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,WOB:4,BAN:2</availability>
+		<model name='BLR-10S2'>
+			<availability>LA:3,FS:2</availability>
 		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:4-,FS:5-</availability>
+		<model name='C'>
+			<availability>CLAN:5</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:1,WOB:2</availability>
+		<model name='BLR-M3'>
+			<roles>spotter</roles>
+			<availability>FWL:2,WOB:3</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>FWL:4,WOB:3</availability>
 		</model>
+		<model name='BLR-K4'>
+			<availability>FRR:3,WOB:2,DC:3</availability>
+		</model>
 		<model name='BLR-CM'>
 			<roles>spotter</roles>
 			<availability>DC:3</availability>
+		</model>
+		<model name='BLR-3M'>
+			<availability>CS:6,CC:6,FVC:5,PIR:4,FWL:6,IS:3,WOB:7,MH:4,MERC:6</availability>
 		</model>
 		<model name='BLR-K3'>
 			<roles>spotter</roles>
@@ -2191,16 +2191,12 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CHH:6,CIH:6,SOC:6,CSV:8,CFM:7,CGS:6,CCO:4,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CJF:7,CGB:6,DC:3+,CB:6</availability>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CIH:7,CNC:9,General:8,CGS:7</availability>
-		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CFM:6,CGS:8,CJF:6</availability>
@@ -2208,8 +2204,12 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,CIH:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -2218,31 +2218,31 @@
 			<roles>spotter</roles>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(C3i)'>
 			<roles>spotter</roles>
 			<availability>WOB:7</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:6,CSR:4,CLAN:1,CGS:5</availability>
-		<model name='(Standard)'>
-			<availability>CSR:5,General:4</availability>
+		<model name='6'>
+			<availability>General:1</availability>
 		</model>
 		<model name='4'>
 			<availability>General:1</availability>
@@ -2253,27 +2253,27 @@
 		<model name='3'>
 			<availability>CHH:5</availability>
 		</model>
-		<model name='6'>
-			<availability>General:1</availability>
-		</model>
 		<model name='5'>
 			<availability>General:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:5,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:4,HL:4,FRR:5,IS:4,WOB:4-,MERC:4,FS:7,Periphery:5,CS:4-,OA:5,CDS:5,LA:5,PIR:4,FWL:3,DC:6</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:4,IS:4,DC:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2,DC:1</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8,DC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:2</availability>
 		</model>
-		<model name='(Kurita)'>
-			<availability>CLAN:4,IS:4,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2302,14 +2302,14 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>LA:7,FRR:3,FS:3,MERC:2</availability>
-		<model name='BRZ-B3'>
-			<availability>LA:3</availability>
+		<model name='BRZ-A3'>
+			<availability>LA:6,FRR:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='BRZ-A3'>
-			<availability>LA:6,FRR:8,FS:8,MERC:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2327,21 +2327,15 @@
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
@@ -2349,38 +2343,44 @@
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:4+,LA:6+,FRR:6+,FS:4+,MERC:4+,DC:7+</availability>
-		<model name='BHKU-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:1,DC:1</availability>
-		</model>
-		<model name='BHKU-OR'>
-			<availability>General:2+,DC:2+</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OE'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OR'>
+			<availability>General:2+,DC:2+</availability>
+		</model>
 		<model name='BHKU-OF'>
 			<availability>General:4</availability>
+		</model>
+		<model name='BHKU-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
@@ -2391,23 +2391,23 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:5,FRR:4,CLAN:6,CFM:5,FS:5,CDP:3,CWIE:7,DC.GHO:3,OA:3,CDS:5,CBS:7,FWL:3,NIOPS:7,CGB:7,CSR:5,CSV:5,WOB:7,FWL.OH:3,MERC:4,CGS:7,Periphery:3,TC:4,CS:7,FVC:3,CW:7,LA:3,CNC:7,CJF:5,DC:4</availability>
-		<model name='BL-12-KNT'>
-			<availability>FS:4</availability>
+		<model name='BL-6b-KNT'>
+			<availability>CS:6,CLAN:5,FWL:6,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
+		</model>
+		<model name='BL-9-KNT'>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='BL-6-KNT'>
 			<availability>DC.GHO:4,CS:4,OA:4,FRR:6,CLAN:6,FWL:6,NIOPS:4,WOB:4,MERC.SI:3,BAN:6,TC:4,DC:6</availability>
 		</model>
-		<model name='BL-6b-KNT'>
-			<availability>CS:6,CLAN:5,FWL:6,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:4-,TC:4-</availability>
-		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:5-,FRR:5-,FWL:2-,MERC:5-,FS:5-,CIR:6,DC:5-</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:4-,TC:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -2415,16 +2415,12 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,CLAN:6</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:6</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6,CCO:6</availability>
@@ -2432,6 +2428,10 @@
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -2450,39 +2450,48 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>MERC:3,MERC.NH:5</availability>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:5-,MOC:4,OA:4,FVC:6,HL:3,IS:1,FS:7,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:3,FS:4,MERC:4,Periphery:3</availability>
-		</model>
 		<model name='BJ-1DC'>
 			<availability>FS:1-</availability>
-		</model>
-		<model name='BJ-4'>
-			<availability>FVC:4,FS:4,MERC:3</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>HL:2,General:4-,Periphery.Deep:8,Periphery:4</availability>
 		</model>
-		<model name='BJ-2'>
-			<availability>CC:3,CS:4,FVC:5,LA:4,PIR:3+,WOB:4,FS:6,MERC:4</availability>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:3,FS:4,MERC:4,Periphery:3</availability>
 		</model>
 		<model name='BJ-1DB'>
 			<availability>FS:1-</availability>
 		</model>
+		<model name='BJ-2'>
+			<availability>CC:3,CS:4,FVC:5,LA:4,PIR:3+,WOB:4,FS:6,MERC:4</availability>
+		</model>
+		<model name='BJ-4'>
+			<availability>FVC:4,FS:4,MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4+,CS:3+,MOC:4+,FVC:3+,FWL:4+,IS:3+,WOB:5+,FS:3+,MERC:3+,DC:5+</availability>
-		<model name='BJ2-O'>
-			<availability>General:7</availability>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
+		</model>
+		<model name='BJ2-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:1+,DC:2+</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:6</availability>
@@ -2490,20 +2499,11 @@
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
-		</model>
 		<model name='BJ2-OD'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:1+,DC:2+</availability>
+		<model name='BJ2-O'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
@@ -2517,39 +2517,39 @@
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,CM:5,WOB:5,MERC:5,TC:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Black Blizzard&apos;'>
 			<availability>CC:4,General:2,WOB:3</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,CHH:4,CCC:3,CBS:3,CB:6</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='G'>
+		<model name='E'>
 			<availability>General:5</availability>
 		</model>
 		<model name='D'>
@@ -2558,20 +2558,20 @@
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
 		<availability>CSA:5,CCC:3,CFM.MiKr:6,CBS:10,CFM:3,CB:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3,CBS:4,CB:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
 		<availability>FWL:5,WOB:4</availability>
-		<model name='B1-HND'>
-			<availability>:0,General:8</availability>
-		</model>
 		<model name='B2-HND'>
 			<availability>General:4</availability>
+		</model>
+		<model name='B1-HND'>
+			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blue Flame' unitType='Mek'>
@@ -2598,13 +2598,17 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:3,OA:5,FVC:3,CDS:4,CLAN:3,IS:1-,NIOPS:3,FWL:1-,WOB:5,DC:3</availability>
-		<model name='BMB-14C'>
+		<model name='BMB-12D'>
 			<roles>fire_support</roles>
-			<availability>CS:6,WOB:6</availability>
+			<availability>CS:4,OA:6,FVC:6,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:8,BAN:8</availability>
 		</model>
 		<model name='BMB-10D'>
 			<roles>fire_support</roles>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='BMB-14C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='BMB-05A'>
 			<roles>missile_artillery,fire_support</roles>
@@ -2613,10 +2617,6 @@
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='BMB-12D'>
-			<roles>fire_support</roles>
-			<availability>CS:4,OA:6,FVC:6,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -2632,13 +2632,13 @@
 			<roles>missile_artillery</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -2653,10 +2653,10 @@
 		<model name='LDT-1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='LDT-X1'>
+		<model name='LDT-X2'>
 			<availability>General:4</availability>
 		</model>
-		<model name='LDT-X2'>
+		<model name='LDT-X1'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -2668,6 +2668,9 @@
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,HL:3,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,CM:6,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -2676,9 +2679,6 @@
 		</model>
 		<model name='(PPC)'>
 			<availability>General:4</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -2690,9 +2690,6 @@
 	</chassis>
 	<chassis name='Buccaneer' unitType='Mek'>
 		<availability>FWL:3,WOB:6</availability>
-		<model name='BCN-3R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BCN-6W'>
 			<roles>fire_support</roles>
 			<availability>WOB:4</availability>
@@ -2700,6 +2697,9 @@
 		<model name='BCN-5W'>
 			<roles>urban</roles>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='BCN-3R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VIII' unitType='Tank'>
@@ -2711,13 +2711,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -2729,11 +2729,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:5,General:8,FS:5,MERC:5,DC:5</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:5,General:8,FS:5,MERC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -2744,11 +2744,11 @@
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CS:7,CHH:4,NIOPS:7,WOB:7</availability>
-		<model name='(HPPC)'>
-			<availability>CS:9,WOB:9</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='(HPPC)'>
+			<availability>CS:9,WOB:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Burrock' unitType='Mek'>
@@ -2784,17 +2784,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>CS:3,FVC:6,LA:4,FS:6,MERC:3</availability>
-		<model name='CES-3R'>
-			<availability>CS:8,FVC:8,General:4,FS:6,MERC:6</availability>
-		</model>
-		<model name='CES-4S'>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='CES-4R'>
 			<availability>FS:4</availability>
 		</model>
 		<model name='CES-3S'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='CES-3R'>
+			<availability>CS:8,FVC:8,General:4,FS:6,MERC:6</availability>
+		</model>
+		<model name='CES-4S'>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -2819,13 +2819,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CCC:1,CHH:1,CSR:3,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -2837,14 +2837,20 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:6,MOC:5,WOB:4,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:3,Periphery.CM:4,Periphery.HR:3,Periphery.ME:3,MH:3</availability>
-		<model name='CTF-1X'>
-			<availability>General:5-,Periphery:6-</availability>
-		</model>
 		<model name='CTF-2X'>
 			<availability>CC:3-,MOC:3,FVC:2,FS:1,MERC:1,TC:3</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:5,LA:6,FS:6</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='CTF-3LL'>
+			<availability>CC:2,MOC:2,MERC:2,TC:2</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FVC:4,FS:4</availability>
@@ -2852,54 +2858,52 @@
 		<model name='CTF-4L'>
 			<availability>CC:6,WOB:6</availability>
 		</model>
-		<model name='CTF-5D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:2,MOC:2,MERC:2,TC:2</availability>
+		<model name='CTF-1X'>
+			<availability>General:5-,Periphery:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,FRR:5,IS:1,MERC:2,CIR:4,FS:1,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:5,DC:6</availability>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,FS:2,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:2-,DC:3-</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:2,PIR:4,MH:6,Periphery:4</availability>
+		</model>
 		<model name='CPLT-K4'>
 			<roles>fire_support</roles>
 			<availability>WOB:3,DC:4</availability>
 		</model>
-		<model name='CPLT-K3'>
+		<model name='CPLT-C1'>
 			<roles>fire_support</roles>
-			<availability>DC:1</availability>
+			<availability>CC:4-,HL:2-,CLAN:2,IS:1-,Periphery.Deep:8,MERC:4-,BAN:5,Periphery:4-</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,TC:4</availability>
+		</model>
+		<model name='CPLT-C4'>
+			<roles>fire_support</roles>
+			<availability>CC:2-,MOC:2-,OA:2-,CDP:2-,TC:2-</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>FRR:5,DC:8</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:5,CS:3,MOC:3,WOB:3,FS:4,CDP:3,TC:3,DC:4</availability>
 		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:4-,HL:2-,CLAN:2,IS:1-,Periphery.Deep:8,MERC:4-,BAN:5,Periphery:4-</availability>
-		</model>
 		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
 			<availability>CC:3</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,PIR:4,MH:6,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>FRR:5,DC:8</availability>
-		</model>
-		<model name='CPLT-A1'>
-			<roles>fire_support</roles>
-			<availability>CC:2-</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:2-,DC:3-</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
@@ -2909,45 +2913,31 @@
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3,TC:3</availability>
 		</model>
-		<model name='CPLT-C4'>
+		<model name='CPLT-K3'>
 			<roles>fire_support</roles>
-			<availability>CC:2-,MOC:2-,OA:2-,CDP:2-,TC:2-</availability>
+			<availability>DC:1</availability>
 		</model>
 		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
 			<availability>DC:3</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,TC:4</availability>
-		</model>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,FS:2,MERC:3,CDP:3,TC:3</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:3,MOC:3</availability>
 		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CCC:5,CSR:5,CDS:5,CW:3,CLAN:3,CNC:5,CGS:6,CJF:3,CGB:3,DC:3+</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:2</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -2956,26 +2946,42 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>LA:1,FS:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,IS:2,CM:3,FS:6,MERC:3</availability>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
@@ -2985,20 +2991,14 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>CSR:2,CBS:4+,SOC:3</availability>
-		<model name='2'>
-			<availability>CSR:6,CBS:6</availability>
-		</model>
 		<model name='4'>
 			<availability>CBS:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSR:6,CBS:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:8,CBS:8</availability>
@@ -3016,14 +3016,14 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CSR:5,CIH:4,CBS:4,SOC:4,CSV:4,CNC:6,CFM:5,CJF:7</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,CSR:6,SOC:6,CNC:8,CFM:6,CJF:6</availability>
+		<model name='4'>
+			<availability>CIH:3</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:6,CIH:4,CBS:6,CSV:4,CFM:6,CJF:4</availability>
 		</model>
-		<model name='4'>
-			<availability>CIH:3</availability>
+		<model name='(Standard)'>
+			<availability>CHH:8,CSR:6,SOC:6,CNC:8,CFM:6,CJF:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:4,CSR:4,CBS:4,CNC:4,CFM:8,CJF:4</availability>
@@ -3031,13 +3031,13 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
@@ -3052,94 +3052,94 @@
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8,WOB:8</availability>
 		</model>
+		<model name='CNT-1A'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:1,IS:2,WOB:2-,Periphery.OS:4,FS:9,MERC:2,CDP:2,Periphery:2,CS:2-,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
-		<model name='CN9-D3'>
-			<availability>FVC:2,FS:3,MERC:3</availability>
-		</model>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:2-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:3</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:6,IS:4,FS:6</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:5,HL:2,LA:2,FRR:2,FWL:2,FS:6,MERC:6,CIR:3,Periphery:4</availability>
+			<availability>FVC:3-,FS:3-,MERC:3-</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:4-,HL:2-,LA:1-,FRR:1-,FWL:1-,Periphery.Deep:8,FS:3-,MERC:3-,Periphery:4-</availability>
 		</model>
+		<model name='CN9-D'>
+			<availability>FVC:5,HL:2,LA:2,FRR:2,FWL:2,FS:6,MERC:6,CIR:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
-			<availability>FVC:3-,FS:3-,MERC:3-</availability>
+			<availability>FVC:2-,FS:2-,MERC:2-</availability>
 		</model>
 		<model name='CN9-D4D'>
 			<availability>FWL:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='CN9-Ar'>
+			<availability>IS:3</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FVC:2,FS:3,MERC:3</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:6,IS:4,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Cephalus' unitType='Mek' omni='Clan'>
 		<availability>SOC:3,CCO:1,CB:2</availability>
-		<model name='A'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='B'>
-			<roles>spotter</roles>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
 		<availability>MOC:4,LA:5,IS:4,MH:4,FS:5,DC:6</availability>
-		<model name='MR-6B'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='MR-5M'>
 			<availability>CC:4,FWL:6,WOB:6</availability>
+		</model>
+		<model name='MR-V2'>
+			<availability>General:8</availability>
 		</model>
 		<model name='MR-V3'>
 			<availability>IS:6</availability>
 		</model>
-		<model name='MR-V2'>
-			<availability>General:8</availability>
+		<model name='MR-6B'>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3162,15 +3162,15 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5,CB:7</availability>
-		<model name='4'>
-			<roles>spotter</roles>
-			<availability>CSR:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<roles>spotter</roles>
+			<availability>CSR:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5</availability>
@@ -3191,51 +3191,47 @@
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:5,CC:5,OA:5,HL:3,LA:6,IS:4,FWL:5,FS:5,TC:5,Periphery:4,DC:4</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:3-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:4,IS:3,FS:4</availability>
 		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:3-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:6,CHH:2,FRR:4,CLAN:2,IS:4,WOB:5,MERC:2,FS:4,CS:5,DC.GHO:6,LA:5,FWL:4,NIOPS:5,CGB:2,DC:5</availability>
+		<model name='CHP-3P'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='CHP-2N'>
+			<availability>IS:4-,NIOPS:0</availability>
+		</model>
 		<model name='CHP-3N'>
 			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,CS:4,LA:4,IS:3,MERC:4</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:3,CHH:2,WOB:4,FS:3,MERC:5,BAN:4,DC.GHO:4-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:3,CGB:2</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:4-,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,CS:4,LA:4,IS:3,MERC:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
-		</model>
-		<model name='CHP-3P'>
-			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CS:4,FRR:3+,IS:3+,NIOPS:4,WOB:6,MERC:2+,BAN:4,Periphery:2+</availability>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
@@ -3248,14 +3244,25 @@
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(CASE)'>
+			<roles>missile_artillery</roles>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:4-,MOC:2-,OA:2-,FVC:2,LA:3-,FRR:4-,FWL:2-,MERC:3-,TC:2-,Periphery:2,DC:4-</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5</availability>
+		</model>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>MERC:4,DC:4</availability>
+		</model>
 		<model name='CGR-3K'>
 			<availability>CC:3-,FRR:3-,MERC:3-,DC:3-</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>CC:4-,FVC:5,HL:3,Periphery:5</availability>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>FVC:4-,OA:4-,FRR:2-,DC:2-</availability>
@@ -3267,67 +3274,60 @@
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:3,MERC:4</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>CC:4-,FVC:5,HL:3,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:2</availability>
+		<model name='F-13'>
+			<availability>FWL:4</availability>
+		</model>
+		<model name='F-12-S'>
+			<availability>FWL:3-,WOB:3-</availability>
+		</model>
+		<model name='F-11-RR'>
+			<roles>recon</roles>
+			<availability>CC:2,FWL:2,MERC:2</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2-,FWL:2-,MERC:2-</availability>
+		</model>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:5-,HL:3-,General:4-,FWL:5-,Periphery.Deep:8,MERC:5-,Periphery:5-</availability>
+		</model>
 		<model name='F-11'>
 			<availability>FRR:6,FWL:8,WOB:8,MERC:6</availability>
 		</model>
 		<model name='F-14-S'>
 			<availability>FWL:8</availability>
 		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:5-,HL:3-,General:4-,FWL:5-,Periphery.Deep:8,MERC:5-,Periphery:5-</availability>
-		</model>
-		<model name='F-11-RR'>
-			<roles>recon</roles>
-			<availability>CC:2,FWL:2,MERC:2</availability>
-		</model>
-		<model name='F-13'>
-			<availability>FWL:4</availability>
-		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2-,FWL:2-,MERC:2-</availability>
-		</model>
-		<model name='F-12-S'>
-			<availability>FWL:3-,WOB:3-</availability>
-		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:5,NIOPS:5,WOB:5,DC:3</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3347,23 +3347,23 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:4,DC:2</availability>
-		<model name='CHP-W7T'>
-			<availability>TC:8</availability>
-		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,FRR:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:2-,LA:4-,IS:3-,Periphery.Deep:8,MERC:4-,BAN:3,Periphery:4-</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>FVC:4,FS:4-,CDP:4,TC:4,Periphery:3-</availability>
 		</model>
-		<model name='CHP-W8'>
-			<availability>LA:5</availability>
-		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:2-,LA:4-,IS:3-,Periphery.Deep:8,MERC:4-,BAN:3,Periphery:4-</availability>
+		<model name='CHP-W7T'>
+			<availability>TC:8</availability>
+		</model>
+		<model name='CHP-W8'>
+			<availability>LA:5</availability>
+		</model>
+		<model name='CHP-W7'>
+			<availability>LA:8,FRR:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
@@ -3377,13 +3377,6 @@
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,LA:2,IS:2,FWL:6,WOB:4-,FS:2,MERC:3,DC:4</availability>
-		<model name='CDA-3P'>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>FWL:4</availability>
-		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
 			<availability>CC:6,FRR:6,FWL:6,WOB:6,MERC:6,DC:6</availability>
@@ -3392,9 +3385,16 @@
 			<roles>recon</roles>
 			<availability>FWL:8,IS:6,MERC:6</availability>
 		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>FWL:4</availability>
+		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:6,IS:4,WOB:5</availability>
+		</model>
+		<model name='CDA-3P'>
+			<availability>FWL:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -3418,20 +3418,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CIH:5,CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -3451,14 +3451,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -3466,29 +3463,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CIH:7,CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -3499,8 +3499,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -3508,18 +3511,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CIH:8,CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -3528,15 +3537,6 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -3554,14 +3554,14 @@
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CIH:6,CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -3569,8 +3569,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -3598,19 +3598,6 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,FRR:2,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,CS:1-,FVC:2,LA:3,FWL:2,NIOPS:1-,DC:2</availability>
-		<model name='CLNT-2-3UL'>
-			<availability>CC:6,TC:4</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>TC:8</availability>
-		</model>
-		<model name='CLNT-5U'>
-			<roles>spotter</roles>
-			<availability>LA:8,MERC:8</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:2-,Periphery.Deep:8,NIOPS:8</availability>
-		</model>
 		<model name='CLNT-2-4T'>
 			<availability>CC:2-,FS:2-</availability>
 		</model>
@@ -3620,20 +3607,33 @@
 		<model name='CLNT-6S'>
 			<availability>LA:6</availability>
 		</model>
+		<model name='CLNT-5U'>
+			<roles>spotter</roles>
+			<availability>LA:8,MERC:8</availability>
+		</model>
+		<model name='CLNT-2-3UL'>
+			<availability>CC:6,TC:4</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:2-,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:6,WOB:6</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,NIOPS:4,WOB:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,NIOPS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra' unitType='Mek'>
@@ -3672,9 +3672,13 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:4,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
-		<model name='COM-1A'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>FVC:2-,LA:2-,Periphery:2-</availability>
+			<availability>FVC:3,LA:8,FRR:6,FS:2,MERC:5</availability>
+		</model>
+		<model name='COM-4H'>
+			<roles>recon</roles>
+			<availability>PIR:8,MH:10</availability>
 		</model>
 		<model name='COM-1B'>
 			<roles>recon</roles>
@@ -3684,50 +3688,46 @@
 			<roles>recon</roles>
 			<availability>WOB:10</availability>
 		</model>
-		<model name='COM-7S'>
+		<model name='COM-1A'>
 			<roles>recon</roles>
-			<availability>LA:6,WOB:6</availability>
-		</model>
-		<model name='COM-5S'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:8,FRR:6,FS:2,MERC:5</availability>
+			<availability>FVC:2-,LA:2-,Periphery:2-</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
 			<availability>LA:3-,MERC:2-</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>PIR:8,MH:10</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>HL:4-,LA:4-,General:5-,Periphery.Deep:6-,TC:5,Periphery:6-</availability>
 		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:6,WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:6,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:8-</availability>
-		</model>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:8,FWL:6,MERC:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,FS:2</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:6-,FVC:4,General:5-,FS:6-,Periphery:5-</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:5-</availability>
 		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:4</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,FS:2</availability>
+		</model>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:8,FWL:6,MERC:6</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>LA:5,IS:5</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:8-</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -3750,24 +3750,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,MERC.WD:1,CSR:1,CW:1,CSV:1,NIOPS:2,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -3789,17 +3789,17 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Copperhead' unitType='Mek'>
@@ -3816,11 +3816,11 @@
 		<model name='CRX-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='CRX-OD'>
-			<availability>General:5</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='CRX-OD'>
+			<availability>General:5</availability>
 		</model>
 		<model name='CRX-OA'>
 			<availability>General:7</availability>
@@ -3837,11 +3837,11 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:7,FWL:1,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:4</availability>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,FRR:6,FS:6,MERC:6</availability>
 		</model>
-		<model name='CSR-V18'>
-			<availability>FS:5</availability>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,FS:2,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>LA:1,FS.AH:3-,Periphery:1</availability>
@@ -3849,11 +3849,11 @@
 		<model name='CSR-V12'>
 			<availability>HL:3-,IS:5-,Periphery.Deep:8,BAN:4,Periphery:5-</availability>
 		</model>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,FRR:6,FS:6,MERC:6</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:4</availability>
 		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,FS:2,BAN:2</availability>
+		<model name='CSR-V18'>
+			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -3871,50 +3871,50 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='XR'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='G'>
 			<availability>CHH:6,General:4</availability>
+		</model>
+		<model name='XR'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
 		<availability>CIH:3,CSV:4,CJF:5,CCO:5</availability>
-		<model name='H'>
-			<availability>CSA:6,General:5</availability>
-		</model>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>CW:3,CJF:3,CWIE:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<availability>CW:3,CJF:3,CWIE:3</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,General:5</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -3923,9 +3923,9 @@
 			<roles>raider</roles>
 			<availability>CS:5,FRR:4,CLAN:4,WOB:5,CGS:6,BAN:2,DC:4</availability>
 		</model>
-		<model name='CRB-27'>
+		<model name='CRB-20'>
 			<roles>raider</roles>
-			<availability>DC.GHO:5-,CS:3,FRR:3,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
+			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
 		<model name='CRB-45'>
 			<availability>WOB:5</availability>
@@ -3933,12 +3933,12 @@
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:5-,CS:3,FRR:3,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
+		</model>
 		<model name='CRB-30'>
 			<availability>CS:8,FRR:5,WOB:6</availability>
-		</model>
-		<model name='CRB-20'>
-			<roles>raider</roles>
-			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
@@ -3952,30 +3952,33 @@
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CFM.MiKr:7,CDS:2,CBS:6,CFM:4,CB:3</availability>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CBS:8,General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:7,CSR:5,FRR:6,CSV:5,CLAN:6,CFM:5,WOB:8,CIR:3,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:7,NIOPS:9,CJF:5,CGB:7</availability>
-		<model name='CRK-5003-3'>
-			<availability>CS:8,FRR:4</availability>
+		<model name='CRK-5004-1'>
+			<availability>CS:6,FRR:4</availability>
+		</model>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
 		<model name='CRK-5005-1'>
 			<availability>WOB:8,CIR:6</availability>
@@ -3986,23 +3989,20 @@
 		<model name='CRK-5003-1'>
 			<availability>CS:4,FRR:4,CLAN:6,NIOPS:4,WOB:4,CIR:4,BAN:8</availability>
 		</model>
-		<model name='CRK-5004-1'>
-			<availability>CS:6,FRR:4</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		<model name='CRK-5003-3'>
+			<availability>CS:8,FRR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
 		<availability>CS:3,HL:3,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:3,MERC:4,Periphery:4</availability>
-		<model name='CNS-5M'>
-			<availability>CS:0,PIR:4,IS:8</availability>
-		</model>
 		<model name='CNS-3M'>
 			<availability>General:4</availability>
 		</model>
 		<model name='CNS-TD9'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='CNS-5M'>
+			<availability>CS:0,PIR:4,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
@@ -4013,25 +4013,25 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CSR:4,CDS:4,CW:4,CBS:5,CSV:8,CLAN:3,CNC:4,CCO:3,CJF:4,CWIE:4,CGB:4</availability>
-		<model name='D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='A'>
 			<availability>General:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
 		<model name='H'>
 			<availability>CLAN:5,IS:2</availability>
 		</model>
-		<model name='E'>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4041,50 +4041,17 @@
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:4,DC:8</availability>
 		</model>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:5,CLAN:5,IS:7,NIOPS:6-,Periphery.Deep:5,WOB:4-,Periphery:6</availability>
-		<model name='CRD-4D'>
-			<availability>FVC:8,FS:8</availability>
-		</model>
-		<model name='CRD-2R'>
-			<availability>CLAN:4,FWL:3,WOB:4,MERC:3,CGS:6,BAN:2</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>MERC:6</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>FRR:5,WOB:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='CRD-6M'>
-			<availability>FWL:3,WOB:3,MERC:3</availability>
-		</model>
-		<model name='CRD-7L'>
-			<availability>CC:5,WOB:4</availability>
-		</model>
-		<model name='CRD-5S'>
-			<availability>LA:8,FS:3,MERC:4</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>FWL:3,WOB:4,MERC:3</availability>
-		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:2-,DC:3-</availability>
-		</model>
 		<model name='CRD-8S'>
 			<availability>LA:4,FS:3</availability>
 		</model>
@@ -4092,52 +4059,85 @@
 			<roles>raider</roles>
 			<availability>CC:4-</availability>
 		</model>
+		<model name='CRD-7L'>
+			<availability>CC:5,WOB:4</availability>
+		</model>
+		<model name='CRD-3R'>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
+		</model>
 		<model name='CRD-5M'>
 			<availability>CC:4,CS:4,FWL:8,IS:3,WOB:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FVC:3-,FS:3-</availability>
+		<model name='CRD-3K'>
+			<availability>FRR:2-,DC:3-</availability>
+		</model>
+		<model name='CRD-7W'>
+			<availability>FWL:3,WOB:4,MERC:3</availability>
 		</model>
 		<model name='CRD-4K'>
 			<availability>LA:3,FRR:8,MERC:3,FS:3,DC:8</availability>
 		</model>
+		<model name='CRD-4BR'>
+			<availability>MERC:6</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:8,FS:3,MERC:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>FRR:5,WOB:4,MERC:4,DC:5</availability>
+		</model>
+		<model name='CRD-2R'>
+			<availability>CLAN:4,FWL:3,WOB:4,MERC:3,CGS:6,BAN:2</availability>
+		</model>
+		<model name='CRD-3D'>
+			<availability>FVC:3-,FS:3-</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>FWL:3,WOB:3,MERC:3</availability>
+		</model>
+		<model name='CRD-4D'>
+			<availability>FVC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
-		<model name='CP-11-C'>
-			<roles>spotter</roles>
-			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,DC:5</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='CP-11-H'>
-			<availability>PIR:6,MH:6,CIR:6,CDP:6,TC:6</availability>
-		</model>
-		<model name='CP-10-Z'>
-			<availability>OA:4-,General:5-,IS:4-,FS:4-,MERC:4-,DC:4-,TC:4-</availability>
-		</model>
-		<model name='CP-11-A'>
-			<availability>CC:6,CS:4,MOC:4,LA:6,FWL:6,IS:6,WOB:6,FS:8,CDP:4,DC:4,TC:4</availability>
-		</model>
 		<model name='CP-11-G'>
 			<availability>CS:6,FRR:6,SL.2:6,MERC:4</availability>
 		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:2-</availability>
 		</model>
-		<model name='CP-10-HQ'>
-			<availability>IS:2</availability>
+		<model name='CP-12-K'>
+			<availability>MERC:5,DC:5</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>CC:6,CS:4,MOC:4,LA:6,FWL:6,IS:6,WOB:6,FS:8,CDP:4,DC:4,TC:4</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:4-,General:5-,IS:4-,FS:4-,MERC:4-,DC:4-,TC:4-</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:5,DC:5</availability>
-		</model>
 		<model name='CP-11-B'>
 			<availability>CC:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='CP-11-C'>
+			<roles>spotter</roles>
+			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,DC:5</availability>
+		</model>
+		<model name='CP-11-H'>
+			<availability>PIR:6,MH:6,CIR:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='CP-10-HQ'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>IS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -4146,6 +4146,10 @@
 			<roles>recon,escort</roles>
 			<availability>HL:2,MERC:4,TC:2,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,escort</roles>
+			<availability>CS:6,General:4,NIOPS:6,WOB:6</availability>
+		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -4153,10 +4157,6 @@
 		<model name='(Plasma)'>
 			<roles>recon,escort</roles>
 			<availability>TC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,escort</roles>
-			<availability>CS:6,General:4,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
@@ -4173,18 +4173,18 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>WOB:4,FS:6+</availability>
-		<model name='DARO-1'>
-			<availability>General:6,FS:8</availability>
-		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='DARO-1C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1'>
+			<availability>General:6,FS:8</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1A'>
 			<availability>General:7</availability>
@@ -4207,13 +4207,13 @@
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
 		<availability>FRR:3+,DC:3+</availability>
-		<model name='67-K'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='67-K2'>
 			<roles>support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='67-K'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
@@ -4221,46 +4221,46 @@
 		<model name='DMO-4K'>
 			<availability>FRR:4,DC:6</availability>
 		</model>
-		<model name='DMO-5K'>
-			<roles>spotter</roles>
-			<availability>FRR:2,DC:2</availability>
+		<model name='DMO-2K'>
+			<availability>FRR:4,DC:5</availability>
 		</model>
 		<model name='DMO-1K'>
 			<availability>General:8,DC:6</availability>
 		</model>
-		<model name='DMO-2K'>
-			<availability>FRR:4,DC:5</availability>
+		<model name='DMO-5K'>
+			<roles>spotter</roles>
+			<availability>FRR:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,IS:3+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,CB:4,DC:3+</availability>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4,CGS:5,CCO:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4289,18 +4289,15 @@
 		<model name='DRT-3S'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='DRT-4S'>
-			<availability>LA:4,FS:6,MERC:4,CIR:4</availability>
-		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5</availability>
+		</model>
+		<model name='DRT-4S'>
+			<availability>LA:4,FS:6,MERC:4,CIR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:4,FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5</availability>
@@ -4308,6 +4305,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -4317,13 +4318,18 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CCC:4,CIH:4,CLAN:4,IS:3+,CCO:3,BAN:4,CSA:3,MERC.WD:4,CDS:4,CJF:3,CGB:7,CB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CIH:3,CDS:3,CBS:2,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CSA:4,CHH:7,CIH:6,General:2,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:3,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:3</availability>
@@ -4331,18 +4337,15 @@
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
 		</model>
+		<model name='K'>
+			<availability>General:2,CGB:4</availability>
+		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:5,CHH:8,CIH:6,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CIH:3,CDS:3,CBS:2,General:4,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CIH:7,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<availability>CSA:4,CHH:7,CIH:6,General:2,CWIE:5,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8,CB:6</availability>
@@ -4350,19 +4353,16 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7,CB:5</availability>
 		</model>
-		<model name='K'>
-			<availability>General:2,CGB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Davion Destroyer' unitType='Warship'>
 		<availability>CB:1</availability>
-		<model name='Block II'>
-			<roles>destroyer</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='Block I'>
 			<roles>destroyer</roles>
 			<availability>CB:8</availability>
+		</model>
+		<model name='Block II'>
+			<roles>destroyer</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Deathstalker' unitType='Aero'>
@@ -4373,19 +4373,19 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:4+,WOB:5+</availability>
-		<model name='DFC-OD'>
-			<roles>ground_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='DFC-OB'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='DFC-OD'>
+			<roles>ground_support</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OB'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -4396,11 +4396,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:3</availability>
-		<model name='DFN-3T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='DFN-3S'>
 			<availability>General:1</availability>
+		</model>
+		<model name='DFN-3T'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -4418,24 +4418,24 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:6,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,MOC:4,CS:4,LA:4,FRR:4,IS:2,FWL:4,WOB:4,FS:4,CDP:4,TC:4,DC:4</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:8,CS:8,MOC:4,LA:8,FRR:6,FWL:8,IS:5,WOB:8,FS:8,DC:8,TC:4,CWIE:4</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>DC:5</availability>
+		<model name='(Defensive)'>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,MOC:4,CS:4,LA:4,FRR:4,IS:2,FWL:4,WOB:4,FS:4,CDP:4,TC:4,DC:4</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -4444,12 +4444,12 @@
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
 		<availability>LA:5,CWIE:3</availability>
-		<model name='(Thunderbolt)'>
-			<availability>LA:2,CWIE:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>LA:2,CWIE:2</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -4465,11 +4465,11 @@
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
 		<availability>CS:8,FRR:6,CLAN:6,NIOPS:8,WOB:9,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(HGR)'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CS:4,CHH:6,CLAN:4,NIOPS:4,WOB:4</availability>
@@ -4480,31 +4480,27 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:2,FRR:3,IS:3,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:3,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
-		<model name='DV-1S'>
-			<availability>IS:2-</availability>
-		</model>
 		<model name='DV-8D'>
 			<availability>FS:4,MERC:4</availability>
-		</model>
-		<model name='DV-6Mr'>
-			<availability>General:2</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:6,LA:6,FS:8,MERC:4,TC:4</availability>
-		</model>
-		<model name='DV-9D'>
-			<availability>FS:4</availability>
 		</model>
 		<model name='DV-6M'>
 			<availability>HL:4,CLAN:4,IS:5-,Periphery.Deep:6,Periphery:6</availability>
 		</model>
+		<model name='DV-9D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='DV-7D'>
+			<availability>FVC:6,LA:6,FS:8,MERC:4,TC:4</availability>
+		</model>
+		<model name='DV-6Mr'>
+			<availability>General:2</availability>
+		</model>
+		<model name='DV-1S'>
+			<availability>IS:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Deva' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
-		<model name='C-DVA-OE Eminus'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-DVA-OS Caelestis'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:4</availability>
@@ -4517,9 +4513,13 @@
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-O Invictus'>
+		<model name='C-DVA-OE Eminus'>
 			<deployedWith>Grigori</deployedWith>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-DVA-OA Dominus'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:7</availability>
 		</model>
 		<model name='C-DVA-OU Exanimus'>
 			<deployedWith>Grigori</deployedWith>
@@ -4529,9 +4529,9 @@
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-OA Dominus'>
+		<model name='C-DVA-O Invictus'>
 			<deployedWith>Grigori</deployedWith>
-			<availability>General:7</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -4542,14 +4542,14 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:3,FVC:6,LA:6,FS:6,MERC:3,TC:4</availability>
-		<model name='DVS-1D'>
-			<availability>FVC:8,LA:2,FS:2,TC:8</availability>
+		<model name='DVS-3'>
+			<availability>LA:3,FS:3</availability>
 		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='DVS-3'>
-			<availability>LA:3,FS:3</availability>
+		<model name='DVS-1D'>
+			<availability>FVC:8,LA:2,FS:2,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Djinn Battle Armor' unitType='BattleArmor'>
@@ -4564,9 +4564,6 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:4</availability>
@@ -4574,6 +4571,9 @@
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CIH:4,CGS:6,CB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau Assault Interceptor' unitType='Dropship'>
@@ -4597,14 +4597,14 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,LA:2,FRR:7,MERC:3,DC:6</availability>
-		<model name='DRG-5N'>
-			<availability>FRR:6,MERC:6,DC:6</availability>
-		</model>
 		<model name='DRG-7N'>
 			<availability>LA:3,MERC:4,DC:4</availability>
 		</model>
 		<model name='DRG-1N'>
 			<availability>FRR:2-,DC:2-,Periphery:4</availability>
+		</model>
+		<model name='DRG-5N'>
+			<availability>FRR:6,MERC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
@@ -4613,16 +4613,6 @@
 			<roles>anti_infantry</roles>
 			<availability>CIH:5,General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>General:2,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
@@ -4630,38 +4620,48 @@
 			<roles>spotter</roles>
 			<availability>SOC:10,CCO:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:1</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7</availability>
 		</model>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>General:2,CGB:5</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7</availability>
+		</model>
 		<model name='I'>
 			<availability>CIH:5,General:2</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,FWL:3-,CC.MAC:4-,DC:3-</availability>
-		<model name='(SRM)'>
-			<availability>CC:6-,General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:4-,General:5-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>LA:8,WOB:6,FS:6</availability>
+		<model name='(SRM)'>
+			<availability>CC:6-,General:3</availability>
 		</model>
 		<model name='(ERLL)'>
 			<availability>LA:1,WOB:2,FS:1</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:8,WOB:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -4689,14 +4689,8 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
-		<model name='EGL-R6'>
-			<availability>LA:1-,General:6-,FS:1-</availability>
-		</model>
 		<model name='EGL-R4'>
 			<availability>LA:2,FS:2</availability>
-		</model>
-		<model name='EGL-R11'>
-			<availability>LA:3,MERC:3</availability>
 		</model>
 		<model name='EGL-R9'>
 			<availability>LA:1-,FS:1-</availability>
@@ -4705,15 +4699,21 @@
 			<roles>ground_support</roles>
 			<availability>LA:2-,FS:2-</availability>
 		</model>
+		<model name='EGL-R11'>
+			<availability>LA:3,MERC:3</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:1-,General:6-,FS:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,FWL.MM:6,FWL:5,MH:4,FWL.FO:6,MERC:4</availability>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
-		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -4724,86 +4724,86 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:3+,MERC:2+</availability>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='EST-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='EST-OA'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:7,MERC.WD:7,CW:7,CLAN:7,CNC:7+</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [AP Gauss]' mechanized='true'>
 			<availability>CJF:3</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='(Fire) [MicroPL]' mechanized='true'>
-			<availability>CJF:3</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='[MicroPL]' mechanized='true'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:4,CLAN:2</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Space) [MicroPL]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:3,CLAN:2</availability>
 		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Fire) [Flamer]' mechanized='true'>
 			<availability>CJF:3</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:4,CLAN:2</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [MicroPL]' mechanized='true'>
+			<availability>CJF:3</availability>
+		</model>
+		<model name='[MicroPL]' mechanized='true'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:3,MOC:4,CLAN:2,IS:4,WOB:7,FS:3,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
-		<model name='EMP-6M'>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
-		<model name='EMP-6D'>
-			<availability>FS:6</availability>
-		</model>
 		<model name='EMP-6L'>
 			<availability>CC:5</availability>
 		</model>
-		<model name='EMP-6S'>
-			<availability>LA:6</availability>
+		<model name='EMP-7L'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>CC:6,CS:8,HL:6,LA:6,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:6,FS:6,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='EMP-7L'>
-			<availability>CC:4</availability>
+		<model name='EMP-6M'>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
+		<model name='EMP-6S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='EMP-6D'>
+			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
@@ -4812,17 +4812,20 @@
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4,FS:4</availability>
 		</model>
-		<model name='END-6S'>
-			<roles>urban</roles>
-			<availability>LA:3,MERC:3</availability>
-		</model>
 		<model name='END-6Q'>
 			<roles>urban</roles>
 			<availability>LA:6,General:4,MERC:6</availability>
 		</model>
+		<model name='END-6S'>
+			<roles>urban</roles>
+			<availability>LA:3,MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:6,FS:6,MERC:4</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
 		<model name='ENF-6H'>
 			<availability>FS:3</availability>
 		</model>
@@ -4832,17 +4835,14 @@
 		<model name='ENF-6G'>
 			<availability>FS:2,MERC:4</availability>
 		</model>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>CC:2,FS:8,MERC:5,Periphery.OS:3,CDP:3,TC:3,Periphery:2,FVC:7,OA:3,LA:4,Periphery.HR:3,MH:2,DC:2</availability>
-		<model name='ENF-4R'>
-			<availability>FVC:4-,General:4-,FS:5-,TC:5-</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>FVC:8,LA:3,FS:8,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>FVC:4-,General:4-,FS:5-,TC:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -4868,14 +4868,6 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CIH:3+,CDS:4+,CW:4+,CNC:3+,CGS:3+,CGB:3+,CWIE:4+,CB:3+</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>CHH:8</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
@@ -4884,13 +4876,21 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>CHH:8</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
+			<availability>General:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Erinyes' unitType='ProtoMek'>
@@ -4907,17 +4907,21 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CS:4,CIH:1,CSR:1,CDS:2,CSV:1,FWL:2,WOB:2,CGS:1,CCO:1,DC:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CS:4,CLAN:8,DC:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,FS:6</availability>
@@ -4925,20 +4929,12 @@
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:4,FS:3,MERC:2</availability>
 		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5,CIR:2+,DC:4</availability>
 		<model name='EXC-B2b'>
 			<roles>fire_support</roles>
 			<availability>CLAN:4,WOB:4,CGS:6,BAN:2</availability>
-		</model>
-		<model name='EXC-CS'>
-			<roles>fire_support</roles>
-			<availability>CS:8,WOB:8,DC:8</availability>
 		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
@@ -4951,6 +4947,10 @@
 		<model name='EXC-D1'>
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='EXC-CS'>
+			<roles>fire_support</roles>
+			<availability>CS:8,WOB:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -4966,11 +4966,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,DC.GHO:1,CLAN:1,NIOPS:4,WOB:4,DC:1</availability>
-		<model name='EXT-5F'>
-			<availability>CS:6</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:2,DC:8</availability>
+		</model>
+		<model name='EXT-5F'>
+			<availability>CS:6</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -4981,41 +4981,41 @@
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
 		<availability>MOC:5</availability>
-		<model name='EYL-45A'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='EYL-4A'>
+			<availability>MOC:2</availability>
 		</model>
 		<model name='EYL-35A'>
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='EYL-4A'>
-			<availability>MOC:2</availability>
+		<model name='EYL-45A'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:7</availability>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CC:5</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='(Support) [King David]' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -5035,12 +5035,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5063,11 +5063,11 @@
 		<model name='FLC-6C'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
@@ -5085,75 +5085,71 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:4</availability>
-		<model name='(Upgrade)'>
-			<roles>cruiser</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Upgrade)'>
+			<roles>cruiser</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SRM]' mechanized='false'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[SL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:2</availability>
+		</model>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[SRM]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:3+,CHH:4,CIH:6,CSV:4,CLAN:2,IS:3+,CWIE:7,MERC.WD:7,CDS:2,CW:7,CNC:2,CJF:5,CGB:4</availability>
-		<model name='B'>
-			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CGS:4,CWIE:3</availability>
-		</model>
-		<model name='H'>
-			<availability>General:2,CWIE:5</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:7,CSV:5,CNC:4,General:6,CJF:7</availability>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CIH:6,CDS:7,CW:6,CSV:6,CNC:6,General:4,CJF:6,CGB:6</availability>
 		</model>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		<model name='A'>
+			<availability>CDS:7,CSV:5,CNC:4,General:6,CJF:7</availability>
+		</model>
+		<model name='B'>
+			<availability>CIH:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>General:2,CWIE:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CIH:5,CDS:6,CW:3,CSV:3,CNC:5,General:4,CGS:4,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:4,HL:4,LA:5,Periphery.HR:4,Periphery.MW:4,Periphery.CM:4,FWL:4,FS:6</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
-		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
 			<availability>LA:3,FWL:2,FS:5</availability>
@@ -5161,6 +5157,10 @@
 		<model name='(Standard)'>
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -5187,63 +5187,15 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(LBX20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(UAC20)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
-		</model>
 		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -5251,9 +5203,57 @@
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(LBX2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LBX10)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
@@ -5262,67 +5262,67 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CIH:5,SOC:5,CNC:3,CFM:6,CLAN.HW:5,CJF:7</availability>
-		<model name='Prime'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:2,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CSA:7,CLAN:6,IS:2</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CSA:7,CLAN:6,IS:2</availability>
+		</model>
+		<model name='E'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:2,CCO:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
 		<availability>CGS:8</availability>
-		<model name='(Standard)'>
+		<model name='2'>
 			<roles>urban</roles>
-			<availability>CLAN:8</availability>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='3'>
 			<roles>urban</roles>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='2'>
+		<model name='(Standard)'>
 			<roles>urban</roles>
-			<availability>CLAN:6</availability>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,FS:7,MERC:5</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:6,MERC:6,FS:6</availability>
-		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,LA:4,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -5344,19 +5344,19 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:6,MERC.WD:2,CIH:4,CLAN:2,WOB:5,BAN:1</availability>
-		<model name='C'>
-			<availability>MERC.WD:4,CLAN:8,BAN:1</availability>
+		<model name='FFL-4D'>
+			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4,CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FFL-4C'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='FFL-4DA'>
-			<availability>MERC.WD:4</availability>
-		</model>
-		<model name='FFL-4D'>
 			<availability>MERC.WD:4</availability>
 		</model>
 	</chassis>
@@ -5365,15 +5365,6 @@
 		<model name='FS9-B'>
 			<availability>WOB:6</availability>
 		</model>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:4,CS:4,MOC:5,LA:7,FRR:5,General:4,FS:5,TC:4</availability>
-		</model>
 		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
 			<availability>LA:1-,LA.SR:2-</availability>
@@ -5381,8 +5372,17 @@
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,CIR:7,Periphery:3,TC:4</availability>
 		</model>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
 		<model name='FS9-P'>
 			<availability>FVC:2,Periphery:2</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:4,CS:4,MOC:5,LA:7,FRR:5,General:4,FS:5,TC:4</availability>
 		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
@@ -5391,47 +5391,50 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:5+,CC:4+,FVC:4+,LA:5+,IS:4+,WOB:5+,FS:5+,MERC:4+,DC:7+</availability>
-		<model name='FS9-OE'>
+		<model name='FS9-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='FS9-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OX'>
-			<availability>General:2</availability>
-		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='FS9-OH'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OA'>
+		<model name='FS9-OE'>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OR'>
 			<availability>CLAN:4,IS:1+,DC:1+</availability>
 		</model>
+		<model name='FS9-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OX'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:3,CSV:5,FRR:4,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:5,Periphery.R:2,CDS:3,LA:5,CBS:3,FWL:2,NIOPS:5,CJF:5,CGB:3,DC:4</availability>
-		<model name='FLS-9M'>
-			<availability>FWL:6</availability>
+		<model name='FLS-9C'>
+			<availability>CS:6</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:4-,LA:4-</availability>
 		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,CS:4,LA:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
@@ -5439,11 +5442,8 @@
 		<model name='FLS-C'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='FLS-9C'>
-			<availability>CS:6</availability>
-		</model>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:4-,LA:4-</availability>
+		<model name='FLS-9M'>
+			<availability>FWL:6</availability>
 		</model>
 		<model name='FLS-9B'>
 			<availability>WOB:6</availability>
@@ -5451,49 +5451,49 @@
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:4,MERC:4,CIR:4,Periphery:4,TC:4</availability>
-		<model name='FLE-15'>
-			<availability>MERC.WD:1,FWL:1</availability>
-		</model>
-		<model name='FLE-20'>
-			<availability>CC:2</availability>
-		</model>
-		<model name='FLE-17'>
-			<availability>CC:8,FWL:4,WOB:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='FLE-19'>
 			<roles>urban</roles>
 			<availability>MOC:4-,CC:4-,FVC:4-,OA:4-,HL:4-,FWL:4-,WOB:4-,MERC:5-,Periphery:6-,TC:4-</availability>
 		</model>
+		<model name='FLE-20'>
+			<availability>CC:2</availability>
+		</model>
+		<model name='FLE-15'>
+			<availability>MERC.WD:1,FWL:1</availability>
+		</model>
 		<model name='&apos;Fire Ant&apos;'>
 			<roles>urban</roles>
 			<availability>CC:2,CM:4</availability>
+		</model>
+		<model name='FLE-17'>
+			<availability>CC:8,FWL:4,WOB:4,MERC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -5504,20 +5504,18 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
@@ -5528,20 +5526,22 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
 		<availability>CS:4,LA:4,CBS:1,NIOPS:4,FS:4,Periphery:1</availability>
-		<model name='(2613)'>
-			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3058)'>
 			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
 			<availability>CS:8,LA:8,FS:8</availability>
+		</model>
+		<model name='(2613)'>
+			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortune Wheeled Assault Vehicle' unitType='Tank'>
@@ -5588,14 +5588,14 @@
 			<roles>apc,spotter</roles>
 			<availability>FS:3</availability>
 		</model>
-		<model name='CX-17'>
-			<availability>CS:8</availability>
+		<model name='(Royal)'>
+			<availability>CLAN:4,WOB:4,BAN:2</availability>
 		</model>
 		<model name='(C3S)'>
 			<availability>FS:5</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:4,WOB:4,BAN:2</availability>
+		<model name='CX-17'>
+			<availability>CS:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -5615,10 +5615,6 @@
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
 		<availability>CS:3,FRR:2,NIOPS:3,WOB:4,TC:4</availability>
-		<model name='(TDF)'>
-			<roles>recon</roles>
-			<availability>TC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
@@ -5626,74 +5622,78 @@
 		<model name='(ERSL)'>
 			<availability>TC:4</availability>
 		</model>
+		<model name='(TDF)'>
+			<roles>recon</roles>
+			<availability>TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:4,CW:4,CLAN:3</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:6</availability>
-		</model>
 		<model name='3'>
 			<availability>CSA:6,CB:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CW:6,CLAN:4,CGS:6,CCO:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:1,LA:1,FRR:1,IS:1,DC:1,Periphery:1</availability>
+		<model name='GAL-102'>
+			<roles>recon</roles>
+			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
 		</model>
 		<model name='GAL-104'>
 			<availability>WOB:5</availability>
 		</model>
-		<model name='GAL-103'>
-			<roles>recon</roles>
-			<availability>WOB:6</availability>
+		<model name='GAL-200'>
+			<availability>MOC:1,LA:1,FRR:1,IS:1,DC:1,Periphery:1</availability>
 		</model>
 		<model name='GAL-100'>
 			<deployedWith>Harasser</deployedWith>
 			<availability>General:5-</availability>
 		</model>
-		<model name='GAL-102'>
+		<model name='GAL-103'>
 			<roles>recon</roles>
-			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
+			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>CC:3,MOC:3,MERC.WD:8,IS:5,FWL:3,MH:4,MERC:6,TC:3</availability>
-		<model name='GAL-2GLS'>
-			<availability>HL:2-,IS:4-,Periphery:4-</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:6,Periphery:8</availability>
-		</model>
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,MERC:4</availability>
 		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:3</availability>
 		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,MERC:4</availability>
+		<model name='GAL-2GLS'>
+			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8-</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,MERC:4</availability>
+		</model>
 		<model name='GAL-4GLSA'>
 			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:6,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:5,FS:5,MERC:4,CDP:4,TC:4</availability>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01B'>
 			<availability>FVC:7,IS:7,CDP:7</availability>
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
-		</model>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -5709,32 +5709,32 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:3,CDS:5,CSR:2,CNC:5,CLAN:5,IS:2+,CJF:4,BAN:4,CGB:9,CB:4,CWIE:3</availability>
-		<model name='Prime'>
-			<availability>CW:7,CSV:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:7,CSV:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
-		</model>
-		<model name='P'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CSV:5,General:7,CGB:4</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CGB:5</availability>
 		</model>
-		<model name='K'>
-			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		</model>
+		<model name='P'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CSV:5,General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
@@ -5751,22 +5751,22 @@
 	</chassis>
 	<chassis name='Gladius Medium Hover Tank' unitType='Tank'>
 		<availability>CC:1,MOC:3,Periphery.CM:1,Periphery.ME:1,MH:6,CDP:4,TC:5,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk II'>
 			<availability>MH:4,TC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Glaive Medium Tank' unitType='Tank'>
 		<availability>LA:3,LA.SR:6</availability>
-		<model name='(MFB)'>
-			<roles>support</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MFB)'>
+			<roles>support</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
@@ -5782,20 +5782,20 @@
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:3</availability>
-		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -5833,11 +5833,11 @@
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CGB:4</availability>
-		<model name='(Fast Assault)' mechanized='false'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>CGB:8</availability>
+		</model>
+		<model name='(Fast Assault)' mechanized='false'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Rock Golem)' mechanized='false'>
 			<availability>CHH:8</availability>
@@ -5845,6 +5845,10 @@
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:3,MOC:2,IS:1,FS:3,MERC:3,TC:2,Periphery:2,CS:1,OA:1,FVC:2,LA:5,Periphery.MW:1,FWL:6,MH:1</availability>
+		<model name='GOL-4S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:8,FWL:8,WOB:8,MERC:6</availability>
@@ -5861,9 +5865,9 @@
 			<roles>fire_support</roles>
 			<availability>Periphery.HR:2,Periphery.CM:2,Periphery.MW:2,Periphery.ME:2,MH:3,Periphery:2</availability>
 		</model>
-		<model name='GOL-4S'>
+		<model name='GOL-1H'>
 			<roles>fire_support</roles>
-			<availability>LA:4</availability>
+			<availability>CC:4-,HL:2-,LA:5-,General:2-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
 		</model>
 		<model name='GOL-2H'>
 			<roles>fire_support</roles>
@@ -5873,10 +5877,6 @@
 			<roles>fire_support</roles>
 			<availability>LA:5,MERC:4</availability>
 		</model>
-		<model name='GOL-1H'>
-			<roles>fire_support</roles>
-			<availability>CC:4-,HL:2-,LA:5-,General:2-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
-		</model>
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CSA:7,CSR:6,CIH:4,CBS:4,SOC:4,CSV:4,CNC:4,CFM:5,CJF:8,CCO:4</availability>
@@ -5884,23 +5884,23 @@
 			<roles>anti_infantry</roles>
 			<availability>CSA:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:5,CSR:5,CBS:5,SOC:5,CNC:5,CFM:5,CJF:5</availability>
+		<model name='2'>
+			<availability>CSA:8,CIH:8,CSV:8,CFM:8,CJF:8,CCO:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CSR:6,CBS:6</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CIH:8,CSV:8,CFM:8,CJF:8,CCO:8</availability>
+		<model name='(Standard)'>
+			<availability>CSA:5,CSR:5,CBS:5,SOC:5,CNC:5,CFM:5,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:4,CLAN:1</availability>
-		<model name='(Standard)'>
-			<availability>CSV:4,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:4,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:4,General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSV:8</availability>
@@ -5911,26 +5911,26 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6-</availability>
-		<model name='GTHA-600'>
-			<availability>FWL:5,WOB:5</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:4,FWL:4,BAN:2</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:4,FWL:4,BAN:2</availability>
-		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:5-,FWL:5-,MH:5-,MERC:5-</availability>
+		</model>
+		<model name='GTHA-600'>
+			<availability>FWL:5,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Crusader II' unitType='Mek'>
 		<availability>WOB:4</availability>
-		<model name='GRN-D-03'>
-			<availability>General:6</availability>
-		</model>
 		<model name='GRN-D-04'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GRN-D-03'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Crusader' unitType='Mek'>
@@ -5944,6 +5944,12 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,CNC:5,WOB:4,DC:8</availability>
+		<model name='DRG-1G'>
+			<availability>FRR:5-,DC:5-</availability>
+		</model>
+		<model name='DRG-5K'>
+			<availability>FRR:6,CNC:8,WOB:8,DC:6</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>FRR:7,DC:7</availability>
 		</model>
@@ -5951,47 +5957,41 @@
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
 		</model>
-		<model name='DRG-7K'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='DRG-1G'>
-			<availability>FRR:5-,DC:5-</availability>
-		</model>
 		<model name='DRG-5K-DC'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='DRG-5K'>
-			<availability>FRR:6,CNC:8,WOB:8,DC:6</availability>
+		<model name='DRG-7K'>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>CC:5,MOC:5,IS:3,WOB:5,FWL.KIS:8,FS:5,MERC:5,CS:3,DTA:7,FVC:5,Periphery.MW:3,FWL:7,MH:3,DC:5</availability>
-		<model name='T-IT-N10M'>
-			<availability>HL:6,General:4,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
-		</model>
 		<model name='T-IT-N11M'>
 			<availability>DTA:4,FWL:6,WOB:6,MERC:4</availability>
+		</model>
+		<model name='T-IT-N10M'>
+			<availability>HL:6,General:4,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+		<model name='GHR-7K'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='GHR-5J'>
 			<availability>CS:3,IS:3,WOB:3,Periphery:3</availability>
 		</model>
-		<model name='GHR-7K'>
-			<availability>DC:4</availability>
+		<model name='GHR-6K'>
+			<availability>FRR:5,MERC:3,FS:3,DC:6</availability>
 		</model>
 		<model name='GHR-5H'>
 			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
-		<model name='GHR-C'>
-			<availability>IS:3,DC:4</availability>
-		</model>
 		<model name='GHR-5N'>
 			<availability>General:2</availability>
 		</model>
-		<model name='GHR-6K'>
-			<availability>FRR:5,MERC:3,FS:3,DC:6</availability>
+		<model name='GHR-C'>
+			<availability>IS:3,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -6009,39 +6009,39 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
 		<availability>CSA:4,CCC:4,CHH:3,CSV:4,CLAN:1,CFM:4,CCO:4,CGB:3</availability>
-		<model name='2'>
-			<availability>CHH:6,CGB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:3,TC:2</availability>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[TAG]' mechanized='false'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='[MagShot]' mechanized='false'>
 			<availability>FS:5</availability>
 		</model>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[TAG]' mechanized='false'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
@@ -6052,8 +6052,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:3,IS:1</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:7,CHH:8,CLAN:5,IS:2</availability>
@@ -6064,44 +6070,35 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3,CCO:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:4</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:3,IS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:5,CIH:6,CDS:6,CW:4,CNC:7,CLAN:4,CCO:6,CJF:4,CWIE:4,CGB:4,DC:3</availability>
-		<model name='6'>
-			<availability>CNC:4,DC:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CSA:6,CDS:6,CNC:8,CLAN:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CLAN:4-,CNC:4</availability>
-		</model>
-		<model name='2'>
-			<availability>MERC.WD:8,CIH:4,CNC:5,CLAN:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:8,CNC:5,CLAN:4,CCO:8</availability>
 		</model>
+		<model name='2'>
+			<availability>MERC.WD:8,CIH:4,CNC:5,CLAN:4</availability>
+		</model>
+		<model name='6'>
+			<availability>CNC:4,DC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CLAN:4-,CNC:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:4,CNC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,HL:4,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:5,CS:2,OA:1,LA:7,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-3M'>
-			<availability>LA:7,FWL:8,IS:6,FS:6,DC:4</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:4,FRR:3,FS:3,MERC:3,DC:3</availability>
+		<model name='GRF-1S'>
+			<availability>LA:4-,FRR:2-,MERC:4-</availability>
 		</model>
 		<model name='GRF-6CS'>
 			<availability>CS:5,WOB:4</availability>
@@ -6109,30 +6106,41 @@
 		<model name='GRF-2N'>
 			<availability>CLAN:6,FWL:2,WOB:3,MERC:2,BAN:4</availability>
 		</model>
-		<model name='GRF-5M'>
-			<availability>FWL:4,WOB:5,MERC:4</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,BAN:2,Periphery:5-</availability>
-		</model>
 		<model name='GRF-1A'>
 			<availability>LA:2-,MERC:2-,TC:2-</availability>
 		</model>
-		<model name='GRF-1S'>
-			<availability>LA:4-,FRR:2-,MERC:4-</availability>
+		<model name='GRF-5M'>
+			<availability>FWL:4,WOB:5,MERC:4</availability>
 		</model>
-		<model name='GRF-5K'>
-			<availability>CNC:4,DC:4</availability>
+		<model name='GRF-3M'>
+			<availability>LA:7,FWL:8,IS:6,FS:6,DC:4</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>FVC:6,LA:5,FRR:5,FS:7,MERC:5,DC:6</availability>
 		</model>
+		<model name='GRF-5K'>
+			<availability>CNC:4,DC:4</availability>
+		</model>
 		<model name='GRF-5L'>
 			<availability>CC:3</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,BAN:2,Periphery:5-</availability>
+		</model>
+		<model name='GRF-6S'>
+			<availability>LA:4,FRR:3,FS:3,MERC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Grigori' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
+		<model name='C-GRG-OS Caelestis'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:4</availability>
+		</model>
+		<model name='C-GRG-OC Comminus'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
 		<model name='C-GRG-OB Infernus'>
 			<roles>fire_support</roles>
 			<deployedWith>Deva</deployedWith>
@@ -6142,10 +6150,6 @@
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-GRG-OS Caelestis'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='C-GRG-OD Luminos'>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
@@ -6154,86 +6158,70 @@
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-GRG-OC Comminus'>
+		<model name='C-GRG-OU Exanimus'>
 			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='C-GRG-O Invictus'>
 			<roles>fire_support</roles>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='C-GRG-OU Exanimus'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>CS:5,WOB:6,MERC:5,DC:5</availability>
-		<model name='GRM-R-PR30'>
-			<availability>WOB:6+,MERC:3</availability>
-		</model>
 		<model name='GRM-R (Einar)'>
 			<roles>spotter</roles>
 			<availability>CS:1</availability>
-		</model>
-		<model name='GRM-R-PR29'>
-			<availability>CS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='GRM-R-PR31'>
 			<roles>fire_support</roles>
 			<availability>WOB:6+,MERC:4</availability>
 		</model>
+		<model name='GRM-R-PR30'>
+			<availability>WOB:6+,MERC:3</availability>
+		</model>
+		<model name='GRM-R-PR29'>
+			<availability>CS:8,MERC:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CCC:3,CIH:4,CSR:3,CBS:4,CSV:4,CLAN:3,CCO:4,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:2,FVC:1,IS:1,FWL:2,MERC:1,TC:2,Periphery:1</availability>
-		<model name='D'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CC:2,IS:1,FWL:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CC:2,IS:1,FWL:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CC:3,MOC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>CHH:3-,CW:3-,CLAN:2-,CNC:3-,CCO:3-,CWIE:3-</availability>
-		<model name='2'>
-			<availability>CW:4,CCO:5,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:4,CCO:5,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:3,CSR:3,FRR:3,IS:1,WOB:7,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:5,NIOPS:7,DC:3</availability>
-		<model name='GLT-3N'>
-			<roles>raider</roles>
-			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
-		</model>
-		<model name='GLT-6WB'>
-			<roles>raider</roles>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='GLT-6WB2'>
-			<roles>raider</roles>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='GLT-4L'>
 			<roles>raider</roles>
 			<availability>HL:2-,IS:4-,FWL:5-,Periphery.Deep:8,NIOPS:0,MERC:5-,Periphery:4-</availability>
@@ -6245,6 +6233,18 @@
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,FWL:8,WOB:4,FS:5,MERC:2</availability>
+		</model>
+		<model name='GLT-6WB2'>
+			<roles>raider</roles>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='GLT-6WB'>
+			<roles>raider</roles>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
@@ -6263,6 +6263,10 @@
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='GUR-8G'>
+			<deployedWith>Vanquisher</deployedWith>
+			<availability>WOB:3</availability>
+		</model>
 		<model name='GUR-6G'>
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:3</availability>
@@ -6270,10 +6274,6 @@
 		<model name='GUR-4G'>
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:4</availability>
-		</model>
-		<model name='GUR-8G'>
-			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='HALO Paratrooper' unitType='Infantry'>
@@ -6285,27 +6285,27 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:2,CDS:5,CBS:3,LA:4,CNC:5,CFM:3,DC:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>LA:2+,CLAN:8,DC:2+</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4</availability>
-		</model>
 		<model name='HKO-1C'>
 			<roles>fire_support</roles>
 			<availability>LA:8,DC:8</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>LA:2+,CLAN:8,DC:2+</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:7,CBS:6,CLAN:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(AAA)'>
 			<roles>fire_support</roles>
 			<availability>OA:4,CSR:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hamilcar' unitType='Dropship'>
@@ -6339,23 +6339,23 @@
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>FS:3</availability>
+		<model name='HMH-6D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='HMH-3D'>
 			<availability>General:6-,MERC:6-</availability>
 		</model>
 		<model name='HMH-5D'>
 			<availability>General:4,MERC:4</availability>
 		</model>
-		<model name='HMH-6D'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:3,NIOPS:7,WOB:7,DC:4</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,NIOPS:8,WOB:6</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:4</availability>
 		</model>
 		<model name='HMR-HF'>
 			<availability>WOB:6</availability>
@@ -6366,30 +6366,30 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CIH:3,CDS:4,CSV:5,CNC:5,CLAN:2,IS:3+,CJF:4,CCO:3,CGB:3</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='E'>
-			<roles>anti_infantry</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:2</availability>
 		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
+		</model>
+		<model name='E'>
+			<roles>anti_infantry</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -6408,16 +6408,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5-,CC:5-,HL:4-,FRR:5-,IS:5-,Periphery.Deep:4,WOB:5-,MERC:5-,Periphery:5-,CS:5-,FWL.pm:6-,LA:5-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,DC:5-</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:6-</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:5</availability>
 		</model>
 		<model name='&apos;Mini-Peggy&apos;'>
 			<roles>recon</roles>
@@ -6429,29 +6429,29 @@
 		<model name='(Standard)'>
 			<availability>CSA:4,CHH:4,CBS:4,CFM:4,CJF:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CHH:8,CBS:8,CSV:8,CFM:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6,CHH:3,CFM:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CHH:8,CBS:8,CSV:8,CFM:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:5,WOB:4,MERC:4,DC:8</availability>
-		<model name='HTM-28T'>
-			<availability>WOB:6,DC:5</availability>
-		</model>
-		<model name='HTM-27T'>
-			<availability>FRR:8,MERC:6,DC:7</availability>
-		</model>
 		<model name='HTM-26T'>
 			<availability>DC:4-</availability>
 		</model>
+		<model name='HTM-28T'>
+			<availability>WOB:6,DC:5</availability>
+		</model>
 		<model name='HTM-28Tr'>
 			<availability>WOB:5,DC:2</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>FRR:8,MERC:6,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -6487,27 +6487,27 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>Periphery.R:3,MERC.KH:4,FVC:5,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,FS:5,MERC:3,Periphery:2,DC:4</availability>
-		<model name='HCT-5DD'>
-			<availability>FS:4,MERC:4</availability>
+		<model name='HCT-6S'>
+			<availability>LA:5,MERC:5</availability>
+		</model>
+		<model name='HCT-3NH'>
+			<availability>DC:3-</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>FS:2,MERC:2</availability>
 		</model>
-		<model name='HCT-6D'>
-			<availability>FS:6,MERC:5</availability>
-		</model>
 		<model name='HCT-5S'>
 			<availability>FVC:5,LA:6,FRR:4,FS:6,MERC:4,DC:2</availability>
 		</model>
-		<model name='HCT-3NH'>
-			<availability>DC:3-</availability>
+		<model name='HCT-5DD'>
+			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:3,LA:3,TC.PL:5,MERC:3,FS:2,Periphery:3</availability>
 		</model>
-		<model name='HCT-6S'>
-			<availability>LA:5,MERC:5</availability>
+		<model name='HCT-6D'>
+			<availability>FS:6,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
@@ -6525,24 +6525,24 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:5+</availability>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OB'>
-			<availability>General:7</availability>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='HA1-OC'>
+		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OD'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OC'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
@@ -6572,25 +6572,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -6624,8 +6624,8 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:4,CC:3,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
@@ -6633,14 +6633,14 @@
 		<model name='Meteor-U'>
 			<availability>FS:3</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:4,CC:3,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CIR:4,TC:1</availability>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
 		</model>
 		<model name='Meteor-G'>
 			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -6651,10 +6651,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -6662,6 +6658,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -6670,6 +6670,18 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(WoB)'>
+			<roles>apc,support</roles>
+			<availability>WOB:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -6678,21 +6690,13 @@
 			<roles>apc,support</roles>
 			<availability>General:8,WOB:6</availability>
 		</model>
-		<model name='(WoB)'>
-			<roles>apc,support</roles>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:3,CSV:2,CWIE:5</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -6700,30 +6704,29 @@
 		<model name='Prime'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
 		<availability>CC:5,CS:4,MOC:5,WOB:3,FS:3,MERC:3,DC:3,TC:5</availability>
+		<model name='HEL-4A'>
+			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
+		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,CS:8,MOC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 		<model name='HEL-6X'>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
-		<model name='HEL-4A'>
-			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,LA:3,CNC:3,NIOPS:6,WOB:6,FS:3,DC:4</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
+		</model>
+		<model name='HCT-215'>
+			<availability>CS:4</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -6732,36 +6735,33 @@
 		<model name='HCT-214'>
 			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
-		<model name='HCT-215'>
-			<availability>CS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,OA:4,FVC:2,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:2-,CDP:3,TC:2-,Periphery:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:2,FS:3</availability>
+		<model name='HCT-213S'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='HCT-313'>
+			<availability>OA:8,FVC:4,CSR:8,CDP:4</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:3,FS:3</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:3,FS:2</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
 		</model>
-		<model name='HCT-313'>
-			<availability>OA:8,FVC:4,CSR:8,CDP:4</availability>
+		<model name='HCT-213D'>
+			<availability>LA:2,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
 		<availability>CSA:5,CCC:4,CHH:4,CB:5</availability>
-		<model name='(Standard)'>
-			<availability>CSA:8,CCC:8,CB:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3,CB:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:8,CCC:8,CB:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
@@ -6769,8 +6769,8 @@
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:2,CHH:4,CIH:4,CDS:3,DC.AL:2,CLAN:2,CNC:5,CJF:4</availability>
-		<model name='2'>
-			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
+		<model name='5'>
+			<availability>CNC:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
@@ -6778,15 +6778,27 @@
 		<model name='4'>
 			<availability>CNC:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CLAN:4,CJF:8</availability>
-		</model>
-		<model name='5'>
-			<availability>CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CIH:10,SOC:5,CSV:4,CLAN:3,CFM:5,CGS:4,CCO:5,CSA:5,CDS:5,CBS:2,CNC:5,CJF:2,CB:5</availability>
+		<model name='B'>
+			<availability>CSA:8,General:7,CJF:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:4,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:3,General:7,CJF:3</availability>
+		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -6795,36 +6807,36 @@
 			<roles>fire_support</roles>
 			<availability>CSA:3,General:6,CJF:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:8,General:7,CJF:3</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:3,General:7,CJF:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:4,General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>FS:5,MERC:3</availability>
-		<model name='HSN-7D'>
+		<model name='HSN-9F'>
 			<roles>fire_support</roles>
-			<availability>FS:8,MERC:8</availability>
+			<availability>FS:4</availability>
 		</model>
 		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='HSN-9F'>
+		<model name='HSN-7D'>
 			<roles>fire_support</roles>
-			<availability>FS:4</availability>
+			<availability>FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:4+,CB:4+</availability>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>recon,apc,fire_support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -6832,18 +6844,6 @@
 		<model name='Prime'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon,apc,fire_support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -6868,13 +6868,13 @@
 			<roles>recon</roles>
 			<availability>FWL:3</availability>
 		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
 		<model name='HER-6D'>
 			<roles>recon</roles>
 			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-2M &apos;Mercury&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:1-</availability>
 		</model>
 		<model name='HER-5C'>
 			<roles>recon</roles>
@@ -6888,60 +6888,60 @@
 			<roles>recon</roles>
 			<availability>HL:3-,IS:5-,FWL:5-,Periphery.Deep:8,MERC:5-,Periphery:5-</availability>
 		</model>
+		<model name='HER-2M &apos;Mercury&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:1-</availability>
+		</model>
 		<model name='HER-5S'>
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:5,FWL:8,WOB:8,FS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
-			<roles>recon</roles>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:2,FRR:3,FWL:7,NIOPS:3,WOB:3,CGB:2,DC:5</availability>
-		<model name='HER-4WB'>
-			<roles>recon</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='HER-3S2'>
 			<roles>recon,spotter</roles>
 			<availability>FWL:4,WOB:4</availability>
-		</model>
-		<model name='HER-4K'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:6,WOB:5</availability>
-		</model>
-		<model name='HER-3S'>
-			<roles>recon</roles>
-			<availability>FWL:8,WOB:8</availability>
 		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>DC.GHO:5-,CS:4,CLAN:6,NIOPS:4,BAN:8</availability>
 		</model>
-		<model name='HER-4S'>
+		<model name='HER-3S'>
 			<roles>recon</roles>
-			<availability>CS:3,FRR:3,FWL:5,WOB:3</availability>
+			<availability>FWL:8,WOB:8</availability>
 		</model>
 		<model name='HER-4M'>
 			<roles>recon</roles>
 			<availability>FWL:5,WOB:5</availability>
 		</model>
+		<model name='HER-4WB'>
+			<roles>recon</roles>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='HER-4S'>
+			<roles>recon</roles>
+			<availability>CS:3,FRR:3,FWL:5,WOB:3</availability>
+		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:6,WOB:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,MERC:2,Periphery:2,CWIE:3,CGB:2</availability>
-		<model name='(SRM)'>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8-</availability>
 		</model>
-		<model name='(AC10)'>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
@@ -6949,11 +6949,11 @@
 		<model name='(LB-X)'>
 			<availability>CC:6,MOC:4,TC:5</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:3,IS:3,Periphery:3</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -6966,15 +6966,21 @@
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>MERC.WD:3,CHH:3,CDS:4,CW:6,CLAN:3,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CDS:6,CW:6,CLAN:6,CNC:6,IS:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:6,CW:6,CLAN:6,CNC:6,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:1,CS:9,LA:6,CLAN:6,NIOPS:9,CFM:7,WOB:9,MERC:4,FS:5,CJF:7,DC:1</availability>
+		<model name='HGN-733C'>
+			<availability>CC:1,:0,LA:1</availability>
+		</model>
+		<model name='HGN-734'>
+			<availability>LA:6,MERC:6</availability>
+		</model>
 		<model name='HGN-736'>
 			<availability>CS:8,WOB:6</availability>
 		</model>
@@ -6990,29 +6996,23 @@
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1</availability>
 		</model>
-		<model name='HGN-734'>
-			<availability>LA:6,MERC:6</availability>
-		</model>
-		<model name='HGN-733C'>
-			<availability>CC:1,:0,LA:1</availability>
-		</model>
-		<model name='HGN-738'>
-			<availability>LA:4</availability>
+		<model name='HGN-733'>
+			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>MOC:6,DC.GHO:8,CS:3,LA:6,CLAN:6,IS:6,NIOPS:3,WOB:3,MERC.SI:8,MERC:6,FS:6,BAN:8</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
+		<model name='HGN-738'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:2</availability>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7038,11 +7038,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:5,MERC:4,FS:4</availability>
-		<model name='BZK-F5'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BZK-F7'>
 			<availability>General:6</availability>
+		</model>
+		<model name='BZK-F5'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -7056,17 +7056,17 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:2,MERC.WD:2,CLAN:1,CGS:2</availability>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
-		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:4,CLAN:1</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:1</availability>
 		</model>
 		<model name='HOP-4D'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:4,CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -7074,16 +7074,16 @@
 		<model name='HNT-161'>
 			<availability>MERC.WD:3-</availability>
 		</model>
+		<model name='HNT-152'>
+			<roles>recon,urban</roles>
+			<availability>FVC:2-,IS:2-</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:4-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='HNT-152'>
-			<roles>recon,urban</roles>
-			<availability>FVC:2-,IS:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -7100,13 +7100,13 @@
 	</chassis>
 	<chassis name='Huitzilopochtli Assault Tank &apos;Huey&apos;' unitType='Tank'>
 		<availability>CLAN:5,CNC:3,CWIE:3</availability>
-		<model name='(AAA)'>
-			<roles>missile_artillery,anti_aircraft</roles>
-			<availability>CGB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>missile_artillery,anti_aircraft</roles>
+			<availability>CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Humming Bird VTOL' unitType='VTOL'>
@@ -7118,23 +7118,26 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:6,CDS:7,CSR:6,CW:6,CSV:5,CLAN:2,IS:3,CJF:6,CGB:6,CWIE:5</availability>
-		<model name='3'>
-			<availability>CSR:8,CCO:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:8,CBS:8,CB:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:5,General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CSR:8,CCO:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:4,CC:4,HL:4,FRR:6,IS:4-,Periphery.Deep:5,WOB:3-,FS:4,CIR:5,Periphery:5,TC:4,CS:4-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
+		<model name='HBK-5SS'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
 		<model name='HBK-6S'>
 			<availability>LA:3,MERC:3</availability>
-		</model>
-		<model name='HBK-4N'>
-			<availability>FVC:2-,IS:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:2-,IS:2-,FWL:2-,MERC:2-,Periphery:2-</availability>
@@ -7142,35 +7145,32 @@
 		<model name='HBK-5P'>
 			<availability>FWL:4,WOB:4,MERC:3</availability>
 		</model>
-		<model name='HBK-4SP'>
-			<availability>FVC:2-,IS:1-,FWL:2-,MERC:2-,DC:2-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5M'>
-			<availability>CS:4,CC:2,MOC:2,FRR:2,FWL:2,WOB:4,MERC:2,CDP:2,TC:2</availability>
-		</model>
-		<model name='HBK-5SS'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>IS:2-,Periphery:2</availability>
-		</model>
-		<model name='HBK-5S'>
-			<availability>LA:5,FRR:3,MERC:3</availability>
-		</model>
-		<model name='HBK-6N'>
-			<availability>FWL:5,WOB:6,MERC:5</availability>
-		</model>
 		<model name='HBK-4H'>
 			<availability>FVC:2-,IS:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-5H'>
 			<availability>MH:5,Periphery:2</availability>
 		</model>
+		<model name='HBK-4SP'>
+			<availability>FVC:2-,IS:1-,FWL:2-,MERC:2-,DC:2-,Periphery:2-</availability>
+		</model>
 		<model name='HBK-5N'>
 			<availability>MOC:5,CC:5,CS:5,FRR:5,FWL:6,WOB:5,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:2-,Periphery:2</availability>
+		</model>
+		<model name='HBK-5M'>
+			<availability>CS:4,CC:2,MOC:2,FRR:2,FWL:2,WOB:4,MERC:2,CDP:2,TC:2</availability>
+		</model>
+		<model name='HBK-5S'>
+			<availability>LA:5,FRR:3,MERC:3</availability>
+		</model>
+		<model name='HBK-4N'>
+			<availability>FVC:2-,IS:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-6N'>
+			<availability>FWL:5,WOB:6,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -7184,50 +7184,50 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
-		<model name='&apos;Assault Hunter&apos;'>
-			<availability>LA:2,FS:2</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:2-</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3-</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:6-</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:3</availability>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>LA:8,FS:5</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
+		<model name='(LRM15)'>
 			<roles>fire_support</roles>
-			<availability>LA:8,FS:5</availability>
+			<availability>General:3-</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='&apos;Assault Hunter&apos;'>
+			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,WOB:3,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4O'>
+			<availability>CC:8,MOC:8,MERC:4</availability>
+		</model>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:4,MOC:4,FWL:5</availability>
 		</model>
 		<model name='HUR-WO-R4N'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
-		</model>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4O'>
-			<availability>CC:8,MOC:8,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
@@ -7239,16 +7239,16 @@
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>CS:3+,FRR:5+,CNC:3</availability>
-		<model name='HSCL-1-OD'>
-			<availability>General:4</availability>
-		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HSCL-1-OA'>
+		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OB'>
+		<model name='HSCL-1-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OC'>
@@ -7257,39 +7257,39 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:6,CIH:6,LA:3,CSV:5,FRR:3,CLAN:4,NIOPS:4,WOB:4,MERC:3,DC:2</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:2-</availability>
-		</model>
-		<model name='HSR-900-D'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
+		<model name='HSR-500-D'>
+			<availability>CS:4,WOB:8</availability>
 		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:4,General:8,CLAN:6,NIOPS:4,MERC.SI:4,WOB:4,BAN:8</availability>
 		</model>
+		<model name='HSR-900-D'>
+			<availability>WOB:6</availability>
+		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:2-</availability>
+		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:4-</availability>
-		</model>
-		<model name='HSR-500-D'>
-			<availability>CS:4,WOB:8</availability>
 		</model>
 		<model name='HSR-950-D'>
 			<availability>WOB:4</availability>
 		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CCC:6,CSR:5,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Algar)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
@@ -7297,19 +7297,19 @@
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
 		<availability>CHH:5,CBS:2,CFM:6</availability>
+		<model name='2'>
+			<availability>CHH:6</availability>
+		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CBS:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CHH:6,CBS:6,CFM:6</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CBS:5,CFM:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:6,CBS:6,CFM:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hyena' unitType='Mek'>
@@ -7321,35 +7321,35 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:5,MOC:8,LA:4,FWL:4,IS:8,WOB:3,MH:8,FS:2,DC:3,TC:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [LRR]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [SRM]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -7383,13 +7383,13 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
+		<model name='IMP-4E'>
 			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='IMP-2E'>
 			<availability>MERC.WD:1</availability>
 		</model>
-		<model name='IMP-4E'>
+		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
@@ -7409,11 +7409,11 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,CNC:3,CWIE:3</availability>
-		<model name='(BA)'>
-			<availability>CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(BA)'>
+			<availability>CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
@@ -7429,14 +7429,14 @@
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>FS:3,TC:3</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
+		<model name='&apos;Puma&apos;' mechanized='true'>
+			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>FS:3</availability>
 		</model>
-		<model name='&apos;Puma&apos;' mechanized='true'>
-			<availability>FS:8,TC:8</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Initiate' unitType='Mek'>
@@ -7467,26 +7467,26 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CS:6,CLAN:1,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-,DC:2</availability>
-		<model name='IRN-SD1'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='IRN-SD3'>
 			<availability>WOB:5</availability>
+		</model>
+		<model name='IRN-SD1'>
+			<availability>General:8,CNC:4</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
@@ -7519,15 +7519,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -7544,29 +7544,29 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:4-,MOC:4-,CC:2-,DC.LV:5-,HL:3-,FRR:4-,DC.GR:5-,FS.AH:4-,IS:4-,Periphery.Deep:5,WOB:3-,FS:3-,CIR:4-,Periphery:4-,TC:5-,CS:2-,OA:4-,LA:4-,FWL:2-,NIOPS:2-,DC:4-</availability>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>FVC:3,IS:4,TC:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Kurita)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>DC:8,TC:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Kurita)'>
-			<roles>recon,raider</roles>
-			<availability>DC:8,TC:4</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jabberwocky ConstructionMech' unitType='Mek'>
@@ -7613,27 +7613,27 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:4,CW:5,General:2</availability>
 		</model>
-		<model name='E'>
-			<availability>CSR:6,CW:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CSR:6,CW:4</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -7647,70 +7647,70 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:3,CC:5-,FRR:5,IS:2,WOB:3,MERC:3,Periphery.OS:2,FS:8,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:4,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,FWL:2,NIOPS:3,MH:4,DC:3</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>FVC:6,OA:8,LA:8,FRR:8,WOB:6,FS:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>CC:4-,FRR:3-,IS:4-,FS:4-,Periphery:8</availability>
 		</model>
-		<model name='JM6-DGr'>
-			<roles>anti_aircraft</roles>
-			<availability>FVC:3,LA:3,FRR:3,WOB:2,FS:3,MERC:3,DC:3</availability>
-		</model>
-		<model name='JM6-A'>
-			<roles>anti_aircraft</roles>
-			<availability>FVC:2,FS:2-</availability>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:6,MERC:5</availability>
 		</model>
-		<model name='JM7-F'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:3</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
-		</model>
 		<model name='JM6-DDa'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:2,MERC:2</availability>
+		</model>
+		<model name='JM6-A'>
+			<roles>anti_aircraft</roles>
+			<availability>FVC:2,FS:2-</availability>
 		</model>
 		<model name='JM6-H'>
 			<roles>anti_aircraft</roles>
 			<availability>PIR:2,MH:4</availability>
 		</model>
+		<model name='JM7-F'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:3</availability>
+		</model>
+		<model name='JM6-DGr'>
+			<roles>anti_aircraft</roles>
+			<availability>FVC:3,LA:3,FRR:3,WOB:2,FS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='JM7-G'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>FVC:6,OA:8,LA:8,FRR:8,WOB:6,FS:8,MERC:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,HL:3,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:4,LA:3,Periphery.HR:6</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+		<model name='JVN-10P'>
 			<roles>recon</roles>
-			<availability>MOC:2,IS:1,FS:2-,MERC:2,TC:2,Periphery:1</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>FS:5</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
+			<availability>MOC:4,LA:6,Periphery.HR:4,PIR:4,FS:6,MERC:6,CDP:4,TC:4</availability>
 		</model>
 		<model name='JVN-11F'>
 			<roles>recon</roles>
 			<availability>FS:2</availability>
 		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:2,IS:1,FS:2-,MERC:2,TC:2,Periphery:1</availability>
+		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
-			<availability>MOC:4,LA:6,Periphery.HR:4,PIR:4,FS:6,MERC:6,CDP:4,TC:4</availability>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>FS:5</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -7719,14 +7719,14 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -7734,63 +7734,55 @@
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CSR:5,General:2,CJF:5</availability>
+		<model name='B'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CIH:6,CDS:6,CW:5,CSV:6,CNC:8,CLAN:3,CGS:5,CCO:5,CB:4,DC:2</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
-		<model name='3'>
+		<model name='(Standard)'>
+			<availability>CW:5,CLAN:4,CNC:5</availability>
+		</model>
+		<model name='2'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:8,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CW:5,CLAN:4,CNC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:3-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3-,DC:8</availability>
-		<model name='JR7-K'>
+		<model name='JR7-F'>
 			<roles>raider</roles>
-			<availability>MOC:5,OA:5,FRR:8,MERC:5,DC:5,TC:5</availability>
+			<availability>FS.DMM:1,DC:2</availability>
 		</model>
 		<model name='JR7-D'>
 			<roles>raider</roles>
 			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>DC:3</availability>
-		</model>
 		<model name='JR7-C3'>
 			<roles>raider</roles>
 			<availability>DC:3+</availability>
 		</model>
-		<model name='JR7-F'>
+		<model name='JR7-K'>
 			<roles>raider</roles>
-			<availability>FS.DMM:1,DC:2</availability>
+			<availability>MOC:5,OA:5,FRR:8,MERC:5,DC:5,TC:5</availability>
 		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
 			<availability>MERC:4+,FS:4+,DC:8</availability>
 		</model>
+		<model name='JR7-C2'>
+			<roles>raider</roles>
+			<availability>DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:3,FS:4,TC:3</availability>
-		<model name='JI-50 (Q-Vehicle)'>
-			<roles>support</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='JI-50'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='JI-50 (ML)'>
+		<model name='JI-50 (Hoist)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7798,21 +7790,29 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='JI-50 (Hoist)'>
+		<model name='JI-50'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Q-Vehicle)'>
+			<roles>support</roles>
+			<availability>TC:2</availability>
+		</model>
+		<model name='JI-50 (ML)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:4,MOC:3,TC:3</availability>
-		<model name='JN-G8A'>
-			<availability>General:8</availability>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
+		<model name='JN-G8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jumbo' unitType='Dropship'>
@@ -7824,11 +7824,11 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
@@ -7840,8 +7840,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -7864,20 +7864,16 @@
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>DC:5</availability>
-		<model name='KBO-7B'>
-			<availability>General:5</availability>
-		</model>
 		<model name='KBO-7A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='KBO-7B'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
-		</model>
-		<model name='(DEST)' mechanized='true'>
+		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
@@ -7885,42 +7881,46 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Space)' mechanized='true'>
-			<roles>marine</roles>
-			<availability>DC:2</availability>
-		</model>
-		<model name='(Vibro-Claw)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(DEST)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Space)' mechanized='true'>
+			<roles>marine</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Salvage Arm]' mechanized='false'>
+			<roles>support</roles>
+			<availability>DC.SL:6,General:6</availability>
+		</model>
 		<model name='[Industrial Drill]' mechanized='false'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Salvage Arm]' mechanized='false'>
-			<roles>support</roles>
-			<availability>DC.SL:6,General:6</availability>
-		</model>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -7935,35 +7935,35 @@
 			<roles>cargo</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(AC)'>
+			<availability>MH:6,MERC:6</availability>
+		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,OA:5,HL:3,PIR:7,MH:6,CIR:6,Periphery:5,TC:5</availability>
+		</model>
 		<model name='(3055 Upgrade)'>
 			<roles>cargo</roles>
 			<availability>HL:2,IS:6,Periphery:4</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:6,MERC:6</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>CS:5,FWL:5,IS:6,WOB:5</availability>
 		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,OA:5,HL:3,PIR:7,MH:6,CIR:6,Periphery:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:5,FRR:2,DC:5</availability>
+		<model name='CRK-5003-2'>
+			<availability>FRR:8,DC:6-</availability>
+		</model>
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:4</availability>
 		</model>
-		<model name='CRK-5003-2'>
-			<availability>FRR:8,DC:6-</availability>
+		<model name='CRK-5003-C'>
+			<availability>DC:3</availability>
 		</model>
 		<model name='CRK-5003-CM'>
 			<roles>spotter</roles>
 			<availability>DC:7</availability>
-		</model>
-		<model name='CRK-5003-C'>
-			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
@@ -7972,21 +7972,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kimagure Pursuit Cruiser' unitType='Warship'>
@@ -8001,26 +8001,26 @@
 		<model name='KGC-001'>
 			<availability>CS:8,FVC:8,LA:6,IS:6,WOB:5,CIR:6,MERC:6</availability>
 		</model>
-		<model name='KGC-008B'>
-			<availability>WOB.PM:8</availability>
-		</model>
-		<model name='KGC-005'>
-			<availability>CS:5,WOB:4</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CS:4,FRR:3,CLAN:4,WOB:3,CGS:6,BAN:2,DC:3</availability>
 		</model>
-		<model name='KGC-008'>
-			<availability>WOB:8</availability>
+		<model name='KGC-007'>
+			<availability>LA:5,FS:5,MERC:5</availability>
 		</model>
 		<model name='KGC-0000'>
 			<availability>IS:5-,CIR:5</availability>
 		</model>
+		<model name='KGC-008B'>
+			<availability>WOB.PM:8</availability>
+		</model>
 		<model name='KGC-000'>
 			<availability>CS:4,FRR:8,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
 		</model>
-		<model name='KGC-007'>
-			<availability>LA:5,FS:5,MERC:5</availability>
+		<model name='KGC-005'>
+			<availability>CS:5,WOB:4</availability>
+		</model>
+		<model name='KGC-008'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
@@ -8028,38 +8028,35 @@
 		<model name='C'>
 			<availability>General:5,CGB:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6,CGB:5</availability>
-		</model>
 		<model name='E'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:1</availability>
+		<model name='D'>
+			<availability>General:6,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:1</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:7,CHH:2,CDS:2,CSV:2,FRR:4,CLAN:1,NIOPS:7,WOB:7,FS:3,MERC:5,DC:5</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:8</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:5,CS:4,DC.SL:4,CLAN:6,NIOPS:4,WOB:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-21'>
-			<availability>CS:6,WOB:5</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:4,WOB:5,FS:4,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:5-,MERC:5-,DC:4-</availability>
@@ -8070,29 +8067,32 @@
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:5,WOB:4,MERC:6,DC:6</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:8</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:4,WOB:5,FS:4,CGS:6,BAN:2</availability>
+		</model>
+		<model name='KTO-21'>
+			<availability>CS:6,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='E'>
 			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -8115,8 +8115,16 @@
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
 		<availability>CS:5,FRR:4</availability>
-		<model name='[GL/Flamer]' mechanized='true'>
-			<availability>FRR:6</availability>
+		<model name='[GL]' mechanized='true'>
+			<availability>FRR:4</availability>
+		</model>
+		<model name='(CS) [GL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CS:6</availability>
+		</model>
+		<model name='[SL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>FRR:8</availability>
 		</model>
 		<model name='[SL/Flamer]' mechanized='true'>
 			<availability>FRR:6</availability>
@@ -8124,34 +8132,29 @@
 		<model name='(CS) [GL/Flamer]' mechanized='true'>
 			<availability>CS:6</availability>
 		</model>
-		<model name='[SL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>FRR:8</availability>
-		</model>
-		<model name='[GL]' mechanized='true'>
-			<availability>FRR:4</availability>
-		</model>
 		<model name='(CS) [GL]' mechanized='true'>
 			<availability>CS:4</availability>
 		</model>
-		<model name='(CS) [GL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:6</availability>
-		</model>
 		<model name='(CS) [SL/Flamer]' mechanized='true'>
 			<availability>CS:6</availability>
-		</model>
-		<model name='[GL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>FRR:6</availability>
 		</model>
 		<model name='(CS) [SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:8</availability>
 		</model>
+		<model name='[GL/Flamer]' mechanized='true'>
+			<availability>FRR:6</availability>
+		</model>
+		<model name='[GL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>FRR:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:4,CCC:3,CIH:5,CSR:6,CNC:3,CLAN:3,CGS:4,CCO:3,CGB:8</availability>
+		<model name='5'>
+			<availability>CGB:4</availability>
+		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
 			<availability>CSR:5</availability>
@@ -8160,9 +8163,6 @@
 			<availability>CGB:5</availability>
 		</model>
 		<model name='4'>
-			<availability>CGB:4</availability>
-		</model>
-		<model name='5'>
 			<availability>CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -8175,9 +8175,6 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='KIM-2'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>General:8,DC:6</availability>
@@ -8186,13 +8183,13 @@
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,WOB:4,MERC:4</availability>
 		<model name='KSC-4I'>
-			<availability>MERC:2</availability>
-		</model>
-		<model name='KSC-4L'>
 			<availability>MERC:2</availability>
 		</model>
 		<model name='KSC-5I'>
@@ -8201,12 +8198,47 @@
 		<model name='KSC-5MC'>
 			<availability>MOC:8</availability>
 		</model>
+		<model name='KSC-4L'>
+			<availability>MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CIH:8,CSR:7,CSV:8,CLAN:3,IS:3+,CCO:3,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CJF:6,CB:7</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CLAN:5,IS:2</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='Z'>
+			<roles>recon</roles>
+			<availability>SOC:10,CCO:4</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='B'>
+			<roles>recon</roles>
+			<availability>CSA:6,CIH:6,CDS:6,CW:6,General:5,CGS:6,CCO:4,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<roles>recon</roles>
@@ -8215,38 +8247,6 @@
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:5,IS:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CLAN:5,IS:2</availability>
-		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='Z'>
-			<roles>recon</roles>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CSA:6,CIH:6,CDS:6,CW:6,General:5,CGS:6,CCO:4,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
@@ -8263,9 +8263,6 @@
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:4,CLAN:2,CJF:4</availability>
-		<model name='2'>
-			<availability>CSV:4,CLAN:2,CJF:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CJF:6</availability>
 		</model>
@@ -8276,15 +8273,18 @@
 			<roles>fire_support</roles>
 			<availability>CSV:4,CLAN:2,CJF:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CSV:4,CLAN:2,CJF:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
 		<availability>CHH:6,CIH:6,CSR:6,CSV:6,CLAN:2,CGS:6,CWIE:2,CSA:6,CDS:3,CW:4,CNC:3,CJF:4,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(IFV) &apos;Turhan II&apos;'>
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kuan Ti' unitType='Dropship'>
@@ -8333,6 +8333,12 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,CIH:5,FRR:3,CLAN:4,NIOPS:6,CFM:5,WOB:6,CGS:5,BAN:7,DC:6</availability>
+		<model name='LNC25-06'>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='LNC25-04'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
 		<model name='LNC25-02'>
 			<roles>fire_support</roles>
 			<availability>:0,FRR:4-,DC:4-</availability>
@@ -8340,50 +8346,44 @@
 		<model name='LNC25-03'>
 			<availability>DC:4-</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:4,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:6</availability>
-		</model>
-		<model name='LNC25-08'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:2,NIOPS:2,WOB:2</availability>
 		</model>
-		<model name='LNC25-04'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='LNC25-08'>
+			<availability>WOB:4</availability>
 		</model>
-		<model name='LNC25-06'>
-			<availability>WOB:8</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:4,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>FWL:4,WOB:3</availability>
-		<model name='LX-2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LX-2A'>
 			<availability>FWL:5</availability>
 		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
+		<model name='LX-2'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:6,MOC:4,FS:2,TC:4</availability>
-		<model name='LHU-3C'>
-			<availability>CC:4+,MOC:4+</availability>
+		<model name='LHU-3L'>
+			<availability>CC:4,MOC:4,FS:8</availability>
 		</model>
 		<model name='LHU-2B'>
 			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4+,MOC:4+</availability>
+		</model>
 		<model name='LHU-3B'>
 			<roles>spotter</roles>
 			<availability>CC:6,MOC:6</availability>
-		</model>
-		<model name='LHU-3L'>
-			<availability>CC:4,MOC:4,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -8395,15 +8395,12 @@
 	</chassis>
 	<chassis name='Legacy' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='LGC-04-WVR'>
-			<availability>WOB:2</availability>
-		</model>
 		<model name='LGC-02'>
 			<roles>fire_support</roles>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='LGC-03'>
-			<availability>WOB:4</availability>
+		<model name='LGC-04-WVR'>
+			<availability>WOB:2</availability>
 		</model>
 		<model name='LGC-01'>
 			<availability>WOB:8</availability>
@@ -8411,26 +8408,29 @@
 		<model name='LGC-05'>
 			<availability>WOB:2</availability>
 		</model>
+		<model name='LGC-03'>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>CC:8,LA:8,FWL:8,WOB:8,FS:8</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:5-</availability>
 		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>CC:8,LA:8,FWL:8,WOB:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:8,FWL:8,FS:8</availability>
+		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
@@ -8466,30 +8466,30 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FVC:5,FS:5,MERC:1</availability>
-		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>FWL:4</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:4,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='Andurien'>
-			<availability>FWL:3</availability>
+		<model name='Comet'>
+			<availability>FVC:5,FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,HL:4,LA:4</availability>
 		</model>
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
+		</model>
+		<model name='Andurien'>
+			<availability>FWL:3</availability>
+		</model>
+		<model name='Angel (Upgrade)'>
+			<availability>FWL:4</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -8500,6 +8500,13 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CS:2,CIH:6,CLAN:5,NIOPS:2,WOB:7,CJF:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6,WOB:4</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='(ERSL)'>
 			<availability>WOB:4</availability>
 		</model>
@@ -8509,44 +8516,37 @@
 		<model name='(RL)'>
 			<availability>WOB:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6,WOB:4</availability>
-		</model>
 		<model name='CX-3'>
 			<availability>CS:8</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='LTN-G15b'>
-			<availability>CC:3,MOC:3,CLAN:3,MERC:2</availability>
-		</model>
-		<model name='LTN-G16L'>
-			<availability>CC:4,MOC:4,MERC:3</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:6-</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='LTN-G16S'>
-			<availability>LA:4</availability>
+		<model name='LTN-G15b'>
+			<availability>CC:3,MOC:3,CLAN:3,MERC:2</availability>
 		</model>
 		<model name='LTN-G16D'>
 			<availability>FS:4,MERC:3</availability>
 		</model>
+		<model name='LTN-G16L'>
+			<availability>CC:4,MOC:4,MERC:3</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:4</availability>
+		</model>
 		<model name='LTN-G16O'>
 			<availability>OA:4,FVC:3,CDP:3</availability>
+		</model>
+		<model name='LTN-G16S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightray' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='LGH-4Y'>
+		<model name='LGH-5W'>
 			<roles>recon</roles>
 			<availability>WOB:4</availability>
 		</model>
@@ -8554,11 +8554,7 @@
 			<roles>recon</roles>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='LGH-6W'>
-			<roles>recon</roles>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='LGH-5W'>
+		<model name='LGH-4Y'>
 			<roles>recon</roles>
 			<availability>WOB:4</availability>
 		</model>
@@ -8566,17 +8562,24 @@
 			<roles>recon</roles>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='LGH-6W'>
+			<roles>recon</roles>
+			<availability>WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CHH:3,CCC:4,CSR:5,CW:5,SOC:4,CSV:4,CCO:4,CJF:4,CWIE:6,CB:4</availability>
 		<model name='B'>
 			<availability>CIH:6,CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:4,CIH:5,CW:4,CBS:4,CSV:3,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
@@ -8584,29 +8587,26 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,CCO:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CIH:5,CW:4,CBS:4,CSV:3,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4</availability>
+		<model name='D'>
+			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lineholder' unitType='Mek'>
 		<availability>CC:4,FWL:4,IS:3,CM:8,WOB:5,FS:5,CIR:6,TC:6</availability>
-		<model name='KW2-LHW'>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
-			<availability>WOB:4,FS:7</availability>
-		</model>
 		<model name='KW1-LH3'>
 			<availability>General:2,CM:6,WOB:3,FS:3</availability>
 		</model>
 		<model name='KW1-LH2'>
 			<availability>General:8,WOB:2,FS:2</availability>
+		</model>
+		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
+			<availability>WOB:4,FS:7</availability>
+		</model>
+		<model name='KW2-LHW'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -8636,63 +8636,59 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CS:3,CHH:6,CW:7,LA:2,CLAN:3,IS:2,CJF:6,DC:2,CGB:6</availability>
+		<model name='3'>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CW:5,General:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CSA:4,CS:6,CCC:3,CHH:4,CW:4,LA:6,CJF:6,CB:4</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:4,CW:4,CCO:3,CGB:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:2,CIH:2,CJF:2</availability>
 		</model>
-		<model name='3'>
-			<availability>General:2</availability>
+		<model name='5'>
+			<availability>CHH:4,CW:4,CCO:3,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:3-,HL:5,CLAN:2-,IS:8,NIOPS:3-,Periphery.Deep:5,WOB:3-,Periphery:5</availability>
-		<model name='LCT-3M'>
+		<model name='LCT-6M'>
 			<roles>recon</roles>
-			<availability>MOC:4,FWL:8,IS:4,MERC:6</availability>
-		</model>
-		<model name='LCT-1L'>
-			<roles>recon</roles>
-			<availability>CC:1</availability>
+			<availability>FWL:2,WOB:3</availability>
 		</model>
 		<model name='LCT-5T'>
 			<roles>recon,anti_infantry</roles>
 			<availability>MOC:3,CC:3,TC:4</availability>
 		</model>
-		<model name='LCT-5M'>
+		<model name='LCT-1L'>
 			<roles>recon</roles>
-			<availability>PIR:4,FWL:5,IS:3,WOB:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='LCT-6M'>
-			<roles>recon</roles>
-			<availability>FWL:2,WOB:3</availability>
+			<availability>CC:1</availability>
 		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CC:3,CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-5V'>
+		<model name='LCT-3V'>
 			<roles>recon</roles>
-			<availability>MOC:4,CC:2,PIR:3,TC:4</availability>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>PIR:4,FWL:5,IS:3,WOB:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='LCT-1V2'>
+			<roles>recon</roles>
+			<availability>PIR:4,MH:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:3,General:4,FS:4</availability>
 		</model>
-		<model name='LCT-3V'>
+		<model name='LCT-5V'>
 			<roles>recon</roles>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>MOC:4,CC:2,PIR:3,TC:4</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -8702,22 +8698,26 @@
 			<roles>recon</roles>
 			<availability>LA:8,FRR:6,MERC:6</availability>
 		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:4,FWL:8,IS:4,MERC:6</availability>
+		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:5-,MERC:4</availability>
 		</model>
-		<model name='LCT-1V2'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>PIR:4,MH:4</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CDS:3,CW:5,CBS:5,CSV:5,CLAN:3,IS:3+,CFM:5,CJF:3,BAN:6,CWIE:6,CGB:3</availability>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
@@ -8728,15 +8728,15 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -8752,6 +8752,10 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3,DC:6</availability>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,FVC:4,FWL:7,IS:4</availability>
+		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:5-</availability>
@@ -8760,37 +8764,30 @@
 			<roles>missile_artillery,fire_support</roles>
 			<availability>LA:2,FRR:2,FWL:2,FS:3,MERC:2</availability>
 		</model>
-		<model name='LGB-14C'>
+		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
-			<availability>CC:3,CS:3,LA:3,FS:3,MERC:3,DC:3</availability>
-		</model>
-		<model name='LGB-13NAIS'>
-			<availability>WOB:2,FS:3</availability>
-		</model>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,FVC:4,FWL:7,IS:4</availability>
+			<availability>MOC:4-,OA:4-,General:4-,TC:4-,Periphery:4-</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:4,LA:3,FWL:3,MH:3,FS:3,MERC:3</availability>
 		</model>
+		<model name='LGB-13NAIS'>
+			<availability>WOB:2,FS:3</availability>
+		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:3,FWL:3,FS:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='LGB-7Q'>
+		<model name='LGB-14C'>
 			<roles>fire_support</roles>
-			<availability>MOC:4-,OA:4-,General:4-,TC:4-,Periphery:4-</availability>
+			<availability>CC:3,CS:3,LA:3,FS:3,MERC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:8,WOB:8,MH:4</availability>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:4</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -8798,14 +8795,8 @@
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[David] (WoB)' mechanized='true'>
-			<availability>CS:5,WOB:5</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:4</availability>
 		</model>
 		<model name='[Laser] (WoB)' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
@@ -8813,47 +8804,56 @@
 		<model name='[Flamer] (WoB)' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[David] (WoB)' mechanized='true'>
+			<availability>CS:5,WOB:5</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Magnetic) (WOB)' mechanized='true'>
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>FRR:4,MERC:3,DC:4</availability>
-		<model name='LCF-R16K'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>FRR:6,MERC:3,DC:6</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,Periphery.R:4,OA:3,HL:4,LA:8,FRR:4,Periphery.MW:3,FS:5-,MERC:3,CIR:3,TC:2,Periphery:2</availability>
+		<model name='LCF-R16'>
+			<availability>LA:8,FS:4,MERC:6</availability>
+		</model>
 		<model name='LCF-R15'>
 			<availability>LA:2-,General:2-,Periphery.Deep:4,MERC:8-,Periphery:2-</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:5-,FS:5-</availability>
 		</model>
-		<model name='LCF-R16'>
-			<availability>LA:8,FS:4,MERC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM5/M'>
-			<availability>LA:2-</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='LM5/M'>
+			<availability>LA:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -8890,17 +8890,17 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3,WOB:3</availability>
-		<model name='W1'>
-			<roles>missile_artillery,escort</roles>
-			<availability>WOB:6</availability>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6</availability>
+		<model name='W1'>
+			<roles>missile_artillery,escort</roles>
+			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -8925,8 +8925,11 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:2,MERC.WD:9,CIH:4,CDS:6,CW:9,CBS:4,CLAN:5,CCO:6,CJF:6,BAN:3,CWIE:9</availability>
-		<model name='Prime'>
-			<availability>CSA:6,CCC:7,CDS:8,CSV:7,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,CW:5,CLAN:4,General:2,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -8936,50 +8939,47 @@
 			<roles>spotter</roles>
 			<availability>CHH:4,CIH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CFM:4,CCO:6,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='Z'>
 			<availability>SOC:10,CCO:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CIH:5,CW:5,CSV:3,CNC:3,General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		<model name='Prime'>
+			<availability>CSA:6,CCC:7,CDS:8,CSV:7,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,CW:5,CLAN:4,General:2,CJF:6,CWIE:5,CGB:5</availability>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CIH:4,CDS:5,CW:4,LA:3,CNC:6,FS:3,CWIE:4,DC:3</availability>
-		<model name='2'>
-			<availability>CDS:4,CW:4,LA:4,CNC:4,FS:4,DC:4,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:4,CW:4,LA:4,CNC:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
 		<availability>LA:5,FS:4,MERC:3,DC:6</availability>
-		<model name='MTR-6E'>
-			<roles>recon,spotter</roles>
-			<availability>DC:2</availability>
+		<model name='MTR-5K'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:4</availability>
 		</model>
-		<model name='MTR-5K'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='MTR-6E'>
+			<roles>recon,spotter</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Magellan Jumpship' unitType='Jumpship'>
@@ -8990,24 +8990,24 @@
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
 		<availability>CS:5,FRR:2,NIOPS:5,WOB:5,WOB.PM:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UCSV)'>
 			<roles>apc,urban</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>FWL:8,WOB:3</availability>
-		<model name='(C3)'>
-			<availability>IS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(XL)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mako Corvette' unitType='Warship'>
@@ -9019,24 +9019,24 @@
 	</chassis>
 	<chassis name='Malak' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
-		<model name='C-MK-OC Comminus'>
-			<roles>spotter</roles>
+		<model name='C-MK-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-MK-OB Infernus'>
 			<availability>General:7</availability>
-		</model>
-		<model name='C-MK-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-MK-O Invictus'>
-			<availability>General:8</availability>
 		</model>
 		<model name='C-MK-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-MK-OE Eminus'>
 			<availability>General:5</availability>
+		</model>
+		<model name='C-MK-O Invictus'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C-MK-OC Comminus'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mammoth' unitType='Dropship'>
@@ -9048,9 +9048,6 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CIH:9,CSV:8,CLAN:4,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:5,CJF:9,CGB:4</availability>
-		<model name='E'>
-			<availability>CLAN:6,General:2,CCO:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
@@ -9061,17 +9058,20 @@
 		<model name='G'>
 			<availability>CIH:4,General:2</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:2,CCO:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CJF:2,CGB:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
@@ -9094,6 +9094,9 @@
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
+		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
@@ -9101,30 +9104,27 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:7,CC:7,HL:7,FRR:9,IS:8,Periphery.Deep:8,WOB:8,MERC:8,FS:8,CIR:7,Periphery:8,TC:8,CS:8,OA:8,LA:8,FWL:7,NIOPS:8,DC:10</availability>
-		<model name='(C3S)'>
-			<availability>FS:6,DC:7</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>FS:3,DC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>FS:3</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>LA:5,WOB:5,FS:5</availability>
+		</model>
+		<model name='(C3S)'>
+			<availability>FS:6,DC:7</availability>
 		</model>
 		<model name='(3055 Upgrade)'>
 			<availability>FVC:8,LA:8,FS:8,MERC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,LA:3-,General:6-,Periphery.Deep:5,FS:3-,DC:3-,Periphery:6</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>FS:3,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
@@ -9138,17 +9138,17 @@
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:7,MERC.WD:6,CSR:5,CW:6,LA:2,CLAN:4,CNC:6,CJF:7,CWIE:6,CGB:7</availability>
-		<model name='3'>
-			<availability>CSA:6,CLAN:3,CJF:5,CGB:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:8,CLAN:4,CJF:5,CGB:5</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:5,CCC:3,CDS:2,CSR:2,CGS:3,CJF:3,CWIE:2,CGB:3,CB:4</availability>
-		</model>
 		<model name='5'>
 			<availability>CW:2,LA:8,CJF:3,CWIE:4,CGB:2</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:6,CLAN:3,CJF:5,CGB:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:5,CCC:3,CDS:2,CSR:2,CGS:3,CJF:3,CWIE:2,CGB:3,CB:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CNC:4,CGB:3</availability>
@@ -9159,85 +9159,67 @@
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:3,FRR:4,WOB:2,FS:5,MERC:5,TC:3,CS:3,MERC.WD:6,LA:4,PIR:3,CNC:3,FWL:4,MH:3,SL.2:4,DC:4</availability>
-		<model name='MAD-4H'>
-			<availability>PIR:8,MH:8,TC:8</availability>
-		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='MAD-5W'>
-			<availability>CC:4,CS:4,WOB:8</availability>
 		</model>
 		<model name='MAD-6M'>
 			<availability>FWL:3,MERC:3</availability>
 		</model>
-		<model name='C'>
-			<availability>MERC.WD:3</availability>
-		</model>
 		<model name='MAD-4S'>
 			<availability>CS:8,LA:8,FRR:8,CNC:8,FWL:6,SL.2:8,FS:8,MERC:4,DC:8</availability>
-		</model>
-		<model name='MAD-4K'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:2</availability>
 		</model>
 		<model name='MAD-4A'>
 			<availability>MERC:4</availability>
 		</model>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:2</availability>
+		</model>
+		<model name='MAD-5W'>
+			<availability>CC:4,CS:4,WOB:8</availability>
+		</model>
+		<model name='MAD-4K'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='MAD-4H'>
+			<availability>PIR:8,MH:8,TC:8</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,DC:4,CGB:2</availability>
-		<model name='MAD-5T'>
-			<availability>FS:3</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>FWL:4,WOB:4,MERC:3</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:5,LA:2,FRR:6,WOB:4,FS:6,MERC:4,DC:8</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>LA:4,FRR:3,MERC:2</availability>
+		<model name='MAD-3D'>
+			<availability>FVC:4-,MH:3-,FS:4-</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>FWL:3,WOB:3,MERC:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:3</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>FVC:4,LA:6,FRR:3,FS:5,MERC:4</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:3</availability>
-		</model>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>FWL:4,WOB:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:4-,Periphery.MW:4-,PIR:4-,Periphery.ME:4-,FWL:3-,MH:4-,MERC:4-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:5,LA:2,FRR:6,WOB:4,FS:6,MERC:4,DC:8</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>CS:6,FWL:8,IS:3,WOB:7,MERC:4</availability>
 		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:2</availability>
+		<model name='MAD-6L'>
+			<availability>CC:3,MOC:3</availability>
 		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:4-,MH:3-,FS:4-</availability>
+		<model name='C'>
+			<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:3</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:2-,HL:3-,IS:4-,Periphery.Deep:8,WOB:2-,Periphery:5-,TC:5-</availability>
 		</model>
+		<model name='MAD-9S'>
+			<availability>LA:4,FRR:3,MERC:2</availability>
+		</model>
 		<model name='MAD-3L'>
 			<availability>CC:1</availability>
-		</model>
-		<model name='MAD-5L'>
-			<availability>CC:4,MOC:3,WOB:3,CIR:3,TC:2</availability>
 		</model>
 		<model name='MAD-2R'>
 			<availability>CLAN:1,CGS:1,BAN:1,TC:2</availability>
@@ -9245,28 +9227,46 @@
 		<model name='MAD-1R'>
 			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-,MERC:0,BAN:1</availability>
 		</model>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:2</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:4-,Periphery.MW:4-,PIR:4-,Periphery.ME:4-,FWL:3-,MH:4-,MERC:4-</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:4,MOC:3,WOB:3,CIR:3,TC:2</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>FVC:4,LA:6,FRR:3,FS:5,MERC:4</availability>
+		</model>
+		<model name='MAD-7D'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
 		<availability>LA:4</availability>
-		<model name='(Light PPC)'>
-			<roles>artillery</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CHH:8,BAN:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>artillery</roles>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
-		<model name='(ATM)'>
-			<availability>General:5,CCO:6,CJF:2</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CSA:3,CHH:4,CCC:3,CIH:4,CGS:3,CCO:3,CGB:3,CB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ATM)'>
+			<availability>General:5,CCO:6,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -9286,36 +9286,36 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CSV:1,CLAN:2,IS:2+,CFM:8,MERC:2+,CGS:7,BAN:3,CWIE:2,CSA:3,MERC.WD:4,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4,CFM:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:8,CSV:6,General:5</availability>
+		<model name='E'>
+			<availability>General:4,CFM:6</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CSV:6,General:5,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:8,CSV:6,General:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
@@ -9323,20 +9323,17 @@
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CSR:2,CSV:5,CLAN.IS:3,CJF:3</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>LA:3,FRR:5,MERC:4,FS:3,DC:7</availability>
 		<model name='MAL-1R'>
 			<availability>FRR:8,MERC:6,DC:3</availability>
-		</model>
-		<model name='MAL-1K'>
-			<availability>DC:3</availability>
 		</model>
 		<model name='MAL-2R'>
 			<availability>LA:8,FS:8,MERC:8</availability>
@@ -9347,18 +9344,13 @@
 		<model name='MAL-3R'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='MAL-1K'>
+			<availability>DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:4,CLAN:2,MH:4,FS:2,TC:6</availability>
-		<model name='(Intermediate)'>
-			<roles>apc</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='(Basic)'>
-			<roles>apc</roles>
-			<availability>FS:8,TC:3-</availability>
-		</model>
-		<model name='(BA)'>
+		<model name='(Fusion)'>
 			<roles>apc</roles>
 			<availability>TC:4</availability>
 		</model>
@@ -9366,13 +9358,21 @@
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
+		<model name='(Intermediate)'>
+			<roles>apc</roles>
+			<availability>TC:2</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>TC:4</availability>
 		</model>
-		<model name='(Fusion)'>
+		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>TC:4</availability>
+		</model>
+		<model name='(Basic)'>
+			<roles>apc</roles>
+			<availability>FS:8,TC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -9389,59 +9389,59 @@
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:4</availability>
-		<model name='(Company Command)'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:3,CC:4,HL:2,FRR:5,CLAN:3,IS:3,Periphery.Deep:5,WOB:4-,MERC:3,FS:2,CIR:3,Periphery:3,TC:3,CS:4-,OA:3,LA:5,FWL:4,NIOPS:4-,DC:4</availability>
+		<model name='(SRM2)'>
+			<roles>apc</roles>
+			<availability>IS:2-,Periphery:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>IS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
 		<model name='(BA Field Upgrade)'>
 			<roles>apc,spotter</roles>
 			<availability>FRR:3,IS:2,MERC:3,DC:4</availability>
 		</model>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>LA:1,FRR:1,IS:1,FS:1,DC:2</availability>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
 		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
 			<availability>CC:5,FRR:5,FWL:5,IS:4,DC:5</availability>
 		</model>
-		<model name='(SRM2)'>
-			<roles>apc</roles>
-			<availability>IS:2-,Periphery:2</availability>
+		<model name='(C3S)'>
+			<roles>apc,spotter</roles>
+			<availability>IS:4</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2,Periphery:2</availability>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>LA:1,FRR:1,IS:1,FS:1,DC:2</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:3</availability>
 		</model>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(C3S)'>
-			<roles>apc,spotter</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
-			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
+			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -9465,12 +9465,12 @@
 			<roles>interceptor</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<roles>interceptor</roles>
 			<availability>FVC:1,FRR:1,MERC:1,Periphery:1,DC:1</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Assault XCT' unitType='Infantry'>
@@ -9492,8 +9492,11 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -9502,11 +9505,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -9514,35 +9514,35 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -9555,11 +9555,11 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -9594,11 +9594,11 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7+,MOC:5+</availability>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -9606,9 +9606,9 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='MS1-OA'>
 			<roles>recon,spotter</roles>
@@ -9638,17 +9638,17 @@
 			<roles>recon</roles>
 			<availability>CS:4,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6</availability>
 		</model>
-		<model name='MCY-104'>
-			<roles>recon,spotter</roles>
-			<availability>WOB:4</availability>
+		<model name='MCY-97'>
+			<roles>recon</roles>
+			<availability>CS:4</availability>
 		</model>
 		<model name='MCY-102'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
 		</model>
-		<model name='MCY-97'>
-			<roles>recon</roles>
-			<availability>CS:4</availability>
+		<model name='MCY-104'>
+			<roles>recon,spotter</roles>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -9666,14 +9666,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>OA:8,HL:3,MERC:6,Periphery:4</availability>
-		<model name='MLN-1C'>
-			<availability>OA:6,FVC:3,MERC:3</availability>
-		</model>
 		<model name='MLN-1A'>
 			<availability>General:5-</availability>
 		</model>
 		<model name='MLN-1B'>
 			<availability>OA:8,HL:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='MLN-1C'>
+			<availability>OA:6,FVC:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -9696,18 +9696,18 @@
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CSA:6,CHH:8,CCC:8,CSR:3,CIH:3,CBS:4,CSV:4,CFM:3,CGS:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='4'>
 			<availability>CBS:3</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:5,CHH:8,CCC:5,CGS:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CIH:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:5,CHH:8,CCC:5,CGS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -9739,25 +9739,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -9794,24 +9794,24 @@
 	</chassis>
 	<chassis name='Mongoose II' unitType='Mek'>
 		<availability>CS:4</availability>
-		<model name='MON-266'>
-			<roles>recon</roles>
-			<availability>CS:8,LA:2</availability>
-		</model>
 		<model name='MON-267'>
 			<roles>recon</roles>
 			<availability>LA:8,MERC:8</availability>
 		</model>
+		<model name='MON-266'>
+			<roles>recon</roles>
+			<availability>CS:8,LA:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>CS:2,CHH:2,CDS:2,CBS:2,CLAN:2,NIOPS:2,WOB:3,CJF:2,CGB:2</availability>
-		<model name='MON-66'>
-			<roles>recon</roles>
-			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='MON-66b'>
 			<roles>recon</roles>
 			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		</model>
+		<model name='MON-66'>
+			<roles>recon</roles>
+			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -9824,9 +9824,6 @@
 		<availability>CLAN:2,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
@@ -9876,33 +9873,33 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized XCT Infantry' unitType='Infantry'>
@@ -9931,26 +9928,26 @@
 	</chassis>
 	<chassis name='Mule' unitType='Dropship'>
 		<availability>HL:7,CLAN:5,IS:7,Periphery.Deep:7,BAN:4,Periphery:8</availability>
-		<model name='(2737)'>
-			<roles>cargo,civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:4</availability>
 		</model>
 		<model name='(Armored Pocket Warship)'>
 			<availability>WOB:4</availability>
 		</model>
+		<model name='(2737)'>
+			<roles>cargo,civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>FS:6</availability>
-		<model name='(Armor)'>
-			<roles>spotter</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Armor)'>
+			<roles>spotter</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
@@ -9965,32 +9962,32 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>WOB:4,DC:6</availability>
-		<model name='NG-C3A'>
-			<roles>fire_support,spotter</roles>
-			<availability>WOB:8,DC:8</availability>
-		</model>
 		<model name='NG-C3C'>
 			<roles>fire_support</roles>
 			<availability>DC:2</availability>
+		</model>
+		<model name='NG-C3A'>
+			<roles>fire_support,spotter</roles>
+			<availability>WOB:8,DC:8</availability>
 		</model>
 		<model name='NG-C3B'>
 			<roles>spotter</roles>
@@ -10013,11 +10010,11 @@
 	</chassis>
 	<chassis name='Nephilim Assault Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:1</availability>
-		<model name='(Seeker) [MG]' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Gauss)' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Seeker) [MG]' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Neptune Submarine' unitType='Naval'>
@@ -10025,11 +10022,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -10051,20 +10048,26 @@
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
 		<availability>CS:6,WOB:4</availability>
-		<model name='NXS1-A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='NXS1-B'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='NXS1-A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:2,CGS:3,CJF:5,CB:3</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:7,CLAN:5,IS:2</availability>
@@ -10072,28 +10075,22 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:2</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='F'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>OA:3,FVC:3,CW:5,LA:5,CLAN:3,FWL:3,MERC:3,FS:3,CGS:4,CGB:5</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nighthawk PA(L)' unitType='BattleArmor'>
@@ -10115,40 +10112,40 @@
 		<model name='(Standard)'>
 			<availability>General:8,WOB:2</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='(Light PPC)'>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>Periphery.R:2,LA:8,WOB:3,FS:7,MERC:4,CIR:2</availability>
-		<model name='NGS-4T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-4S'>
 			<availability>:0,HL:6,LA:6,General:8,Periphery.Deep:6,FS:6,MERC:6,Periphery:8</availability>
 		</model>
-		<model name='NGS-5T'>
+		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6T'>
 			<availability>LA:4,WOB:8,MERC:4,FS:4</availability>
 		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
+		<model name='NGS-5T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -10156,11 +10153,11 @@
 		<model name='NSR-9FC'>
 			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
-		<model name='NSR-9SS'>
-			<availability>LA:4,MERC:2,FS:4</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9SS'>
+			<availability>LA:4,MERC:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ninja-To' unitType='Mek'>
@@ -10174,28 +10171,37 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:6,DC.SL:2,FRR:4,WOB:3,MERC:2,DC:5</availability>
-		<model name='NDA-2KC'>
-			<availability>MERC:5,DC:5</availability>
+		<model name='NDA-2KO'>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>MERC:6,DC:6</availability>
 		</model>
+		<model name='NDA-2KC'>
+			<availability>MERC:5,DC:5</availability>
+		</model>
 		<model name='NDA-1K'>
 			<availability>FRR:8,WOB:8,MERC:8,DC:8</availability>
-		</model>
-		<model name='NDA-2KO'>
-			<availability>MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,CDS:3,CNC:8,CFM:4,CB:6</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,CNC:4</availability>
+		</model>
+		<model name='N'>
+			<availability>CDS:4,CNC:4,CFM:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:4,CNC:4,CFM:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10204,18 +10210,9 @@
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,CNC:4,CFM:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,CNC:4,CFM:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -10227,6 +10224,15 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CIH:4,CDS:6,CNC:9,CLAN:3,CWIE:4,CB:4</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -10235,25 +10241,16 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='O-66 &apos;Oppie&apos; Hazardous Materials Recovery Vehicle' unitType='Tank'>
@@ -10265,37 +10262,37 @@
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>CS:2,DC:3+</availability>
-		<model name='OBK-M12'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>DC:2</availability>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
+		<model name='OBK-M12'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ocelot' unitType='Mek'>
 		<availability>CNC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CNC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
 		<availability>CLAN:5,CJF:2</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>recon,spotter</roles>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Odyssey Jumpship' unitType='Jumpship'>
@@ -10319,8 +10316,8 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,TC:5,FVC:7,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:4,FWL:9,MH:5,DC:4</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:8,CNC:8,IS:8</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,FVC:2,LA:2,FWL:2,FS:2</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<availability>CC:6,MOC:5,IS:5,FWL:6</availability>
@@ -10329,25 +10326,25 @@
 			<roles>fire_support</roles>
 			<availability>CC:3,LA:3,FWL:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:2,FVC:2,LA:2,FWL:2,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,General:5,Periphery.Deep:6,Periphery:6</availability>
+		</model>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:8,CNC:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:4,CGS:3,CCO:3</availability>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
@@ -10359,38 +10356,38 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:3,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:4,CWIE:2,CS:4-,OA:4,CW:2,LA:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
-		<model name='ON1-MD'>
-			<availability>FWL:4,WOB:4,MERC:2,FS:2</availability>
-		</model>
 		<model name='ON1-MA'>
 			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2,MOC:2,FWL:4,WOB:4,FS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='ON2-M'>
-			<availability>FWL:4,WOB:4,MERC:3</availability>
-		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1-</availability>
 		</model>
 		<model name='ON1-MC'>
 			<availability>FRR:4,FS:2,MERC:2,DC:4</availability>
 		</model>
+		<model name='ON1-V'>
+			<availability>IS:2-,MH:2-,CDP:2-,TC:2-</availability>
+		</model>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1-</availability>
+		</model>
+		<model name='ON1-MB'>
+			<availability>CC:2,MOC:2,FWL:4,WOB:4,FS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:3-,General:5-,CLAN:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
 		<model name='ON1-M'>
 			<availability>CS:6,MOC:6,Periphery.MW:5,PIR:5,Periphery.ME:5,FWL:8,IS:6,WOB:6,MH:5,DC:6</availability>
 		</model>
-		<model name='ON1-V'>
-			<availability>IS:2-,MH:2-,CDP:2-,TC:2-</availability>
+		<model name='ON1-MD'>
+			<availability>FWL:4,WOB:4,MERC:2,FS:2</availability>
 		</model>
 		<model name='ON1-VA'>
 			<availability>IS:2</availability>
 		</model>
+		<model name='ON2-M'>
+			<availability>FWL:4,WOB:4,MERC:3</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:6</availability>
-		</model>
-		<model name='ON1-K'>
-			<availability>HL:3-,General:5-,CLAN:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -10404,20 +10401,32 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,LA:4,FS:6,MERC:4</availability>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Osteon' unitType='Mek' omni='Clan'>
 		<availability>SOC:5,CCO:3,CB:3</availability>
+		<model name='F'>
+			<availability>General:5</availability>
+		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='G'>
 			<roles>missile_artillery</roles>
@@ -10426,27 +10435,14 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='F'>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,TC:4,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
-		<model name='OSR-5W'>
-			<roles>urban</roles>
-			<availability>WOB:2</availability>
+		<model name='OSR-3C'>
+			<availability>FVC:2-,IS:2-,Periphery.Deep:4,MERC:3-,Periphery:3-</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
@@ -10455,9 +10451,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:3,BAN:2</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>FVC:2-,IS:2-,Periphery.Deep:4,MERC:3-,Periphery:3-</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:2-</availability>
@@ -10468,26 +10461,22 @@
 		<model name='OSR-4C'>
 			<availability>CIR:8,TC:5</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:3-</availability>
+		</model>
 		<model name='OSR-4L'>
 			<availability>CC:5,MOC:4</availability>
 		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:3-</availability>
+		<model name='OSR-5W'>
+			<roles>urban</roles>
+			<availability>WOB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,FRR:3,CLAN:1-,IS:1,WOB:3,FS:2,MERC:3,CS:3,FVC:2,LA:2,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='OTT-10CS'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:3</availability>
-		</model>
-		<model name='OTT-9CS'>
+		<model name='OTT-7K'>
 			<roles>recon,spotter</roles>
-			<availability>CS:5,WOB:4</availability>
+			<availability>FVC:7,IS:8,DC:7</availability>
 		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
@@ -10497,9 +10486,17 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:5,MERC:3</availability>
 		</model>
-		<model name='OTT-7K'>
+		<model name='OTT-10CS'>
+			<roles>recon</roles>
+			<availability>CS:4,WOB:3</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='OTT-9CS'>
 			<roles>recon,spotter</roles>
-			<availability>FVC:7,IS:8,DC:7</availability>
+			<availability>CS:5,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -10507,8 +10504,11 @@
 		<model name='OTL-7M'>
 			<availability>FWL:5,WOB:4,MERC:4</availability>
 		</model>
-		<model name='OTL-5D'>
-			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:4</availability>
+		<model name='OTL-8D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>HL:2-,IS:4-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
 		</model>
 		<model name='OTL-6D'>
 			<availability>FS:4,MERC:2,DC:2</availability>
@@ -10519,14 +10519,11 @@
 		<model name='OTL-8M'>
 			<availability>FWL:4,WOB:3,MERC:3</availability>
 		</model>
-		<model name='OTL-8D'>
-			<availability>FS:4</availability>
+		<model name='OTL-5D'>
+			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:4</availability>
 		</model>
 		<model name='OTL-4F'>
 			<availability>FVC:2-,FS:2-</availability>
-		</model>
-		<model name='OTL-4D'>
-			<availability>HL:2-,IS:4-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -10537,13 +10534,13 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:5,CW:4,CFM:3</availability>
-		<model name='(3063)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(3070)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(3063)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Overlord C' unitType='Dropship'>
@@ -10555,10 +10552,6 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:5,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:6,FS:6</availability>
@@ -10567,26 +10560,26 @@
 			<roles>assault</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:5,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:3+,CS:3+,CNC:3,FWL:3+,WOB:3+,FS:3+,MERC:3+,DC:4+</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='OW-1C'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -10594,15 +10587,19 @@
 			<roles>recon,spotter</roles>
 			<availability>General:2+,CLAN:6</availability>
 		</model>
-		<model name='OW-1A'>
+		<model name='OW-1E'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='OW-1B'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CCC:3,MERC.KH:1,CDS:3,CIH:3,CSR:3,CSV:3,CNC:4,CLAN:3,CCO:3,CWIE:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CWIE:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CWIE:4</availability>
@@ -10610,16 +10607,12 @@
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -10628,13 +10621,17 @@
 			<roles>recon,raider</roles>
 			<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
 		</model>
-		<model name='&apos;Gespenst&apos;'>
-			<roles>recon,specops</roles>
-			<availability>LA:2</availability>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
 			<availability>FWL.pm:4</availability>
+		</model>
+		<model name='&apos;Gespenst&apos;'>
+			<roles>recon,specops</roles>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -10650,77 +10647,92 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:9,WOB:4,MERC:5,FS:2,Periphery.OS:5,Periphery:3,CS:2,LA:2,FS.DMM:5,CNC:5,FWL:2,NIOPS:2,DC:10</availability>
-		<model name='PNT-16K'>
+		<model name='PNT-10KA'>
 			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>FS.RR:3+,FRR:3+,CNC:8,FS.DMM:3+,MERC:3+,DC:3+</availability>
 		</model>
 		<model name='PNT-14S'>
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='PNT-10KA'>
+		<model name='PNT-12A'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:3+,FRR:3+,CNC:8,FS.DMM:3+,MERC:3+,DC:3+</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:5,FRR:6,CNC:4,FS.DMM:5,WOB:6,MERC:5,DC:6</availability>
-		</model>
-		<model name='PNT-10K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:2,FS.DMM:2,MERC:2,DC:2</availability>
+			<availability>DC:6</availability>
 		</model>
 		<model name='PNT-CA'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:3,FRR:3,FS.DMM:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='PNT-12A'>
+		<model name='PNT-10K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FRR:2,FS.DMM:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:5,FRR:6,CNC:4,FS.DMM:5,WOB:6,MERC:5,DC:6</availability>
+		</model>
+		<model name='PNT-16K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
-		</model>
-		<model name='PNT-C'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
 		</model>
 		<model name='PNT-9R'>
 			<roles>fire_support</roles>
 			<availability>HL:3-,IS:5-,Periphery.Deep:8,MERC:5-,Periphery:5-,DC:5-</availability>
 		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:6,FRR:6,FS.DMM:6,MERC:6,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
 		<availability>FWL:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MFB)'>
 			<roles>support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pariah (Septicemia)' unitType='Mek' omni='Clan'>
 		<availability>SOC:10,CCO:6,CB:5</availability>
-		<model name='B-Z'>
-			<roles>spotter</roles>
-			<availability>SOC:7,General:4</availability>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='E'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='D-Z'>
 			<availability>SOC:7,General:4</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:3,General:1</availability>
-		</model>
 		<model name='C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='US'>
 			<availability>General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B-Z'>
+			<roles>spotter</roles>
+			<availability>SOC:7,General:4</availability>
+		</model>
+		<model name='F'>
+			<roles>missile_artillery</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A-Z'>
+			<roles>spotter</roles>
+			<availability>SOC:7,General:4</availability>
+		</model>
+		<model name='C-Z'>
+			<availability>SOC:7,General:4</availability>
 		</model>
 		<model name='UW'>
 			<availability>General:4</availability>
@@ -10728,68 +10740,53 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<roles>missile_artillery</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-Z'>
-			<availability>SOC:7,General:4</availability>
-		</model>
-		<model name='A-Z'>
-			<roles>spotter</roles>
-			<availability>SOC:7,General:4</availability>
+		<model name='Z'>
+			<availability>SOC:3,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,CS:6,HL:2,LA:7,FRR:4,CNC:4,IS:5,WOB:6,FS:8,DC:6,Periphery:3,CWIE:5</availability>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:4,FS:5</availability>
-		</model>
 		<model name='(Quad RAC)'>
 			<roles>anti_aircraft</roles>
 			<availability>WOB:1,FS:2+</availability>
-		</model>
-		<model name='(Company Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:2,FS:2</availability>
-		</model>
-		<model name='(XL)'>
-			<roles>anti_aircraft</roles>
-			<availability>WOB:6,FS:6</availability>
 		</model>
 		<model name='(RAC)'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:5</availability>
 		</model>
+		<model name='(Lance Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:4,FS:5</availability>
+		</model>
+		<model name='(XL)'>
+			<roles>anti_aircraft</roles>
+			<availability>WOB:6,FS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:2,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:7-,CC:4-,HL:6-,FRR:4-,IS:5-,Periphery.Deep:7-,WOB:6-,FS:6-,CIR:4-,Periphery:7-,TC:7-,CS:6-,OA:3-,CDS:4,LA:5-,FWL:5-,DC:4-</availability>
+		<model name='(Standard)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(AC2)'>
 			<roles>anti_aircraft</roles>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 		<model name='(C3)'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Patriot' unitType='Mek'>
@@ -10812,30 +10809,34 @@
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
 		<availability>LA:8,FRR:5,FS:6,MERC:5,CWIE:4</availability>
-		<model name='(Standard)'>
-			<availability>HL:4,IS:4-,Periphery.Deep:4,Periphery:6</availability>
-		</model>
 		<model name='(Ultra)'>
 			<availability>LA:8,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:4,IS:4-,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:2,CC:3,FRR:3,IS:3,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:2,TC:2,CWIE:3,CS:5-,OA:2,LA:6,FWL:3,DC:6</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
+		<model name='(C3)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:3,WOB:3,FS:3,DC:5</availability>
 		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>FVC:1,IS:1</availability>
 		</model>
+		<model name='(MRM)'>
+			<roles>recon</roles>
+			<availability>WOB:3,DC:4</availability>
+		</model>
 		<model name='(Missile)'>
 			<roles>recon</roles>
 			<availability>IS:1</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:3,WOB:3,FS:3,DC:5</availability>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
@@ -10845,43 +10846,39 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:6,WOB:8,FS:8,DC:7</availability>
 		</model>
-		<model name='(MRM)'>
-			<roles>recon</roles>
-			<availability>WOB:3,DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:3</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='PTR-6T'>
-			<availability>FS.DBG:8,FS:4</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-6T'>
+			<availability>FS.DBG:8,FS:4</availability>
+		</model>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:2,CGB:4</availability>
-		<model name='5'>
-			<availability>CGS:9</availability>
-		</model>
-		<model name='4'>
-			<availability>CSR:8,CBS:7,CGS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='5'>
+			<availability>CGS:9</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='4'>
+			<availability>CSR:8,CBS:7,CGS:6</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_infantry</roles>
@@ -10890,11 +10887,11 @@
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:1-,LA:3-,FRR:1-,FWL:1-,IS:1-,FS:3-,MERC:1-,DC:2-</availability>
-		<model name='(Cargo)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,DC:2</availability>
@@ -10902,10 +10899,14 @@
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>FWL:6+,WOB:5+</availability>
-		<model name='P1E'>
-			<availability>General:3</availability>
-		</model>
 		<model name='P1D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1A'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1'>
@@ -10914,15 +10915,11 @@
 		<model name='P1C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='P1B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1A'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='P1W'>
 			<availability>General:2,WOB:6</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -10936,59 +10933,56 @@
 		<model name='(C)' mechanized='true'>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='(B)' mechanized='true'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='(WoB-A)' mechanized='true'>
 			<availability>WOB:8</availability>
 		</model>
 		<model name='(WoB-B)' mechanized='true'>
 			<availability>WOB:3</availability>
 		</model>
+		<model name='(B)' mechanized='true'>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CIH:6,CSR:6,CW:8,CGS:8,CCO:4,CJF:7,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CIH:7,General:8,CCO:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:7,CIH:6,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:5,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:5,CIH:6,General:5,CCO:4,CGB:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:5,CIH:6,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CIH:7,General:8,CCO:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:5,CIH:6,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CIH:5,CSR:5,CDS:5,CBS:3,CSV:5,CLAN:3,CFM:5,CCO:5,CB:3</availability>
-		<model name='5'>
-			<availability>CLAN:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:5,CLAN:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCC:5,CSR:5,CIH:5,CDS:5,CSV:5,CLAN:4,CNC:5,CFM:5,CCO:5</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:4,CSV:6,CLAN:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:5,CLAN:3</availability>
 		</model>
 		<model name='6'>
 			<availability>CDS:4,CGB:4</availability>
@@ -10997,33 +10991,32 @@
 			<roles>fire_support</roles>
 			<availability>CCC:2,CSR:6,CDS:2,CSV:6,CNC:2,CFM:6,CCO:2</availability>
 		</model>
+		<model name='5'>
+			<availability>CLAN:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK1R'>
-            <availability>IS:2+</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK1R'>
+			<availability>IS:2+</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:5,HL:5,CLAN:1,IS:9,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:3,Periphery:6,CGB:1</availability>
-		<model name='PXH-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,FWL:2,WOB:3,CGS:5</availability>
+		<model name='PXH-7K'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='PXH-7S'>
 			<availability>LA:4,MERC:3</availability>
@@ -11035,6 +11028,35 @@
 			<roles>recon</roles>
 			<availability>FVC:3-,PIR:3-,FS:3-,MERC:3-</availability>
 		</model>
+		<model name='PXH-5L'>
+			<availability>CC:2,MOC:2</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:5,FWL:3,WOB:3,BAN:1</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:2-,DC:3-</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>FRR:8,DC:8</availability>
+		</model>
+		<model name='PXH-3S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:6</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>DTA:8,FWL:8,IS:4</availability>
+		</model>
+		<model name='PXH-7CS'>
+			<availability>CS:4</availability>
+		</model>
 		<model name='PXH-3PL'>
 			<availability>WOB:3,FS:4,MERC:3</availability>
 		</model>
@@ -11042,38 +11064,13 @@
 			<roles>recon</roles>
 			<availability>General:4-,BAN:6,Periphery:4-</availability>
 		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,FWL:2,WOB:3,CGS:5</availability>
+		</model>
 		<model name='PXH-3D'>
 			<roles>recon</roles>
 			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
-		<model name='PXH-5L'>
-			<availability>CC:2,MOC:2</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>DTA:8,FWL:8,IS:4</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:2-,DC:3-</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>FRR:8,DC:8</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,FWL:3,WOB:3,BAN:1</availability>
-		</model>
-		<model name='PXH-3S'>
-			<roles>recon</roles>
-			<availability>LA:8,MERC:6</availability>
-		</model>
-		<model name='PXH-7K'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='PXH-7CS'>
-			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -11081,17 +11078,17 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:6,CC:3-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:4-,WOB:4-,FS:3-,MERC:4-,CIR:3-,CWIE:6,Periphery:3-,TC:4-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:3-,CNC:6,FWL:2-,MH:5-,DC:4-</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:7,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:6,IS:6,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(RAC) &apos;Assault Pike&apos;'>
 			<availability>MOC:4,FS:6,TC:4</availability>
 		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
+		<model name='(Standard)'>
+			<availability>HL:6,IS:6,Periphery.Deep:6,Periphery:8</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -11099,6 +11096,9 @@
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,CS:4,MOC:3,MERC.WD:4,MERC.KH:4,CNC:6,CLAN:1,NIOPS:4,FS:2,MERC:4,TC:2</availability>
+		<model name='PLG-5Z'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
@@ -11109,19 +11109,16 @@
 		<model name='PLG-3Z'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PLG-5Z'>
-			<availability>CC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,FS:7</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -11147,9 +11144,6 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:4,CIH:6,CDS:3,CSR:3,CBS:3,CLAN:2,CFM:3,CWIE:3</availability>
-		<model name='2'>
-			<availability>CIH:8</availability>
-		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4</availability>
@@ -11159,6 +11153,9 @@
 		</model>
 		<model name='3'>
 			<availability>CIH:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CIH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -11206,38 +11203,38 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:3,CCO:2,CWIE:1,CSA:1,CS:1,CDS:5,NIOPS:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CGS:7,CCO:6,CWIE:8,CB:6</availability>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:6,CSV:6,General:8,CJF:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:6,CSV:6,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:3,CIH:6,General:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,CGB:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
@@ -11258,6 +11255,15 @@
 	</chassis>
 	<chassis name='Preta' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:4,WOB:1+</availability>
+		<model name='C-PRT-OE Eminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-PRT-OD Luminos'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-PRT-O Invictus'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C-PRT-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
@@ -11268,32 +11274,23 @@
 		<model name='C-PRT-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-PRT-O Invictus'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C-PRT-OE Eminus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-PRT-OD Luminos'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:4,CBS:3,SOC:6,CCO:5</availability>
-		<model name='3'>
-			<availability>SOC:8,CCO:4</availability>
+		<model name='2'>
+			<availability>CHH:3,CCO:3</availability>
 		</model>
 		<model name='4'>
 			<availability>CCO:4</availability>
+		</model>
+		<model name='3'>
+			<availability>SOC:8,CCO:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CHH:8,CBS:8,CCO:8</availability>
 		</model>
 		<model name='5'>
 			<availability>CCO:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:3,CCO:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -11319,10 +11316,6 @@
 			<roles>support</roles>
 			<availability>IS:5,Periphery:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8,General:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -11331,9 +11324,20 @@
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:8,CLAN:8,IS:2+,CFM:8,MERC:2+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:6,CDS:9,CW:9,CBS:7,CNC:9,CJF:6,CGB:7</availability>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CFM:6,CJF:6</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CGB:3</availability>
 		</model>
@@ -11341,25 +11345,18 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CJF:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CBS:6,CSV:6,CNC:7,General:8,CFM:6,CJF:7,CGB:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CFM:6,CJF:6</availability>
+		<model name='E'>
+			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -11367,43 +11364,43 @@
 		<model name='PAT-005'>
 			<availability>CS:5,CHH:2,CW:2,FRR:8,NIOPS:8,WOB:8,CWIE:2</availability>
 		</model>
+		<model name='PAT-007'>
+			<availability>CS:7,WOB:6</availability>
+		</model>
 		<model name='PAT-008'>
 			<availability>WOB:5+</availability>
 		</model>
 		<model name='PAT-005b'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='PAT-007'>
-			<availability>CS:7,WOB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Purifier Adaptive Battle Armor' unitType='BattleArmor'>
 		<availability>WOB:6,MH:4,CIR:4,TC:4</availability>
-		<model name='[Laser] (RAF)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CS:7,WOB:7,Periphery:7</availability>
+		<model name='[PPC] (RAF)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[PPC]' mechanized='true'>
 			<availability>CS:6,WOB:6,Periphery:6</availability>
-		</model>
-		<model name='[Narc]' mechanized='true'>
-			<availability>CS:4,WOB:4,Periphery:4</availability>
-		</model>
-		<model name='[PPC] (RAF)' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:5,WOB:5,Periphery:5</availability>
 		</model>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Laser] (RAF)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CS:7,WOB:7,Periphery:7</availability>
+		</model>
+		<model name='[Narc]' mechanized='true'>
+			<availability>CS:4,WOB:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
@@ -11420,8 +11417,11 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,FS:3,CIR:4,CDP:4,Periphery:4,TC:5,CS:3-,OA:5,FVC:4,LA:5,FWL:7,NIOPS:3-,DC:5</availability>
-		<model name='QKD-4H'>
-			<availability>General:2-</availability>
+		<model name='QKD-5K2'>
+			<availability>MERC:1,DC:1</availability>
+		</model>
+		<model name='QKD-5K'>
+			<availability>FRR:6,MERC:6,DC:8</availability>
 		</model>
 		<model name='QKD-5A'>
 			<availability>General:1-,MERC:3-,DC:3-,Periphery:3-</availability>
@@ -11429,23 +11429,20 @@
 		<model name='QKD-8K'>
 			<availability>FRR:4,MERC:2,DC:6</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>FRR:6,MERC:6,DC:8</availability>
-		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:2,FWL:4</availability>
-		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:5,FVC:5,Periphery.CM:5,Periphery.ME:5,FWL:8,IS:5,MH:5,TC:5</availability>
-		</model>
-		<model name='QKD-5K2'>
-			<availability>MERC:1,DC:1</availability>
+		<model name='QKD-C'>
+			<availability>FRR:7,MERC:6,DC:8</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:4-,OA:4-,HL:2-,Periphery.Deep:8,FWL:4-,IS:4-,Periphery:4-,DC:4-,TC:4-</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>FRR:7,MERC:6,DC:8</availability>
+		<model name='QKD-4H'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:5,FVC:5,Periphery.CM:5,Periphery.ME:5,FWL:8,IS:5,MH:5,TC:5</availability>
+		</model>
+		<model name='QKD-5Mr'>
+			<availability>General:2,FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
@@ -11457,43 +11454,43 @@
 	</chassis>
 	<chassis name='Rabid Coyote' unitType='Mek'>
 		<availability>CCC:3,CW:3,CCO:5-</availability>
-		<model name='2'>
-			<availability>CW:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCC:8,CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:8</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin II' unitType='Mek'>
 		<availability>WOB:6+</availability>
+		<model name='RJN-200-C'>
+			<availability>General:4+</availability>
+		</model>
 		<model name='RJN-200-B'>
 			<roles>recon,spotter</roles>
 			<availability>General:5+</availability>
-		</model>
-		<model name='RJN-200-C'>
-			<availability>General:4+</availability>
 		</model>
 		<model name='RJN-200-A'>
 			<availability>General:8</availability>
@@ -11510,24 +11507,18 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:4,FS:5,MERC:3</availability>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:6,LA:4,CLAN:3,NIOPS:6,WOB:6</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:4-</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:4</availability>
@@ -11535,31 +11526,49 @@
 		<model name='RPR-100'>
 			<availability>CS:8,General:5,NIOPS:8,WOB:8</availability>
 		</model>
-		<model name='RPR-300'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:1,CSR:1,CBS:1,CNC:2</availability>
+		</model>
+		<model name='RPR-102'>
+			<availability>LA:4-</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='RPR-300'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
 		<availability>WOB:4</availability>
-		<model name='RPT-2X1'>
-			<roles>specops</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='RPT-2X'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='RPT-2X1'>
+			<roles>specops</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:3+,FS:3+,DC:6+</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:2+</availability>
+		</model>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OG'>
+			<availability>General:3</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
@@ -11571,55 +11580,43 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OG'>
-			<availability>General:3</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,MOC:4,FWL:5,FS:3,MERC:5,TC:4,DC:2</availability>
-		<model name='RVN-SR &apos;Shattered Raven&apos;'>
-			<availability>FS.CMM:3</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:5,MOC:3,FWL:2,FS:2,MERC:3,DC:3,TC:3</availability>
-		</model>
-		<model name='RVN-SS &apos;Shattered Raven&apos;'>
-			<roles>spotter</roles>
-			<availability>FS.CMM:3</availability>
+		<model name='RVN-4X'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='RVN-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3,FWL:4,FS:1,MERC:3,DC:1,TC:3</availability>
 		</model>
-		<model name='RVN-4L'>
-			<roles>spotter</roles>
-			<availability>CC:7,MOC:7,TC:7</availability>
-		</model>
-		<model name='RVN-4X'>
-			<availability>CC:4</availability>
+		<model name='RVN-SR &apos;Shattered Raven&apos;'>
+			<availability>FS.CMM:3</availability>
 		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,TC:2</availability>
 		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:5,MOC:3,FWL:2,FS:2,MERC:3,DC:3,TC:3</availability>
+		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:7,MOC:7,TC:7</availability>
+		</model>
+		<model name='RVN-SS &apos;Shattered Raven&apos;'>
+			<roles>spotter</roles>
+			<availability>FS.CMM:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>LA:6,FRR:4,MERC:4,FS:4</availability>
-		<model name='RZK-9S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RZK-10T'>
 			<availability>LA:3</availability>
+		</model>
+		<model name='RZK-9S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
@@ -11634,6 +11631,11 @@
 	</chassis>
 	<chassis name='Red Shift' unitType='Mek'>
 		<availability>WOB:6</availability>
+		<model name='RDS-2A'>
+			<roles>spotter</roles>
+			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
+			<availability>General:8</availability>
+		</model>
 		<model name='RDS-2B'>
 			<roles>recon,spotter</roles>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
@@ -11642,11 +11644,6 @@
 		<model name='RDS-3A'>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
 			<availability>General:4</availability>
-		</model>
-		<model name='RDS-2A'>
-			<roles>spotter</roles>
-			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
@@ -11664,56 +11661,62 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,FRR:5,CLAN:6,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 		</model>
-		<model name='(ML)'>
+		<model name='(MG)'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(ML)'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,FVC:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+		<model name='F-700a'>
+			<availability>CC:7,FWL:7,WOB:7,FS:5,MERC:7</availability>
+		</model>
+		<model name='F-100b'>
+			<availability>FRR:5-,DC:5-</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>CC:4,FWL:5,MERC:5</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:8,FWL:8,WOB:8,MERC:8</availability>
 		</model>
-		<model name='F-100b'>
-			<availability>FRR:5-,DC:5-</availability>
+		<model name='F-700b'>
+			<availability>FWL:4,WOB:5,MERC:4,DC:4</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:4-,FVC:5-,HL:3-,LA:2,FRR:2,FWL:5-,Periphery.Deep:8,MERC:5-,DC:2,Periphery:5-</availability>
 		</model>
-		<model name='F-700a'>
-			<availability>CC:7,FWL:7,WOB:7,FS:5,MERC:7</availability>
-		</model>
-		<model name='F-700b'>
-			<availability>FWL:4,WOB:5,MERC:4,DC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:2,CNC:5,IS:1,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:4,CNC:5,IS:2</availability>
+		<model name='5'>
+			<availability>CSA:4,CDS:2,SOC:3,IS:2,CLAN.HW:3,CB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:4,CLAN:3,CNC:4</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:6,CCC:5,CIH:3,CDS:4,CBS:5,CCO:3,CB:6</availability>
 		</model>
 		<model name='6'>
 			<availability>CSA:4,CHH:2,CDS:2</availability>
@@ -11721,14 +11724,8 @@
 		<model name='3'>
 			<availability>CSA:5,CCC:6,CDS:4,CIH:4,CBS:3,CCO:3,CB:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CDS:4,CLAN:3,CNC:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CSA:4,CDS:2,SOC:3,IS:2,CLAN.HW:3,CB:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:6,CCC:5,CIH:3,CDS:4,CBS:5,CCO:3,CB:6</availability>
+		<model name='2'>
+			<availability>CLAN:4,CNC:5,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -11740,20 +11737,32 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,CCC:6,HL:3,FRR:7,CSV:6,IS:7,Periphery.Deep:5,WOB:5,CFM:6,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CB:6</availability>
-		<model name='C'>
-			<availability>LA:2,CLAN:8,FS:2,BAN:2,DC:2</availability>
+		<model name='RFL-6D'>
+			<availability>FS:3</availability>
 		</model>
 		<model name='RFL-7M'>
 			<availability>FRR:3,FWL:5,WOB:4,DC:3</availability>
 		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RFL-4D'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:1-,MERC:1-</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
 		<model name='RFL-5D'>
 			<availability>FVC:5,LA:5,FS:5,MERC:5</availability>
 		</model>
+		<model name='RFL-3Cr'>
+			<availability>FS:1</availability>
+		</model>
 		<model name='RFL-8D'>
 			<availability>LA:3,FS:5</availability>
-		</model>
-		<model name='RFL-6D'>
-			<availability>FS:3</availability>
 		</model>
 		<model name='RFL-9T'>
 			<availability>TC:3</availability>
@@ -11761,26 +11770,14 @@
 		<model name='RFL-8X'>
 			<availability>MERC:3</availability>
 		</model>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:2</availability>
+		<model name='RFL-6X'>
+			<availability>FVC:2,FS:3,MERC:2</availability>
 		</model>
 		<model name='RFL-5M'>
 			<availability>CC:5,MOC:5,IS:4,FWL:4,MERC:5,DC:5</availability>
 		</model>
-		<model name='RFL-3Cr'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='RFL-4D'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:1-,MERC:1-</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:2,FS:3,MERC:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		<model name='C'>
+			<availability>LA:2,CLAN:8,FS:2,BAN:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Riga Frigate' unitType='Warship'>
@@ -11796,9 +11793,6 @@
 			<roles>destroyer</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2747)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Riot Police' unitType='Infantry'>
 		<availability>WOB.PM:4</availability>
@@ -11809,48 +11803,48 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,CSR:1,FRR:5,CLAN:2,WOB:6,FS:5,CS:6,FVC:4,LA:5,NIOPS:6,CJF:1,DC:5</availability>
-		<model name='(SPL)'>
-			<roles>apc</roles>
-			<availability>FVC:4,IS:4</availability>
-		</model>
-		<model name='(ERML)'>
-			<roles>apc</roles>
-			<availability>CC:6,LA:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>DC:5</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8,BAN:2</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>DC:5</availability>
+		</model>
+		<model name='(ERML)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(Infantry)'>
+			<roles>apc</roles>
+			<availability>LA:5</availability>
+		</model>
+		<model name='(SPL)'>
+			<roles>apc</roles>
+			<availability>FVC:4,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:3,CHH:4,CSR:7,CBS:7,SOC:8,CSV:4,CNC:7,CFM:5,CGS:6,CCO:8,CWIE:8</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CCC:5,CSR:8,CBS:8,CSV:6,CNC:5,CFM:8,CCO:8,CGS:5</availability>
+		</model>
 		<model name='3'>
 			<availability>CSR:6,CBS:6,CSV:5,CNC:4,CFM:6,CCO:4,CWIE:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CSR:4,CCO:3</availability>
-		</model>
-		<model name='2'>
-			<availability>CCC:5,CSR:8,CBS:8,CSV:6,CNC:5,CFM:8,CCO:8,CGS:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
@@ -11861,24 +11855,24 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:8</availability>
+		<model name='RGU-133Eb'>
+			<availability>CLAN:5,BAN:2</availability>
+		</model>
+		<model name='RGU-133E'>
+			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
 		</model>
 		<model name='RGU-133L'>
 			<availability>CS:1,General:4,NIOPS:1,WOB:2</availability>
 		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:8</availability>
+		</model>
 		<model name='RGU-133F'>
 			<availability>CS:2,General:6,NIOPS:2,WOB:4</availability>
 		</model>
-		<model name='RGU-133Eb'>
-			<availability>CLAN:5,BAN:2</availability>
-		</model>
 		<model name='RGU-133P'>
 			<availability>CS:1</availability>
-		</model>
-		<model name='RGU-133E'>
-			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
@@ -11909,16 +11903,16 @@
 			<roles>urban</roles>
 			<availability>LA:3</availability>
 		</model>
-		<model name='(Firedrake)' mechanized='false'>
-			<roles>anti_infantry</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>LA:8</availability>
 		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='(Firedrake)' mechanized='false'>
+			<roles>anti_infantry</roles>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -11931,7 +11925,7 @@
 	</chassis>
 	<chassis name='Rusalka' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:5</availability>
-		<model name='S-RSL-OD Luminos'>
+		<model name='S-RSL-OB Infernus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
@@ -11943,53 +11937,53 @@
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-RSL-OC Comminus'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='S-RSL-OA Dominus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-RSL-OB Infernus'>
+		<model name='S-RSL-OD Luminos'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='S-RSL-OC Comminus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:8,CSR:9,CSV:7,CLAN:8,WOB:3+,MERC:2+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CBS:9,CNC:6,CJF:9,DC:3+</availability>
-		<model name='G'>
-			<availability>CHH:5,General:2</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
 		</model>
+		<model name='A'>
+			<availability>CDS:9,CW:6,CSV:8,General:6,CJF:5,CGB:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:5,CCC:5,CBS:4,CSV:5,CLAN:3,General:1</availability>
-		</model>
-		<model name='I'>
-			<availability>CLAN:3,General:1</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:9,CW:6,CSV:8,General:6,CJF:5,CGB:3</availability>
+		<model name='F'>
+			<availability>General:2,CJF:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CJF:4,CGB:3</availability>
-		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='I'>
+			<availability>CLAN:3,General:1</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CSR:6,CDS:6,CNC:4,General:5,CFM:4,CCO:7,CJF:4,CWIE:6</availability>
 		</model>
-		<model name='F'>
-			<availability>General:2,CJF:5</availability>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:5,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
@@ -12012,21 +12006,21 @@
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:7,CLAN:3,WOB:8</availability>
-		<model name='(WoB)'>
-			<roles>sr_fire_support,spotter</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:6,LA:7,FWL:6,IS:4,FS:7,DC:6,Periphery:5</availability>
+		<model name='(WoB)'>
+			<roles>sr_fire_support,spotter</roles>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='(C3)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:4,Periphery:3</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:6,LA:7,FWL:6,IS:4,FS:7,DC:6,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -12049,32 +12043,23 @@
 		<model name='SB-29'>
 			<availability>MERC:4,DC:6</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CC:6,MOC:4,CLAN:4,FS:6,MERC:4</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,LA:6,NIOPS:6,WOB:6,FS:4,MERC:4</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CC:6,MOC:4,CLAN:4,FS:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CSR:5,General:2,CJF:5</availability>
+		<model name='E'>
+			<availability>CSR:5,CJF:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='X'>
-			<availability>CSR:3,General:1,CJF:3</availability>
-		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CSR:5,CJF:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -12082,6 +12067,15 @@
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:5,General:2,CJF:5</availability>
+		</model>
+		<model name='X'>
+			<availability>CSR:3,General:1,CJF:3</availability>
+		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
@@ -12099,8 +12093,8 @@
 		<model name='S-4X'>
 			<availability>DC:1</availability>
 		</model>
-		<model name='S-7'>
-			<availability>CNC:4,DC:4</availability>
+		<model name='S-4C'>
+			<availability>CLAN:8,DC:3</availability>
 		</model>
 		<model name='S-3'>
 			<availability>DC:3-</availability>
@@ -12111,43 +12105,51 @@
 		<model name='S-4'>
 			<availability>FRR:6,FS:5,DC:6</availability>
 		</model>
-		<model name='S-4C'>
-			<availability>CLAN:8,DC:3</availability>
+		<model name='S-7'>
+			<availability>CNC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:7,Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,LA:7,FWL:7,CJF:4,DC:9</availability>
-		<model name='(Armor)'>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>IS:5,DC:6</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
+		<model name='(LB-X)'>
+			<availability>IS:6,DC:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:8-,Periphery:8-</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>IS:6,DC:7</availability>
+		<model name='(Armor)'>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:5,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3,CFM:6</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>anti_infantry</roles>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='(Laser)' mechanized='true'>
 			<availability>CSR:6,CW:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>anti_infantry</roles>
+			<availability>CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>CS:5,LA:7,FS:5,MERC:5</availability>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
+		</model>
+		<model name='PPR-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:3,FS:3</availability>
@@ -12156,31 +12158,23 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
-		<model name='PPR-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>CS:4,OA:1,LA:5,FRR:4,WOB:4,DC:1</availability>
+		<model name='SL-25'>
+			<roles>ground_support</roles>
+			<availability>OA:6,FRR:6-,DC:6</availability>
+		</model>
 		<model name='SL-27'>
 			<availability>IS:6</availability>
 		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='SL-25'>
-			<roles>ground_support</roles>
-			<availability>OA:6,FRR:6-,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -12194,11 +12188,11 @@
 	</chassis>
 	<chassis name='Sasquatch' unitType='Mek'>
 		<availability>WOB:5</availability>
-		<model name='SQS-TH-001'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SQS-TH-002'>
 			<availability>General:6</availability>
+		</model>
+		<model name='SQS-TH-001'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sassanid' unitType='Dropship'>
@@ -12210,46 +12204,46 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:3,CSR:3,CIH:7,CBS:4,CSV:3,CNC:2,CFM:3,CGS:6,CCO:7,CWIE:7</availability>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CIH:3,CSR:3,CNC:3</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CIH:3,CSR:3,CNC:3</availability>
+		</model>
 		<model name='3'>
 			<roles>recon,raider</roles>
 			<availability>CIH:6,CGS:3,CWIE:3</availability>
 		</model>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CW:5,SOC:7,CCO:7,CB:4</availability>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:8,CLAN:6</availability>
-		</model>
-		<model name='W'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>CHH:3,CW:3</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:3,General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
+		<model name='C'>
+			<availability>CSA:8,CLAN:6</availability>
+		</model>
+		<model name='J'>
+			<availability>CHH:4,CW:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
 		</model>
 		<model name='Z'>
 			<availability>SOC:10,CCO:4</availability>
 		</model>
-		<model name='J'>
-			<availability>CHH:4,CW:4</availability>
+		<model name='W'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>CHH:3,CW:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
@@ -12275,32 +12269,36 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MASH)'>
-			<roles>apc,support</roles>
-			<availability>General:4</availability>
+		<model name='(HQ)'>
+			<roles>apc,support,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(HQ)'>
-			<roles>apc,support,spotter</roles>
-			<availability>General:2</availability>
+		<model name='(MASH)'>
+			<roles>apc,support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>CS:4,LA:5,FS:6,MERC:4</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>LA:6,FS:3,MERC:5</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>LA:6,FS:3,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>FRR:4,FWL:4,WOB:4,FS:4,MERC:4,MERC.NH:4,DC:4</availability>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -12309,6 +12307,10 @@
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
@@ -12316,14 +12318,6 @@
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
@@ -12368,23 +12362,23 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,HL:6,LA:6,FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(MRM)'>
-			<availability>IS:4,DC:5,Periphery:3</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:3,LA:3,FWL:3,WOB:3,FS:3,MERC:3,DC:3</availability>
+		<model name='(LRM)'>
+			<availability>General:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:6-</availability>
 		</model>
-		<model name='(ML)'>
-			<availability>General:3</availability>
+		<model name='(LAC)'>
+			<availability>CC:3,LA:3,FWL:3,WOB:3,FS:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>IS:4,DC:5,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -12392,8 +12386,8 @@
 		<model name='SCP-1N'>
 			<availability>HL:4-,FRR:6-,Periphery.Deep:6-,MERC:6-,Periphery:6-</availability>
 		</model>
-		<model name='SCP-12S'>
-			<availability>LA:4,MERC:2</availability>
+		<model name='SCP-12C'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
@@ -12402,11 +12396,11 @@
 		<model name='SCP-1O'>
 			<availability>IS:6</availability>
 		</model>
+		<model name='SCP-12S'>
+			<availability>LA:4,MERC:2</availability>
+		</model>
 		<model name='SCP-1TB'>
 			<availability>MERC:4</availability>
-		</model>
-		<model name='SCP-12C'>
-			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -12433,30 +12427,30 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
+		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Se&apos;irim Medium Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:6</availability>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Capture Team)' mechanized='true'>
 			<availability>General:2</availability>
@@ -12493,14 +12487,14 @@
 		<model name='STN-3M'>
 			<availability>DC.GHO:5-,DC:2</availability>
 		</model>
-		<model name='STN-5WB'>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='STN-C'>
 			<availability>DC:6</availability>
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-5WB'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -12514,12 +12508,6 @@
 	</chassis>
 	<chassis name='Seraph' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
-		<model name='C-SRP-OE Eminus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-SRP-OD Luminos'>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-SRP-OA Dominus'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
@@ -12533,40 +12521,46 @@
 		<model name='C-SRP-OC Comminus'>
 			<availability>General:7</availability>
 		</model>
+		<model name='C-SRP-OE Eminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-SRP-OD Luminos'>
+			<availability>General:7</availability>
+		</model>
 		<model name='C-SRP-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:3-,MH:2,DC:4-</availability>
-		<model name='SYD-21'>
+		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
-			<availability>FVC:2-,MERC.KH:3-,LA:3-,Periphery.Deep:4,FS:2-,MERC:3-,Periphery:3-</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>OA:5-,HL:6,FRR:5-,Periphery.Deep:6,FWL:5-,WOB:4-,Periphery:8,TC:5-,DC:5-</availability>
-		</model>
-		<model name='SYD-Z4'>
-			<availability>OA:3,LA:5,FRR:2,MERC:4</availability>
-		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:2-,FS:2-</availability>
+			<availability>HL:2-,LA:4-,Periphery.Deep:8,FS:3-,Periphery:4-</availability>
 		</model>
 		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
 			<availability>LA:8,FRR:6,FS:8,MERC:6</availability>
 		</model>
-		<model name='SYD-Z2'>
+		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
-			<availability>HL:2-,LA:4-,Periphery.Deep:8,FS:3-,Periphery:4-</availability>
+			<availability>OA:5-,HL:6,FRR:5-,Periphery.Deep:6,FWL:5-,WOB:4-,Periphery:8,TC:5-,DC:5-</availability>
+		</model>
+		<model name='SYD-Z3A'>
+			<availability>LA:6,FRR:3,MERC:3</availability>
+		</model>
+		<model name='SYD-Z4'>
+			<availability>OA:3,LA:5,FRR:2,MERC:4</availability>
+		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>FVC:2-,MERC.KH:3-,LA:3-,Periphery.Deep:4,FS:2-,MERC:3-,Periphery:3-</availability>
 		</model>
 		<model name='SYD-Z2B'>
 			<availability>OA:3,LA:4</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>LA:6,FRR:3,MERC:3</availability>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:2-,FS:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
@@ -12575,10 +12569,10 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='SYU-4B'>
+		<model name='SYU-6B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SYU-6B'>
+		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -12590,16 +12584,16 @@
 		<model name='S-HA-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-HA-OB Infernus'>
+		<model name='S-HA-OC Comminus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-HA-OD Luminos'>
+		<model name='S-HA-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-HA-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='S-HA-OC Comminus'>
+		<model name='S-HA-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -12612,91 +12606,91 @@
 			<roles>recon</roles>
 			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='J'>
-			<availability>General:4</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
+		<model name='J'>
+			<availability>General:4</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,FRR:2,CLAN:5,FS:2,MERC:2,CWIE:6,CS:2,CDS:6,LA:2,CNC:6,FWL:2,CJF:4,DC:2,CGB:6</availability>
-		<model name='2'>
-			<availability>CSA:4,CCC:4,CIH:4,CGB:4,CB:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:4,CDS:5,CNC:5,CB:4</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='5'>
-			<availability>CS:4,CDS:4,LA:4,FRR:4,FWL:4,FS:4,MERC:4,DC:4</availability>
+		<model name='2'>
+			<availability>CSA:4,CCC:4,CIH:4,CGB:4,CB:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:5</availability>
 		</model>
+		<model name='3'>
+			<availability>CSA:4,CDS:5,CNC:5,CB:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CS:4,CDS:4,LA:4,FRR:4,FWL:4,FS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:3,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:1</availability>
-		<model name='SHD-2D2'>
-			<availability>FVC:6,LA:6,FS:8</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:3,MOC:3,CLAN:4,FWL:3,MERC:3,BAN:2</availability>
-		</model>
-		<model name='SHD-7CS'>
-			<availability>CS:5,WOB:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,BAN:1,Periphery:5-</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FVC:4-,FS:3-</availability>
-		</model>
 		<model name='SHD-2K'>
 			<availability>FRR:3-,MERC:2-,DC:5-</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:8,CCC:8,LA:4,CSV:8,CFM:8,FS:4,CGS:8,CB:8,DC:4</availability>
-		</model>
-		<model name='SHD-9D'>
-			<availability>WOB:2,FS:3</availability>
-		</model>
-		<model name='SHD-5M'>
-			<availability>CC:6,FRR:6,Periphery.MW:4,Periphery.ME:3,FWL:8,IS:3,WOB:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='SHD-5D'>
-			<availability>LA:3,WOB:3,FS:4,MERC:3</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:3,MOC:3,FWL:4,TC:3</availability>
-		</model>
-		<model name='SHD-11CS'>
-			<availability>CS:6,WOB:5</availability>
+		<model name='SHD-2D2'>
+			<availability>FVC:6,LA:6,FS:8</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:2-,MOC:2-,FWL:2-,MERC:2-</availability>
 		</model>
+		<model name='SHD-2D'>
+			<availability>FVC:4-,FS:3-</availability>
+		</model>
+		<model name='SHD-11CS'>
+			<availability>CS:6,WOB:5</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,BAN:1,Periphery:5-</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CC:3,MOC:3,CLAN:4,FWL:3,MERC:3,BAN:2</availability>
+		</model>
+		<model name='SHD-5M'>
+			<availability>CC:6,FRR:6,Periphery.MW:4,Periphery.ME:3,FWL:8,IS:3,WOB:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:8,CCC:8,LA:4,CSV:8,CFM:8,FS:4,CGS:8,CB:8,DC:4</availability>
+		</model>
+		<model name='SHD-7M'>
+			<availability>CC:3,MOC:3,FWL:4,TC:3</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>WOB:2,FS:3</availability>
+		</model>
+		<model name='SHD-7CS'>
+			<availability>CS:5,WOB:4</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:3,WOB:3,FS:4,MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CSA:5,CIH:5,CDS:5,CW:5,CBS:7,CLAN:3,CGS:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>CDS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shedu Assault Battle Armor' unitType='BattleArmor'>
@@ -12716,11 +12710,11 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
-		<model name='SL-17'>
-			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
 		<model name='SL-18'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='SL-17'>
+			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>OA:4,FRR:6,MERC:4,DC:6</availability>
@@ -12731,11 +12725,14 @@
 	</chassis>
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>FWL:4+,WOB:3+,FWL.KIS:6+,FWL.FWG:5+</availability>
-		<model name='SHV-OB'>
+		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
+		</model>
+		<model name='SHV-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -12743,21 +12740,18 @@
 		<model name='SHV-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SHV-OA'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,CDS:4,CW:3,CNC:5,CJF:3,DC:3</availability>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:4,DC:4</availability>
+		</model>
 		<model name='(Streak)'>
 			<availability>CW:6,CNC:6,CJF:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
@@ -12805,10 +12799,22 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverback Coastal Cutter' unitType='Naval'>
+		<availability>LA:7</availability>
+		<model name='(Standard)'>
+			<availability>LA:7</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:5,CCC:7,CIH:6,CCO:4</availability>
-		<model name='5'>
-			<availability>CIH:4</availability>
+		<model name='2'>
+			<availability>CSA:8,CCC:8,CIH:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4,CIH:6</availability>
@@ -12816,47 +12822,47 @@
 		<model name='(Standard)'>
 			<availability>CSA:4,CCC:4,CIH:4,CCO:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CCC:8,CIH:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CIH:5</availability>
+		</model>
+		<model name='5'>
+			<availability>CIH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>CC:3,FWL:5,WOB:4,MERC:3</availability>
-		<model name='SRC-6C'>
-			<availability>FWL:3,WOB:3</availability>
-		</model>
 		<model name='SRC-5C'>
 			<availability>FWL:5,WOB:5</availability>
 		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
 		</model>
+		<model name='SRC-6C'>
+			<availability>FWL:3,WOB:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,FWL:3,NIOPS:3-,DC:6</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:2,DC:7</availability>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,DC:1</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>OA:6,FRR:8,FS:6,MERC:6,CDP:4,DC:8,TC:4</availability>
-		</model>
-		<model name='SL-15'>
-			<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>FRR:1,MERC:1,DC:1</availability>
@@ -12864,11 +12870,11 @@
 		<model name='SL-15K'>
 			<availability>FRR:3,DC:3</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,DC:1</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -12898,15 +12904,15 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CIH:6,CNC:4,CJF:4</availability>
+		<model name='(Standard)'>
+			<availability>CIH:8,CNC:8</availability>
+		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CIH:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CJF:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CIH:8,CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -12925,10 +12931,6 @@
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Space Marine' unitType='Infantry'>
 		<availability>CS:5,WOB:5</availability>
@@ -12939,11 +12941,11 @@
 	</chassis>
 	<chassis name='Spad' unitType='Aero'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
-		<model name='SPD-504'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>WOB:5</availability>
 		</model>
 		<model name='SPD-503'>
 			<availability>CS:6,WOB:6,BAN:2</availability>
@@ -12951,23 +12953,23 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3,DC:2-</availability>
-		<model name='SPR-8H'>
-			<roles>interceptor</roles>
-			<availability>FS.CMM:1-</availability>
+		<model name='SPR-6D'>
+			<availability>FVC:7,FRR:5,PIR:2+,FS:8,MERC:5,CDP:2+,TC:2+</availability>
 		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:5-,General:4-,Periphery.Deep:8,FS:5-,MERC:5-,CDP:5-,DC:1,TC:5-</availability>
 		</model>
+		<model name='SPR-7D'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='SPR-H5K'>
 			<roles>interceptor</roles>
 			<availability>OA:2,FRR:4-,DC:4-</availability>
 		</model>
-		<model name='SPR-7D'>
-			<availability>FS:5,MERC:5</availability>
-		</model>
-		<model name='SPR-6D'>
-			<availability>FVC:7,FRR:5,PIR:2+,FS:8,MERC:5,CDP:2+,TC:2+</availability>
+		<model name='SPR-8H'>
+			<roles>interceptor</roles>
+			<availability>FS.CMM:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Spartan' unitType='Mek'>
@@ -13003,46 +13005,46 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,OA:1,FVC:4,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:4-</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:1-,Periphery:4-</availability>
-		</model>
-		<model name='SDR-7M'>
-			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,DC:6</availability>
-		</model>
-		<model name='SDR-7K2'>
-			<availability>MERC:3,DC:4</availability>
-		</model>
-		<model name='SDR-7Kr'>
-			<availability>MERC:2,DC:2</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>FWL:8,MERC:2</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:4,FWL:4,FS:4,MERC:4,DC:6</availability>
-		</model>
-		<model name='SDR-7K'>
-			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:4-,DC:4-</availability>
 		</model>
+		<model name='SDR-7Kr'>
+			<availability>MERC:2,DC:2</availability>
+		</model>
+		<model name='SDR-7K'>
+			<availability>MERC:4,DC:4</availability>
+		</model>
+		<model name='SDR-7M'>
+			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,DC:6</availability>
+		</model>
 		<model name='SDR-7KC'>
 			<availability>MERC:4,DC:5</availability>
+		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:4-</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:4,FWL:4,FS:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='SDR-7K2'>
+			<availability>MERC:3,DC:4</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>FWL:8,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
 		<availability>CGS:3-,CJF:5-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
@@ -13050,6 +13052,14 @@
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>FRR:5,IS:4,DC:6</availability>
+		</model>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='(C3i)'>
+			<roles>recon</roles>
+			<availability>CS:5,WOB:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
@@ -13059,34 +13069,29 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3i)'>
-			<roles>recon</roles>
-			<availability>CS:5,WOB:6</availability>
-		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
 		<availability>CHH:3,CBS:3,SOC:4,CCO:4</availability>
-		<model name='2'>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:8,CC:6,HL:9,FRR:6,CLAN:3,IS:7,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:9,CS:5,OA:9,LA:7,FWL:8,NIOPS:5,DC:6</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		<model name='STK-8S'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
+		</model>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-7D'>
 			<availability>FS:4</availability>
-		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
@@ -13094,30 +13099,27 @@
 		<model name='STK-3Fb'>
 			<availability>CLAN:8,FWL:2,MERC:2,BAN:2</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-6M'>
 			<availability>FWL:6,WOB:6,MERC:6</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
-		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,CSV:3,MERC:4,FS:5,CJF:3,TC:4</availability>
-		</model>
-		<model name='STK-8S'>
-			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:6+,CBS:3+</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
@@ -13152,30 +13154,30 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:2,FS:4,MERC:2</availability>
 		</model>
-		<model name='STH-3S'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='STH-1D'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>LA:2,FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-2D'>
 			<roles>recon</roles>
 			<availability>LA:2,FS:6,MERC:4</availability>
 		</model>
+		<model name='STH-3S'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='STH-2D1'>
+			<roles>recon</roles>
+			<availability>LA:2,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Stiletto' unitType='Mek'>
 		<availability>LA:4,MERC:2</availability>
-		<model name='STO-4A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='STO-4B'>
 			<availability>General:4</availability>
+		</model>
+		<model name='STO-4A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -13186,96 +13188,96 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
-		<model name='STG-5R'>
-			<roles>recon</roles>
-			<availability>CC:3,MOC:3,PIR:3,WOB:4,CIR:4,CDP:3,TC:4</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FVC:4,FWL:8,IS:4,WOB:8,FS:4,MERC:4,CDP:4,DC:4,TC:4</availability>
-		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,CC:2,TC:2</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
-		</model>
-		<model name='STG-6L'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:3</availability>
-		</model>
-		<model name='STG-3Gb'>
-			<roles>recon</roles>
-			<availability>CLAN:8,FWL:3,WOB:4,BAN:2</availability>
-		</model>
-		<model name='STG-3P'>
-			<roles>recon</roles>
-			<availability>LA:3,WOB.PM:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='STG-6S'>
 			<roles>recon</roles>
 			<availability>LA:3,MERC:3</availability>
 		</model>
+		<model name='STG-3Gb'>
+			<roles>recon</roles>
+			<availability>CLAN:8,FWL:3,WOB:4,BAN:2</availability>
+		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,FVC:4,FWL:8,IS:4,WOB:8,FS:4,MERC:4,CDP:4,DC:4,TC:4</availability>
+		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:2-,Periphery.Deep:4,Periphery:2-</availability>
 		</model>
+		<model name='STG-6L'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:3</availability>
+		</model>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:3,CC:2,TC:2</availability>
+		</model>
+		<model name='STG-3P'>
+			<roles>recon</roles>
+			<availability>LA:3,WOB.PM:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='STG-5R'>
+			<roles>recon</roles>
+			<availability>CC:3,MOC:3,PIR:3,WOB:4,CIR:4,CDP:3,TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,DC:4</availability>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:6</availability>
+		</model>
+		<model name='F-95'>
+			<availability>FWL:4</availability>
+		</model>
 		<model name='F-94'>
 			<availability>IS:6</availability>
 		</model>
 		<model name='F-92'>
 			<availability>FWL:7,IS:4</availability>
 		</model>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:6</availability>
-		</model>
 		<model name='F-90'>
 			<availability>CS:4-,LA:3-,IS:4-,FS:4-,Periphery:4-</availability>
-		</model>
-		<model name='F-95'>
-			<availability>FWL:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>:0,CLAN:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='F'>
+		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>:0,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -13287,42 +13289,42 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:4+,FWL:4+,FS:4+,MERC:4+,DC:7+</availability>
-		<model name='SR1-OA'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SR1-OD'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
+		<model name='SR1-OG'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SR1-OR'>
 			<availability>CLAN:6,General:1+</availability>
 		</model>
-		<model name='SR1-OG'>
-			<availability>General:4</availability>
-		</model>
 		<model name='SR1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striga' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:6</availability>
-		<model name='S-STR-O Invictus'>
-			<availability>General:8</availability>
+		<model name='S-STR-OB Infernus'>
+			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OA Dominus'>
+		<model name='S-STR-OE Eminus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-STR-OC Comminus'>
@@ -13331,21 +13333,25 @@
 		<model name='S-STR-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OE Eminus'>
-			<availability>General:7</availability>
+		<model name='S-STR-O Invictus'>
+			<availability>General:8</availability>
 		</model>
-		<model name='S-STR-OB Infernus'>
+		<model name='S-STR-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:3,FRR:4,IS:5,WOB:3-,FS:8,MERC:3,CS:3-,FVC:7,CDS:3,LA:5,PIR:3,FWL:3,DC:3</availability>
+		<model name='(Narc)'>
+			<availability>LA:2,FS:2,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>FVC:4-,IS:4-</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,LA:6,FS:7,DC:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2</availability>
@@ -13356,27 +13362,23 @@
 		<model name='(SRM)'>
 			<availability>FVC:4-,IS:4-</availability>
 		</model>
-		<model name='(Narc)'>
-			<availability>LA:2,FS:2,DC:1</availability>
-		</model>
 		<model name='(3061 Upgrade)'>
 			<availability>LA:4,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:6-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,LA:6,FS:7,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:5,CS:4,MOC:5,MERC.WD:2-,LA:3-,NIOPS:4,WOB:4</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>CC:5-,General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -13384,17 +13386,17 @@
 		<model name='STU-K5'>
 			<availability>FVC:5-,HL:3-,IS:5-,Periphery.Deep:8,BAN:8,Periphery:5-</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:3,LA:3,FS.DMM:4-</availability>
-		</model>
-		<model name='STU-K15'>
-			<availability>OA:2,FS:1-,TC:2,Periphery:1</availability>
-		</model>
 		<model name='STU-D7'>
 			<availability>FS:5</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,FS:2,BAN:2</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:3,LA:3,FS.DMM:4-</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:2,FS:1-,TC:2,Periphery:1</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>LA:6,FS:8,MERC:6</availability>
@@ -13402,12 +13404,12 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:4,CDS:3,HL:3,LA:7,CNC:4,MERC:3,FS:5,CWIE:4</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:6,WOB:0</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Heavy Gauss)'>
 			<availability>LA:6,CNC:6,CWIE:6</availability>
@@ -13415,13 +13417,13 @@
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,WOB:4</availability>
-		<model name='(Standard)'>
-			<roles>recon,fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(WOB)'>
 			<roles>recon,fire_support</roles>
@@ -13440,14 +13442,14 @@
 		<model name='E'>
 			<availability>CW:4,CLAN:2,CGB:4</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:6,CBS:6,General:2,CGB:6,CB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:6,General:2,CJF:6,CGB:6,CB:6</availability>
@@ -13464,12 +13466,15 @@
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4+,LA:5+,FS:5+,MERC:3+,DC:7+</availability>
-		<model name='SD1-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='SD1-OX'>
+			<availability>General:2</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='SD1-OR'>
 			<availability>General:1+,CLAN:6,DC:2+</availability>
@@ -13480,9 +13485,6 @@
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
-		</model>
-		<model name='SD1-OX'>
-			<availability>General:2</availability>
 		</model>
 		<model name='SD1-OC'>
 			<availability>General:6,DC:7</availability>
@@ -13499,11 +13501,11 @@
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='4'>
 			<availability>CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -13523,10 +13525,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:2,MOC:2,CDP:2,TC:2</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -13538,33 +13540,33 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:2</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:5,NIOPS:8,WOB:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:9,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:2,CCC:6,CSR:3,CDS:2,CB:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
@@ -13588,11 +13590,11 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:5,CC:3,MERC:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(RL)'>
 			<availability>MOC:4</availability>
@@ -13603,39 +13605,39 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>CS:3,MOC:3,CC:5,FVC:3,FWL:6,IS:3,WOB:4,MERC:4,DC:6</availability>
-		<model name='ZPH-3A'>
-			<roles>recon</roles>
-			<availability>FVC:4,FWL:5,IS:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='ZPH-2A'>
 			<roles>recon</roles>
 			<availability>CC:6,FVC:5,FWL:6,IS:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:5,General:4,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>FVC:4,IS:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:5,MOC:5,General:4,FWL:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='ZPH-3A'>
+			<roles>recon</roles>
+			<availability>FVC:4,FWL:5,IS:4,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>FRR:4+,CNC:4,DC:5+</availability>
+		<model name='MIK-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='MIK-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='MIK-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-O'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsumaki Destroyer' unitType='Warship'>
@@ -13647,8 +13649,8 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>FWL.MM:8,FWL:7,WOB:6,MERC:3</availability>
-		<model name='TMP-3G'>
-			<availability>FWL:2,WOB:2,MERC:2</availability>
+		<model name='TMP-3M'>
+			<availability>FWL:6,WOB:6,MERC:6</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>FWL:4,WOB:4,MERC:4</availability>
@@ -13656,8 +13658,8 @@
 		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
 			<availability>FWL:5,WOB:5</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>FWL:6,WOB:6,MERC:6</availability>
+		<model name='TMP-3G'>
+			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
@@ -13668,9 +13670,8 @@
 		<model name='TLR1-OB'>
 			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OG'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OC'>
 			<availability>General:5</availability>
@@ -13679,15 +13680,16 @@
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='TLR1-OF'>
 			<roles>spotter</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='TLR1-OG'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Tengu Heavy Battle Armor' unitType='BattleArmor'>
@@ -13711,33 +13713,33 @@
 			<roles>recon,spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='TSN-1C'>
-			<roles>recon,spotter</roles>
-			<availability>CS:8,WOB:8,SL.2:8</availability>
-		</model>
 		<model name='TSN-1Cr'>
 			<roles>recon,spotter</roles>
 			<availability>CS:4,DC:4</availability>
 		</model>
+		<model name='TSN-1C'>
+			<roles>recon,spotter</roles>
+			<availability>CS:8,WOB:8,SL.2:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
 		<availability>LA:5,FS:5,MERC:4</availability>
-		<model name='TNS-4T'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TNS-4T'>
+			<availability>IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tharkad Battlecruiser' unitType='Warship'>
@@ -13756,47 +13758,51 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CSR:5,CIH:3,CLAN:5,IS:2+,CCO:5,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CDS:5,CW:5,CNC:5,CJF:8,CGB:5,CB:3</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
 		<model name='Z'>
 			<availability>SOC:10,CCO:4</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:4,CIH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CGS:4,CWIE:6,CGB:8</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
-		<model name='G'>
-			<availability>CHH:4,CIH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
-		</model>
-		<model name='HH'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CGS:4,CWIE:6,CGB:8</availability>
+		<model name='HH'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
 		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,WOB:3,BAN:5</availability>
+		<model name='(C3i)'>
+			<roles>artillery</roles>
+			<availability>CS:4,WOB:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CS:5,NIOPS:8,WOB:5</availability>
@@ -13805,18 +13811,11 @@
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='(C3i)'>
-			<roles>artillery</roles>
-			<availability>CS:4,WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>MOC:2,CLAN:1,WOB:7,CCO:1,Periphery:2,TC:2,CS:5,DC.GHO:2,CSA:2,OA:2,CDS:1,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
 		<model name='THE-S'>
 			<availability>HL:6,Periphery.Deep:6,DC:4-,Periphery:8</availability>
-		</model>
-		<model name='THE-N1'>
-			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:1-</availability>
@@ -13827,49 +13826,52 @@
 		<model name='THE-N2'>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='THE-N1'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CSR:2,CLAN:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:6-,FVC:5-,HL:4-,General:5-,FWL:6-,Periphery.Deep:6-,MERC:6-,Periphery:6-</availability>
+		</model>
 		<model name='TR-8'>
 			<availability>CC:6</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:6-,FVC:5-,HL:4-,General:5-,FWL:6-,Periphery.Deep:6-,MERC:6-,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:4,FRR:2,CSV:6,CLAN:5,IS:3,CFM:7,WOB:7,FS:4,CWIE:6,DC.GHO:6,CS:8,OA:3,FVC:3,CDS:4,CW:6,CBS:4,LA:3,CNC:4,FWL:6,NIOPS:8,CJF:6,CGB:6</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:4,FWL:4,WOB:4,MERC:4,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>DC.GHO:8,CS:4,OA:4,FRR:6,CLAN:6,IS:6,FWL:8,NIOPS:4,WOB:4,FS:8,BAN:8,DC:8</availability>
 		</model>
-		<model name='THG-13K'>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='THG-12K'>
-			<availability>WOB:3,DC:4</availability>
+		<model name='THG-11Eb'>
+			<availability>CLAN:4,FWL:4,WOB:4,MERC:4,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:5,MERC:5</availability>
 		</model>
 		<model name='THG-12E'>
 			<availability>CS:6,WOB:3</availability>
+		</model>
+		<model name='THG-13K'>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='THG-12K'>
+			<availability>WOB:3,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -13889,9 +13891,6 @@
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>CS:2,LA:8,CLAN:1,NIOPS:2,MERC:4</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:6</availability>
@@ -13901,6 +13900,9 @@
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -13917,9 +13919,6 @@
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,MERC:4,TC:4</availability>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
@@ -13927,71 +13926,74 @@
 		<model name='THR-1L'>
 			<availability>General:8</availability>
 		</model>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>MOC:4,LA:8,FRR:6,MH:4,MERC:6</availability>
-		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:4-</availability>
-		</model>
-		<model name='TRB-D36b'>
-			<roles>ground_support</roles>
-			<availability>CLAN:4,FS:3</availability>
-		</model>
 		<model name='TRB-D56'>
 			<availability>LA:4+</availability>
 		</model>
 		<model name='TRB-D50'>
 			<availability>TC:5+</availability>
 		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>MOC:4,LA:8,FRR:6,MH:4,MERC:6</availability>
+		</model>
+		<model name='TRB-D36b'>
+			<roles>ground_support</roles>
+			<availability>CLAN:4,FS:3</availability>
+		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:4-</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:6,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,FS:6,MERC:6,Periphery:4,TC:4,CS:3-,LA:6,NIOPS:3-,MH:4,DC:6</availability>
-		<model name='TDR-9NAIS'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>CLAN:2,TC:3</availability>
-		</model>
-		<model name='TDR-9M'>
-			<availability>MOC:3,CC:3,FWL:4,MH:3,WOB:3</availability>
-		</model>
-		<model name='TDR-9S'>
-			<availability>FVC:5,LA:8,FS:6,MERC:3</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>CC:2-,MOC:2-,LA:2-,MERC:2-,TC:2-</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
-		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:5-,MERC:2-</availability>
-		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,MERC:5,FS:2</availability>
-		</model>
-		<model name='TDR-5S'>
-			<availability>CC:5-,HL:3-,LA:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
 		<model name='TDR-9SE'>
 			<availability>FVC:3,LA:3,MERC.ELH:8,MERC:3,FS:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:6,CCC:6,LA:2,CSV:6,CFM:6,FS:2,CGS:6,CB:6,DC:2</availability>
-		</model>
-		<model name='TDR-7M'>
-			<availability>CS:6,CC:4,FWL:8,IS:3,WOB:6,MERC:4</availability>
+		<model name='TDR-9S'>
+			<availability>FVC:5,LA:8,FS:6,MERC:3</availability>
 		</model>
 		<model name='TDR-11SE'>
 			<availability>LA:2,FWL:2,WOB:3,MERC:3,FS:2</availability>
 		</model>
+		<model name='TDR-5S'>
+			<availability>CC:5-,HL:3-,LA:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
+		<model name='TDR-7M'>
+			<availability>CS:6,CC:4,FWL:8,IS:3,WOB:6,MERC:4</availability>
+		</model>
+		<model name='TDR-9M'>
+			<availability>MOC:3,CC:3,FWL:4,MH:3,WOB:3</availability>
+		</model>
+		<model name='TDR-5SS'>
+			<availability>LA:5-,MERC:2-</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:6,CCC:6,LA:2,CSV:6,CFM:6,FS:2,CGS:6,CB:6,DC:2</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>CLAN:2,TC:3</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
+		</model>
 		<model name='TDR-17S'>
 			<availability>LA:3</availability>
+		</model>
+		<model name='TDR-10SE'>
+			<availability>CC:2,MERC:5,FS:2</availability>
+		</model>
+		<model name='TDR-9NAIS'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
@@ -13999,12 +14001,12 @@
 		<model name='TSG-9J'>
 			<availability>General:5</availability>
 		</model>
+		<model name='TSG-9C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='TSG-9C'>
-			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -14021,58 +14023,58 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:5,CLAN:4,NIOPS:3,WOB:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,FRR:6,CNC:6,DC:8</availability>
-		<model name='(C3)'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='TKG-150'>
-			<availability>FRR:3-,DC:3-</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>FRR:6-,DC:6-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>CDS:8,CNC:8,DC:4</availability>
+		<model name='(C3)'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>CDS:8,CNC:8,DC:4</availability>
 		</model>
 		<model name='(MRM)'>
 			<roles>spotter</roles>
 			<availability>DC:3</availability>
 		</model>
+		<model name='TKG-150'>
+			<availability>FRR:3-,DC:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:4</availability>
-		<model name='CH'>
-			<availability>CLAN:3</availability>
-		</model>
-		<model name='THK-63CS'>
-			<availability>CS:8,WOB:6</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:2,NIOPS:2,WOB:2</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:2,BAN:2</availability>
-		</model>
-		<model name='&apos;C&apos;'>
-			<availability>CW:6,CLAN:4</availability>
+		<model name='CH'>
+			<availability>CLAN:3</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='&apos;C&apos;'>
+			<availability>CW:6,CLAN:4</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:2,BAN:2</availability>
+		</model>
+		<model name='THK-63CS'>
+			<availability>CS:8,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
@@ -14083,10 +14085,10 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -14099,33 +14101,33 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>CS:2,FWL:2,WOB:2,MH:1</availability>
-		<model name='G13 [Grenade Launcher]' mechanized='true'>
+		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
+			<roles>specops</roles>
+			<availability>CS:8</availability>
+		</model>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
-		<model name='G13 [Machine Gun]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
+		<model name='G14' mechanized='true'>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='G12' mechanized='true'>
 			<roles>specops</roles>
 			<availability>FWL:8,WOB:8</availability>
 		</model>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
+		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
-		</model>
-		<model name='G13 [Flamer]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
-		</model>
-		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
-			<roles>specops</roles>
-			<availability>CS:8</availability>
-		</model>
-		<model name='G14' mechanized='true'>
-			<availability>WOB:3</availability>
 		</model>
 		<model name='G17' mechanized='true'>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Machine Gun]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
 	</chassis>
@@ -14141,11 +14143,11 @@
 		<model name='TYM-1C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='TYM-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='TYM-1A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TYM-1B'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -14156,56 +14158,51 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,PIR:2,FWL:3,MERC:3,TC:5</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:4-,FWL:4</availability>
-		</model>
-		<model name='TR-16'>
-			<availability>CC:7,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='TR-13'>
-			<availability>CC:5-,HL:3-,IS:4-,MERC:5-,Periphery:5-</availability>
-		</model>
 		<model name='TR-13A'>
 			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:4-,FWL:4</availability>
 		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13'>
+			<availability>CC:5-,HL:3-,IS:4-,MERC:5-,Periphery:5-</availability>
+		</model>
+		<model name='TR-16'>
+			<availability>CC:7,MOC:5,MERC:5,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:4,Periphery.CM:3,Periphery.ME:3,FWL:3,TC:4</availability>
-		<model name='TR-10'>
-			<availability>CC:6,MOC:6,General:6,TC:6</availability>
-		</model>
-		<model name='TR-12'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='TR-12'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>CC:6,MOC:6,General:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:4,CC:4,FRR:4,IS:4,WOB:3-,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:3-,DC:4</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:3-</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:3-,CS:2-,MOC:6-,LA:3-,FWL:2-,IS:6-,NIOPS:2-,WOB:2-,FS:3-,MERC:6-,DC:3-,Periphery:6-</availability>
 		</model>
-		<model name='TBT-5S'>
-			<availability>MOC:3-,IS:3-,Periphery.Deep:4,FWL:3-,MERC:3-,CDP:3,Periphery:3-,TC:3-</availability>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
 		</model>
 		<model name='TBT-7M'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
-		</model>
-		<model name='TBT-9K'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
 		</model>
 		<model name='TBT-7K'>
 			<roles>fire_support</roles>
@@ -14215,22 +14212,24 @@
 			<roles>fire_support</roles>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='TBT-3C'>
+		<model name='TBT-9K'>
 			<roles>fire_support</roles>
-			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
+			<availability>DC:6</availability>
 		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:3-,CS:2-,MOC:6-,LA:3-,FWL:2-,IS:6-,NIOPS:2-,WOB:2-,FS:3-,MERC:6-,DC:3-,Periphery:6-</availability>
+		<model name='TBT-5J'>
+			<availability>FWL:3-</availability>
+		</model>
+		<model name='TBT-5S'>
+			<availability>MOC:3-,IS:3-,Periphery.Deep:4,FWL:3-,MERC:3-,CDP:3,Periphery:3-,TC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
-		<model name='TRN-3T'>
-			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='TRN-3V'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='TRN-3T'>
+			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
@@ -14238,17 +14237,8 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:5,MOC:4,MH:2,TC:4</availability>
-		<model name='(Theseus RL)[LRR]' mechanized='true'>
-			<availability>MOC:4</availability>
-		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
-			<availability>TC:2</availability>
-		</model>
-		<model name='(Asterion)[PPC]' mechanized='true'>
-			<availability>MH:6,TC:6</availability>
-		</model>
-		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
-			<availability>MOC:4</availability>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Asterion)[MRR]' mechanized='true'>
 			<availability>MH:6,TC:6</availability>
@@ -14256,24 +14246,33 @@
 		<model name='(Ying Long)(Plasma)' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
+		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
+			<availability>MOC:4</availability>
+		</model>
 		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:2</availability>
 		</model>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
+		<model name='(Theseus RL)[LRR]' mechanized='true'>
+			<availability>MOC:4</availability>
+		</model>
+		<model name='(Asterion)[PPC]' mechanized='true'>
+			<availability>MH:6,TC:6</availability>
+		</model>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+			<availability>TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Triton' unitType='ProtoMek'>
 		<availability>CGS:4</availability>
+		<model name='3'>
+			<availability>General:4</availability>
+		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='3'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -14292,11 +14291,11 @@
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
 		<availability>CC:3,MOC:4,Periphery.CM:2,Periphery.ME:2,TC:5</availability>
-		<model name='CMT-4U'>
-			<availability>General:5</availability>
-		</model>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
+		</model>
+		<model name='CMT-4U'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Trojan' unitType='Dropship'>
@@ -14308,11 +14307,11 @@
 	</chassis>
 	<chassis name='Tsunami' unitType='Mek'>
 		<availability>MERC:3</availability>
-		<model name='TS-P1D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='TS-P1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TS-P1D'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Turhan Urban Combat Vehicle' unitType='Tank'>
@@ -14328,8 +14327,8 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -14340,30 +14339,18 @@
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CSR:2,SOC:4,CNC:4,CLAN.HW:4,CJF:7</availability>
-		<model name='A'>
-			<availability>CHH:7,CW:7,CNC:7,CFM:7,CGS:7,CJF:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:7,CW:7,CNC:7,CFM:7,CJF:7,CGS:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CW:9,General:7,CGB:9</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
-		</model>
 		<model name='Z'>
 			<roles>spotter</roles>
 			<availability>SOC:10,CCO:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:7,CW:7,CNC:7,CFM:7,CGS:7,CJF:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CW:8,CNC:8,CFM:8,CJF:8,CCO:8</availability>
@@ -14371,9 +14358,25 @@
 		<model name='D'>
 			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:7,CW:7,CNC:7,CFM:7,CJF:7,CGS:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:9,General:7,CGB:9</availability>
+		</model>
+		<model name='H'>
+			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,FS:6,MERC:3</availability>
+		<model name='(RAC)'>
+			<roles>urban</roles>
+			<availability>General:4,FS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
@@ -14381,10 +14384,6 @@
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>urban</roles>
-			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -14396,38 +14395,39 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,FRR:2,CGB:5,DC:2</availability>
-		<model name='(Kurita)'>
-			<roles>apc</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>FRR:8,CLAN:8</availability>
 		</model>
+		<model name='(Kurita)'>
+			<roles>apc</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:2,CCO:3,CWIE:4,MERC.WD:4,CDS:3,CW:4,CBS:6,CNC:2,CJF:7,CGB:2</availability>
-		<model name='B'>
-			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
+		<model name='F'>
+			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2,CB:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<roles>urban,spotter,anti_infantry</roles>
 			<availability>CW:6,CSV:3,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
@@ -14436,19 +14436,18 @@
 			<roles>fire_support</roles>
 			<availability>CSA:5,CCC:6,CIH:6,CSR:6,CBS:6,General:5,CCO:4</availability>
 		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
+		<model name='B'>
+			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2,CB:6</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
@@ -14473,24 +14472,24 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:2,LA.SR:4</availability>
-		<model name='(3065)'>
-			<roles>troop_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(3071)'>
 			<roles>troop_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(3065)'>
+			<roles>troop_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:5,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>CS:8,LA:6,IS:6,WOB:8,FS:8</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:5,BAN:4</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:4</availability>
@@ -14521,38 +14520,38 @@
 			<roles>urban</roles>
 			<availability>CC:4-,Periphery:3</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:3</availability>
-		</model>
-		<model name='UM-R63'>
+		<model name='UM-R60'>
 			<roles>urban</roles>
-			<availability>CC:8,CS:6,MOC:4,MERC:4,TC:4</availability>
+			<availability>CC:5-,HL:3-,General:4-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>FS.CMM:6,FS:4</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R63'>
 			<roles>urban</roles>
-			<availability>CC:5-,HL:3-,General:4-,Periphery.Deep:8,Periphery:5-</availability>
+			<availability>CC:8,CS:6,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
 		<availability>CGB:6</availability>
-		<model name='(Standard)'>
-			<deployedWith>IS</deployedWith>
-			<availability>General:8</availability>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:2</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:2</availability>
+		<model name='(Standard)'>
+			<deployedWith>IS</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -14567,41 +14566,41 @@
 	</chassis>
 	<chassis name='Valiant' unitType='Mek'>
 		<availability>LA:2,FS:3,MERC:2,DC:4</availability>
-		<model name='V4-LNT-J3'>
-			<availability>FS:8,MERC:6</availability>
+		<model name='V4-LNT-K7'>
+			<availability>General:8</availability>
 		</model>
 		<model name='VLN-3T'>
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='V4-LNT-K7'>
-			<availability>General:8</availability>
+		<model name='V4-LNT-J3'>
+			<availability>FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:4,WOB:4,FS:9,MERC:4,CDP:2,TC:2</availability>
-		<model name='VLK-QD2'>
+		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:2,FS:2</availability>
+			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:3</availability>
 		</model>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4-,LA:2-,FS:5-,MERC:5-,CDP:4-,TC:5-</availability>
-		</model>
 		<model name='VLK-QW5'>
 			<roles>recon,fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='VLK-QF'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:2,FS:2,MERC:2</availability>
-		</model>
 		<model name='VLK-QD'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:8,FS:8,MERC:6</availability>
+		</model>
+		<model name='VLK-QD2'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:2,FS:2</availability>
+		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4-,LA:2-,FS:5-,MERC:5-,CDP:4-,TC:5-</availability>
 		</model>
 		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
@@ -14621,39 +14620,39 @@
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<roles>ground_support</roles>
 			<availability>CSR:6,General:5</availability>
 		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Vanquisher' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='VQR-7U'>
-			<availability>WOB:3</availability>
+		<model name='VQR-5V'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='VQR-2A'>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='VQR-5V'>
-			<availability>WOB:4</availability>
+		<model name='VQR-7U'>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='VQR-2B'>
 			<availability>WOB:3</availability>
@@ -14664,122 +14663,122 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:5-,HL:9,IS:10,Periphery.Deep:8,WOB:4-,Periphery:10,CGB:3</availability>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(Liao)'>
 			<availability>CC:6-</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>CC:6,MOC:7,FVC:6,Periphery.CM:7,PIR:6,MH:6,CDP:7,TC:7</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>IS:2,FS:4</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>CC:5,MOC:5,DTA:5,CDP:5,TC:5</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
+		<model name='(RAC)'>
+			<availability>IS:2,FS:4</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>CC:3-,General:3-</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CC:3-,General:5-</availability>
-		</model>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,FWL:4,NIOPS:5,DC:4</availability>
-		<model name='(3056)'>
-			<roles>asf_carrier</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='(2682)'>
 			<roles>asf_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>asf_carrier</roles>
+			<availability>FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
 		<availability>CS:3,FRR:5,CNC:5,FWL:3,MERC:3,FS:3,DC:8</availability>
+		<model name='SDR-9KC'>
+			<availability>FWL:3,MERC:3,DC:3</availability>
+		</model>
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
-		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,DC:5</availability>
 		</model>
-		<model name='SDR-9KC'>
-			<availability>FWL:3,MERC:3,DC:3</availability>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:2,LA:2,ARDC:2,CWIE:2</availability>
-		<model name='VR6-C'>
-			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:4</availability>
-		</model>
 		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='VR6-C'>
+			<deployedWith>Wolfhound</deployedWith>
+			<availability>MERC.KH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
-		<model name='VTR-C'>
-			<availability>CC:4,FRR:6,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9B'>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:3,HL:2,FRR:8,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
+		</model>
+		<model name='VTR-Cr'>
+			<availability>FS:1,DC:1</availability>
 		</model>
 		<model name='VTR-10S'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='VTR-9B'>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-9D'>
-			<availability>CC:4,FVC:3,LA:4,FS:3,CDP:3</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>CC:1,CS:1,FVC:1,IS:1,FS:1,MERC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-10D'>
-			<availability>FS:6,MERC:2</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,FRR:6,MERC:4,FS:4,DC:6</availability>
 		</model>
 		<model name='VTR-11D'>
 			<roles>urban</roles>
 			<availability>FS:2,MERC:1</availability>
 		</model>
-		<model name='VTR-Cr'>
-			<availability>FS:1,DC:1</availability>
-		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='VTR-9A'>
-			<availability>CC:1,CS:1,IS:1,FS:1</availability>
-		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:3,HL:2,FRR:8,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
+		<model name='VTR-9A1'>
+			<availability>CC:1,CS:1,FVC:1,IS:1,FS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='VTR-9S'>
 			<availability>LA:2-,CIR:2-</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='VTR-10D'>
+			<availability>FS:6,MERC:2</availability>
+		</model>
+		<model name='VTR-9A'>
+			<availability>CC:1,CS:1,IS:1,FS:1</availability>
+		</model>
+		<model name='VTR-9D'>
+			<availability>CC:4,FVC:3,LA:4,FS:3,CDP:3</availability>
+		</model>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CS:6,FRR:6,WOB:4,CGB:4</availability>
-		<model name='VKG-2F'>
-			<roles>fire_support</roles>
-			<availability>General:8,WOB:2</availability>
-		</model>
 		<model name='VKG-2G'>
 			<availability>CS:5,FRR:6,CGB:6</availability>
 		</model>
 		<model name='VKG-3W'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='VKG-2F'>
+			<roles>fire_support</roles>
+			<availability>General:8,WOB:2</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
@@ -14799,26 +14798,26 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,FRR:2,MH:1,MERC:4,TC:6</availability>
-		<model name='VND-1SIC'>
-			<availability>CC:1</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:5,MOC:4,TC:4</availability>
-		</model>
-		<model name='VND-3L'>
-			<availability>CC:9,MOC:5,General:5,TC:5</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>FRR:8,TC:3</availability>
 		</model>
 		<model name='VND-5L'>
 			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
 		</model>
-		<model name='VND-6L'>
-			<availability>CC:1+</availability>
+		<model name='VND-4L'>
+			<availability>CC:5,MOC:4,TC:4</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:6</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>FRR:8,TC:3</availability>
+		<model name='VND-3L'>
+			<availability>CC:9,MOC:5,General:5,TC:5</availability>
+		</model>
+		<model name='VND-1SIC'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='VND-6L'>
+			<availability>CC:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -14838,29 +14837,35 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CSR:6,General:2,CJF:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:6,General:2,CJF:6</availability>
 		</model>
 		<model name='E'>
 			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CIH:7,CLAN:3,CGS:6,CJF:5</availability>
+		<model name='2'>
+			<availability>CLAN:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:4,CJF:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CHH:4,CIH:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:2</availability>
@@ -14868,24 +14873,18 @@
 		<model name='5'>
 			<availability>CHH:4,CIH:6</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:4,CIH:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:3,DC:4+</availability>
-		<model name='(Nova Cat)' mechanized='true'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Nova Cat)' mechanized='true'>
+			<availability>CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -14898,36 +14897,32 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CS:6,LA:2,FRR:4,FWL:1,WOB:6,MERC:2,FS:3,DC:4</availability>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
-		</model>
-		<model name='VNL-K70'>
-			<availability>FRR:2,DC:2</availability>
+		<model name='VNL-K100'>
+			<availability>FS:2</availability>
 		</model>
 		<model name='VNL-K75N'>
 			<availability>LA:8,FRR:6,FWL:8,FS:8,DC:8</availability>
 		</model>
-		<model name='VNL-K100'>
-			<availability>FS:2</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:4</availability>
+		</model>
+		<model name='VNL-K70'>
+			<availability>FRR:2,DC:2</availability>
+		</model>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>MERC:4,CDP:2,TC:2</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-5N'>
 			<availability>General:3</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 		<model name='VLC-8N'>
 			<availability>FS:8</availability>
@@ -14935,38 +14930,47 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:4,CS:3,MOC:5,LA:6,FRR:4,FWL:6,IS:5,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VT-6C'>
+		<model name='VT-6M'>
 			<roles>anti_infantry</roles>
-			<availability>WOB:8</availability>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='VL-2T'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:3-,General:5-,FS:3-</availability>
 		</model>
+		<model name='VL-5T'>
+			<roles>anti_infantry</roles>
+			<availability>MOC:2,FVC:4,PIR:2,IS:2,FS:5-,CIR:2,Periphery:2,TC:2</availability>
+		</model>
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
 		</model>
-		<model name='VL-5T'>
+		<model name='VT-6C'>
 			<roles>anti_infantry</roles>
-			<availability>MOC:2,FVC:4,PIR:2,IS:2,FS:5-,CIR:2,Periphery:2,TC:2</availability>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:5,LA:8,FRR:5,FS:5,MERC:5</availability>
 		</model>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>WOB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:6,CW:4,CNC:4,CJF:7,CGB:9,DC:2+</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:5,CDS:7,CSV:8,CNC:7,General:5,CGB:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:5,CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
@@ -14976,15 +14980,6 @@
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:5,CDS:7,CSV:8,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CNC:5,CLAN:4,General:1</availability>
@@ -15008,67 +15003,46 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:7,IS:2</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:3,CLAN:2,IS:2</availability>
+		</model>
 		<model name='6'>
 			<availability>CSR:4,CGB:4</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:5,CDS:6,CNC:5,CCO:5,CWIE:5,CGB:5,CB:5</availability>
+		</model>
+		<model name='3'>
+			<availability>CCC:3,CDS:4,CLAN:3</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:2,IS:2</availability>
 		</model>
-		<model name='3'>
-			<availability>CCC:3,CDS:4,CLAN:3</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:3,CLAN:2,IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:5,CDS:6,CNC:5,CCO:5,CWIE:5,CGB:5,CB:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:2+,FS:2+,DC:2+</availability>
-		</model>
-		<model name='WHM-10T'>
-			<availability>TC:5</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:2-</availability>
+		</model>
+		<model name='WHM-9S'>
+			<availability>LA:4,WOB:3,CIR:3,MERC:3</availability>
+		</model>
+		<model name='WHM-8M'>
+			<availability>FWL:2,WOB:4</availability>
 		</model>
 		<model name='WHM-7K'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='WHM-8M'>
-			<availability>FWL:2,WOB:4</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2,TC:3</availability>
-		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:3,FVC:4,PIR:2,IS:3,FS:4,MERC:3,TC:3</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:5,LA:8,FS:6,MERC:4</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:6,CC:3,FVC:2,FRR:3,FWL:8,WOB:7,MERC:4,DC:3,Periphery:3</availability>
-		</model>
-		<model name='WHM-9S'>
-			<availability>LA:4,WOB:3,CIR:3,MERC:3</availability>
+		<model name='WHM-6R'>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:1,FVC:1-,FS.DMM:1,FS:1,DC:2-</availability>
@@ -15076,17 +15050,38 @@
 		<model name='WHM-4L'>
 			<availability>CC:5</availability>
 		</model>
+		<model name='WHM-8K'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='WHM-6D'>
 			<availability>FVC:2-,FS:2-</availability>
+		</model>
+		<model name='WHM-7M'>
+			<availability>CS:6,CC:3,FVC:2,FRR:3,FWL:8,WOB:7,MERC:4,DC:3,Periphery:3</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:5,LA:8,FS:6,MERC:4</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='WHM-10T'>
+			<availability>TC:5</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:2+,FS:2+,DC:2+</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:4,FS:3</availability>
-		<model name='BLR-2G'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BLR-2D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BLR-2G'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
@@ -15098,42 +15093,74 @@
 			<roles>apc</roles>
 			<availability>LA:3,FWL:3</availability>
 		</model>
-		<model name='H-7C'>
-			<availability>IS:3-,Periphery:3-</availability>
-		</model>
 		<model name='H-8'>
 			<availability>HL:4,LA:6,FS.CH:8,FRR:6,Periphery.Deep:4,FS:8,MERC:6,Periphery:6</availability>
 		</model>
 		<model name='H-7A'>
 			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
+		<model name='H-7C'>
+			<availability>IS:3-,Periphery:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>CS:2-,HL:5,IS:8,NIOPS:2-,Periphery.Deep:5,WOB:2-,CIR:4,Periphery:6</availability>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:3,CC:2,TC:2</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='WSP-1W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:4-</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4,FRR:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>FRR:2,DC:2</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:4-</availability>
+		</model>
+		<model name='WSP-1S'>
+			<roles>recon</roles>
+			<availability>FVC:5,LA:8,FS:6,MERC:4</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,WOB:8,MH:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='WSP-1L'>
+			<roles>recon</roles>
+			<availability>CC:2</availability>
 		</model>
 		<model name='WSP-1D'>
 			<roles>recon</roles>
@@ -15146,38 +15173,6 @@
 		<model name='WSP-3L'>
 			<roles>recon</roles>
 			<availability>CC:4,MOC:3,PIR:3,WOB:3,TC:3</availability>
-		</model>
-		<model name='WSP-1W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:4-</availability>
-		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4,FRR:2,FS:2,MERC:2</availability>
-		</model>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,CC:2,TC:2</availability>
-		</model>
-		<model name='WSP-1S'>
-			<roles>recon</roles>
-			<availability>FVC:5,LA:8,FS:6,MERC:4</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:2</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,WOB:8,MH:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='WSP-1K'>
-			<roles>recon</roles>
-			<availability>FRR:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
@@ -15202,11 +15197,11 @@
 	</chassis>
 	<chassis name='White Flame' unitType='Mek'>
 		<availability>WOB.SD:6,WOB:4</availability>
-		<model name='WHF-3C'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='WHF-3B'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='WHF-3C'>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='White Tip Submarine' unitType='Naval'>
@@ -15220,31 +15215,31 @@
 		<model name='WTH-3'>
 			<availability>FS.CMM:3</availability>
 		</model>
+		<model name='WTH-2A'>
+			<availability>DC:1</availability>
+		</model>
+		<model name='WTH-1'>
+			<roles>fire_support</roles>
+			<availability>HL:2,Periphery.Deep:8,MERC:4,Periphery:4</availability>
+		</model>
+		<model name='WTH-2'>
+			<roles>fire_support</roles>
+			<availability>CS:8,OA:6,MH:4,FS:4,CDP:6,DC:4,TC:6</availability>
+		</model>
 		<model name='WTH-1H'>
 			<availability>PIR:5,MH:5</availability>
 		</model>
 		<model name='WTH-K'>
 			<availability>DC:3</availability>
 		</model>
-		<model name='WTH-1'>
-			<roles>fire_support</roles>
-			<availability>HL:2,Periphery.Deep:8,MERC:4,Periphery:4</availability>
-		</model>
-		<model name='WTH-2A'>
-			<availability>DC:1</availability>
-		</model>
-		<model name='WTH-2'>
-			<roles>fire_support</roles>
-			<availability>CS:8,OA:6,MH:4,FS:4,CDP:6,DC:4,TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>DC:4</availability>
-		<model name='WGT-1LAW/SC3'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='WGT-4NC &apos;Dezgra&apos;'>
 			<availability>CNC:8</availability>
+		</model>
+		<model name='WGT-1LAW/SC3'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='WGT-1LAW/SC'>
 			<availability>DC:8</availability>
@@ -15259,9 +15254,6 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>FRR:3,WOB:3,MERC:3,DC:5</availability>
-		<model name='WFT-C'>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='WFT-2'>
 			<availability>DC:4</availability>
 		</model>
@@ -15271,18 +15263,12 @@
 		<model name='WFT-1'>
 			<availability>General:4</availability>
 		</model>
+		<model name='WFT-C'>
+			<availability>FRR:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,MERC.KH:7,MERC.WD:5,FVC:3,LA:7,FRR:5,MH:4,FS:4,CIR:4,MERC:4,CWIE:5</availability>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:2,MERC:2,CWIE:5</availability>
-		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:6,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-1A'>
-			<availability>MERC.KH:1,LA:1</availability>
-		</model>
 		<model name='WLF-4WA'>
 			<roles>ew_support</roles>
 			<availability>MERC.KH:1,MERC.WD:1,LA:1,CWIE:1</availability>
@@ -15290,59 +15276,68 @@
 		<model name='WLF-1'>
 			<availability>MERC.KH:4,MERC.WD:2,HL:6,LA:4,Periphery.Deep:6,FS:2,MERC:4,Periphery:8</availability>
 		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,LA:5,FRR:6,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:2,MERC:2,CWIE:5</availability>
+		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4,CWIE:4</availability>
 		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1,LA:1</availability>
 		</model>
+		<model name='WLF-1A'>
+			<availability>MERC.KH:1,LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
-		<model name='WVR-6R'>
+		<model name='WVR-7M'>
 			<roles>recon</roles>
-			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>FVC:6,LA:6,WOB:4,FS:8</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>DC:4</availability>
+			<availability>CC:4,FWL:8,WOB:6,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-9D'>
 			<roles>spotter</roles>
 			<availability>FS:4,MERC:3</availability>
 		</model>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,FWL:8,WOB:6,MERC:6,DC:4</availability>
-		</model>
-		<model name='WVR-8D'>
-			<availability>FS:4</availability>
+		<model name='WVR-8K'>
+			<availability>FRR:5,CNC:8,MERC:3,DC:5</availability>
 		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>FRR:8,MERC:6,DC:5</availability>
 		</model>
-		<model name='WVR-9M'>
-			<availability>FWL:3</availability>
+		<model name='WVR-8D'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='WVR-6M'>
 			<roles>recon</roles>
 			<availability>Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:4-,MH:4</availability>
 		</model>
-		<model name='WVR-8K'>
-			<availability>FRR:5,CNC:8,MERC:3,DC:5</availability>
+		<model name='WVR-8C'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>HL:3-,General:5-,Periphery.Deep:8,Periphery:5-</availability>
+		</model>
+		<model name='WVR-9M'>
+			<availability>FWL:3</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>FVC:6,LA:6,WOB:4,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -15359,19 +15354,19 @@
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
 		<availability>CHH:4,CW:4,CLAN:2</availability>
+		<model name='2'>
+			<availability>CW:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>CW:6,CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CW:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:3,CIH:2,FRR:5,CLAN:2,IS:3,CFM:3,WOB:4-,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:6</availability>
-		<model name='WVE-9N'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CS:8,WOB:8</availability>
+			<availability>DC.GHO:4-,CS:4,FRR:8,NIOPS:4,WOB:4,CFM:2,FS:8,MERC:8,BAN:3,DC:3</availability>
 		</model>
 		<model name='WVE-10N'>
 			<roles>urban</roles>
@@ -15381,9 +15376,9 @@
 			<roles>urban</roles>
 			<availability>CLAN:1,CFM:1,CGS:1</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-9N'>
 			<roles>urban</roles>
-			<availability>DC.GHO:4-,CS:4,FRR:8,NIOPS:4,WOB:4,CFM:2,FS:8,MERC:8,BAN:3,DC:3</availability>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -15415,14 +15410,14 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CIH:5,CSR:6,CLAN:5,CFM:6</availability>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CIH:3,CB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CIH:3,CB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
@@ -15443,12 +15438,12 @@
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
 		<availability>FWL.FWL:6,FWL:4,WOB:4,MH:3,MERC:3</availability>
-		<model name='YMN-10-OR'>
-			<availability>FWL:4,MERC:4</availability>
-		</model>
 		<model name='YMN-6Y'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='YMN-10-OR'>
+			<availability>FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ymir' unitType='Mek'>
@@ -15466,15 +15461,15 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H10G'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Y-H9G'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
+		</model>
+		<model name='Y-H10G'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zechetinu Corvette' unitType='Warship'>
@@ -15493,13 +15488,6 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:7,DC.GHO:2,FRR:5,CLAN:5,NIOPS:7,WOB:7,MERC:4,DC:2</availability>
-		<model name='(LRM)'>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='(C3i)'>
-			<roles>spotter</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
@@ -15510,47 +15498,54 @@
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,FRR:8,NIOPS:8,WOB:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='(C3i)'>
+			<roles>spotter</roles>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-115'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
 		<model name='ZRO-114'>
 			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-</availability>
+		</model>
+		<model name='ZRO-115'>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:3,MERC.KH:2,LA:3-</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='ZEU-X'>
 			<availability>LA:7</availability>
 		</model>
 		<model name='ZEU-9WD'>
 			<availability>General:4</availability>
 		</model>
-		<model name='ZEU-X2'>
-			<availability>LA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>HL:5,FRR:4,IS:2,WOB:3,FS:6-,MERC:5,CDP:4,Periphery:4,TC:4,Periphery.R:5,LA:10,PIR:4,MH:4</availability>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,WOB:8</availability>
-		</model>
-		<model name='ZEU-6S'>
-			<availability>HL:5,General:3-,Periphery.Deep:5,Periphery:7</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>FVC:4,LA:8,FRR:6,PIR:5,FS:3,MERC:5,CDP:5,TC:5</availability>
 		</model>
-		<model name='ZEU-9S2'>
-			<availability>LA:4,FS:4,MERC:4</availability>
+		<model name='ZEU-6T'>
+			<availability>FVC:3-,LA:3-,FS:3-</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='ZEU-6T'>
-			<availability>FVC:3-,LA:3-,FS:3-</availability>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,WOB:8</availability>
+		</model>
+		<model name='ZEU-9S2'>
+			<availability>LA:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:5,General:3-,Periphery.Deep:5,Periphery:7</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,MERC:4</availability>
@@ -15570,14 +15565,14 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,CBS:8,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(ATM)'>
 			<availability>CW:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3075.xml
+++ b/megamek/data/forcegenerator/3075.xml
@@ -1194,15 +1194,6 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(WoB) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(WoB) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
@@ -1210,21 +1201,30 @@
 			<roles>spotter</roles>
 			<availability>CS:5,WOB:5</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='(WoB) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(WoB) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
 		<model name='(WoB)' mechanized='true'>
 			<availability>CS:4,WOB:4</availability>
 		</model>
 		<model name='(WoB) [David]' mechanized='true'>
 			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(WoB) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1269,17 +1269,17 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CSL:5,CJF:5</availability>
-		<model name='(Jade Falcon)' mechanized='true'>
-			<availability>CJF:8</availability>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Jade Falcon)' mechanized='true'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Agamemnon Heavy Cruiser' unitType='Warship'>
@@ -1291,9 +1291,6 @@
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
 		<availability>CS:7,CLAN:1,FWL:2,NIOPS:7,WOB:7,DC:2</availability>
-		<model name='AHB-MD'>
-			<availability>WOB:3</availability>
-		</model>
 		<model name='AHB-643'>
 			<availability>WOB:5</availability>
 		</model>
@@ -1302,6 +1299,9 @@
 		</model>
 		<model name='AHB-443b'>
 			<availability>CLAN:1,WOB:4</availability>
+		</model>
+		<model name='AHB-MD'>
+			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ailette Zero-G Engineering Exoskeleton' unitType='BattleArmor'>
@@ -1313,13 +1313,12 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>CS:3,FS:6</availability>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4</availability>
@@ -1327,32 +1326,33 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>CNC:4,WOB:4,DC:6</availability>
-		<model name='AKU-2X'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,WOB:4,DC:5</availability>
-		</model>
 		<model name='AKU-1X'>
 			<availability>WOB:6,DC:5</availability>
 		</model>
 		<model name='AKU-2XC'>
 			<availability>DC:2</availability>
 		</model>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,WOB:4,DC:5</availability>
+		</model>
+		<model name='AKU-2X'>
+			<availability>DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:3,CS:7,CDS:4,LA:6,CNC:4,NIOPS:7,WOB:7,FS:5,MERC:3,CWIE:6,DC:3</availability>
-		<model name='Mk VII'>
-			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk VII'>
+			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
@@ -1360,20 +1360,20 @@
 		<model name='ALB-3U'>
 			<availability>FWL:8,WOB:8,MERC:8</availability>
 		</model>
-		<model name='ALB-3Ur'>
-			<availability>FWL:3,WOB:3,MERC:3</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,FWL:6,WOB:6</availability>
+		</model>
+		<model name='ALB-3Ur'>
+			<availability>FWL:3,WOB:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CGS:5,CCO:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='XR'>
 			<availability>CDS:2</availability>
@@ -1397,11 +1397,14 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:3,MERC.WD:8,CHH:2,CSR:2,LA:4,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CGB:2</availability>
-		<model name='ANH-4A'>
-			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:2,MERC:2,CWIE:5</availability>
+		<model name='C 2'>
+			<availability>MERC.WD:4,CLAN:6,IS:2,BAN:1</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>CLAN:1-,MERC:2-</availability>
+		</model>
+		<model name='ANH-4A'>
+			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:2,MERC:2,CWIE:5</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
@@ -1411,9 +1414,6 @@
 		</model>
 		<model name='ANH-3A'>
 			<availability>MERC.WD:5,CHH:3,LA:4,MERC:4,CWIE:3</availability>
-		</model>
-		<model name='C 2'>
-			<availability>MERC.WD:4,CLAN:6,IS:2,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1432,11 +1432,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:4,MOC:6,PIR:3,TC:3</availability>
-		<model name='ABS-3T'>
-			<availability>CC:5,MOC:5,TC:5</availability>
-		</model>
 		<model name='ABS-3R'>
 			<availability>General:4</availability>
+		</model>
+		<model name='ABS-3T'>
+			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
@@ -1445,18 +1445,12 @@
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>CC:2,DTA:6,FWL:5,WOB:2,MERC:3</availability>
-		<model name='ANV-5M'>
-			<availability>DTA:5,FWL:6,WOB:6</availability>
-		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>DTA:5,FWL:4,WOB:4</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>CC:8,FWL:4,WOB:4,MERC:5</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:5,FWL:6,WOB:6</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
@@ -1465,14 +1459,20 @@
 		<model name='ANV-5Q'>
 			<availability>DTA:4,FWL:4,WOB:4</availability>
 		</model>
+		<model name='ANV-3R'>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>CC:8,FWL:4,WOB:4,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,LA:2,FWL:8,MH:2,MERC:4,FS:2,DC:6</availability>
-		<model name='APL-3T'>
+		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
-		<model name='APL-1R'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1530,123 +1530,114 @@
 	</chassis>
 	<chassis name='Archangel' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
-		<model name='C-ANG-O Invictus'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C-ANG-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-ANG-OE Eminus'>
-			<roles>fire_support</roles>
+		<model name='C-ANG-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OS Caelestis'>
 			<availability>General:4</availability>
 		</model>
-		<model name='C-ANG-OD Luminos'>
+		<model name='C-ANG-OC Comminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-ANG-O Invictus'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C-ANG-OE Eminus'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-ANG-OC Comminus'>
+		<model name='C-ANG-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,HL:3,FRR:4,CLAN:1,IS:4-,Periphery.Deep:5,WOB:2-,FS:4-,Periphery:4,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
-		<model name='ARC-6W'>
-			<roles>fire_support</roles>
-			<availability>FVC:3,TC:4,Periphery:3</availability>
-		</model>
-		<model name='ARC-6S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,FRR:3,MERC:3</availability>
-		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:2-</availability>
-		</model>
-		<model name='ARC-8M'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:3,DTA:5,FRR:3,PIR:3,FWL:4,WOB:3,MERC:3,DC:2</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6,CWIE:2</availability>
-		</model>
 		<model name='ARC-7L'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:2-,DC:4-</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,WOB:4</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>FRR:8,MERC:4,DC:2</availability>
-		</model>
-		<model name='ARC-9K'>
-			<roles>fire_support</roles>
-			<availability>CNC:4,DC:4</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:6,FS:2</availability>
-		</model>
-		<model name='ARC-9M'>
-			<roles>fire_support</roles>
-			<availability>LA:4,FWL:3,WOB:4,MERC:3,DC:3</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:2-,LA:3-,FRR:3-,IS:3-,Periphery.Deep:8,BAN:2,DC:3-,Periphery:4-</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:4,MERC:4</availability>
 		</model>
 		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
 			<availability>CLAN:4,FWL:4,BAN:2</availability>
 		</model>
-		<model name='C'>
+		<model name='ARC-5W'>
 			<roles>fire_support</roles>
-			<availability>CSA:6,CCC:6,CW:2,LA:3+,CSV:6,FS:3+,CGS:6,CWIE:2,DC:3+</availability>
-		</model>
-		<model name='ARC-4M'>
-			<roles>fire_support</roles>
-			<availability>CS:6,CC:5,FVC:3,LA:2,PIR:4,FWL:6,WOB:6,MERC:5,FS:2,DC:5</availability>
+			<availability>MERC.WD:8,LA:4,MERC:4</availability>
 		</model>
 		<model name='ARC-2W'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:2-</availability>
 		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,FRR:3,MERC:3</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,WOB:4</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:2-</availability>
+		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:3,TC:4,Periphery:3</availability>
+		</model>
+		<model name='ARC-9K'>
+			<roles>fire_support</roles>
+			<availability>CNC:4,DC:4</availability>
+		</model>
+		<model name='ARC-9M'>
+			<roles>fire_support</roles>
+			<availability>LA:4,FWL:3,WOB:4,MERC:3,DC:3</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>CSA:6,CCC:6,CW:2,LA:3+,CSV:6,FS:3+,CGS:6,CWIE:2,DC:3+</availability>
+		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:6,FS:2</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6,CWIE:2</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:8,MERC:4,DC:2</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:2-,LA:3-,FRR:3-,IS:3-,Periphery.Deep:8,BAN:2,DC:3-,Periphery:4-</availability>
+		</model>
+		<model name='ARC-4M'>
+			<roles>fire_support</roles>
+			<availability>CS:6,CC:5,FVC:3,LA:2,PIR:4,FWL:6,WOB:6,MERC:5,FS:2,DC:5</availability>
+		</model>
+		<model name='ARC-2K'>
+			<roles>fire_support</roles>
+			<availability>FRR:2-,DC:4-</availability>
+		</model>
+		<model name='ARC-8M'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:3,DTA:5,FRR:3,PIR:3,FWL:4,WOB:3,MERC:3,DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1E'>
-			<availability>General:6</availability>
+		<model name='AF1C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
@@ -1654,6 +1645,15 @@
 		</model>
 		<model name='AF1B'>
 			<availability>General:5</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
@@ -1670,11 +1670,11 @@
 		<model name='A'>
 			<availability>General:4</availability>
 		</model>
-		<model name='J'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:6</availability>
+		</model>
+		<model name='J'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -1704,52 +1704,32 @@
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
 		<availability>FS:5</availability>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
 		<model name='AGS-4D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1759,17 +1739,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1785,19 +1785,19 @@
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
 		<availability>MOC:3-,CC:3-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:3-,CS:3-,OA:1-,FVC:1,LA:1,FS.CMM:1-</availability>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
+		<model name='ASN-99'>
+			<roles>spotter</roles>
+			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,FVC:4,Periphery.HR:3,PIR:2,MH:4,MERC:4,FS:4,RCM:4,CDP:6,TC:6</availability>
 		</model>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
 		<model name='ASN-21'>
 			<availability>General:1-</availability>
-		</model>
-		<model name='ASN-99'>
-			<roles>spotter</roles>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -1840,20 +1840,20 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,CCC:5,CSR:5,CDS:5,CW:5,CSV:5,CSL:8,CGS:5,CJF:3,CCO:3,CGB:6</availability>
-		<model name='(HAG)'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>LA:3,CLAN:1,WOB:3</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -1861,60 +1861,48 @@
 		<model name='AS7-Dr'>
 			<availability>LA:3,MERC:3</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4,IS:4,DC:4</availability>
+		<model name='AS7-K'>
+			<availability>CC:2,MOC:3,CS:3,OA:3,FRR:5,CNC:5,FWL:2,WOB:3,MERC:4,CDP:3,TC:3,DC:8</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:5,MERC:2</availability>
+		</model>
+		<model name='AS8-D'>
+			<availability>FS:3</availability>
+		</model>
+		<model name='AS7-D-DC'>
+			<availability>IS:1-,MERC:0,DC:1-</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:2,FS:4,DC:4</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>FRR:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>FRR:5,MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
-		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2,MERC:2,DC:2</availability>
-		</model>
 		<model name='AS7-S2'>
 			<availability>LA:3,MERC:2</availability>
 		</model>
-		<model name='AS7-D'>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:5,MERC:2</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1-,MERC:0,DC:1-</availability>
-		</model>
-		<model name='AS8-D'>
-			<availability>FS:3</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>CC:2,MOC:3,CS:3,OA:3,FRR:5,CNC:5,FWL:2,WOB:3,MERC:4,CDP:3,TC:3,DC:8</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(CV)'>
@@ -1925,6 +1913,14 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Gunship)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
@@ -1932,6 +1928,10 @@
 		<model name='(Tanker)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1943,24 +1943,24 @@
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CW:4,CLAN:3,CNC:4,BAN:5,CWIE:4</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:7,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:8,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:7,General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CSV:6,General:5,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
@@ -1971,31 +1971,31 @@
 		<model name='AV1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='AV1-OA'>
-			<availability>General:7</availability>
-		</model>
 		<model name='AV1-OH'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AV1-OE'>
+		<model name='AV1-OD'>
 			<availability>General:6</availability>
+		</model>
+		<model name='AV1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AV1-OR'>
 			<availability>General:2+,CLAN:6,DC:2+</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
@@ -2003,13 +2003,13 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:2,OA:2,LA:4,FRR:2,IS:2,FWL:3,FS:4,CIR:2,TC:2,Periphery:1,DC:3</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>LA:2-,General:4,FS:2-</availability>
+		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
@@ -2017,23 +2017,23 @@
 		<model name='AWS-8R'>
 			<availability>IS:1-,FWL:2-</availability>
 		</model>
+		<model name='AWS-10KM'>
+			<availability>DTA:4,FWL:4,WOB:4,DC:4</availability>
+		</model>
 		<model name='AWS-8T'>
 			<availability>IS:2-,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
-		<model name='AWS-10KM'>
-			<availability>DTA:4,FWL:4,WOB:4,DC:4</availability>
-		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:4,PIR:4,FWL:6,IS:5,MH:4,TC:4,Periphery:2</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:4,LA:4,FWL:4,FS:4</availability>
-		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:4,HL:2,FWL:6,IS:4,MH:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='AWS-9Ma'>
+			<availability>DTA:4,LA:4,FWL:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
@@ -2056,8 +2056,15 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:2,LA:3,FRR:2,FS:2,MERC:1</availability>
+		<model name='AXM-3S'>
+			<availability>LA:5,FS:4,MERC:4</availability>
+		</model>
 		<model name='AXM-4D'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='AXM-2N'>
+			<roles>fire_support</roles>
+			<availability>FVC:1,LA:3,FS:1</availability>
 		</model>
 		<model name='AXM-1N'>
 			<availability>FVC:6,LA:6,FRR:6,MERC:6,FS:6</availability>
@@ -2065,16 +2072,13 @@
 		<model name='AXM-3Sr'>
 			<availability>LA:4,FS:5</availability>
 		</model>
-		<model name='AXM-3S'>
-			<availability>LA:5,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-2N'>
-			<roles>fire_support</roles>
-			<availability>FVC:1,LA:3,FS:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:4,CSR:5,CSV:6,CJF:5</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CSR:5,CSV:8</availability>
+		</model>
 		<model name='3 &apos;Devil&apos;'>
 			<availability>CSR:6</availability>
 		</model>
@@ -2082,14 +2086,30 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CSR:5,CSV:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:2,MERC.WD:2,CW:2,CSL:2</availability>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:6,CLAN:5,General:3</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:6,General:3</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2101,38 +2121,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>CLAN:6,General:3</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:4</availability>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
@@ -2148,32 +2144,36 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='F'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:3+</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -2181,33 +2181,41 @@
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:3,FWL:3,WOB:3,FS:3,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:4</availability>
+		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
 		<model name='BNDR-01B'>
 			<availability>General:4,MERC:8</availability>
 		</model>
-		<model name='BNDR-01Ar'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:3,CLAN:1,CSL:3</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3,CCO:6</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
@@ -2217,16 +2225,8 @@
 			<roles>apc</roles>
 			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -2235,9 +2235,13 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:4,MERC:5</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -2247,9 +2251,9 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:6</availability>
+			<availability>General:5</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
@@ -2259,36 +2263,38 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:7-,CC:2-,HL:8-,FRR:3-,IS:2-,Periphery.Deep:9-,FS:2-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,OA:7-,FVC:3-,LA:5-,FWL:3-,MH:7-,DC:2-</availability>
+		<model name='BNC-3Mr'>
+			<availability>MOC:4,FWL:4,WOB:5,CDP:4,TC:4</availability>
+		</model>
 		<model name='BNC-3MC'>
 			<availability>MOC:6-</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>OA:2-,LA:3-,IS:1-,FS:1-,MERC:2-,CIR:3,CDP:2,TC:2-</availability>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
-		<model name='BNC-6S'>
-			<availability>LA:4</availability>
+		<model name='BNC-9S'>
+			<availability>LA:3</availability>
 		</model>
-		<model name='BNC-3Mr'>
-			<availability>MOC:4,FWL:4,WOB:5,CDP:4,TC:4</availability>
+		<model name='BNC-8S'>
+			<availability>LA:6,WOB:9</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:2-,FVC:2-,OA:2-,FWL:2-,MH:2-,MERC:2-,CDP:2-,TC:2-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>FWL:2-</availability>
@@ -2296,24 +2302,24 @@
 		<model name='BNC-3E'>
 			<availability>HL:2-,General:2-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
 		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6,WOB:9</availability>
+		<model name='BNC-3S'>
+			<availability>OA:2-,LA:3-,IS:1-,FS:1-,MERC:2-,CIR:3,CDP:2,TC:2-</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:5,FRR:3,MH:2,FS:6,MERC:5</availability>
 		</model>
-		<model name='BNC-9S'>
-			<availability>LA:3</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:2-,FVC:2-,OA:2-,FWL:2-,MH:2-,MERC:2-,CDP:2-,TC:2-,Periphery:2-</availability>
+		<model name='BNC-6S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,FRR:4,MERC:4</availability>
+		<model name='BGS-1T'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BGS-3T'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
 		<model name='BGS-2T'>
 			<availability>LA:5,MERC:5</availability>
 		</model>
@@ -2321,33 +2327,27 @@
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BGS-1T'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BGS-3T'>
-			<availability>LA:4,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:7,CNC:6,CLAN:4,IS:2+,BAN:5</availability>
-		<model name='D'>
-			<availability>CSR:6,CNC:3,CLAN:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:7,CSV:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:8,CSV:9,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Z'>
 			<availability>SOC:10,CCO:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:6,CNC:3,CLAN:2</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,CSV:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
@@ -2356,67 +2356,67 @@
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CSA:4,CCC:6,CSV:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6,CSV:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:2,CDS:2,CBS:7,CSV:9,CNC:2,CLAN.IS:2,CSL:4,CGS:7,CCO:3,CJF:6</availability>
+		<model name='C'>
+			<availability>General:6,CCO:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='F'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='F'>
-			<availability>General:5</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:6,CCO:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='IS'>
 		<availability>CS:5</availability>
-		<model name='BTL-C-2O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTL-C-2OE'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='BTL-C-2OB'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='BTL-C-2OF'>
-			<roles>anti_infantry</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='BTL-C-2OA'>
 			<roles>ew_support,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='BTL-C-2OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BTL-C-2OC'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='BTL-C-2OB'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='BTL-C-2O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BTL-C-2OF'>
+			<roles>anti_infantry</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='BTL-C-2OD'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2442,48 +2442,41 @@
 		<model name='BKX-7K'>
 			<availability>FS:4-,MERC:5-</availability>
 		</model>
-		<model name='BKX-1X'>
-			<availability>LA:8-,FS:4-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='BKX-1X'>
+			<availability>LA:8-,FS:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:5,LA:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1-,MERC:0</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:1,WOB:2</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>CS:6,CC:6,FVC:5,PIR:5,FWL:5,IS:2,WOB:7,MH:5,MERC:6</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:5,FRR:3,WOB:5,MERC:4,CJF:2</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,WOB:5,BAN:2</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>CLAN:1,WOB:1</availability>
 		</model>
-		<model name='BLR-10S'>
-			<availability>LA:5,FS:3</availability>
+		<model name='BLR-1D'>
+			<availability>FVC:3-,FS:4-</availability>
 		</model>
-		<model name='BLR-10S2'>
-			<availability>LA:5,FS:3</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:6</availability>
+		<model name='BLR-4S'>
+			<availability>LA:5,FRR:3,WOB:5,MERC:4,CJF:2</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>CS:1,DC.GHO:1,WOB:1</availability>
 		</model>
-		<model name='BLR-M3'>
-			<roles>spotter</roles>
-			<availability>DTA:4,FWL:3,WOB:4,MERC:3</availability>
-		</model>
-		<model name='BLR-K4'>
-			<availability>FRR:4,WOB:3,DC:4</availability>
-		</model>
 		<model name='BLR-1S'>
 			<availability>LA:2-</availability>
+		</model>
+		<model name='BLR-10S'>
+			<availability>LA:5,FS:3</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1-,MERC:0</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:4,FS:2</availability>
@@ -2491,21 +2484,28 @@
 		<model name='BLR-1G'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:1-,BAN:8,Periphery:4-</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,WOB:5,BAN:2</availability>
+		<model name='BLR-10S2'>
+			<availability>LA:5,FS:3</availability>
 		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:3-,FS:4-</availability>
+		<model name='C'>
+			<availability>CLAN:6</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:1,WOB:2</availability>
+		<model name='BLR-M3'>
+			<roles>spotter</roles>
+			<availability>DTA:4,FWL:3,WOB:4,MERC:3</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:5,FWL:4,WOB:3</availability>
 		</model>
+		<model name='BLR-K4'>
+			<availability>FRR:4,WOB:3,DC:4</availability>
+		</model>
 		<model name='BLR-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-3M'>
+			<availability>CS:6,CC:6,FVC:5,PIR:5,FWL:5,IS:2,WOB:7,MH:5,MERC:6</availability>
 		</model>
 		<model name='BLR-K3'>
 			<roles>spotter</roles>
@@ -2521,16 +2521,12 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CHH:6,SOC:6,CSV:8,CGS:6,CCO:4,CWIE:4,CSA:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CGB:6,DC:2+</availability>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CNC:9,General:8,CGS:7</availability>
-		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CGS:8,CJF:6</availability>
@@ -2538,8 +2534,12 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
 		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,CSV:5,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -2548,34 +2548,34 @@
 			<roles>spotter</roles>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='(Sealed)'>
-			<availability>CS:8,WOB:4</availability>
+		<model name='(C3i)'>
+			<roles>spotter</roles>
+			<availability>WOB:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3i)'>
-			<roles>spotter</roles>
-			<availability>WOB:7</availability>
+		<model name='(Sealed)'>
+			<availability>CS:8,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>CGB:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:6,CSR:4,CLAN:1,CGS:5</availability>
-		<model name='(Standard)'>
-			<availability>CSR:4,General:2</availability>
+		<model name='6'>
+			<availability>General:1</availability>
 		</model>
 		<model name='4'>
 			<availability>General:1</availability>
@@ -2586,27 +2586,27 @@
 		<model name='3'>
 			<availability>CHH:7</availability>
 		</model>
-		<model name='6'>
-			<availability>General:1</availability>
-		</model>
 		<model name='5'>
 			<availability>General:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:4,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:3,HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:5,Periphery:4,CS:4-,OA:4,CDS:5,LA:4,PIR:3,CNC:3,FWL:2,DC:5</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:5,IS:5,DC:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>FVC:3,CDS:3,General:8,DC:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:1</availability>
 		</model>
-		<model name='(Kurita)'>
-			<availability>CLAN:5,IS:5,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>FVC:3,CDS:3,General:8,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2618,22 +2618,22 @@
 	</chassis>
 	<chassis name='Bellona Hover Tank' unitType='Tank'>
 		<availability>CHH:5</availability>
-		<model name='(Laser)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>CS:6,FRR:6,CNC:4,CGB:4</availability>
-		<model name='BEO-14'>
-			<roles>recon</roles>
-			<availability>CS:4</availability>
-		</model>
 		<model name='BEO-12'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='BEO-14'>
+			<roles>recon</roles>
+			<availability>CS:4</availability>
 		</model>
 		<model name='BEO-X-7a'>
 			<roles>recon,spotter</roles>
@@ -2642,14 +2642,14 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>LA:7,FRR:3,FS:3,MERC:2</availability>
-		<model name='BRZ-B3'>
-			<availability>LA:3</availability>
+		<model name='BRZ-A3'>
+			<availability>LA:5,FRR:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>LA:5,MERC:5</availability>
 		</model>
-		<model name='BRZ-A3'>
-			<availability>LA:5,FRR:8,FS:8,MERC:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2667,70 +2667,70 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CHH:4,CSR:3,CW:2,CLAN:1,IS:3+,CGS:2,CCO:2,CJF:3,BAN:4,CWIE:4,CGB:3</availability>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:6,CW:3,CSV:4,General:5,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CSV:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,CSV:4,General:5,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:5,CSV:7,General:6,CJF:8,CGB:7</availability>
 		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:1</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:6,FRR:6,FS:4,MERC:4,DC:7</availability>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OX'>
+			<availability>DC:1</availability>
+		</model>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='BHKU-OX'>
-			<availability>DC:1</availability>
-		</model>
 		<model name='BHKU-OR'>
 			<availability>General:2+,DC:2+</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
@@ -2741,23 +2741,23 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:5,FRR:4,CLAN:6,FS:5,CDP:3,CWIE:7,DC.GHO:3,OA:3,CDS:5,CBS:7,FWL:3,NIOPS:7,CGB:7,CSR:5,CSV:5,WOB:7,FWL.OH:3,MERC:4,CGS:7,Periphery:3,TC:4,CS:7,DTA:5,FVC:3,CW:7,LA:3,CNC:7,RCM:5,CJF:5,DC:4</availability>
-		<model name='BL-12-KNT'>
-			<availability>FS:6</availability>
+		<model name='BL-6b-KNT'>
+			<availability>DTA:6,CS:6,LA:4,CLAN:5,FWL:6,NIOPS:6,MERC:4,FS:4,CGS:6,BAN:2,DC:4</availability>
+		</model>
+		<model name='BL-9-KNT'>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='BL-6-KNT'>
 			<availability>FRR:6,CLAN:6,WOB:4,BAN:6,TC:4,Periphery:4,DC.GHO:4,CS:4,OA:4,FWL:6,NIOPS:4,MERC.SI:3,DC:6</availability>
 		</model>
-		<model name='BL-6b-KNT'>
-			<availability>DTA:6,CS:6,LA:4,CLAN:5,FWL:6,NIOPS:6,MERC:4,FS:4,CGS:6,BAN:2,DC:4</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:2-,TC:2-</availability>
-		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:4-,FRR:4-,FWL:1-,MERC:4-,FS:4-,CIR:6,DC:4-</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:2-,TC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -2765,19 +2765,15 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:6</availability>
 		</model>
 		<model name='X'>
 			<availability>CJF:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6,CCO:6</availability>
@@ -2785,6 +2781,10 @@
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -2803,36 +2803,42 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>MERC:3,MERC.NH:5</availability>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:4-,MOC:4,OA:4,FVC:6,HL:3,IS:1,FS:6,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:3,FS:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:6,MERC:5</availability>
-		</model>
 		<model name='BJ-1'>
 			<availability>General:2-,Periphery.Deep:8,Periphery:3</availability>
+		</model>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>CC:2,CS:4,FVC:5,LA:4,PIR:3,WOB:4,FS:5,MERC:4</availability>
 		</model>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:6,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,CS:3,MOC:4,FVC:3,FWL:5,IS:3,WOB:5,FS:5,MERC:3,DC:6</availability>
-		<model name='BJ2-O'>
-			<availability>General:7</availability>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
 		</model>
-		<model name='BJ2-OX'>
-			<availability>General:1</availability>
+		<model name='BJ2-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:2+,DC:2+</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:6</availability>
@@ -2840,23 +2846,17 @@
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OC'>
+		<model name='BJ2-OD'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
+		<model name='BJ2-O'>
+			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:2+,DC:2+</availability>
+		<model name='BJ2-OX'>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
@@ -2870,39 +2870,39 @@
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:5,WOB:5,MERC:5,TC:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Black Blizzard&apos;'>
 			<availability>CC:4,General:3,WOB:3</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,CHH:5,CCC:4,CBS:4,CSL:5</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='G'>
+		<model name='E'>
 			<availability>General:5</availability>
 		</model>
 		<model name='D'>
@@ -2911,20 +2911,20 @@
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
 		<availability>CSA:5,CCC:3,CBS:10</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3,CBS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
 		<availability>DTA:6,FWL:6,WOB:4</availability>
-		<model name='B1-HND'>
-			<availability>:0,General:8</availability>
-		</model>
 		<model name='B2-HND'>
 			<availability>General:4,RCM:0</availability>
+		</model>
+		<model name='B1-HND'>
+			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blue Flame' unitType='Mek'>
@@ -2951,28 +2951,32 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank' unitType='Tank' omni='IS'>
 		<availability>WOB:4</availability>
-		<model name='Comminus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Infernus'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Invictus'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Dominus'>
 			<availability>General:7</availability>
 		</model>
+		<model name='Comminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='Infernus'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:3,OA:5,FVC:4,CDS:4,CLAN:3,IS:1-,NIOPS:3,FWL:1-,WOB:5,DC:4</availability>
-		<model name='BMB-14C'>
+		<model name='BMB-12D'>
 			<roles>fire_support</roles>
-			<availability>CS:6,WOB:6</availability>
+			<availability>CS:4,OA:5,FVC:6,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:8,BAN:8</availability>
 		</model>
 		<model name='BMB-10D'>
 			<roles>fire_support</roles>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:2-</availability>
+		</model>
+		<model name='BMB-14C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='BMB-05A'>
 			<roles>missile_artillery,fire_support</roles>
@@ -2981,10 +2985,6 @@
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='BMB-12D'>
-			<roles>fire_support</roles>
-			<availability>CS:4,OA:5,FVC:6,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -3003,13 +3003,13 @@
 			<roles>missile_artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -3021,19 +3021,19 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2,CIR:2,TC:3</availability>
-		<model name='LDT-5'>
-			<availability>PIR:6</availability>
-		</model>
 		<model name='LDT-X3'>
 			<availability>PIR:3</availability>
 		</model>
 		<model name='LDT-1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='LDT-X1'>
-			<availability>General:4</availability>
+		<model name='LDT-5'>
+			<availability>PIR:6</availability>
 		</model>
 		<model name='LDT-X2'>
+			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X1'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -3045,6 +3045,9 @@
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,HL:3,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -3057,9 +3060,6 @@
 		<model name='(HPPC)'>
 			<availability>CC:3,MOC:2</availability>
 		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
 		<availability>CS:3,HL:6,CLAN:3,IS:6,NIOPS:3,Periphery.Deep:6,WOB:3,MERC:5,BAN:5,Periphery:7</availability>
@@ -3070,9 +3070,6 @@
 	</chassis>
 	<chassis name='Buccaneer' unitType='Mek'>
 		<availability>FWL:3,WOB:6</availability>
-		<model name='BCN-3R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BCN-6W'>
 			<roles>fire_support</roles>
 			<availability>WOB:4</availability>
@@ -3080,6 +3077,9 @@
 		<model name='BCN-5W'>
 			<roles>urban</roles>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='BCN-3R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VIII' unitType='Tank'>
@@ -3091,13 +3091,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -3109,11 +3109,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:4,General:8,FS:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:4,General:8,FS:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3124,11 +3124,11 @@
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CS:7,CHH:4,NIOPS:7,WOB:7</availability>
-		<model name='(HPPC)'>
-			<availability>CS:9,WOB:9</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='(HPPC)'>
+			<availability>CS:9,WOB:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Burrock' unitType='Mek'>
@@ -3149,14 +3149,14 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,FS:5,MERC:3</availability>
+		<model name='BSW-S2r'>
+			<availability>General:2</availability>
+		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4,FS:2</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BSW-S2r'>
-			<availability>General:2</availability>
 		</model>
 		<model name='BSW-X2'>
 			<availability>LA:4,General:2,MERC:4</availability>
@@ -3167,17 +3167,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>CS:4,FVC:6,LA:4,FS:6,MERC:4</availability>
-		<model name='CES-3R'>
-			<availability>CS:8,FVC:8,FS:5,MERC:5</availability>
-		</model>
-		<model name='CES-4S'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='CES-4R'>
 			<availability>FS:5</availability>
 		</model>
 		<model name='CES-3S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='CES-3R'>
+			<availability>CS:8,FVC:8,FS:5,MERC:5</availability>
+		</model>
+		<model name='CES-4S'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -3202,13 +3202,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CHH:1,CSR:3,CDS:3,CW:1,CSV:1,CNC:5,CCO:1,CGS:1,CJF:1,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3220,14 +3220,20 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:6,MOC:5,WOB:5,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:2,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2</availability>
-		<model name='CTF-1X'>
-			<availability>General:4-,Periphery:5-</availability>
-		</model>
 		<model name='CTF-2X'>
 			<availability>CC:2-,MOC:2,FVC:2,MERC:1,TC:2</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:5,LA:4,FS:5</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CTF-3LL'>
+			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FVC:4,FS:4</availability>
@@ -3235,50 +3241,52 @@
 		<model name='CTF-4L'>
 			<availability>CC:6,WOB:6</availability>
 		</model>
-		<model name='CTF-5D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
+		<model name='CTF-1X'>
+			<availability>General:4-,Periphery:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,FRR:5,MERC:3,CIR:4,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:5,RCM:2,DC:6</availability>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,FS:2,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:1-,DC:2-</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:2,PIR:4,MH:7,Periphery:4</availability>
+		</model>
 		<model name='CPLT-K4'>
 			<roles>fire_support</roles>
 			<availability>WOB:4,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:3-,Periphery.Deep:8,MERC:3-,BAN:4,Periphery:3-</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
+		</model>
+		<model name='CPLT-C4'>
+			<roles>fire_support</roles>
+			<availability>CDP:1-,TC:1-</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>FRR:6,DC:8</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,CS:3,MOC:3,FWL:2,WOB:3,MERC:2,FS:4,CDP:3,TC:3,DC:4</availability>
 		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:3-,Periphery.Deep:8,MERC:3-,BAN:4,Periphery:3-</availability>
-		</model>
 		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:2,MERC:2,TC:2</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,PIR:4,MH:7,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>FRR:6,DC:8</availability>
-		</model>
-		<model name='CPLT-A1'>
-			<roles>fire_support</roles>
-			<availability>CC:1-</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:1-,DC:2-</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
@@ -3288,36 +3296,22 @@
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
 		</model>
-		<model name='CPLT-C4'>
-			<roles>fire_support</roles>
-			<availability>CDP:1-,TC:1-</availability>
-		</model>
 		<model name='CPLT-K2K'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
-		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
-		</model>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,FS:2,MERC:3,CDP:3,TC:3</availability>
 		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,MOC:4,MERC:2,RCM:2</availability>
 		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CCC:5,CSR:5,CDS:5,CW:2,CLAN:2,CNC:5,CGS:6,CJF:2,CGB:2,DC:3+</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
@@ -3327,9 +3321,8 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='X'>
+			<availability>CHH:2,CW:2</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -3338,29 +3331,42 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
-		<model name='X'>
-			<availability>CHH:2,CW:2</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>LA:1,FS:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,IS:2,FS:6,MERC:3</availability>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
@@ -3370,20 +3376,14 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>CSR:2,CBS:5+</availability>
-		<model name='2'>
-			<availability>CSR:6,CBS:6</availability>
-		</model>
 		<model name='4'>
 			<availability>CBS:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSR:6,CBS:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:8,CBS:8</availability>
@@ -3398,11 +3398,11 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CSR:5,CBS:4,SOC:4,CSV:4,CNC:6,CSL:5,CJF:7</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,SOC:5,CNC:8,CSL:5,CJF:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CSR:6,CBS:6,CSV:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8,SOC:5,CNC:8,CSL:5,CJF:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CSL:5</availability>
@@ -3410,13 +3410,13 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
@@ -3434,72 +3434,72 @@
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8,WOB:8</availability>
 		</model>
+		<model name='CNT-1A'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,FRR:1,IS:1,WOB:2-,Periphery.OS:4,FS:8,MERC:2,CDP:2,Periphery:2,CS:2-,DTA:2,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:4,DC:1</availability>
-		<model name='CN9-D3'>
-			<availability>FVC:2,FS:3,MERC:3</availability>
-		</model>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:2-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:4,Periphery:2</availability>
-		</model>
-		<model name='CN9-H'>
-			<availability>MH:6</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:5,HL:2,LA:1,FWL:1,FS:4,MERC:6,CIR:3,Periphery:4</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:3-,Periphery.Deep:8,FS:2-,MERC:2-,Periphery:3-</availability>
 		</model>
+		<model name='CN9-D'>
+			<availability>FVC:5,HL:2,LA:1,FWL:1,FS:4,MERC:6,CIR:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:2-,FS:2-,MERC:2-</availability>
 		</model>
-		<model name='CN9-Da'>
-			<availability>FVC:1,FWL:1,FS:1,MERC:1,Periphery:1</availability>
+		<model name='CN9-H'>
+			<availability>MH:6</availability>
 		</model>
 		<model name='CN9-D4D'>
 			<availability>DTA:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='CN9-Ar'>
+			<availability>IS:4,Periphery:2</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FVC:2,FS:3,MERC:3</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
+		</model>
+		<model name='CN9-Da'>
+			<availability>FVC:1,FWL:1,FS:1,MERC:1,Periphery:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
 		<availability>MOC:4,LA:5,IS:4,MH:4,FS:5,DC:6</availability>
-		<model name='MR-6B'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='MR-5M'>
 			<availability>CC:4,FWL:6,WOB:6</availability>
+		</model>
+		<model name='MR-V2'>
+			<availability>General:8</availability>
 		</model>
 		<model name='MR-V3'>
 			<availability>IS:6</availability>
 		</model>
-		<model name='MR-V2'>
-			<availability>General:8</availability>
+		<model name='MR-6B'>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3522,15 +3522,15 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
-		<model name='4'>
-			<roles>spotter</roles>
-			<availability>CSR:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<roles>spotter</roles>
+			<availability>CSR:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:5</availability>
@@ -3554,51 +3554,47 @@
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:5,CC:5,OA:5,HL:3,LA:6,IS:4,FWL:5,FS:5,TC:5,Periphery:4,DC:4</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:2-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:4,IS:3,FS:4</availability>
 		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CC:5,CHH:2,FRR:4,IS:3,WOB:5,FS:3,MERC:2,DC.GHO:5,CS:5,DTA:2,FVC:2,LA:4,FWL:3,NIOPS:5,RCM:2,CGB:2,DC:4</availability>
+		<model name='CHP-3P'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='CHP-2N'>
+			<availability>IS:2-,NIOPS:0</availability>
+		</model>
 		<model name='CHP-3N'>
 			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,CS:4,LA:4,IS:2,MERC:4</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:2,CHH:2,WOB:4,FS:2,MERC:5,BAN:3,DC.GHO:3-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:2,CGB:2</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:2-,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,CS:4,LA:4,IS:2,MERC:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
-		</model>
-		<model name='CHP-3P'>
-			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CS:4,FRR:3+,IS:3+,NIOPS:4,WOB:6,MERC:2+,BAN:4,Periphery:2+</availability>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4,WOB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
@@ -3607,22 +3603,33 @@
 			<roles>missile_artillery</roles>
 			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='(ERML)'>
+		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(CASE)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4,WOB:4</availability>
+		</model>
+		<model name='(ERML)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:3-,MOC:2-,OA:2-,FVC:2,LA:3-,FRR:4-,FWL:1-,MERC:2-,TC:2-,Periphery:2,DC:4-</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5,Periphery:3</availability>
+		</model>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>LA:3,MERC:4,DC:4</availability>
+		</model>
 		<model name='CGR-3K'>
 			<availability>CC:2-,FRR:3-,MERC:3-,DC:3-</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>CC:3-,FVC:4,HL:2,Periphery:4</availability>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>FVC:4-,OA:4-</availability>
@@ -3634,67 +3641,60 @@
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5,Periphery:3</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:3,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:2,MERC:4</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:3,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>LA:3,MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>CC:3-,FVC:4,HL:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,OA:4,FVC:2,LA:2-,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,RCM:10,DC:2-</availability>
+		<model name='F-13'>
+			<availability>DTA:4,FWL:4</availability>
+		</model>
+		<model name='F-12-S'>
+			<availability>FWL:2-,WOB:2-</availability>
+		</model>
+		<model name='F-11-RR'>
+			<roles>recon</roles>
+			<availability>CC:2,DTA:2,FWL:2,MERC:2,RCM:2</availability>
+		</model>
+		<model name='F-11-R'>
+			<roles>recon</roles>
+			<availability>CC:2-,FVC:1,FWL:2-,MERC:2-,Periphery:1</availability>
+		</model>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:4-,DTA:2-,HL:2-,General:2-,Periphery.Deep:8,FWL:4-,MERC:4-,RCM:2-,Periphery:4-</availability>
+		</model>
 		<model name='F-11'>
 			<availability>CC:2,MOC:2,DTA:8,FRR:6,Periphery.MW:2,PIR:2,FWL:8,WOB:8,MERC:6,RCM:8</availability>
 		</model>
 		<model name='F-14-S'>
 			<availability>DTA:8,FWL:8,MH:2,MERC:2,RCM:8</availability>
 		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:4-,DTA:2-,HL:2-,General:2-,Periphery.Deep:8,FWL:4-,MERC:4-,RCM:2-,Periphery:4-</availability>
-		</model>
-		<model name='F-11-RR'>
-			<roles>recon</roles>
-			<availability>CC:2,DTA:2,FWL:2,MERC:2,RCM:2</availability>
-		</model>
-		<model name='F-13'>
-			<availability>DTA:4,FWL:4</availability>
-		</model>
-		<model name='F-11-R'>
-			<roles>recon</roles>
-			<availability>CC:2-,FVC:1,FWL:2-,MERC:2-,Periphery:1</availability>
-		</model>
-		<model name='F-12-S'>
-			<availability>FWL:2-,WOB:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:5,CDS:2,LA:1,CNC:2,NIOPS:5,WOB:5,FS:1,DC:3</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:3,LA:3,WOB:4,FS:3,RCM:3,DC:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3714,23 +3714,23 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:3,DC:1,CGB:3</availability>
-		<model name='CHP-W7T'>
-			<availability>TC:8</availability>
-		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,FRR:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:2-,LA:3-,IS:2-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>FVC:4,FS:2-,CDP:4,TC:4,Periphery:2-</availability>
 		</model>
-		<model name='CHP-W8'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:2-,LA:3-,IS:2-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
+		<model name='CHP-W7T'>
+			<availability>TC:8</availability>
+		</model>
+		<model name='CHP-W8'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='CHP-W7'>
+			<availability>LA:8,FRR:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
@@ -3744,13 +3744,6 @@
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,CS:4-,LA:2,IS:2,FWL:6,WOB:4-,FS:1,MERC:3,DC:4</availability>
-		<model name='CDA-3P'>
-			<availability>FWL:6,WOB:6</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
-		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
 			<availability>CC:6,FRR:6,FWL:6,WOB:6,MERC:6,DC:6</availability>
@@ -3759,9 +3752,16 @@
 			<roles>recon</roles>
 			<availability>FWL:8,IS:6,MERC:6</availability>
 		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
+		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:5,IS:4,WOB:5</availability>
+		</model>
+		<model name='CDA-3P'>
+			<availability>FWL:6,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -3785,20 +3785,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -3818,14 +3818,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -3833,29 +3830,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -3866,8 +3866,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -3875,18 +3878,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -3895,15 +3904,6 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -3924,14 +3924,14 @@
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -3939,8 +3939,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -3972,19 +3972,6 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,FRR:1,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,FWL:1,NIOPS:1-,MH:2,RCM:2,DC:2</availability>
-		<model name='CLNT-2-3UL'>
-			<availability>CC:8,MOC:3,TC:6</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:4,Periphery.HR:4,Periphery.CM:4,MH:4,CDP:4,TC:8</availability>
-		</model>
-		<model name='CLNT-5U'>
-			<roles>spotter</roles>
-			<availability>LA:8,General:4,MERC:8</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
-		</model>
 		<model name='CLNT-2-4T'>
 			<availability>CC:1,FS:1</availability>
 		</model>
@@ -3994,31 +3981,44 @@
 		<model name='CLNT-6S'>
 			<availability>LA:6</availability>
 		</model>
+		<model name='CLNT-5U'>
+			<roles>spotter</roles>
+			<availability>LA:8,General:4,MERC:8</availability>
+		</model>
+		<model name='CLNT-2-3UL'>
+			<availability>CC:8,MOC:3,TC:6</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:4,Periphery.HR:4,Periphery.CM:4,MH:4,CDP:4,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:6,WOB:6</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,NIOPS:4,WOB:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,NIOPS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra' unitType='Mek'>
 		<availability>LA:6,FRR:4,MERC:3</availability>
-		<model name='CBR-03'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='CBR-02'>
 			<roles>fire_support</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='CBR-03'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
@@ -4050,66 +4050,66 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:3,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
-		<model name='COM-1A'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>FVC:3-,LA:3-,Periphery:3-</availability>
+			<availability>MOC:3+,FVC:3,LA:8,FRR:6,MH:3+,FS:2,MERC:5,CDP:3+,TC:3+</availability>
+		</model>
+		<model name='COM-4H'>
+			<roles>recon</roles>
+			<availability>PIR:8,MH:10</availability>
 		</model>
 		<model name='COM-1B'>
 			<roles>recon</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='COM-7B'>
-			<roles>recon</roles>
-			<availability>WOB:10</availability>
-		</model>
 		<model name='COM-2Dr'>
 			<roles>recon</roles>
 			<availability>HL:2,LA:4,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='COM-7S'>
+		<model name='COM-7B'>
 			<roles>recon</roles>
-			<availability>LA:7,WOB:8,MERC:5</availability>
+			<availability>WOB:10</availability>
 		</model>
-		<model name='COM-5S'>
+		<model name='COM-1A'>
 			<roles>recon</roles>
-			<availability>MOC:3+,FVC:3,LA:8,FRR:6,MH:3+,FS:2,MERC:5,CDP:3+,TC:3+</availability>
+			<availability>FVC:3-,LA:3-,Periphery:3-</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
 			<availability>LA:2-,MERC:1-,Periphery:1</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>PIR:8,MH:10</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>HL:2-,LA:2-,General:4-,Periphery.Deep:8,TC:4-,Periphery:4-</availability>
 		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:7,WOB:8,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:5,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:6-</availability>
-		</model>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:8,FWL:6,MERC:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,FS:2</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:5-,FVC:4-,General:3-,FS:5-,Periphery:3-</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:3-</availability>
 		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:6</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,FS:2</availability>
+		</model>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:8,FWL:6,MERC:6</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,IS:3</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -4132,24 +4132,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,MERC.WD:1,CSR:1,CW:1,CSV:1,NIOPS:2,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -4171,17 +4171,17 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Copperhead' unitType='Mek'>
@@ -4198,17 +4198,17 @@
 		<model name='CRX-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='CRX-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='CRX-OR'>
-			<availability>OA:2,CLAN:8</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='CRX-OD'>
+			<availability>General:5</availability>
+		</model>
 		<model name='CRX-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='CRX-OR'>
+			<availability>OA:2,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
@@ -4222,11 +4222,14 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:5,FWL:1,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:2</availability>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,FRR:6,FS:6,MERC:6</availability>
 		</model>
-		<model name='CSR-V18'>
-			<availability>FVC:5,FS:5</availability>
+		<model name='CSR-X12 Rigid Night'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,FS:3,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>LA:1,FS.AH:2-,Periphery:1</availability>
@@ -4234,14 +4237,11 @@
 		<model name='CSR-V12'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,BAN:4,Periphery:4-</availability>
 		</model>
-		<model name='CSR-X12 Rigid Night'>
-			<availability>FS:1</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:2</availability>
 		</model>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,FRR:6,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,FS:3,BAN:2</availability>
+		<model name='CSR-V18'>
+			<availability>FVC:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -4265,50 +4265,50 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='XR'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='G'>
 			<availability>CHH:6,General:4</availability>
+		</model>
+		<model name='XR'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
 		<availability>CSV:4,CJF:5,CCO:5</availability>
-		<model name='H'>
-			<availability>CSA:6,General:5</availability>
-		</model>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>CW:3,CJF:3,CWIE:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<availability>CW:3,CJF:3,CWIE:3</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,General:5</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -4317,9 +4317,9 @@
 			<roles>raider</roles>
 			<availability>CS:7,FRR:5,CLAN:4,WOB:7,CGS:6,BAN:2,DC:5</availability>
 		</model>
-		<model name='CRB-27'>
+		<model name='CRB-20'>
 			<roles>raider</roles>
-			<availability>DC.GHO:5-,CS:3,FRR:3,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
+			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
 		<model name='CRB-45'>
 			<availability>WOB:5</availability>
@@ -4327,12 +4327,12 @@
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:5-,CS:3,FRR:3,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
+		</model>
 		<model name='CRB-30'>
 			<availability>CS:8,FRR:3,WOB:6</availability>
-		</model>
-		<model name='CRB-20'>
-			<roles>raider</roles>
-			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
@@ -4340,39 +4340,42 @@
 		<model name='(Standard)'>
 			<availability>CLAN.IS:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CDS:4,CBS:8</availability>
-		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:4,CBS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:4,CDS:3,CBS:6</availability>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CBS:8,General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:7,CSR:5,FRR:6,CSV:5,CLAN:6,WOB:8,CIR:4,CGS:5,CWIE:7,DC.GHO:3,CS:9,CDS:5,CW:7,CBS:7,NIOPS:9,CJF:5,CGB:7</availability>
-		<model name='CRK-5003-3'>
-			<availability>CS:8,FRR:4</availability>
+		<model name='CRK-5004-1'>
+			<availability>CS:6,FRR:4</availability>
+		</model>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
 		<model name='CRK-5005-1'>
 			<availability>WOB:8,CIR:6</availability>
@@ -4383,23 +4386,20 @@
 		<model name='CRK-5003-1'>
 			<availability>CS:4,FRR:4,CLAN:6,NIOPS:4,WOB:4,CIR:4,BAN:8</availability>
 		</model>
-		<model name='CRK-5004-1'>
-			<availability>CS:6,FRR:4</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		<model name='CRK-5003-3'>
+			<availability>CS:8,FRR:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
 		<availability>CS:3,HL:3,Periphery.MW:4,Periphery.ME:4,FWL:3,WOB:3,MERC:4,Periphery:4</availability>
-		<model name='CNS-5M'>
-			<availability>CS:0,PIR:4,IS:8</availability>
-		</model>
 		<model name='CNS-3M'>
 			<availability>General:4</availability>
 		</model>
 		<model name='CNS-TD9'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='CNS-5M'>
+			<availability>CS:0,PIR:4,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
@@ -4410,28 +4410,28 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CSR:5,CDS:4,CW:4,CBS:5,CSV:8,CLAN:3,CNC:4,CCO:3,CJF:4,CWIE:4,CGB:4</availability>
-		<model name='D'>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
 			<availability>General:4</availability>
 		</model>
 		<model name='U'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
-		<model name='C'>
+		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
+		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4441,50 +4441,17 @@
 			<roles>recon</roles>
 			<availability>DC:5</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:4,DC:8</availability>
 		</model>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:5,CLAN:5,IS:7,NIOPS:6-,Periphery.Deep:5,WOB:4-,Periphery:6</availability>
-		<model name='CRD-4D'>
-			<availability>FVC:8,FS:8</availability>
-		</model>
-		<model name='CRD-2R'>
-			<availability>CLAN:4,FWL:4,IS:2,WOB:5,MERC:4,CGS:6,BAN:2</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>MERC:5</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>FRR:5,WOB:4,MERC:5,DC:6</availability>
-		</model>
-		<model name='CRD-6M'>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
-		</model>
-		<model name='CRD-7L'>
-			<availability>CC:6,WOB:4</availability>
-		</model>
-		<model name='CRD-5S'>
-			<availability>LA:6,FS:2,MERC:4</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>HL:2-,General:3-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>DTA:5,FWL:4,WOB:4,MERC:4,RCM:5</availability>
-		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:1-,DC:2-</availability>
-		</model>
 		<model name='CRD-8S'>
 			<availability>LA:5,FS:4</availability>
 		</model>
@@ -4492,56 +4459,89 @@
 			<roles>raider</roles>
 			<availability>CC:2-</availability>
 		</model>
+		<model name='CRD-7L'>
+			<availability>CC:6,WOB:4</availability>
+		</model>
+		<model name='CRD-3R'>
+			<availability>HL:2-,General:3-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
+		</model>
 		<model name='CRD-5M'>
 			<availability>CC:4,CS:4,FWL:8,IS:2,WOB:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FVC:2-,FS:2-</availability>
+		<model name='CRD-3K'>
+			<availability>FRR:1-,DC:2-</availability>
+		</model>
+		<model name='CRD-7W'>
+			<availability>DTA:5,FWL:4,WOB:4,MERC:4,RCM:5</availability>
 		</model>
 		<model name='CRD-4K'>
 			<availability>LA:2,FRR:8,MERC:2,FS:2,DC:6</availability>
 		</model>
+		<model name='CRD-4BR'>
+			<availability>MERC:5</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:6,FS:2,MERC:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>FRR:5,WOB:4,MERC:5,DC:6</availability>
+		</model>
+		<model name='CRD-2R'>
+			<availability>CLAN:4,FWL:4,IS:2,WOB:5,MERC:4,CGS:6,BAN:2</availability>
+		</model>
+		<model name='CRD-3D'>
+			<availability>FVC:2-,FS:2-</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
+		<model name='CRD-4D'>
+			<availability>FVC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-11-C'>
-			<roles>spotter</roles>
-			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,DC:5</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='CP-11-H'>
-			<availability>FVC:4,HL:2,PIR:6,MH:6,CIR:6,CDP:6,TC:6,Periphery:4</availability>
-		</model>
-		<model name='CP-10-Z'>
-			<availability>OA:2-,General:4-,IS:2-,FS:2-,MERC:2-,DC:2-,TC:2-</availability>
-		</model>
-		<model name='CP-11-C3'>
-			<roles>spotter</roles>
-			<availability>FS:1,DC:1</availability>
-		</model>
-		<model name='CP-11-A'>
-			<availability>CC:6,CS:4,MOC:4,LA:6,FWL:8,IS:6,WOB:6,MH:2,FS:7,CDP:4,DC:3,TC:4</availability>
-		</model>
 		<model name='CP-11-G'>
 			<availability>CS:8,MOC:2,FRR:8,IS:2,MERC:4,CDP:2,TC:2</availability>
 		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:1-</availability>
 		</model>
-		<model name='CP-10-HQ'>
-			<availability>IS:2</availability>
+		<model name='CP-12-K'>
+			<availability>MERC:6,DC:6</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>CC:6,CS:4,MOC:4,LA:6,FWL:8,IS:6,WOB:6,MH:2,FS:7,CDP:4,DC:3,TC:4</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:2-,General:4-,IS:2-,FS:2-,MERC:2-,DC:2-,TC:2-</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:6,DC:6</availability>
-		</model>
 		<model name='CP-11-B'>
 			<availability>CC:4,IS:2+,MERC:4,DC:4</availability>
+		</model>
+		<model name='CP-11-C'>
+			<roles>spotter</roles>
+			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,DC:5</availability>
+		</model>
+		<model name='CP-11-H'>
+			<availability>FVC:4,HL:2,PIR:6,MH:6,CIR:6,CDP:6,TC:6,Periphery:4</availability>
+		</model>
+		<model name='CP-11-C3'>
+			<roles>spotter</roles>
+			<availability>FS:1,DC:1</availability>
+		</model>
+		<model name='CP-10-HQ'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
@@ -4562,6 +4562,10 @@
 			<roles>recon,escort</roles>
 			<availability>HL:2,MERC:4,TC:2,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,escort</roles>
+			<availability>CS:4,General:4,NIOPS:4,WOB:4</availability>
+		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -4570,22 +4574,18 @@
 			<roles>recon,escort</roles>
 			<availability>TC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon,escort</roles>
-			<availability>CS:4,General:4,NIOPS:4,WOB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:5</availability>
 		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dagger' unitType='Aero'>
@@ -4596,18 +4596,18 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>WOB:4,FS:6</availability>
-		<model name='DARO-1'>
-			<availability>General:6,FS:8</availability>
-		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='DARO-1C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1'>
+			<availability>General:6,FS:8</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1A'>
 			<availability>General:7</availability>
@@ -4615,12 +4615,12 @@
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>DC:8</availability>
-		<model name='DAI-01r'>
-			<availability>General:3</availability>
-		</model>
 		<model name='DAI-01'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='DAI-01r'>
+			<availability>General:3</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
@@ -4633,13 +4633,13 @@
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
 		<availability>FRR:3+,DC:3+,CGB:1</availability>
-		<model name='67-K'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='67-K2'>
 			<roles>support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='67-K'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
@@ -4647,49 +4647,49 @@
 		<model name='DMO-4K'>
 			<availability>FRR:4,DC:7</availability>
 		</model>
-		<model name='DMO-5K'>
-			<roles>spotter</roles>
-			<availability>FRR:3,DC:3</availability>
+		<model name='DMO-2K'>
+			<availability>FRR:4,DC:6</availability>
 		</model>
 		<model name='DMO-1K'>
 			<availability>General:8,DC:5</availability>
 		</model>
-		<model name='DMO-2K'>
-			<availability>FRR:4,DC:6</availability>
+		<model name='DMO-5K'>
+			<roles>spotter</roles>
+			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,IS:3+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CHH:2,CW:2,CSV:1,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4,CGS:5,CCO:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:8,CSV:4,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4715,24 +4715,21 @@
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>CS:4,LA:5,MH:2,FS:6,MERC:4,CIR:4</availability>
-		<model name='DRT-3S'>
-			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='DRT-4S'>
-			<availability>LA:4,MH:2,FS:5,MERC:4,CIR:4</availability>
-		</model>
 		<model name='DRT-6T'>
 			<availability>CS:8,LA:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='DRT-3S'>
+			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:2</availability>
 		</model>
+		<model name='DRT-4S'>
+			<availability>LA:4,MH:2,FS:5,MERC:4,CIR:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:4,FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5</availability>
@@ -4740,6 +4737,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -4749,13 +4750,18 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CHH:5,CCC:3,MERC.WD:3,CDS:3,CLAN:3,IS:3+,CCO:2,CJF:3,BAN:3,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CDS:4,CBS:3,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:3,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -4763,27 +4769,21 @@
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
 		</model>
+		<model name='K'>
+			<availability>General:2,CGB:4</availability>
+		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CDS:4,CBS:3,General:4,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:7,CSV:4,General:5,CWIE:7,CGB:7</availability>
-		</model>
-		<model name='K'>
-			<availability>General:2,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
@@ -4800,19 +4800,19 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:4+,MOC:3+,WOB:5+</availability>
-		<model name='DFC-OD'>
-			<roles>ground_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='DFC-OB'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='DFC-OD'>
+			<roles>ground_support</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OB'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -4823,11 +4823,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:4,MERC:3</availability>
-		<model name='DFN-3T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='DFN-3S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='DFN-3T'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -4845,24 +4845,24 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,Periphery.Deep:9,IS:7,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,FVC:8,LA:5,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,FWL:4,DC:4</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:1,Periphery:1</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:3,IS:4,Periphery.Deep:6,Periphery:5</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:8,MOC:6,CS:8,LA:8,FRR:6,IS:6,FWL:8,WOB:8,FS:8,TC:6,CWIE:4,DC:8</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>FVC:3,DC:6,Periphery:3</availability>
+		<model name='(Defensive)'>
+			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:3,IS:4,Periphery.Deep:6,Periphery:5</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,FWL:4,DC:4</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>FVC:3,DC:6,Periphery:3</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -4871,15 +4871,15 @@
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
 		<availability>LA:6,CWIE:4</availability>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MML)'>
 			<availability>LA:3,CWIE:3</availability>
 		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:2,CWIE:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -4895,11 +4895,11 @@
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
 		<availability>CS:8,FRR:6,CLAN:5,NIOPS:8,WOB:9,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(HGR)'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CS:4,CHH:6,CLAN:4,NIOPS:4,WOB:4</availability>
@@ -4910,31 +4910,27 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:2,CC:2,HL:2,FRR:3,IS:2,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:2,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
-		<model name='DV-1S'>
-			<availability>IS:3-</availability>
-		</model>
 		<model name='DV-8D'>
 			<availability>FS:4,MERC:4</availability>
-		</model>
-		<model name='DV-6Mr'>
-			<availability>General:2</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:6,LA:6,FS:6,MERC:4,CDP:3,TC:3</availability>
-		</model>
-		<model name='DV-9D'>
-			<availability>FS:5,MERC:2</availability>
 		</model>
 		<model name='DV-6M'>
 			<availability>HL:3-,CLAN:4,IS:3-,Periphery.Deep:8,Periphery:5-</availability>
 		</model>
+		<model name='DV-9D'>
+			<availability>FS:5,MERC:2</availability>
+		</model>
+		<model name='DV-7D'>
+			<availability>FVC:6,LA:6,FS:6,MERC:4,CDP:3,TC:3</availability>
+		</model>
+		<model name='DV-6Mr'>
+			<availability>General:2</availability>
+		</model>
+		<model name='DV-1S'>
+			<availability>IS:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Deva' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='C-DVA-OE Eminus'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-DVA-OS Caelestis'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:4</availability>
@@ -4947,9 +4943,13 @@
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-O Invictus'>
+		<model name='C-DVA-OE Eminus'>
 			<deployedWith>Grigori</deployedWith>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-DVA-OA Dominus'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:7</availability>
 		</model>
 		<model name='C-DVA-OU Exanimus'>
 			<deployedWith>Grigori</deployedWith>
@@ -4959,9 +4959,9 @@
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-OA Dominus'>
+		<model name='C-DVA-O Invictus'>
 			<deployedWith>Grigori</deployedWith>
-			<availability>General:7</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -4972,14 +4972,14 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:3,FVC:6,LA:6,FS:6,MERC:3,TC:4</availability>
-		<model name='DVS-1D'>
-			<availability>FVC:8,LA:2-,FS:2-,TC:8</availability>
+		<model name='DVS-3'>
+			<availability>LA:3,FS:3</availability>
 		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='DVS-3'>
-			<availability>LA:3,FS:3</availability>
+		<model name='DVS-1D'>
+			<availability>FVC:8,LA:2-,FS:2-,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Djinn Battle Armor' unitType='BattleArmor'>
@@ -4994,9 +4994,6 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:5</availability>
@@ -5004,6 +5001,9 @@
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CSL:4,CGS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau Assault Interceptor' unitType='Dropship'>
@@ -5027,17 +5027,17 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,LA:1,FRR:6,MERC:3,DC:5</availability>
-		<model name='DRG-5N'>
-			<availability>FRR:5,MERC:5,DC:5,Periphery:3</availability>
-		</model>
 		<model name='DRG-7N'>
 			<availability>LA:2,MERC:5,DC:5</availability>
 		</model>
-		<model name='DRG-5Nr'>
-			<availability>FRR:2,MERC:2,DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>FRR:1-,DC:1-,Periphery:3</availability>
+		</model>
+		<model name='DRG-5N'>
+			<availability>FRR:5,MERC:5,DC:5,Periphery:3</availability>
+		</model>
+		<model name='DRG-5Nr'>
+			<availability>FRR:2,MERC:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
@@ -5046,16 +5046,6 @@
 			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:7,CHH:7,CCC:7,CSR:7,CDS:8,CBS:7,General:6,CGS:7,CJF:8,CWIE:7,CGB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>General:2,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
@@ -5063,41 +5053,51 @@
 			<roles>spotter</roles>
 			<availability>SOC:10,CCO:4</availability>
 		</model>
+		<model name='B'>
+			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:1</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:6,CW:6,CSV:5,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
 		</model>
-		<model name='I'>
-			<availability>General:2</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>General:2,CGB:5</availability>
 		</model>
-		<model name='U'>
+		<model name='D'>
+			<availability>CSA:7,CHH:7,CCC:7,CSR:7,CDS:8,CBS:7,General:6,CGS:7,CJF:8,CWIE:7,CGB:7</availability>
+		</model>
+		<model name='I'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,FWL:3-,CC.MAC:4-,DC:3-</availability>
-		<model name='(SRM)'>
-			<availability>CC:4-,General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:3-,General:4-</availability>
-		</model>
-		<model name='(Streak)'>
-			<availability>LA:8,WOB:6,FS:6</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>LA:2,WOB:2,FS:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<availability>CC:4-,General:2</availability>
+		</model>
 		<model name='(ERLL)'>
 			<availability>WOB:2</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:8,WOB:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5125,17 +5125,11 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
-		<model name='EGL-R6'>
-			<availability>LA:1-,General:5-,FS:1-</availability>
-		</model>
-		<model name='EGL-R4'>
-			<availability>LA:1,FS:1</availability>
-		</model>
 		<model name='EGL-R6b'>
 			<availability>RCM:4</availability>
 		</model>
-		<model name='EGL-R11'>
-			<availability>LA:4,MERC:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:1,FS:1</availability>
 		</model>
 		<model name='EGL-R9'>
 			<availability>LA:1-,FS:1-</availability>
@@ -5144,18 +5138,24 @@
 			<roles>ground_support</roles>
 			<availability>LA:1-,FS:1-</availability>
 		</model>
+		<model name='EGL-R11'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:1-,General:5-,FS:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,DTA:6,FWL.MM:7,FWL:6,MH:4,FWL.FO:7,MERC:4</availability>
-		<model name='EGL-3M'>
-			<availability>DTA:3,FWL:3</availability>
+		<model name='EGL-2M'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='EGL-1M'>
 			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
 		</model>
-		<model name='EGL-2M'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='EGL-3M'>
+			<availability>DTA:3,FWL:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Eidolon' unitType='Mek'>
@@ -5166,11 +5166,11 @@
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:4,MERC:3</availability>
-		<model name='EFT-4J'>
-			<availability>LA:3-,MERC:2-</availability>
-		</model>
 		<model name='EFT-7X'>
 			<availability>IS:8</availability>
+		</model>
+		<model name='EFT-4J'>
+			<availability>LA:3-,MERC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5181,68 +5181,68 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:3,MERC:2+</availability>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
+		<model name='EST-OD'>
+			<availability>General:3</availability>
 		</model>
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='EST-OD'>
-			<availability>General:3</availability>
+		<model name='EST-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,MERC.WD:6,CW:6,CLAN:6,CNC:6+</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:3,CLAN:2</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [AP Gauss]' mechanized='true'>
 			<availability>CJF:4</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='(Fire) [MicroPL]' mechanized='true'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='[MicroPL]' mechanized='true'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:3,CLAN:2</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Space) [MicroPL]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:4,CLAN:2</availability>
 		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:3,CLAN:2</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Fire) [Flamer]' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:3,CLAN:2</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [MicroPL]' mechanized='true'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='[MicroPL]' mechanized='true'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5253,17 +5253,11 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,WOB:7,FS:5,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
-		<model name='EMP-6M'>
-			<availability>FWL:4,WOB:4</availability>
-		</model>
-		<model name='EMP-6D'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='EMP-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='EMP-6S'>
-			<availability>LA:7</availability>
+		<model name='EMP-7L'>
+			<availability>CC:5</availability>
 		</model>
 		<model name='EMP-6ME &apos;Mercury Elite&apos;'>
 			<availability>FWL:2</availability>
@@ -5271,8 +5265,14 @@
 		<model name='EMP-6A'>
 			<availability>CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='EMP-7L'>
-			<availability>CC:5</availability>
+		<model name='EMP-6M'>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
+		<model name='EMP-6S'>
+			<availability>LA:7</availability>
+		</model>
+		<model name='EMP-6D'>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
@@ -5281,6 +5281,10 @@
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4,FS:4</availability>
 		</model>
+		<model name='END-6Q'>
+			<roles>urban</roles>
+			<availability>LA:5,General:2,MERC:5</availability>
+		</model>
 		<model name='END-6S'>
 			<roles>urban</roles>
 			<availability>LA:2,MERC:2</availability>
@@ -5288,21 +5292,17 @@
 		<model name='END-6Sr'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
-		<model name='END-6Q'>
-			<roles>urban</roles>
-			<availability>LA:5,General:2,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:6,FS:7,MERC:5</availability>
-		<model name='ENF-6Ma'>
-			<availability>FVC:2,FS:2</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='ENF-6Ma'>
+			<availability>FVC:2,FS:2</availability>
 		</model>
 		<model name='ENF-6T'>
 			<availability>FS:4</availability>
@@ -5313,17 +5313,17 @@
 		<model name='ENF-7C3BS'>
 			<availability>FS:1</availability>
 		</model>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,TC:2,Periphery:2,FVC:7,OA:2,LA:2,Periphery.HR:2,MH:2,DC:1</availability>
-		<model name='ENF-4R'>
-			<availability>FVC:4-,General:2-,FS:4-,TC:4-</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>FVC:8,LA:2,FS:8,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>FVC:4-,General:2-,FS:4-,TC:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -5352,14 +5352,6 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CDS:4+,CW:4+,CNC:3+,CSL:6+,CGS:3+,CGB:3+,CWIE:4+</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>CHH:8</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
@@ -5368,13 +5360,21 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>CHH:8</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
+			<availability>General:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Erinyes' unitType='ProtoMek'>
@@ -5388,17 +5388,21 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CS:4,CSR:1,CDS:2,CSV:1,FWL:1,WOB:2,CGS:1,CCO:1,DC:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CS:4,CLAN:8,DC:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:2,FS:6</availability>
@@ -5406,20 +5410,12 @@
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:5,FS:4,MERC:2</availability>
 		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5,CIR:2+,DC:4</availability>
 		<model name='EXC-B2b'>
 			<roles>fire_support</roles>
 			<availability>CLAN:4,WOB:5,CGS:6,BAN:2</availability>
-		</model>
-		<model name='EXC-CS'>
-			<roles>fire_support</roles>
-			<availability>CS:8,WOB:8,DC:8</availability>
 		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
@@ -5432,6 +5428,10 @@
 		<model name='EXC-D1'>
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='EXC-CS'>
+			<roles>fire_support</roles>
+			<availability>CS:8,WOB:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -5447,11 +5447,11 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4,DC:1</availability>
-		<model name='EXT-5F'>
-			<availability>CS:6</availability>
-		</model>
 		<model name='EXT-4D'>
 			<availability>CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:2,DC:8</availability>
+		</model>
+		<model name='EXT-5F'>
+			<availability>CS:6</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -5462,9 +5462,8 @@
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
 		<availability>MOC:7,CC:3</availability>
-		<model name='EYL-45A'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='EYL-4A'>
+			<availability>MOC:1</availability>
 		</model>
 		<model name='EYL-35A'>
 			<roles>spotter</roles>
@@ -5474,33 +5473,34 @@
 			<roles>spotter</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='EYL-4A'>
-			<availability>MOC:1</availability>
+		<model name='EYL-45A'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:7</availability>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CC:5</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='(Support) [King David]' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -5520,12 +5520,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5548,20 +5548,20 @@
 		<model name='FLC-6C'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>CS:4,LA:8,FS:8,MERC:3</availability>
-		<model name='FLC-8R'>
-			<availability>General:6</availability>
-		</model>
 		<model name='FLC-9R'>
 			<availability>General:4</availability>
+		</model>
+		<model name='FLC-8R'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -5573,25 +5573,19 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:3</availability>
-		<model name='(Upgrade)'>
+		<model name='(Standard)'>
 			<roles>cruiser</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Upgrade)'>
 			<roles>cruiser</roles>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SRM]' mechanized='false'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[SL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='&apos;Longshot&apos;' mechanized='false'>
 			<availability>General:3</availability>
@@ -5599,54 +5593,60 @@
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:3</availability>
+		</model>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[SRM]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:3+,CHH:3,MERC.WD:6,CW:6,CSV:3,CLAN:1,IS:3+,CJF:4,CWIE:6,CGB:3</availability>
-		<model name='B'>
-			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:3,CSV:3,CNC:5,General:4,CGS:4,CWIE:3</availability>
-		</model>
-		<model name='H'>
-			<availability>MERC.KH:2,MERC.WD:2,General:2,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:7,CSV:5,CNC:4,General:6,CJF:7</availability>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:7,CW:6,CSV:6,CNC:6,General:4,CJF:6,CGB:6</availability>
 		</model>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		<model name='A'>
+			<availability>CDS:7,CSV:5,CNC:4,General:6,CJF:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:2,MERC.WD:2,General:2,CWIE:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:3,CSV:3,CNC:5,General:4,CGS:4,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:4,HL:4,LA:5,Periphery.HR:4,Periphery.MW:4,Periphery.CM:4,FWL:3,FS:6</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='&apos;Fermi&apos;'>
+			<roles>apc</roles>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
@@ -5656,9 +5656,9 @@
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:5</availability>
 		</model>
-		<model name='&apos;Fermi&apos;'>
-			<roles>apc</roles>
-			<availability>FS:3</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -5685,63 +5685,15 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(LBX20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(UAC20)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
-		</model>
 		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -5749,9 +5701,57 @@
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(LBX2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LBX10)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
@@ -5760,70 +5760,70 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,SOC:5,CNC:3,CJF:7,CLAN.HW:5</availability>
-		<model name='Prime'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CSA:7,CLAN:6,IS:3</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CSA:7,CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:3,CCO:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
 		<availability>CGS:8</availability>
-		<model name='(Standard)'>
+		<model name='2'>
 			<roles>urban</roles>
-			<availability>CLAN:8</availability>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='3'>
 			<roles>urban</roles>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='2'>
+		<model name='(Standard)'>
 			<roles>urban</roles>
-			<availability>CLAN:6</availability>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,FS:7,MERC:5</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:6,MERC:6,FS:6</availability>
-		</model>
 		<model name='ALM-10D'>
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,LA:2,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -5845,11 +5845,14 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:6,MERC.WD:2,CLAN:2,WOB:5,BAN:1</availability>
-		<model name='C'>
-			<availability>MERC.WD:2,CLAN:8,BAN:1</availability>
+		<model name='FFL-4D'>
+			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:2,CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FFL-4C'>
 			<availability>CS:8,WOB:8</availability>
@@ -5857,23 +5860,14 @@
 		<model name='FFL-4DA'>
 			<availability>MERC.WD:4</availability>
 		</model>
-		<model name='FFL-4D'>
-			<availability>MERC.WD:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:6,IS:5,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
+		<model name='FS9-S2'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='FS9-B'>
 			<availability>WOB:6</availability>
-		</model>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:3,CS:3,MOC:4,LA:6,FRR:4,General:4,FS:4,TC:3</availability>
 		</model>
 		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
@@ -5882,14 +5876,20 @@
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,CIR:7,Periphery:3,TC:4</availability>
 		</model>
-		<model name='FS9-S2'>
-			<availability>LA:4</availability>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='FS9-P'>
 			<availability>FVC:3,Periphery:3</availability>
 		</model>
 		<model name='FS9-S3'>
 			<availability>LA:4,FWL:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:3,CS:3,MOC:4,LA:6,FRR:4,General:4,FS:4,TC:3</availability>
 		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
@@ -5898,61 +5898,61 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:5,CC:4,FVC:4+,LA:5,IS:4,WOB:5,FS:5,MERC:4,DC:7</availability>
-		<model name='FS9-OE'>
+		<model name='FS9-OD'>
 			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OX'>
-			<availability>General:2</availability>
 		</model>
 		<model name='FS9-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='FS9-OH'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OA'>
+		<model name='FS9-OE'>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OR'>
 			<availability>CLAN:4,IS:1+,DC:1+</availability>
 		</model>
+		<model name='FS9-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OX'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:3</availability>
-		<model name='C'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
@@ -5960,8 +5960,11 @@
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:2,CSV:4,FRR:4,CLAN:3,WOB:5,CGS:2,CS:5,DC.GHO:5,Periphery.R:1,CDS:2,LA:4,CBS:2,FWL:3,NIOPS:5,CJF:4,CGB:2,DC:4</availability>
-		<model name='FLS-9M'>
-			<availability>FWL:6</availability>
+		<model name='FLS-9C'>
+			<availability>CS:6</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:2-,LA:2-</availability>
 		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,CS:4,LA:8,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
@@ -5969,11 +5972,8 @@
 		<model name='FLS-C'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='FLS-9C'>
-			<availability>CS:6</availability>
-		</model>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:2-,LA:2-</availability>
+		<model name='FLS-9M'>
+			<availability>FWL:6</availability>
 		</model>
 		<model name='FLS-9B'>
 			<availability>WOB:6</availability>
@@ -5981,46 +5981,46 @@
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:4,MERC:4,CIR:4,RCM:3,Periphery:4,TC:4</availability>
-		<model name='FLE-20'>
-			<availability>CC:3</availability>
-		</model>
-		<model name='FLE-17'>
-			<availability>CC:8,FWL:5,WOB:5,MERC:5,RCM:6,Periphery:5</availability>
-		</model>
 		<model name='FLE-19'>
 			<roles>urban</roles>
 			<availability>MOC:4-,CC:4-,FVC:4-,OA:4-,HL:4-,FWL:4-,WOB:4-,MERC:5-,RCM:4-,Periphery:6-,TC:4-</availability>
 		</model>
+		<model name='FLE-20'>
+			<availability>CC:3</availability>
+		</model>
 		<model name='&apos;Fire Ant&apos;'>
 			<roles>urban</roles>
 			<availability>CC:1</availability>
+		</model>
+		<model name='FLE-17'>
+			<availability>CC:8,FWL:5,WOB:5,MERC:5,RCM:6,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6031,20 +6031,18 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
@@ -6055,33 +6053,35 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
 		<availability>CS:4,LA:4,NIOPS:4,FS:4,Periphery:1</availability>
-		<model name='(2613)'>
-			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3058)'>
 			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
 			<availability>CS:8,LA:8,FS:8</availability>
 		</model>
+		<model name='(2613)'>
+			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Fortune Wheeled Assault Vehicle' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='(Thunderbolt)'>
-			<availability>LA:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>LA:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Thunderbolt)'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -6122,14 +6122,14 @@
 			<roles>apc,spotter</roles>
 			<availability>FS:3</availability>
 		</model>
-		<model name='CX-17'>
-			<availability>CS:8</availability>
+		<model name='(Royal)'>
+			<availability>CLAN:4,WOB:4,BAN:2</availability>
 		</model>
 		<model name='(C3S)'>
 			<availability>FS:5</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:4,WOB:4,BAN:2</availability>
+		<model name='CX-17'>
+			<availability>CS:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -6149,10 +6149,6 @@
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
 		<availability>CS:3,FRR:2,NIOPS:3,WOB:4,TC:4</availability>
-		<model name='(TDF)'>
-			<roles>recon</roles>
-			<availability>TC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
@@ -6160,44 +6156,34 @@
 		<model name='(ERSL)'>
 			<availability>TC:4</availability>
 		</model>
+		<model name='(TDF)'>
+			<roles>recon</roles>
+			<availability>TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:4,CW:4,CLAN:2</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CSA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CW:6,CLAN:4,CGS:6,CCO:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
 		<availability>LA:2,WOB:4</availability>
-		<model name='GLH-2D'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='GLH-3D'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='GLH-2D'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:1,LA:1,FRR:1,IS:1,DC:1,Periphery:1</availability>
-		</model>
-		<model name='GAL-104'>
-			<availability>WOB:5</availability>
-		</model>
-		<model name='GAL-103'>
-			<roles>recon</roles>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
-		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3</availability>
 		</model>
@@ -6205,33 +6191,50 @@
 			<roles>recon</roles>
 			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
 		</model>
+		<model name='GAL-104'>
+			<availability>WOB:5</availability>
+		</model>
+		<model name='GAL-200'>
+			<availability>MOC:1,LA:1,FRR:1,IS:1,DC:1,Periphery:1</availability>
+		</model>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
+		<model name='GAL-103'>
+			<roles>recon</roles>
+			<availability>WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>CC:2,MOC:2,MERC.WD:6,IS:3,FWL:2,MH:4,MERC:5,TC:2,CWIE:3</availability>
-		<model name='GAL-2GLS'>
-			<availability>HL:2-,IS:4-,Periphery:4-</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:5,Periphery:8</availability>
-		</model>
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,MERC:5</availability>
 		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2</availability>
 		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,MERC:5</availability>
+		<model name='GAL-2GLS'>
+			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8-,CWIE:8</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,MERC:5</availability>
+		</model>
 		<model name='GAL-4GLSA'>
 			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,IS:8,Periphery.Deep:6,MERC:5,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:5,FS:6,MERC:4,CDP:4,TC:4</availability>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A2'>
 			<availability>FS:3</availability>
 		</model>
@@ -6240,9 +6243,6 @@
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
-		</model>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -6264,44 +6264,44 @@
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:1,CSR:1,CDS:5,CLAN:5,CNC:5,IS:2+,CJF:4,BAN:4,CWIE:2,CGB:9</availability>
-		<model name='Prime'>
-			<availability>CW:7,CSV:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:7,CSV:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
-		</model>
-		<model name='P'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CSV:5,General:7,CGB:4</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CGB:5</availability>
 		</model>
-		<model name='K'>
-			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		</model>
+		<model name='P'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CSV:5,General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
 		<availability>CS:3,LA:2-,FWL:2-,MH:2-,MERC:2,DC:3-</availability>
-		<model name='GLD-5R'>
-			<availability>CS:8,MERC:6</availability>
-		</model>
 		<model name='GLD-1R'>
 			<availability>LA:3-,FWL:3-,MH:4-,MERC:3-,DC:3-</availability>
 		</model>
 		<model name='GLD-3R'>
 			<availability>MERC:2</availability>
+		</model>
+		<model name='GLD-5R'>
+			<availability>CS:8,MERC:6</availability>
 		</model>
 		<model name='GLD-4R'>
 			<availability>MERC:1</availability>
@@ -6309,22 +6309,22 @@
 	</chassis>
 	<chassis name='Gladius Medium Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:4,Periphery.CM:3,Periphery.ME:3,MH:6,CDP:4,TC:5,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk II'>
 			<availability>MH:5,TC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Glaive Medium Tank' unitType='Tank'>
 		<availability>LA:3,LA.SR:6</availability>
-		<model name='(MFB)'>
-			<roles>support</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MFB)'>
+			<roles>support</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
@@ -6340,20 +6340,20 @@
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6394,22 +6394,26 @@
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CGB:6</availability>
-		<model name='(Fast Assault)' mechanized='false'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Rock Golem)' mechanized='false'>
-			<availability>CHH:8</availability>
+		<model name='(Fast Assault)' mechanized='false'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
 			<roles>urban,anti_infantry</roles>
 			<availability>CGB:4</availability>
 		</model>
+		<model name='(Rock Golem)' mechanized='false'>
+			<availability>CHH:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:3,HL:2,IS:1,FS:3,MERC:4,TC:3,Periphery:3,CS:1,OA:2,FVC:2,LA:5,Periphery.MW:2,FWL:6,MH:2</availability>
+		<model name='GOL-4S'>
+			<roles>fire_support</roles>
+			<availability>LA:5</availability>
+		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:8,FWL:8,WOB:8,MERC:6</availability>
@@ -6426,9 +6430,9 @@
 			<roles>fire_support</roles>
 			<availability>Periphery.HR:4,Periphery.CM:4,Periphery.MW:4,Periphery.ME:4,MH:4,Periphery:3</availability>
 		</model>
-		<model name='GOL-4S'>
+		<model name='GOL-1H'>
 			<roles>fire_support</roles>
-			<availability>LA:5</availability>
+			<availability>CC:3-,LA:4-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 		</model>
 		<model name='GOL-2H'>
 			<roles>fire_support</roles>
@@ -6438,10 +6442,6 @@
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
 		</model>
-		<model name='GOL-1H'>
-			<roles>fire_support</roles>
-			<availability>CC:3-,LA:4-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
-		</model>
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CSA:7,CSR:6,CBS:4,SOC:4,CSV:4,CNC:4,CJF:8,CCO:4</availability>
@@ -6449,23 +6449,23 @@
 			<roles>anti_infantry</roles>
 			<availability>CSA:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:5,CSR:5,CBS:5,SOC:5,CNC:5,CJF:5</availability>
+		<model name='2'>
+			<availability>CSA:8,CSV:8,CJF:8,CCO:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CSR:6,CBS:6</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CSV:8,CJF:8,CCO:8</availability>
+		<model name='(Standard)'>
+			<availability>CSA:5,CSR:5,CBS:5,SOC:5,CNC:5,CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CSV:4,CLAN:1</availability>
-		<model name='(Standard)'>
-			<availability>CSV:2,General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSV:2,General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSV:2,General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSV:8</availability>
@@ -6476,26 +6476,26 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CS:8,DTA:7,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5-</availability>
-		<model name='GTHA-600'>
-			<availability>DTA:6,FWL:5,WOB:5</availability>
+		<model name='GTHA-500b'>
+			<availability>CLAN:4,FWL:5,BAN:2</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>CLAN:4,FWL:5,BAN:2</availability>
-		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
+		</model>
+		<model name='GTHA-600'>
+			<availability>DTA:6,FWL:5,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Crusader II' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='GRN-D-03'>
-			<availability>General:6</availability>
-		</model>
 		<model name='GRN-D-04'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GRN-D-03'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Crusader' unitType='Mek'>
@@ -6509,6 +6509,15 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,CNC:6,WOB:5,DC:8</availability>
+		<model name='DRG-1G'>
+			<availability>FRR:4-,DC:4-</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='DRG-5K'>
+			<availability>FRR:6,CNC:8,WOB:8,MERC:4,DC:5</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>FRR:6,DC:6</availability>
 		</model>
@@ -6516,50 +6525,41 @@
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:4</availability>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='DRG-7K'>
 			<availability>MERC:3,DC:5</availability>
 		</model>
-		<model name='DRG-1G'>
-			<availability>FRR:4-,DC:4-</availability>
-		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-5K'>
-			<availability>FRR:6,CNC:8,WOB:8,MERC:4,DC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>CC:5,MOC:5,IS:2,WOB:5,FWL.KIS:8,FS:5,MERC:5,CS:3,DTA:7,FVC:5,Periphery.MW:4,Periphery.ME:2,FWL:7,MH:4,RCM:7,DC:5</availability>
-		<model name='T-IT-N10M'>
-			<availability>HL:4,General:2,FWL:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='T-IT-N11M'>
 			<availability>DTA:4,CC:4,MOC:4,FWL:6,WOB:6,MERC:4,FS:4,DC:4</availability>
+		</model>
+		<model name='T-IT-N10M'>
+			<availability>HL:4,General:2,FWL:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>CS:4-,MOC:6,OA:6,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+		<model name='GHR-7K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='GHR-5J'>
 			<availability>CS:2-,IS:5,WOB:2-,Periphery:3</availability>
 		</model>
-		<model name='GHR-7K'>
-			<availability>DC:5</availability>
+		<model name='GHR-6K'>
+			<availability>FRR:5,MERC:3,FS:3,DC:5</availability>
 		</model>
 		<model name='GHR-5H'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
-		<model name='GHR-C'>
-			<availability>IS:3,DC:3</availability>
-		</model>
 		<model name='GHR-5N'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='GHR-6K'>
-			<availability>FRR:5,MERC:3,FS:3,DC:5</availability>
+		<model name='GHR-C'>
+			<availability>IS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -6577,32 +6577,38 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
 		<availability>CSA:4,CCC:4,CHH:4,CSV:4,CLAN:1,CCO:4,CGB:4</availability>
-		<model name='2'>
-			<availability>CHH:7,CGB:7</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:7,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:3</availability>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[MagShot]' mechanized='false'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:3</availability>
@@ -6610,12 +6616,6 @@
 		<model name='[TAG]' mechanized='false'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='[MagShot]' mechanized='false'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
@@ -6626,8 +6626,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
@@ -6638,78 +6644,80 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3,CCO:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:4</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:5,CDS:6,CW:3,CNC:7,CLAN:3,CCO:6,CJF:3,CWIE:4,CGB:3,DC:4</availability>
-		<model name='6'>
-			<availability>CNC:5,DC:5</availability>
-		</model>
 		<model name='4'>
 			<availability>CSA:6,CDS:6,CNC:8,CLAN:3</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CLAN:2-,CNC:4</availability>
-		</model>
-		<model name='2'>
-			<availability>MERC.WD:8,CNC:4,CLAN:2</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:8,CNC:5,CLAN:3,CCO:8</availability>
 		</model>
+		<model name='2'>
+			<availability>MERC.WD:8,CNC:4,CLAN:2</availability>
+		</model>
+		<model name='6'>
+			<availability>CNC:5,DC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CLAN:2-,CNC:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:4,CNC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:4,CS:2,OA:1,LA:7,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-3M'>
-			<availability>DTA:5,LA:6,FWL:6,IS:6,FS:5,RCM:6,DC:3</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:5,FRR:3,FS:4,MERC:4,DC:4</availability>
+		<model name='GRF-1S'>
+			<availability>LA:3-,MERC:3-</availability>
 		</model>
 		<model name='GRF-6CS'>
 			<availability>CS:5,WOB:4</availability>
 		</model>
-		<model name='GRF-4R'>
-			<availability>CS:5,FRR:4,WOB:4,CGB:4</availability>
-		</model>
 		<model name='GRF-2N'>
 			<availability>CC:2,CLAN:6,FWL:3,WOB:5,FS:2,MERC:3,RCM:4,BAN:4,DC:2</availability>
-		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,FWL:5,WOB:5,MERC:5</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>LA:3-,MERC:3-,TC:3-</availability>
 		</model>
-		<model name='GRF-1S'>
-			<availability>LA:3-,MERC:3-</availability>
+		<model name='GRF-5M'>
+			<availability>DTA:6,FWL:5,WOB:5,MERC:5</availability>
 		</model>
-		<model name='GRF-5K'>
-			<availability>CNC:5,DC:5</availability>
+		<model name='GRF-3M'>
+			<availability>DTA:5,LA:6,FWL:6,IS:6,FS:5,RCM:6,DC:3</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CS:5,FRR:4,WOB:4,CGB:4</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>FVC:6,LA:4,FRR:4,FS:6,MERC:4,DC:5</availability>
 		</model>
+		<model name='GRF-5K'>
+			<availability>CNC:5,DC:5</availability>
+		</model>
 		<model name='GRF-5L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
+		</model>
+		<model name='GRF-6S'>
+			<availability>LA:5,FRR:3,FS:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grigori' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:7,WOB:2+</availability>
+		<model name='C-GRG-OS Caelestis'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:4</availability>
+		</model>
+		<model name='C-GRG-OC Comminus'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
 		<model name='C-GRG-OB Infernus'>
 			<roles>fire_support</roles>
 			<deployedWith>Deva</deployedWith>
@@ -6719,10 +6727,6 @@
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-GRG-OS Caelestis'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='C-GRG-OD Luminos'>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
@@ -6731,86 +6735,70 @@
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-GRG-OC Comminus'>
+		<model name='C-GRG-OU Exanimus'>
 			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='C-GRG-O Invictus'>
 			<roles>fire_support</roles>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='C-GRG-OU Exanimus'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>CS:5,WOB:6,MERC:5,DC:5</availability>
-		<model name='GRM-R-PR30'>
-			<availability>WOB:6+,MERC:3</availability>
-		</model>
 		<model name='GRM-R (Einar)'>
 			<roles>spotter</roles>
 			<availability>CS:1</availability>
-		</model>
-		<model name='GRM-R-PR29'>
-			<availability>CS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='GRM-R-PR31'>
 			<roles>fire_support</roles>
 			<availability>WOB:6+,MERC:4</availability>
 		</model>
+		<model name='GRM-R-PR30'>
+			<availability>WOB:6+,MERC:3</availability>
+		</model>
+		<model name='GRM-R-PR29'>
+			<availability>CS:8,MERC:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CCC:3,CSR:3,CBS:3,CSV:4,CLAN:2,CCO:3,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:2,FVC:1,IS:1,FWL:2,MERC:1,RCM:3,TC:2,Periphery:1</availability>
-		<model name='D'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CC:1,FWL:1</availability>
-		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CC:1,FWL:1</availability>
+		</model>
+		<model name='D'>
+			<availability>CC:3,MOC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>CHH:3-,CW:3,CLAN:2-,CNC:3-,CCO:3,CWIE:3</availability>
-		<model name='2'>
-			<availability>CW:4,CCO:6,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:4,CCO:6,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:3,CSR:3,FRR:2,IS:1,WOB:7,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:4,FWL:5,NIOPS:7,DC:2</availability>
-		<model name='GLT-3N'>
-			<roles>raider</roles>
-			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
-		</model>
-		<model name='GLT-6WB'>
-			<roles>raider</roles>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='GLT-6WB2'>
-			<roles>raider</roles>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='GLT-4L'>
 			<roles>raider</roles>
 			<availability>IS:2-,FWL:4-,Periphery.Deep:8,NIOPS:0,MERC:4-,Periphery:2-</availability>
@@ -6822,6 +6810,18 @@
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,FWL:8,FS:5,MERC:4</availability>
+		</model>
+		<model name='GLT-6WB2'>
+			<roles>raider</roles>
+			<availability>WOB:5</availability>
+		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='GLT-6WB'>
+			<roles>raider</roles>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
@@ -6840,6 +6840,10 @@
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='GUR-8G'>
+			<deployedWith>Vanquisher</deployedWith>
+			<availability>WOB:3</availability>
+		</model>
 		<model name='GUR-6G'>
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:3</availability>
@@ -6847,10 +6851,6 @@
 		<model name='GUR-4G'>
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:4</availability>
-		</model>
-		<model name='GUR-8G'>
-			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='HALO Paratrooper' unitType='Infantry'>
@@ -6862,27 +6862,27 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,CBS:3,LA:4,CNC:5,DC:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>LA:3+,CLAN:6,DC:3+</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4</availability>
-		</model>
 		<model name='HKO-1C'>
 			<roles>fire_support</roles>
 			<availability>LA:7,DC:7</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>LA:3+,CLAN:6,DC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:7,OA:3,CBS:6,CLAN:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(AAA)'>
 			<roles>fire_support</roles>
 			<availability>OA:6,CSR:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hamilcar' unitType='Dropship'>
@@ -6916,8 +6916,8 @@
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>FS:4,MERC:2</availability>
-		<model name='HMH-6E'>
-			<availability>General:4,MERC:4</availability>
+		<model name='HMH-6D'>
+			<availability>General:6</availability>
 		</model>
 		<model name='HMH-3D'>
 			<availability>General:4-,MERC:4-</availability>
@@ -6925,17 +6925,17 @@
 		<model name='HMH-5D'>
 			<availability>General:3,MERC:4</availability>
 		</model>
-		<model name='HMH-6D'>
-			<availability>General:6</availability>
+		<model name='HMH-6E'>
+			<availability>General:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:3,NIOPS:7,WOB:7,DC:2</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,NIOPS:8,WOB:4</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:4</availability>
 		</model>
 		<model name='HMR-HF'>
 			<availability>WOB:6</availability>
@@ -6949,30 +6949,30 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CDS:4,CSV:5,CNC:5,CLAN:2,IS:3+,CJF:4,CCO:3,CGB:3</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='E'>
-			<roles>anti_infantry</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>CSA:8,CSV:8,General:7</availability>
+		</model>
+		<model name='E'>
+			<roles>anti_infantry</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,CSV:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -6991,16 +6991,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5-,CC:5-,HL:3-,FRR:5-,Periphery.Deep:4,IS:4-,WOB:4-,MERC:5-,Periphery:4-,CS:4-,DTA:5,FWL.pm:6-,LA:4-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,RCM:5,DC:5-</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:4-</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:4</availability>
 		</model>
 		<model name='&apos;Mini-Peggy&apos;'>
 			<roles>recon</roles>
@@ -7012,29 +7012,29 @@
 		<model name='(Standard)'>
 			<availability>CSA:4,CHH:4,CBS:4,CSL:4,CJF:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CHH:8,CBS:8,CSV:8,CSL:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6,CHH:2</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:5,CSL:5</availability>
 		</model>
-		<model name='2'>
-			<availability>CHH:8,CBS:8,CSV:8,CSL:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:4,WOB:5,MERC:3,DC:7</availability>
-		<model name='HTM-28T'>
-			<availability>WOB:6,DC:4</availability>
-		</model>
-		<model name='HTM-27T'>
-			<availability>FRR:7,MERC:5,DC:6</availability>
-		</model>
 		<model name='HTM-26T'>
 			<availability>DC:2-</availability>
 		</model>
+		<model name='HTM-28T'>
+			<availability>WOB:6,DC:4</availability>
+		</model>
 		<model name='HTM-28Tr'>
 			<availability>WOB:6,DC:3</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>FRR:7,MERC:5,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -7076,30 +7076,30 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>Periphery.R:3,MERC.KH:4,FVC:5,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,WOB:4,FS:5,MERC:3,Periphery:2,DC:4</availability>
-		<model name='HCT-5DD'>
-			<availability>FS:5,MERC:5</availability>
+		<model name='HCT-6S'>
+			<availability>LA:6,MERC:6</availability>
+		</model>
+		<model name='HCT-3NH'>
+			<availability>DC:2-</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>FS:2,MERC:2</availability>
 		</model>
-		<model name='HCT-6D'>
-			<availability>FS:5,MERC:6</availability>
-		</model>
 		<model name='HCT-5S'>
 			<availability>FVC:5,LA:5,FRR:4,FS:5,MERC:4,DC:2,Periphery:2</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>WOB:8,DC:8</availability>
-		</model>
-		<model name='HCT-3NH'>
-			<availability>DC:2-</availability>
+		<model name='HCT-5DD'>
+			<availability>FS:5,MERC:5</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:2-,LA:2-,TC.PL:4-,MERC:2-,FS:2-,Periphery:2-</availability>
 		</model>
-		<model name='HCT-6S'>
-			<availability>LA:6,MERC:6</availability>
+		<model name='HCT-6D'>
+			<availability>FS:5,MERC:6</availability>
+		</model>
+		<model name='HCT-5K'>
+			<availability>WOB:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
@@ -7117,24 +7117,24 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:5</availability>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OB'>
-			<availability>General:7</availability>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='HA1-OC'>
+		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OD'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OC'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
@@ -7171,25 +7171,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7229,8 +7229,8 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:4,CC:3,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
@@ -7238,14 +7238,14 @@
 		<model name='Meteor-U'>
 			<availability>FS:3,MERC:1</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:4,CC:3,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CIR:4,TC:1</availability>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
 		</model>
 		<model name='Meteor-G'>
 			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7256,10 +7256,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7267,6 +7263,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7275,6 +7275,18 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(WoB)'>
+			<roles>apc,support</roles>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7283,21 +7295,13 @@
 			<roles>apc,support</roles>
 			<availability>General:8,WOB:4</availability>
 		</model>
-		<model name='(WoB)'>
-			<roles>apc,support</roles>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:2,CSR:2,CSV:2,CNC:2,CSL:4,CWIE:5</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -7305,44 +7309,43 @@
 		<model name='Prime'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
 		<availability>CC:2,MOC:2,MERC:2</availability>
-		<model name='HEP-4H'>
-			<roles>artillery</roles>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='HEP-1H'>
 			<roles>artillery</roles>
 			<availability>CC:3-,MOC:3-,MERC:3-</availability>
 		</model>
+		<model name='HEP-4H'>
+			<roles>artillery</roles>
+			<availability>MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
 		<availability>CC:5,CS:4,MOC:5,WOB:3,FS:3,MERC:3,DC:3,TC:5</availability>
+		<model name='HEL-4A'>
+			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
+		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,CS:8,MOC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 		<model name='HEL-6X'>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
-		<model name='HEL-4A'>
-			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,LA:2,CNC:3,NIOPS:6,WOB:6,FS:2,DC:2</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
+		</model>
+		<model name='HCT-215'>
+			<availability>CS:4</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -7351,36 +7354,33 @@
 		<model name='HCT-214'>
 			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
-		<model name='HCT-215'>
-			<availability>CS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,OA:5,FVC:3,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
-		<model name='HCT-213D'>
-			<availability>LA:1,FS:2</availability>
+		<model name='HCT-213S'>
+			<availability>LA:2,FS:1</availability>
+		</model>
+		<model name='HCT-313'>
+			<availability>OA:8,FVC:6,CSR:8,CDP:6</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:2,FS:2</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:2,FS:1</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
 		</model>
-		<model name='HCT-313'>
-			<availability>OA:8,FVC:6,CSR:8,CDP:6</availability>
+		<model name='HCT-213D'>
+			<availability>LA:1,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
 		<availability>CSA:5,CCC:4,CHH:4</availability>
-		<model name='(Standard)'>
-			<availability>CSA:8,CCC:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
@@ -7388,8 +7388,8 @@
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:2,CHH:3,CDS:3,DC.AL:2,CLAN:2,CNC:6,CJF:3</availability>
-		<model name='2'>
-			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
+		<model name='5'>
+			<availability>CNC:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
@@ -7397,15 +7397,27 @@
 		<model name='4'>
 			<availability>CNC:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CHH:7,CLAN:2,CJF:7</availability>
-		</model>
-		<model name='5'>
-			<availability>CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CDS:5,CBS:2,SOC:5,CSV:4,CLAN:2,CNC:5,CSL:5,CGS:4,CCO:5,CJF:2</availability>
+		<model name='B'>
+			<availability>CSA:8,General:7,CJF:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:4,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:3,General:7,CJF:3</availability>
+		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -7414,42 +7426,42 @@
 			<roles>fire_support</roles>
 			<availability>CSA:3,General:6,CJF:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:8,General:7,CJF:3</availability>
-		</model>
 		<model name='F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:3,General:7,CJF:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:4,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>FS:6,MERC:4</availability>
-		<model name='HSN-7D'>
-			<roles>fire_support</roles>
-			<availability>FS:8,MERC:8</availability>
-		</model>
-		<model name='HSN-8E'>
+		<model name='HSN-9F'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
 		<model name='HSN-10G'>
 			<availability>LA:4,FS:4</availability>
 		</model>
-		<model name='HSN-9F'>
+		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
+		</model>
+		<model name='HSN-7D'>
+			<roles>fire_support</roles>
+			<availability>FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:4+,CSL:4+</availability>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>recon,apc,fire_support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -7457,18 +7469,6 @@
 		<model name='Prime'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon,apc,fire_support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -7493,6 +7493,10 @@
 			<roles>recon</roles>
 			<availability>FWL:3</availability>
 		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:4,WOB:4</availability>
+		</model>
 		<model name='HER-6D'>
 			<roles>recon</roles>
 			<availability>FS.LG:10</availability>
@@ -7500,10 +7504,6 @@
 		<model name='HER-5C'>
 			<roles>recon</roles>
 			<availability>WOB:10</availability>
-		</model>
-		<model name='HER-5Sr'>
-			<roles>recon</roles>
-			<availability>MOC:3,IS:3</availability>
 		</model>
 		<model name='HER-5SA'>
 			<roles>training</roles>
@@ -7517,56 +7517,59 @@
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:3,WOB:8,FS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>FWL:4,WOB:4</availability>
+			<availability>MOC:3,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CS:3,DC.GHO:5,CHH:1,FRR:3,FWL:7,NIOPS:3,WOB:3,CGB:1,DC:6</availability>
-		<model name='HER-4WB'>
-			<roles>recon</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='HER-3S2'>
 			<roles>recon,spotter</roles>
 			<availability>FWL:3</availability>
-		</model>
-		<model name='HER-4K'>
-			<roles>recon</roles>
-			<availability>DC:7</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:5</availability>
-		</model>
-		<model name='HER-3S'>
-			<roles>recon</roles>
-			<availability>FWL:6,WOB:5</availability>
 		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>DC.GHO:4-,CS:4,CLAN:6,NIOPS:4,BAN:8</availability>
 		</model>
-		<model name='HER-4S'>
+		<model name='HER-3S'>
 			<roles>recon</roles>
-			<availability>CS:3,FRR:3,FWL:5,WOB:3</availability>
+			<availability>FWL:6,WOB:5</availability>
 		</model>
 		<model name='HER-4M'>
 			<roles>recon</roles>
 			<availability>FWL:5,WOB:6</availability>
 		</model>
+		<model name='HER-4WB'>
+			<roles>recon</roles>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>DC:7</availability>
+		</model>
+		<model name='HER-4S'>
+			<roles>recon</roles>
+			<availability>CS:3,FRR:3,FWL:5,WOB:3</availability>
+		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,MERC:1,Periphery:1,CWIE:3,CGB:2</availability>
-		<model name='(SRM)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6-</availability>
 		</model>
-		<model name='(AC10)'>
-			<availability>IS:1,Periphery:1</availability>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:2,Periphery:2</availability>
@@ -7574,14 +7577,11 @@
 		<model name='(LB-X)'>
 			<availability>CC:8,MOC:5,CDP:4,TC:6</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:2,IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
-		</model>
-		<model name='(Sealed)'>
-			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -7598,18 +7598,24 @@
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>MERC.WD:2,CHH:4,CDS:4,CW:6,CLAN:2,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CDS:5,CW:5,CLAN:4,CNC:5,IS:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4,CW:2,CJF:4,CGB:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:5,CW:5,CLAN:4,CNC:5,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>MOC:1,CC:2,CS:9,LA:6,CLAN:5,IS:1,NIOPS:9,WOB:9,MERC:4,FS:5,CJF:6,DC:1</availability>
+		<model name='HGN-733C'>
+			<availability>CC:1,:0,LA:1</availability>
+		</model>
+		<model name='HGN-734'>
+			<availability>LA:6,MERC:6</availability>
+		</model>
 		<model name='HGN-736'>
 			<availability>CS:8,WOB:6</availability>
 		</model>
@@ -7625,29 +7631,23 @@
 		<model name='HGN-733P'>
 			<availability>CC:1,:0,LA:1</availability>
 		</model>
-		<model name='HGN-734'>
-			<availability>LA:6,MERC:6</availability>
-		</model>
-		<model name='HGN-733C'>
-			<availability>CC:1,:0,LA:1</availability>
-		</model>
-		<model name='HGN-738'>
-			<availability>LA:5</availability>
+		<model name='HGN-733'>
+			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>MOC:6,CC:3,CLAN:6,IS:6,WOB:3,MERC:6,FS:6,BAN:8,DC.GHO:8,CS:3,LA:6,FWL:3,NIOPS:3,MERC.SI:8,MH:6</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
+		<model name='HGN-738'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:3</availability>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7673,11 +7673,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F5'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BZK-F7'>
 			<availability>General:6</availability>
+		</model>
+		<model name='BZK-F5'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -7691,17 +7691,17 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:1,MERC.WD:2,CLAN:1,CGS:1</availability>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
-		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:2,CLAN:1</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:1</availability>
 		</model>
 		<model name='HOP-4D'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:2,CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -7709,16 +7709,16 @@
 		<model name='HNT-161'>
 			<availability>MERC.WD:2-</availability>
 		</model>
+		<model name='HNT-152'>
+			<roles>recon,urban</roles>
+			<availability>FVC:2-,IS:1-</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:3-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='HNT-152'>
-			<roles>recon,urban</roles>
-			<availability>FVC:2-,IS:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -7735,13 +7735,13 @@
 	</chassis>
 	<chassis name='Huitzilopochtli Assault Tank &apos;Huey&apos;' unitType='Tank'>
 		<availability>CLAN:5,CNC:2,CWIE:2</availability>
-		<model name='(AAA)'>
-			<roles>missile_artillery,anti_aircraft</roles>
-			<availability>CGB:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>missile_artillery,anti_aircraft</roles>
+			<availability>CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Humming Bird VTOL' unitType='VTOL'>
@@ -7753,9 +7753,6 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:5,CDS:7,CSR:6,CW:6,CSV:5,CLAN:2,IS:3,CJF:6,CGB:6,CWIE:5</availability>
-		<model name='3'>
-			<availability>CSR:8,CCO:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:8,CBS:8</availability>
 		</model>
@@ -7765,14 +7762,20 @@
 		<model name='(Standard)'>
 			<availability>CSR:4,General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CSR:8,CCO:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:3,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:3</availability>
+		<model name='HBK-5SS'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 		<model name='HBK-6S'>
 			<availability>LA:4,MERC:4</availability>
-		</model>
-		<model name='HBK-4N'>
-			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:2-,FWL:2-,MERC:2-,Periphery:2-</availability>
@@ -7780,35 +7783,32 @@
 		<model name='HBK-5P'>
 			<availability>FWL:5,WOB:5,MERC:4</availability>
 		</model>
-		<model name='HBK-4SP'>
-			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
-		</model>
-		<model name='HBK-5M'>
-			<availability>CS:4,CC:1,MOC:1,FRR:1,FWL:1,WOB:4,MERC:1,CDP:1,TC:1</availability>
-		</model>
-		<model name='HBK-5SS'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>IS:1-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5S'>
-			<availability>LA:5,FRR:3,MERC:3,FS:2</availability>
-		</model>
-		<model name='HBK-6N'>
-			<availability>FWL:4,MERC:5</availability>
-		</model>
 		<model name='HBK-4H'>
 			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-5H'>
 			<availability>MH:6,Periphery:3</availability>
 		</model>
+		<model name='HBK-4SP'>
+			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
+		</model>
 		<model name='HBK-5N'>
 			<availability>MOC:5,CC:5,CS:5,FRR:5,FWL:6,WOB:5,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:1-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-5M'>
+			<availability>CS:4,CC:1,MOC:1,FRR:1,FWL:1,WOB:4,MERC:1,CDP:1,TC:1</availability>
+		</model>
+		<model name='HBK-5S'>
+			<availability>LA:5,FRR:3,MERC:3,FS:2</availability>
+		</model>
+		<model name='HBK-4N'>
+			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-6N'>
+			<availability>FWL:4,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -7822,50 +7822,50 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:4</availability>
-		<model name='&apos;Assault Hunter&apos;'>
-			<availability>LA:2,FS:2</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:2-</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3-</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:4-</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:3</availability>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>LA:8,FS:6,RCM:4,MERC:4</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
+		<model name='(LRM15)'>
 			<roles>fire_support</roles>
-			<availability>LA:8,FS:6,RCM:4,MERC:4</availability>
+			<availability>General:3-</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='&apos;Assault Hunter&apos;'>
+			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,WOB:3,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4O'>
+			<availability>CC:8,MOC:8,FWL:3,MERC:5,TC:3</availability>
+		</model>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:4,MOC:4,FWL:5</availability>
 		</model>
 		<model name='HUR-WO-R4N'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
-		</model>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4O'>
-			<availability>CC:8,MOC:8,FWL:3,MERC:5,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
@@ -7877,16 +7877,16 @@
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>CS:3,FRR:5,CNC:4,CGB:4</availability>
-		<model name='HSCL-1-OD'>
-			<availability>General:4</availability>
-		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HSCL-1-OA'>
+		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OB'>
+		<model name='HSCL-1-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OC'>
@@ -7895,39 +7895,39 @@
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:4,LA:3,CSV:5,FRR:2,CLAN:4,NIOPS:4,WOB:4,MERC:3,DC:1</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='HSR-900-D'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
+		<model name='HSR-500-D'>
+			<availability>CS:4,WOB:8</availability>
 		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:4,General:8,CLAN:6,NIOPS:4,MERC.SI:4,WOB:4,BAN:8</availability>
 		</model>
+		<model name='HSR-900-D'>
+			<availability>WOB:6</availability>
+		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:1-</availability>
+		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:2-</availability>
-		</model>
-		<model name='HSR-500-D'>
-			<availability>CS:4,WOB:8</availability>
 		</model>
 		<model name='HSR-950-D'>
 			<availability>WOB:4</availability>
 		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>CS:8,LA:8,WOB:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CCC:6,CSR:5,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Algar)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
@@ -7935,19 +7935,19 @@
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
 		<availability>CHH:5,CBS:2,CSL:5</availability>
+		<model name='2'>
+			<availability>CHH:6,CSL:6</availability>
+		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CBS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CHH:6,CBS:6,CSL:6</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:6,CSL:6</availability>
-		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CBS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:6,CBS:6,CSL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hyena' unitType='Mek'>
@@ -7959,35 +7959,35 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:4,MOC:8,LA:3,FWL:3,IS:8,WOB:3,MH:8,FS:1,DC:2,TC:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [LRR]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [SRM]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -8021,10 +8021,10 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
+		<model name='IMP-4E'>
 			<availability>MERC.WD:6</availability>
 		</model>
-		<model name='IMP-4E'>
+		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
@@ -8044,11 +8044,11 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,CNC:2,CWIE:2</availability>
-		<model name='(BA)'>
-			<availability>CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(BA)'>
+			<availability>CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
@@ -8064,14 +8064,14 @@
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>FS:3,TC:3</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
+		<model name='&apos;Puma&apos;' mechanized='true'>
+			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='&apos;Puma&apos;' mechanized='true'>
-			<availability>FS:8,TC:8</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Initiate' unitType='Mek'>
@@ -8091,13 +8091,13 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>WOB:6</availability>
-		<model name='(Sub-Capital)'>
-			<roles>assault</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>assault</roles>
 			<availability>FWL:8,WOB:6</availability>
+		</model>
+		<model name='(Sub-Capital)'>
+			<roles>assault</roles>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -8113,16 +8113,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -8134,11 +8134,11 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CS:6,CLAN:1,CNC:2,NIOPS:6,WOB:6,DC:1</availability>
-		<model name='IRN-SD1'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='IRN-SD3'>
 			<availability>WOB:5</availability>
+		</model>
+		<model name='IRN-SD1'>
+			<availability>General:8,CNC:4</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
@@ -8174,15 +8174,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -8199,29 +8199,29 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:4-,MOC:4-,CC:2-,DC.LV:5-,HL:3-,FRR:4-,DC.GR:4-,FS.AH:4-,Periphery.Deep:5,IS:4-,WOB:3-,FS:3-,CIR:4-,Periphery:4-,TC:5-,CS:2-,DTA:2-,OA:4-,LA:4-,FWL:2-,NIOPS:2-,RCM:2-,DC:4-</availability>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>FVC:3,IS:4,TC:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Kurita)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>DC:8,TC:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Kurita)'>
-			<roles>recon,raider</roles>
-			<availability>DC:8,TC:4</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
@@ -8280,27 +8280,27 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:4,CW:5,General:2</availability>
 		</model>
-		<model name='E'>
-			<availability>CSR:6,CW:4,CLAN:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CSR:6,CW:4,CLAN:2</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8314,35 +8314,16 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:3,CC:4-,FRR:5,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,FWL:1,NIOPS:3,MH:4,DC:3</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>MOC:2,FVC:6,OA:6,LA:6,FRR:6,FS:6,MERC:6,CDP:2,DC:6,TC:2</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='JM7-C3BS'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>CC:3-,FRR:2-,IS:3-,FS:3-,Periphery:6</availability>
 		</model>
-		<model name='JM6-DGr'>
-			<roles>anti_aircraft</roles>
-			<availability>FVC:3,LA:3,FRR:3,FS:3,MERC:3,CDP:2,DC:3</availability>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:5,MERC:6</availability>
-		</model>
-		<model name='JM7-F'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
 		</model>
 		<model name='JM6-DDa'>
 			<roles>anti_aircraft</roles>
@@ -8352,32 +8333,51 @@
 			<roles>anti_aircraft</roles>
 			<availability>FVC:1,PIR:2,MH:5,Periphery:1</availability>
 		</model>
+		<model name='JM7-F'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='JM6-DGr'>
+			<roles>anti_aircraft</roles>
+			<availability>FVC:3,LA:3,FRR:3,FS:3,MERC:3,CDP:2,DC:3</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM7-G'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>MOC:2,FVC:6,OA:6,LA:6,FRR:6,FS:6,MERC:6,CDP:2,DC:6,TC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,HL:3,IS:2,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:2,LA:2,Periphery.HR:5</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+		<model name='JVN-10P'>
 			<roles>recon</roles>
-			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:3,FS:3,MERC:3</availability>
+			<availability>MOC:5,LA:6,Periphery.HR:5,PIR:5,FS:5,MERC:6,CDP:5,TC:5</availability>
 		</model>
 		<model name='JVN-11F'>
 			<roles>recon</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
+		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
-			<availability>MOC:5,LA:6,Periphery.HR:5,PIR:5,FS:5,MERC:6,CDP:5,TC:5</availability>
+			<availability>FVC:3,LA:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>FS:6</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -8386,14 +8386,14 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -8404,67 +8404,59 @@
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CSR:5,General:2,CJF:5</availability>
+		<model name='B'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CDS:6,CW:5,CSV:6,CNC:8,CLAN:2,CGS:5,CCO:5,DC:3</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
-		<model name='3'>
+		<model name='(Standard)'>
+			<availability>CW:4,CLAN:2,CNC:4</availability>
+		</model>
+		<model name='2'>
 			<availability>CCC:6,CSV:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:6,CNC:8,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CW:4,CLAN:2,CNC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:2-,DC:8</availability>
-		<model name='JR7-K'>
+		<model name='JR7-C4'>
 			<roles>raider</roles>
-			<availability>MOC:4,OA:4,FRR:8,MERC:4,DC:4,TC:4</availability>
-		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='JR7-C3'>
-			<roles>raider</roles>
-			<availability>MERC:3,DC:4</availability>
+			<availability>DC:2</availability>
 		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='JR7-C3'>
+			<roles>raider</roles>
+			<availability>MERC:3,DC:4</availability>
+		</model>
+		<model name='JR7-K'>
+			<roles>raider</roles>
+			<availability>MOC:4,OA:4,FRR:8,MERC:4,DC:4,TC:4</availability>
+		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
 			<availability>MERC:5,FS:5,DC:6</availability>
 		</model>
-		<model name='JR7-C4'>
+		<model name='JR7-C2'>
 			<roles>raider</roles>
-			<availability>DC:2</availability>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:5,TC:4</availability>
-		<model name='JI-50 (Q-Vehicle)'>
-			<roles>support</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='JI-50'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='JI-50 (ML)'>
+		<model name='JI-50 (Hoist)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8472,21 +8464,29 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='JI-50 (Hoist)'>
+		<model name='JI-50'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Q-Vehicle)'>
+			<roles>support</roles>
+			<availability>TC:2</availability>
+		</model>
+		<model name='JI-50 (ML)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:5,MOC:4,TC:4</availability>
-		<model name='JN-G8A'>
-			<availability>General:8</availability>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
+		<model name='JN-G8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Joust Medium Tank' unitType='Tank'>
@@ -8505,11 +8505,11 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
@@ -8521,8 +8521,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -8542,29 +8542,28 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='KBO-7B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='KBO-7A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='KBO-7B'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+		<model name='C' mechanized='true'>
+			<availability>DC:2</availability>
 		</model>
-		<model name='(DEST)' mechanized='true'>
+		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
@@ -8572,45 +8571,46 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C' mechanized='true'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='[MG]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Space)' mechanized='true'>
-			<roles>marine</roles>
-			<availability>DC:2</availability>
-		</model>
-		<model name='(Vibro-Claw)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='[Laser]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(DEST)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>DC:4</availability>
+		</model>
+		<model name='(Space)' mechanized='true'>
+			<roles>marine</roles>
+			<availability>DC:2</availability>
+		</model>
+		<model name='[ECM]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>MERC:2,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Salvage Arm]' mechanized='false'>
+			<roles>support</roles>
+			<availability>DC.SL:6,General:6</availability>
+		</model>
 		<model name='[Industrial Drill]' mechanized='false'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Salvage Arm]' mechanized='false'>
-			<roles>support</roles>
-			<availability>DC.SL:6,General:6</availability>
-		</model>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -8625,35 +8625,35 @@
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(AC)'>
+			<availability>MH:6,MERC:6</availability>
+		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:3,OA:5,FVC:3,HL:3,PIR:7,MH:6,CIR:6,Periphery:5,TC:5</availability>
+		</model>
 		<model name='(3055 Upgrade)'>
 			<roles>cargo</roles>
 			<availability>HL:3,IS:8,Periphery:5</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:6,MERC:6</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>CS:5,FWL:5,IS:6,WOB:5</availability>
 		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:3,OA:5,FVC:3,HL:3,PIR:7,MH:6,CIR:6,Periphery:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,FRR:2,DC:6</availability>
+		<model name='CRK-5003-2'>
+			<availability>FRR:8,DC:4-</availability>
+		</model>
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:5,DC:4</availability>
 		</model>
-		<model name='CRK-5003-2'>
-			<availability>FRR:8,DC:4-</availability>
+		<model name='CRK-5003-C'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CRK-5003-CM'>
 			<roles>spotter</roles>
 			<availability>DC:7</availability>
-		</model>
-		<model name='CRK-5003-C'>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
@@ -8662,21 +8662,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
@@ -8684,8 +8684,20 @@
 		<model name='KGC-001'>
 			<availability>CS:8,FVC:8,LA:6,IS:6,WOB:5,MH:6,CIR:6,MERC:6</availability>
 		</model>
+		<model name='KGC-000b'>
+			<availability>CS:5,FRR:4,CLAN:4,WOB:4,CGS:6,BAN:2,DC:4</availability>
+		</model>
+		<model name='KGC-007'>
+			<availability>LA:6,FS:6,MERC:6</availability>
+		</model>
+		<model name='KGC-0000'>
+			<availability>IS:4-,CIR:5</availability>
+		</model>
 		<model name='KGC-008B'>
 			<availability>WOB.PM:8</availability>
+		</model>
+		<model name='KGC-000'>
+			<availability>CS:4,FRR:8,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
 		</model>
 		<model name='KGC-005r'>
 			<availability>CS:2,WOB:2</availability>
@@ -8693,20 +8705,8 @@
 		<model name='KGC-005'>
 			<availability>CS:5,WOB:4</availability>
 		</model>
-		<model name='KGC-000b'>
-			<availability>CS:5,FRR:4,CLAN:4,WOB:4,CGS:6,BAN:2,DC:4</availability>
-		</model>
 		<model name='KGC-008'>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:4-,CIR:5</availability>
-		</model>
-		<model name='KGC-000'>
-			<availability>CS:4,FRR:8,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
-		</model>
-		<model name='KGC-007'>
-			<availability>LA:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
@@ -8714,41 +8714,38 @@
 		<model name='C'>
 			<availability>General:5,CGB:3</availability>
 		</model>
-		<model name='X'>
-			<availability>CGB:2</availability>
+		<model name='E'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6,CGB:5</availability>
 		</model>
-		<model name='E'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='X'>
+			<availability>CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:6,CHH:1,CDS:1,CSV:1,FRR:4,NIOPS:7,WOB:7,FS:3,MERC:5,DC:4</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:7</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:4,CS:4,DC.SL:4,CLAN:6,NIOPS:4,WOB:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-21'>
-			<availability>CS:6,WOB:5</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>CLAN:4,WOB:6,FS:5,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:4-,MERC:4-,DC:2-</availability>
@@ -8759,29 +8756,32 @@
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:4,WOB:4,MERC:5,DC:5</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:7</availability>
+		<model name='KTO-19b'>
+			<availability>CLAN:4,WOB:6,FS:5,CGS:6,BAN:2</availability>
+		</model>
+		<model name='KTO-21'>
+			<availability>CS:6,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,CGS:7,BAN:7,CWIE:6,CGB:7</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='E'>
 			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -8804,46 +8804,49 @@
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
 		<availability>CS:5,FRR:5</availability>
-		<model name='[GL/Flamer]' mechanized='true'>
-			<availability>FRR:6</availability>
+		<model name='[GL]' mechanized='true'>
+			<availability>FRR:4</availability>
 		</model>
-		<model name='[SL/Flamer]' mechanized='true'>
-			<availability>FRR:6</availability>
-		</model>
-		<model name='X-C3' mechanized='true'>
-			<availability>CS:2</availability>
-		</model>
-		<model name='(CS) [GL/Flamer]' mechanized='true'>
+		<model name='(CS) [GL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
 			<availability>CS:6</availability>
 		</model>
 		<model name='[SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>FRR:8</availability>
 		</model>
-		<model name='[GL]' mechanized='true'>
-			<availability>FRR:4</availability>
+		<model name='X-C3' mechanized='true'>
+			<availability>CS:2</availability>
+		</model>
+		<model name='[SL/Flamer]' mechanized='true'>
+			<availability>FRR:6</availability>
+		</model>
+		<model name='(CS) [GL/Flamer]' mechanized='true'>
+			<availability>CS:6</availability>
 		</model>
 		<model name='(CS) [GL]' mechanized='true'>
 			<availability>CS:4</availability>
 		</model>
-		<model name='(CS) [GL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:6</availability>
-		</model>
 		<model name='(CS) [SL/Flamer]' mechanized='true'>
 			<availability>CS:6</availability>
-		</model>
-		<model name='[GL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>FRR:6</availability>
 		</model>
 		<model name='(CS) [SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:8</availability>
 		</model>
+		<model name='[GL/Flamer]' mechanized='true'>
+			<availability>FRR:6</availability>
+		</model>
+		<model name='[GL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>FRR:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:2,CCC:3,CSR:6,CNC:2,CLAN:2,CGS:4,CCO:3,CGB:8</availability>
+		<model name='5'>
+			<availability>CGB:4</availability>
+		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
 			<availability>CSR:5</availability>
@@ -8852,9 +8855,6 @@
 			<availability>CGB:5</availability>
 		</model>
 		<model name='4'>
-			<availability>CGB:4</availability>
-		</model>
-		<model name='5'>
 			<availability>CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -8867,9 +8867,6 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='KIM-2'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>General:8,DC:5</availability>
@@ -8877,6 +8874,9 @@
 		<model name='KIM-2A'>
 			<roles>spotter</roles>
 			<availability>DC:3</availability>
+		</model>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
@@ -8887,14 +8887,7 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,WOB:4,MERC:4</availability>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
-			<availability>MERC:3</availability>
-		</model>
 		<model name='KSC-4I'>
-			<availability>MERC:3</availability>
-		</model>
-		<model name='KSC-4L'>
 			<availability>MERC:3</availability>
 		</model>
 		<model name='KSC-5I'>
@@ -8903,12 +8896,51 @@
 		<model name='KSC-5MC'>
 			<availability>MOC:8,CC:8</availability>
 		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:3</availability>
+		</model>
+		<model name='KSC-4L'>
+			<availability>MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CSR:6,CSV:7,CLAN:2,IS:3+,CCO:2,CGS:5,BAN:6,CSA:6,MERC.WD:6,CDS:6,CW:6,CBS:6,CJF:5</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>CDS:3,CW:7,CSV:2,General:4,CGB:8</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CLAN:5,IS:2</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='Z'>
+			<roles>recon</roles>
+			<availability>SOC:10,CCO:4</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='B'>
+			<roles>recon</roles>
+			<availability>CSA:6,CDS:6,CW:6,General:5,CGS:6,CCO:4,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<roles>recon</roles>
@@ -8917,38 +8949,6 @@
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:5,IS:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CLAN:5,IS:2</availability>
-		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='Z'>
-			<roles>recon</roles>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CSA:6,CDS:6,CW:6,General:5,CGS:6,CCO:4,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CSV:2,CNC:3,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
@@ -8965,9 +8965,6 @@
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:4,CLAN:1,CJF:4</availability>
-		<model name='2'>
-			<availability>CSV:4,CLAN:2,CJF:2</availability>
-		</model>
 		<model name='4'>
 			<availability>CJF:6</availability>
 		</model>
@@ -8978,15 +8975,18 @@
 			<roles>fire_support</roles>
 			<availability>CSV:4,CLAN:2,CJF:3</availability>
 		</model>
+		<model name='2'>
+			<availability>CSV:4,CLAN:2,CJF:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CSR:6,CDS:3,CW:4,CSV:6,CLAN:2,CNC:3,CGS:6,CJF:4,CGB:6,CWIE:2</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(IFV) &apos;Turhan II&apos;'>
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kuan Ti' unitType='Dropship'>
@@ -9035,6 +9035,12 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,FRR:3,CLAN:4,NIOPS:6,WOB:6,CGS:5,BAN:7,DC:5</availability>
+		<model name='LNC25-06'>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='LNC25-04'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
 		<model name='LNC25-02'>
 			<roles>fire_support</roles>
 			<availability>:0,FRR:3-,DC:3-</availability>
@@ -9042,50 +9048,44 @@
 		<model name='LNC25-03'>
 			<availability>DC:2-</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:4,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:5</availability>
-		</model>
-		<model name='LNC25-08'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:2,NIOPS:2,WOB:2</availability>
 		</model>
-		<model name='LNC25-04'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='LNC25-08'>
+			<availability>WOB:4</availability>
 		</model>
-		<model name='LNC25-06'>
-			<availability>WOB:8</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:4,FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>DTA:5,FWL:5,WOB:3,RCM:5</availability>
-		<model name='LX-2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LX-2A'>
 			<availability>DTA:5,FWL:5,RCM:5</availability>
 		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
+		<model name='LX-2'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:7,MOC:5,FS:3,TC:4</availability>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
+		<model name='LHU-3L'>
+			<availability>CC:5,MOC:6,FS:8</availability>
 		</model>
 		<model name='LHU-2B'>
 			<availability>MOC:8,CC:8,TC:8</availability>
 		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
 		<model name='LHU-3B'>
 			<roles>spotter</roles>
 			<availability>CC:6,MOC:6</availability>
-		</model>
-		<model name='LHU-3L'>
-			<availability>CC:5,MOC:6,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -9097,15 +9097,12 @@
 	</chassis>
 	<chassis name='Legacy' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='LGC-04-WVR'>
-			<availability>WOB:2</availability>
-		</model>
 		<model name='LGC-02'>
 			<roles>fire_support</roles>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='LGC-03'>
-			<availability>WOB:4</availability>
+		<model name='LGC-04-WVR'>
+			<availability>WOB:2</availability>
 		</model>
 		<model name='LGC-01'>
 			<availability>WOB:8</availability>
@@ -9113,45 +9110,48 @@
 		<model name='LGC-05'>
 			<availability>WOB:2</availability>
 		</model>
+		<model name='LGC-03'>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>FS:4</availability>
-		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGN-2F'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='LGN-2XA'>
-			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-1X'>
 			<availability>FS.CH:4,FS:1</availability>
 		</model>
+		<model name='LGN-2XU'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGN-2XA'>
+			<roles>missile_artillery</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>CC:8,DTA:8,LA:8,FWL:8,WOB:8,FS:8,RCM:8</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:5-</availability>
 		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>CC:8,DTA:8,LA:8,FWL:8,WOB:8,FS:8,RCM:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>FWL:3,WOB:6</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>DTA:8,LA:8,FWL:8,FS:8,RCM:8</availability>
+		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>FWL:3,WOB:6</availability>
 		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
@@ -9187,30 +9187,30 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FVC:5,FS:5,MERC:1</availability>
-		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:2,FWL:6,IS:2</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,MERC:2</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:3,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='Andurien'>
-			<availability>FWL:3</availability>
+		<model name='Comet'>
+			<availability>FVC:5,FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,HL:4,LA:4</availability>
 		</model>
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
+		</model>
+		<model name='Andurien'>
+			<availability>FWL:3</availability>
+		</model>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:2,FWL:6,IS:2</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -9221,6 +9221,13 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CS:2,CLAN:4,NIOPS:2,WOB:7,CJF:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6,WOB:4</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='(ERSL)'>
 			<availability>WOB:4</availability>
 		</model>
@@ -9230,62 +9237,55 @@
 		<model name='(RL)'>
 			<availability>WOB:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6,WOB:4</availability>
-		</model>
 		<model name='CX-3'>
 			<availability>CS:8</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='LTN-G15b'>
-			<availability>CC:4,MOC:4,CLAN:3,MERC:3</availability>
-		</model>
-		<model name='LTN-G16L'>
-			<availability>CC:5,MOC:5,MERC:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:5-</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='LTN-G16S'>
-			<availability>LA:5</availability>
+		<model name='LTN-G15b'>
+			<availability>CC:4,MOC:4,CLAN:3,MERC:3</availability>
 		</model>
 		<model name='LTN-G16D'>
 			<availability>FS:5,MERC:4</availability>
 		</model>
+		<model name='LTN-G16L'>
+			<availability>CC:5,MOC:5,MERC:4</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:5</availability>
+		</model>
 		<model name='LTN-G16O'>
 			<availability>OA:5,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G16S'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightray' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='LGH-4Y'>
+		<model name='LGH-5W'>
 			<roles>recon</roles>
-			<availability>WOB:3</availability>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='LGH-7W'>
 			<roles>recon</roles>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='LGH-6W'>
+		<model name='LGH-4Y'>
 			<roles>recon</roles>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='LGH-5W'>
-			<roles>recon</roles>
-			<availability>WOB:4</availability>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='LGH-4W'>
 			<roles>recon</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='LGH-6W'>
+			<roles>recon</roles>
+			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
@@ -9293,11 +9293,14 @@
 		<model name='B'>
 			<availability>CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:4,CW:4,CBS:4,CSV:3,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
@@ -9305,29 +9308,26 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CW:4,CBS:4,CSV:3,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
+		<model name='D'>
+			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lineholder' unitType='Mek'>
 		<availability>CC:4,FWL:4,IS:3,WOB:5,FS:5,CIR:6,TC:6,Periphery:2</availability>
-		<model name='KW2-LHW'>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
-			<availability>WOB:5,FS:7</availability>
-		</model>
 		<model name='KW1-LH3'>
 			<availability>General:2,WOB:3,FS:3</availability>
 		</model>
 		<model name='KW1-LH2'>
 			<availability>General:6,WOB:2,FS:2</availability>
+		</model>
+		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
+			<availability>WOB:5,FS:7</availability>
+		</model>
+		<model name='KW2-LHW'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -9361,73 +9361,65 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CS:3,CHH:6,CW:7,LA:2,CLAN:2,IS:2,CJF:6,DC:3,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CW:4,General:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:4,CS:6,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
+		<model name='3'>
+			<availability>General:1</availability>
 		</model>
 		<model name='6'>
 			<availability>CW:4,CGB:4</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:4,CW:4,CCO:4,CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>CW:4,General:2</availability>
 		</model>
 		<model name='7'>
 			<availability>CHH:3</availability>
 		</model>
+		<model name='4'>
+			<availability>CSA:4,CS:6,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
 		<model name='2'>
 			<availability>CCC:2,CJF:2</availability>
 		</model>
-		<model name='3'>
-			<availability>General:1</availability>
+		<model name='5'>
+			<availability>CHH:4,CW:4,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:2-,HL:5,CLAN:2-,IS:8,NIOPS:2-,Periphery.Deep:5,WOB:3-,Periphery:5</availability>
-		<model name='LCT-3M'>
+		<model name='LCT-6M'>
 			<roles>recon</roles>
-			<availability>MOC:3,DTA:5,FWL:6,IS:3,MERC:6,RCM:5</availability>
-		</model>
-		<model name='LCT-1L'>
-			<roles>recon</roles>
-			<availability>CC:1-</availability>
-		</model>
-		<model name='LCT-5W'>
-			<roles>recon,spotter</roles>
-			<availability>WOB:6</availability>
+			<availability>FWL:3,WOB:3</availability>
 		</model>
 		<model name='LCT-5T'>
 			<roles>recon,anti_infantry</roles>
 			<availability>MOC:4,CC:4,FVC:2,TC:5</availability>
 		</model>
-		<model name='LCT-5M'>
+		<model name='LCT-1L'>
 			<roles>recon</roles>
-			<availability>FVC:4,PIR:4,FWL:5,IS:3,WOB:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='LCT-6M'>
-			<roles>recon</roles>
-			<availability>FWL:3,WOB:3</availability>
+			<availability>CC:1-</availability>
 		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CC:4,CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-5V'>
+		<model name='LCT-3V'>
 			<roles>recon</roles>
-			<availability>MOC:4,CC:3,FVC:3,PIR:4,TC:4</availability>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:4,PIR:4,FWL:5,IS:3,WOB:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='LCT-1V2'>
+			<roles>recon</roles>
+			<availability>PIR:4,MH:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:3-,General:4-,FS:4-</availability>
 		</model>
-		<model name='LCT-3V'>
+		<model name='LCT-5V'>
 			<roles>recon</roles>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>MOC:4,CC:3,FVC:3,PIR:4,TC:4</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -9437,22 +9429,30 @@
 			<roles>recon</roles>
 			<availability>LA:8,FRR:6,MERC:6</availability>
 		</model>
+		<model name='LCT-5W'>
+			<roles>recon,spotter</roles>
+			<availability>WOB:6</availability>
+		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:3,DTA:5,FWL:6,IS:3,MERC:6,RCM:5</availability>
+		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:4-,MERC:4-</availability>
 		</model>
-		<model name='LCT-1V2'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>PIR:4,MH:4</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CDS:2,CW:4,CBS:4,CSV:4,CLAN:2,IS:3+,CJF:2,BAN:5,CWIE:5,CGB:2</availability>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
@@ -9463,15 +9463,15 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -9487,6 +9487,10 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3,DC:6</availability>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,FVC:4,FWL:5,IS:4</availability>
+		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:4-</availability>
@@ -9495,37 +9499,30 @@
 			<roles>missile_artillery,fire_support</roles>
 			<availability>LA:3,FRR:3,FWL:3,IS:2,FS:4,MERC:3</availability>
 		</model>
-		<model name='LGB-14C'>
+		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
-			<availability>CC:4,CS:4,LA:4,IS:2,FS:4,MERC:4,DC:4,Periphery:2</availability>
-		</model>
-		<model name='LGB-13NAIS'>
-			<availability>WOB:3,FS:4</availability>
-		</model>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,FVC:4,FWL:5,IS:4</availability>
+			<availability>MOC:3-,OA:3-,General:3-,TC:3-,Periphery:3-</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:5,LA:3,FWL:3,IS:3,MH:4,FS:3,MERC:3,CDP:2,TC:2</availability>
 		</model>
+		<model name='LGB-13NAIS'>
+			<availability>WOB:3,FS:4</availability>
+		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:2,FWL:3,FS:4,MERC:4,RCM:4,DC:4</availability>
 		</model>
-		<model name='LGB-7Q'>
+		<model name='LGB-14C'>
 			<roles>fire_support</roles>
-			<availability>MOC:3-,OA:3-,General:3-,TC:3-,Periphery:3-</availability>
+			<availability>CC:4,CS:4,LA:4,IS:2,FS:4,MERC:4,DC:4,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:8,FWL:8,WOB:8,MH:5,RCM:8</availability>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:5</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -9533,14 +9530,8 @@
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[David] (WoB)' mechanized='true'>
-			<availability>CS:5,WOB:5</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='[Laser] (WoB)' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
@@ -9548,47 +9539,56 @@
 		<model name='[Flamer] (WoB)' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[David] (WoB)' mechanized='true'>
+			<availability>CS:5,WOB:5</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Magnetic) (WOB)' mechanized='true'>
 			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>FRR:4,MERC:3,DC:4</availability>
-		<model name='LCF-R16K'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>FRR:6,MERC:3,DC:6</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:4,FRR:3,FS:3,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:2,FVC:2,LA:8,Periphery.MW:3</availability>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:2,FS:2,MERC:6</availability>
+		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:6-,Periphery:2-</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:3-,FS:3-</availability>
 		</model>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:2,FS:2,MERC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM5/M'>
-			<availability>LA:2-</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='LM5/M'>
+			<availability>LA:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -9625,17 +9625,17 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3,WOB:3</availability>
-		<model name='W1'>
-			<roles>missile_artillery,escort</roles>
-			<availability>WOB:6</availability>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6</availability>
+		<model name='W1'>
+			<roles>missile_artillery,escort</roles>
+			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -9660,20 +9660,23 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>LA:2-,FWL:2-</availability>
-		<model name='MSK-5S'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>FWL:8</availability>
 		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
 		</model>
+		<model name='MSK-5S'>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:1,MERC.WD:8,CDS:5,CW:7,CBS:3,CLAN:4,CCO:5,CJF:5,BAN:2,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>CSA:6,CCC:7,CDS:8,CSV:7,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,CW:5,CLAN:4,General:2,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -9683,53 +9686,50 @@
 			<roles>spotter</roles>
 			<availability>CHH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CSV:3,CNC:3,General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='Z'>
 			<availability>SOC:10,CCO:4</availability>
 		</model>
+		<model name='D'>
+			<availability>CW:5,CSV:3,CNC:3,General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,CW:5,CLAN:4,General:2,CJF:6,CWIE:5,CGB:5</availability>
+		<model name='Prime'>
+			<availability>CSA:6,CCC:7,CDS:8,CSV:7,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,CW:4,LA:3,CNC:6,FS:3,CWIE:4,DC:3</availability>
-		<model name='2'>
-			<availability>CDS:4,CW:4,LA:4,CNC:4,FS:4,DC:4,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:4,CW:4,LA:4,CNC:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
 		<availability>LA:6,FS:4,MERC:3,DC:6</availability>
-		<model name='MTR-6E'>
-			<roles>recon,spotter</roles>
-			<availability>DC:1</availability>
+		<model name='MTR-5K'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:4</availability>
 		</model>
-		<model name='MTR-5K'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='MTR-6E'>
+			<roles>recon,spotter</roles>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Magellan Jumpship' unitType='Jumpship'>
@@ -9740,49 +9740,49 @@
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
 		<availability>CS:5,FRR:1,NIOPS:5,WOB:5,WOB.PM:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UCSV)'>
 			<roles>apc,urban</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>DTA:8,FWL:8,WOB:3,RCM:8</availability>
-		<model name='(C3)'>
-			<availability>IS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(XL)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(C3)'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Malak' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='C-MK-OC Comminus'>
-			<roles>spotter</roles>
+		<model name='C-MK-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-MK-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-MK-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-MK-O Invictus'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C-MK-OD Luminos'>
 			<availability>General:7</availability>
+		</model>
+		<model name='C-MK-OS Caelestis'>
+			<availability>General:5</availability>
 		</model>
 		<model name='C-MK-OE Eminus'>
 			<availability>General:5</availability>
 		</model>
-		<model name='C-MK-OS Caelestis'>
-			<availability>General:5</availability>
+		<model name='C-MK-O Invictus'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C-MK-OC Comminus'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mammoth' unitType='Dropship'>
@@ -9794,9 +9794,6 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CSV:6,CLAN:2,IS:2+,BAN:5,CWIE:8,MERC.WD:8,CDS:8,CW:8,CBS:5,CNC:4,CJF:8,CGB:2</availability>
-		<model name='E'>
-			<availability>CLAN:6,General:2,CCO:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
@@ -9807,17 +9804,20 @@
 		<model name='G'>
 			<availability>General:2</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:2,CCO:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CSV:7,CNC:6,General:5,CJF:2,CGB:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
@@ -9834,25 +9834,37 @@
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>spotter</roles>
-			<availability>General:7,FS:5</availability>
-		</model>
 		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,FS:6</availability>
+		</model>
+		<model name='C'>
+			<roles>spotter</roles>
+			<availability>General:7,FS:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,TC:7,CS:7,OA:7,LA:7,FWL:6,NIOPS:7,DC:9</availability>
+		<model name='(LB-X)'>
+			<availability>LA:6,WOB:6,FS:6</availability>
+		</model>
 		<model name='(C3S)'>
 			<availability>FS:6,DC:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,LA:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:3,LA:2-,General:4-,Periphery.Deep:6,FS:2-,DC:2-,Periphery:5</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -9860,18 +9872,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>FS:3,DC:3</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>LA:6,WOB:6,FS:6</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,LA:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:3,LA:2-,General:4-,Periphery.Deep:6,FS:2-,DC:2-,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
@@ -9885,20 +9885,20 @@
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:7,MERC.WD:6,CSR:5,CW:6,LA:2,CLAN:2,CNC:6,CJF:7,CWIE:6,CGB:7</availability>
-		<model name='3'>
-			<availability>CSA:4,CLAN:2,CJF:5,CGB:5</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:8,CLAN:2,CJF:4,CGB:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CW:2,LA:8,CJF:4,CWIE:5,CGB:2</availability>
 		</model>
 		<model name='6'>
 			<availability>CW:4,CJF:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:8,CLAN:2,CJF:4,CGB:4</availability>
+		<model name='3'>
+			<availability>CSA:4,CLAN:2,CJF:5,CGB:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:5,CCC:3,CDS:1,CSR:1,CGS:3,CJF:3,CWIE:1,CGB:3</availability>
-		</model>
-		<model name='5'>
-			<availability>CW:2,LA:8,CJF:4,CWIE:5,CGB:2</availability>
 		</model>
 		<model name='4'>
 			<availability>CNC:5,CGB:4</availability>
@@ -9909,85 +9909,64 @@
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,FRR:5,WOB:2,FS:6,MERC:6,TC:4,CS:3,MERC.WD:6,LA:4,PIR:4,CNC:2,FWL:5,MH:4,DC:5</availability>
-		<model name='MAD-4H'>
-			<availability>PIR:8,MH:8,TC:8</availability>
-		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='MAD-5W'>
-			<availability>CC:6,CS:4,WOB:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>CS:8,LA:8,FRR:6,CNC:8,FWL:4,FS:8,MERC:6,DC:5</availability>
 		</model>
-		<model name='MAD-4K'>
-			<availability>DC:6</availability>
+		<model name='MAD-4A'>
+			<availability>MERC:2</availability>
 		</model>
 		<model name='MAD-5C'>
 			<availability>MERC.WD:2</availability>
 		</model>
-		<model name='MAD-4A'>
-			<availability>MERC:2</availability>
+		<model name='MAD-5W'>
+			<availability>CC:6,CS:4,WOB:8</availability>
+		</model>
+		<model name='MAD-4K'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='MAD-4H'>
+			<availability>PIR:8,MH:8,TC:8</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,DC:3,CGB:2</availability>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:5,FWL:4,WOB:4,MERC:3</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:5,FRR:6,WOB:4,FS:4,MERC:4,DC:8</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>LA:5,FRR:4,MERC:3</availability>
+		<model name='MAD-3D'>
+			<availability>FVC:3-,MH:3-,FS:3-</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>FWL:3,WOB:4,MERC:4</availability>
 		</model>
-		<model name='C'>
-			<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>FVC:4,LA:5,FRR:3,FS:4,MERC:4</availability>
-		</model>
-		<model name='MAD-9W'>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>DTA:5,FWL:4,WOB:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:3-,Periphery.MW:3-,PIR:3-,Periphery.ME:3-,FWL:2-,MH:3-,MERC:3-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:5,FRR:6,WOB:4,FS:4,MERC:4,DC:8</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>CS:6,MOC:2,FWL:8,IS:2,WOB:7,MERC:4</availability>
 		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
+		<model name='MAD-6L'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:3-,MH:3-,FS:3-</availability>
+		<model name='C'>
+			<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:2-,HL:2-,IS:3-,Periphery.Deep:8,WOB:2-,Periphery:4-,TC:4-</availability>
 		</model>
+		<model name='MAD-9S'>
+			<availability>LA:5,FRR:4,MERC:3</availability>
+		</model>
 		<model name='MAD-3L'>
 			<availability>CC:1-</availability>
-		</model>
-		<model name='MAD-5L'>
-			<availability>CC:5,MOC:4,WOB:3,CIR:3,TC:2</availability>
 		</model>
 		<model name='MAD-2R'>
 			<availability>CLAN:1,CGS:1,BAN:1,TC:3</availability>
@@ -9995,31 +9974,52 @@
 		<model name='MAD-1R'>
 			<availability>CS:4-,NIOPS:4-,WOB:4-,MERC:0,BAN:1</availability>
 		</model>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
+		</model>
+		<model name='MAD-9W'>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:3-,Periphery.MW:3-,PIR:3-,Periphery.ME:3-,FWL:2-,MH:3-,MERC:3-</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:5,MOC:4,WOB:3,CIR:3,TC:2</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>FVC:4,LA:5,FRR:3,FS:4,MERC:4</availability>
+		</model>
+		<model name='MAD-7D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='(Light PPC)'>
-			<roles>artillery</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CHH:8,BAN:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>artillery</roles>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
-		<model name='(HAG)'>
-			<availability>CGB:3</availability>
-		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CCO:6,CJF:2</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CSA:4,CHH:4,CCC:3,CSL:4,CGS:3,CCO:3,CGB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ATM)'>
+			<availability>General:5,CCO:6,CJF:2</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -10030,11 +10030,11 @@
 	</chassis>
 	<chassis name='Marshal' unitType='Mek'>
 		<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,Periphery:2,TC:7</availability>
-		<model name='MHL-6MC'>
-			<availability>MOC:3</availability>
-		</model>
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:3</availability>
 		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,PIR:4,TC:4</availability>
@@ -10042,36 +10042,36 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:3,CSV:1,CLAN:1,IS:2+,MERC:2+,CGS:7,BAN:3,CWIE:1,CSA:3,MERC.WD:4,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:8,CSV:6,General:5</availability>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CSV:6,General:5,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:8,CSV:6,General:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
@@ -10079,20 +10079,17 @@
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CSR:2,CSV:5,CLAN.IS:2,CJF:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>LA:2,FRR:5,MERC:4,FS:2,DC:7</availability>
 		<model name='MAL-1R'>
 			<availability>FRR:8,MERC:6,DC:2</availability>
-		</model>
-		<model name='MAL-1K'>
-			<availability>DC:4</availability>
 		</model>
 		<model name='MAL-2R'>
 			<availability>LA:8,FS:8,MERC:8</availability>
@@ -10103,32 +10100,35 @@
 		<model name='MAL-3R'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='MAL-1K'>
+			<availability>DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:4,CLAN:2,MH:4,FS:1,TC:6</availability>
-		<model name='(Intermediate)'>
+		<model name='(Fusion)'>
 			<roles>apc</roles>
-			<availability>TC:1</availability>
-		</model>
-		<model name='(Basic)'>
-			<roles>apc</roles>
-			<availability>FS:8,TC:2-</availability>
-		</model>
-		<model name='(BA)'>
-			<roles>apc</roles>
-			<availability>TC:5</availability>
+			<availability>TC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
+		<model name='(Intermediate)'>
+			<roles>apc</roles>
+			<availability>TC:1</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>TC:5</availability>
 		</model>
-		<model name='(Fusion)'>
+		<model name='(BA)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:5</availability>
+		</model>
+		<model name='(Basic)'>
+			<roles>apc</roles>
+			<availability>FS:8,TC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -10148,59 +10148,59 @@
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:5</availability>
-		<model name='(Company Command)'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:2,CC:2,FRR:4,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,TC:2,CS:2-,OA:2,LA:4,FWL:2,NIOPS:2-,DC:2</availability>
+		<model name='(SRM2)'>
+			<roles>apc</roles>
+			<availability>IS:1-,Periphery:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>IS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='(BA Field Upgrade)'>
 			<roles>apc,spotter</roles>
 			<availability>FRR:3,IS:2,MERC:3,DC:4</availability>
 		</model>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>DC:1</availability>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
 		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
 			<availability>CC:5,FRR:5,FWL:5,IS:4,DC:5</availability>
 		</model>
-		<model name='(SRM2)'>
-			<roles>apc</roles>
-			<availability>IS:1-,Periphery:2</availability>
+		<model name='(C3S)'>
+			<roles>apc,spotter</roles>
+			<availability>IS:4</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2-,Periphery:2</availability>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>DC:1</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:3</availability>
 		</model>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(C3S)'>
-			<roles>apc,spotter</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
-			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
+			<availability>IS:2-,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -10224,12 +10224,12 @@
 			<roles>interceptor</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<roles>interceptor</roles>
 			<availability>FVC:1,FRR:1,MERC:1,Periphery:1,DC:1</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Assault XCT' unitType='Infantry'>
@@ -10251,8 +10251,11 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -10261,11 +10264,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -10273,35 +10273,35 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -10314,11 +10314,11 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -10353,11 +10353,11 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5+</availability>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -10365,21 +10365,21 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='MS1-OU'>
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='MS1-OA'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
@@ -10405,17 +10405,17 @@
 			<roles>recon</roles>
 			<availability>CS:4,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6</availability>
 		</model>
-		<model name='MCY-104'>
-			<roles>recon,spotter</roles>
-			<availability>WOB:4</availability>
+		<model name='MCY-97'>
+			<roles>recon</roles>
+			<availability>CS:4</availability>
 		</model>
 		<model name='MCY-102'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
 		</model>
-		<model name='MCY-97'>
-			<roles>recon</roles>
-			<availability>CS:4</availability>
+		<model name='MCY-104'>
+			<roles>recon,spotter</roles>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -10433,14 +10433,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>OA:8,CSR:4,HL:3,MERC:6,Periphery:4</availability>
-		<model name='MLN-1C'>
-			<availability>OA:6,FVC:4,CSR:6,MERC:4</availability>
-		</model>
 		<model name='MLN-1A'>
 			<availability>General:4-</availability>
 		</model>
 		<model name='MLN-1B'>
 			<availability>OA:8,HL:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='MLN-1C'>
+			<availability>OA:6,FVC:4,CSR:6,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -10463,11 +10463,11 @@
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CSA:6,CHH:8,CCC:8,CSR:3,CBS:4,CSV:4,CSL:8,CGS:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='4'>
 			<availability>CBS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CHH:8,CCC:6,CSL:8,CGS:6</availability>
@@ -10511,25 +10511,25 @@
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -10559,11 +10559,11 @@
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
 		<availability>FWL:4</availability>
-		<model name='M2'>
-			<availability>General:6</availability>
-		</model>
 		<model name='M1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='M2'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>
@@ -10579,17 +10579,21 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:3</availability>
 		</model>
-		<model name='MON-266'>
-			<roles>recon</roles>
-			<availability>CS:8,LA:2</availability>
-		</model>
 		<model name='MON-267'>
 			<roles>recon</roles>
 			<availability>LA:8,MERC:8</availability>
 		</model>
+		<model name='MON-266'>
+			<roles>recon</roles>
+			<availability>CS:8,LA:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>CHH:1,FRR:3,CLAN:1,WOB:3,MERC:2,DC.GHO:2,CS:4,CDS:1,CBS:1,NIOPS:1,CJF:1,CGB:1,DC:2</availability>
+		<model name='MON-66b'>
+			<roles>recon</roles>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		</model>
 		<model name='MON-76'>
 			<roles>recon</roles>
 			<availability>CS:4,FRR:4,MERC:4,FS:4,DC:4</availability>
@@ -10597,10 +10601,6 @@
 		<model name='MON-66'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
-		<model name='MON-66b'>
-			<roles>recon</roles>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -10613,9 +10613,6 @@
 		<availability>CLAN:2,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
@@ -10669,33 +10666,33 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized XCT Infantry' unitType='Infantry'>
@@ -10724,35 +10721,35 @@
 	</chassis>
 	<chassis name='Mule' unitType='Dropship'>
 		<availability>HL:7,CLAN:5,IS:7,Periphery.Deep:7,BAN:4,Periphery:8</availability>
-		<model name='(2737)'>
-			<roles>cargo,civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:6</availability>
 		</model>
 		<model name='(Armored Pocket Warship)'>
 			<availability>WOB:5</availability>
 		</model>
+		<model name='(2737)'>
+			<roles>cargo,civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>FS:6</availability>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>spotter</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:4,OA:2,LA:5,WOB:4,FS:4,MERC:4,CIR:4,TC:2,Periphery:2,DC:4</availability>
-		<model name='Type 2'>
-			<availability>CC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Type 2'>
+			<availability>CC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Naga' unitType='Mek' omni='Clan'>
@@ -10761,36 +10758,36 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,CSV:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>WOB:4,DC:6</availability>
-		<model name='NG-C3A'>
-			<roles>fire_support,spotter</roles>
-			<availability>WOB:8,DC:8</availability>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+		<model name='NG-C3A'>
+			<roles>fire_support,spotter</roles>
+			<availability>WOB:8,DC:8</availability>
 		</model>
 		<model name='NG-C3B'>
 			<roles>spotter</roles>
@@ -10813,22 +10810,22 @@
 	</chassis>
 	<chassis name='Nephilim Assault Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:2</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Seeker) [MG]' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Narc)' mechanized='false'>
 			<availability>General:3</availability>
 		</model>
 		<model name='(Gauss)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Capture Team)[HMG]' mechanized='false'>
-			<availability>General:3</availability>
+		<model name='(Seeker) [MG]' mechanized='false'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Capture Team)[HMG]' mechanized='false'>
 			<availability>General:3</availability>
 		</model>
 	</chassis>
@@ -10837,11 +10834,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -10863,20 +10860,26 @@
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
 		<availability>CS:6,WOB:3</availability>
-		<model name='NXS1-A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='NXS1-B'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='NXS1-A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CGS:3,CJF:5</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:7,CLAN:5,IS:3</availability>
@@ -10884,28 +10887,22 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='F'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>OA:3,FVC:3,CW:5,LA:5,CLAN:3,FWL:2,MERC:3,FS:2,CGS:4,CGB:5</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nighthawk PA(L)' unitType='BattleArmor'>
@@ -10933,40 +10930,40 @@
 		<model name='(Standard)'>
 			<availability>General:8,WOB:2</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='(Light PPC)'>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>Periphery.R:2,LA:8,WOB:3,FS:7,MERC:5,CIR:2</availability>
-		<model name='NGS-4T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-4S'>
 			<availability>:0,HL:6,LA:5,General:8,Periphery.Deep:6,FS:5,MERC:5,Periphery:8</availability>
 		</model>
-		<model name='NGS-5T'>
+		<model name='NGS-4T'>
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6T'>
 			<availability>LA:5,WOB:8,MERC:5,FS:5</availability>
 		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
+		<model name='NGS-5T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6S'>
 			<availability>LA:6,MERC:2</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -10974,11 +10971,11 @@
 		<model name='NSR-9FC'>
 			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
-		<model name='NSR-9SS'>
-			<availability>LA:4,MERC:2,FS:4</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9SS'>
+			<availability>LA:4,MERC:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ninja-To' unitType='Mek'>
@@ -10986,37 +10983,46 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-4'>
-			<availability>DC:3</availability>
-		</model>
 		<model name='NJT-3'>
 			<availability>General:2</availability>
+		</model>
+		<model name='NJT-4'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:7,DC.SL:2,FRR:4,WOB:3,MERC:2,DC:6,CGB:3</availability>
-		<model name='NDA-2KC'>
-			<availability>MERC:5,DC:6</availability>
+		<model name='NDA-2KO'>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>MERC:6,DC:6</availability>
 		</model>
+		<model name='NDA-2KC'>
+			<availability>MERC:5,DC:6</availability>
+		</model>
 		<model name='NDA-1K'>
 			<availability>FRR:6,WOB:8,MERC:6,DC:6,CGB:4</availability>
-		</model>
-		<model name='NDA-2KO'>
-			<availability>MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,CDS:2,CNC:8</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,CNC:4</availability>
+		</model>
+		<model name='N'>
+			<availability>CDS:4,CNC:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:4,CNC:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -11025,18 +11031,9 @@
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -11048,6 +11045,15 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CDS:6,CNC:9,CLAN:3,CWIE:4</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -11056,25 +11062,16 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
@@ -11093,26 +11090,26 @@
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>CS:2,DC:3</availability>
-		<model name='OBK-M12'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>DC:2</availability>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
+		<model name='OBK-M12'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ocelot' unitType='Mek'>
 		<availability>CNC:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:4</availability>
@@ -11120,13 +11117,13 @@
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
 		<availability>CLAN:5,CJF:2</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>recon,spotter</roles>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Odyssey Jumpship' unitType='Jumpship'>
@@ -11150,38 +11147,38 @@
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:7,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5,DC:4</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:8,CNC:8,IS:8</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,FVC:2,LA:2,FWL:2,FS:2</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<availability>CC:7,MOC:6,IS:6,FWL:7</availability>
-		</model>
-		<model name='(MML)'>
-			<availability>MOC:4,IS:4</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:2,LA:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:2,FVC:2,LA:2,FWL:2,FS:2</availability>
+		<model name='(MML)'>
+			<availability>MOC:4,IS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 		</model>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:8,CNC:8,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:5,CSL:5,CGS:3,CCO:3</availability>
+		<model name='3'>
+			<availability>CHH:4,CSL:4</availability>
+		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:4,CSL:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<availability>CHH:4,CSL:4</availability>
 		</model>
 	</chassis>
@@ -11193,38 +11190,38 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:2,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:3,CWIE:2,CS:4-,OA:3,CW:2,LA:2,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
-		<model name='ON1-MD'>
-			<availability>MOC:3,CC:3,FWL:4,WOB:4,MERC:2,FS:2</availability>
-		</model>
 		<model name='ON1-MA'>
 			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2,MOC:2,FWL:4,WOB:4,FS:1,MERC:2,RCM:4,DC:2</availability>
-		</model>
-		<model name='ON2-M'>
-			<availability>MOC:2,FWL:4,IS:2,MH:2,WOB:4,MERC:3</availability>
-		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1-</availability>
 		</model>
 		<model name='ON1-MC'>
 			<availability>FRR:4,FS:2,MERC:2,DC:4</availability>
 		</model>
+		<model name='ON1-V'>
+			<availability>IS:2-,MH:2-,CDP:2-,TC:2-</availability>
+		</model>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1-</availability>
+		</model>
+		<model name='ON1-MB'>
+			<availability>CC:2,MOC:2,FWL:4,WOB:4,FS:1,MERC:2,RCM:4,DC:2</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:2-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 		<model name='ON1-M'>
 			<availability>CS:6,MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,WOB:6,MH:6,DC:6</availability>
 		</model>
-		<model name='ON1-V'>
-			<availability>IS:2-,MH:2-,CDP:2-,TC:2-</availability>
+		<model name='ON1-MD'>
+			<availability>MOC:3,CC:3,FWL:4,WOB:4,MERC:2,FS:2</availability>
 		</model>
 		<model name='ON1-VA'>
 			<availability>IS:2-</availability>
 		</model>
+		<model name='ON2-M'>
+			<availability>MOC:2,FWL:4,IS:2,MH:2,WOB:4,MERC:3</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:7</availability>
-		</model>
-		<model name='ON1-K'>
-			<availability>HL:2-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -11238,11 +11235,11 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,LA:2,FS:6,MERC:4</availability>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -11250,19 +11247,21 @@
 		<model name='OSP-26'>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='OSP-25'>
-			<availability>General:6</availability>
-		</model>
 		<model name='OSP-15'>
 			<roles>fire_support,urban</roles>
 			<availability>CC:3</availability>
 		</model>
+		<model name='OSP-25'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,TC:4,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
-		<model name='OSR-5W'>
-			<roles>urban</roles>
-			<availability>WOB:3</availability>
+		<model name='OSR-3C'>
+			<availability>FVC:2-,IS:1-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='OSR-4K'>
+			<availability>DC:3</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
@@ -11271,12 +11270,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2</availability>
-		</model>
-		<model name='OSR-4K'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>FVC:2-,IS:1-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:1-</availability>
@@ -11287,26 +11280,22 @@
 		<model name='OSR-4C'>
 			<availability>CIR:8,TC:6,Periphery:2</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:2-</availability>
+		</model>
 		<model name='OSR-4L'>
 			<availability>CC:6,MOC:4</availability>
 		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:2-</availability>
+		<model name='OSR-5W'>
+			<roles>urban</roles>
+			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,FRR:3,CLAN:1-,IS:1,WOB:3,FS:2,MERC:3,CS:3,FVC:2,LA:2,FWL:2,NIOPS:3,DC:3</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='OTT-10CS'>
-			<roles>recon</roles>
-			<availability>CS:6,WOB:4</availability>
-		</model>
-		<model name='OTT-9CS'>
+		<model name='OTT-7K'>
 			<roles>recon,spotter</roles>
-			<availability>CS:5,WOB:4</availability>
+			<availability>FVC:8,IS:8,DC:8</availability>
 		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
@@ -11316,9 +11305,17 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:6,MERC:4</availability>
 		</model>
-		<model name='OTT-7K'>
+		<model name='OTT-10CS'>
+			<roles>recon</roles>
+			<availability>CS:6,WOB:4</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='OTT-9CS'>
 			<roles>recon,spotter</roles>
-			<availability>FVC:8,IS:8,DC:8</availability>
+			<availability>CS:5,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -11326,14 +11323,14 @@
 		<model name='OTL-7M'>
 			<availability>DTA:6,FWL:6,WOB:4,MERC:4</availability>
 		</model>
-		<model name='OTL-5D'>
-			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:4</availability>
+		<model name='OTL-8D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>IS:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 		</model>
 		<model name='OTL-6D'>
 			<availability>FS:4,MERC:1,DC:1</availability>
-		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:5,MERC:4</availability>
 		</model>
 		<model name='OTL-5M'>
 			<availability>CS:4,FWL:5,WOB:6,MERC:4</availability>
@@ -11341,32 +11338,32 @@
 		<model name='OTL-8M'>
 			<availability>DTA:5,FWL:4,WOB:3,MERC:3</availability>
 		</model>
-		<model name='OTL-8D'>
-			<availability>FS:5</availability>
+		<model name='OTL-9R'>
+			<availability>DTA:5,MERC:4</availability>
+		</model>
+		<model name='OTL-5D'>
+			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:4</availability>
 		</model>
 		<model name='OTL-4F'>
 			<availability>FVC:1-,FS:1-</availability>
 		</model>
-		<model name='OTL-4D'>
-			<availability>IS:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>MOC:2-,LA:2-,FWL:3,MERC:2-,DC:2-</availability>
-		<model name='OWR-2M'>
-			<availability>General:8,FWL:3-</availability>
-		</model>
 		<model name='OWR-3M'>
 			<availability>FWL:6</availability>
+		</model>
+		<model name='OWR-2M'>
+			<availability>General:8,FWL:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:6,CW:4,CSL:6</availability>
-		<model name='(3063)'>
+		<model name='(3070)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(3070)'>
+		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:6</availability>
 		</model>
@@ -11380,41 +11377,37 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='A3A'>
-			<availability>LA:1,FS:1</availability>
-		</model>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:4,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:6,IS:2,FS:6</availability>
+		</model>
+		<model name='A3A'>
+			<availability>LA:1,FS:1</availability>
 		</model>
 		<model name='A3'>
 			<roles>assault</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:4,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:3,CS:3,CNC:4,FWL:3,WOB:3,FS:3,MERC:3,DC:5</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='OW-1C'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -11422,13 +11415,17 @@
 			<roles>recon,spotter</roles>
 			<availability>General:2+,CLAN:6</availability>
 		</model>
-		<model name='OW-1A'>
+		<model name='OW-1E'>
 			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='OW-1F'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter II' unitType='Mek'>
@@ -11439,8 +11436,8 @@
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CCC:3,MERC.KH:1,CDS:3,CSR:2,CSV:3,CNC:3,CLAN:2,CCO:3,CWIE:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CWIE:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CWIE:4</availability>
@@ -11448,16 +11445,12 @@
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -11466,13 +11459,17 @@
 			<roles>recon,raider</roles>
 			<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
 		</model>
-		<model name='&apos;Gespenst&apos;'>
-			<roles>recon,specops</roles>
-			<availability>LA:2</availability>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
 			<availability>FWL.pm:4</availability>
+		</model>
+		<model name='&apos;Gespenst&apos;'>
+			<roles>recon,specops</roles>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -11488,13 +11485,13 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>WOB:3</availability>
-		<model name='(Standard)'>
-			<roles>artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LTC)'>
 			<roles>artillery</roles>
 			<availability>LA:3,WOB:3,FS:3,DC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>artillery</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Palmoni Assault Infantry Fighting Vehicle' unitType='Tank'>
@@ -11506,78 +11503,78 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:1,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,WOB:4,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CS:2,LA:1,FS.DMM:5,CNC:3,FWL:1,NIOPS:2,DC:9</availability>
-		<model name='PNT-16K'>
+		<model name='PNT-10KA'>
 			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>FS.RR:2,FRR:2,CNC:8,FS.DMM:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='PNT-14S'>
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='PNT-10KA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:2,CNC:8,FS.DMM:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,FVC:2,FRR:5,PIR:2,CNC:4,FS.DMM:4,WOB:6,MERC:4,DC:5,TC:2</availability>
-		</model>
-		<model name='PNT-10K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:2,FS.DMM:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:2,FS.DMM:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='PNT-13K'>
-			<roles>fire_support</roles>
-			<availability>FRR:3,DC:3</availability>
-		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
-		</model>
-		<model name='PNT-C'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,FRR:4,FS.DMM:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='PNT-9R'>
-			<roles>fire_support</roles>
-			<availability>HL:2-,IS:4-,Periphery.Deep:8,MERC:4-,Periphery:4-,DC:4-</availability>
 		</model>
 		<model name='PNT-12K2'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='PNT-CA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FRR:2,FS.DMM:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='PNT-10K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FRR:2,FS.DMM:2,MERC:2,DC:4</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:4,FVC:2,FRR:5,PIR:2,CNC:4,FS.DMM:4,WOB:6,MERC:4,DC:5,TC:2</availability>
+		</model>
+		<model name='PNT-16K'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PNT-9R'>
+			<roles>fire_support</roles>
+			<availability>HL:2-,IS:4-,Periphery.Deep:8,MERC:4-,Periphery:4-,DC:4-</availability>
+		</model>
+		<model name='PNT-13K'>
+			<roles>fire_support</roles>
+			<availability>FRR:3,DC:3</availability>
+		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:4,FRR:4,FS.DMM:4,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
 		<availability>FWL:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MFB)'>
 			<roles>support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,CS:6,HL:3,LA:7,FRR:4,CNC:5,IS:5,WOB:6,FS:8,Periphery:4,CWIE:5,DC:6</availability>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:4,FS:5</availability>
-		</model>
 		<model name='(Quad RAC)'>
 			<roles>anti_aircraft</roles>
 			<availability>WOB:3,FS:4</availability>
 		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='(Company Command)'>
+		<model name='(Lance Command)'>
 			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:2,FS:2</availability>
+			<availability>WOB:4,FS:5</availability>
 		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
@@ -11586,31 +11583,31 @@
 		<model name='(Cell)'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:2,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:5-,CC:2-,HL:4-,FRR:2-,IS:4-,Periphery.Deep:9,WOB:4-,FS:5-,CIR:3-,Periphery:5-,TC:5-,CS:4-,OA:2-,CDS:2,LA:4-,FWL:4-,DC:2-</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
-		<model name='(C3)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:2-,Periphery:3</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -11649,38 +11646,22 @@
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
 		<availability>FVC:3,LA:7,FRR:4,FS:5,MERC:4,CWIE:5</availability>
-		<model name='(Standard)'>
-			<availability>HL:3,IS:3-,Periphery:5</availability>
-		</model>
 		<model name='(Ultra)'>
 			<availability>LA:8,General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:3,IS:3-,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:1,CC:2,FRR:2,IS:2,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,TC:1,CWIE:2,CS:5-,OA:1,LA:6,FWL:2,DC:6</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>FVC:1,IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,WOB:4,FS:4,DC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Unarmed)'>
 			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(3058 Upgrade)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,WOB:8,FS:8,DC:7</availability>
+			<availability>FVC:1,IS:1</availability>
 		</model>
 		<model name='(MRM)'>
 			<roles>recon</roles>
@@ -11690,23 +11671,39 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:4</availability>
 		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(3058 Upgrade)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,WOB:8,FS:8,DC:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='PTR-6T'>
-			<availability>FS.DBG:8,FS:4</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-6T'>
+			<availability>FS.DBG:8,FS:4</availability>
+		</model>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pentagon' unitType='Dropship'>
@@ -11717,18 +11714,18 @@
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:2,CGB:4</availability>
-		<model name='5'>
-			<availability>CGS:9</availability>
-		</model>
-		<model name='4'>
-			<availability>CSR:8,CBS:7,CGS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CGS:9</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='4'>
+			<availability>CSR:8,CBS:7,CGS:6</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_infantry</roles>
@@ -11737,11 +11734,11 @@
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:1-,LA:2-,FRR:1-,FWL:1-,IS:1-,FS:2-,MERC:1-,DC:2-</availability>
-		<model name='(Cargo)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,DC:2</availability>
@@ -11749,10 +11746,14 @@
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,FWL:6,WOB:5</availability>
-		<model name='P1E'>
-			<availability>General:4</availability>
-		</model>
 		<model name='P1D'>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1A'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1'>
@@ -11761,15 +11762,11 @@
 		<model name='P1C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='P1B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1A'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='P1W'>
 			<availability>General:2,WOB:6</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -11783,59 +11780,56 @@
 		<model name='(C)' mechanized='true'>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='(B)' mechanized='true'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='(WoB-A)' mechanized='true'>
 			<availability>WOB:8</availability>
 		</model>
 		<model name='(WoB-B)' mechanized='true'>
 			<availability>WOB:3</availability>
 		</model>
+		<model name='(B)' mechanized='true'>
+			<availability>FWL:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CSR:6,CW:8,CSL:7,CGS:8,CCO:4,CJF:7,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,General:8,CCO:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:7,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,General:8,CCO:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CSR:5,CDS:5,CBS:3,CSV:5,CLAN:3,CCO:5</availability>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:6,CLAN:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCC:3,CSR:3,CDS:4,CSV:3,CLAN:2,CNC:4,CCO:4,DC:2</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CSV:8,CLAN:2</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:6,CLAN:2</availability>
 		</model>
 		<model name='6'>
 			<availability>CDS:5,CGB:5</availability>
@@ -11844,36 +11838,35 @@
 			<roles>fire_support</roles>
 			<availability>CCC:2,CSR:5,CDS:2,CSV:5,CNC:2,CCO:2</availability>
 		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK1R'>
-            <availability>IS:2+</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-        <model name='PHX-HK1RB'>
-            <availability>WOB:1</availability>
-        </model>
-    </chassis>
+		<availability>IS:2</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK1R'>
+			<availability>IS:2+</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK1RB'>
+			<availability>WOB:1</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:5,HL:5,CLAN:1,IS:8,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:3,Periphery:6,CGB:1</availability>
-		<model name='PXH-6D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:3,FWL:3,WOB:4,RCM:3,CGS:5</availability>
+		<model name='PXH-7K'>
+			<availability>DC:3</availability>
 		</model>
 		<model name='PXH-7S'>
 			<availability>LA:5,MERC:4</availability>
@@ -11885,6 +11878,35 @@
 			<roles>recon</roles>
 			<availability>FVC:2-,PIR:3-,FS:2-,MERC:2-</availability>
 		</model>
+		<model name='PXH-5L'>
+			<availability>CC:3,MOC:3</availability>
+		</model>
+		<model name='PXH-1b (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:5,FWL:4,WOB:4,BAN:1</availability>
+		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:1-,DC:2-</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>FRR:8,DC:8</availability>
+		</model>
+		<model name='PXH-3S'>
+			<roles>recon</roles>
+			<availability>LA:6,MERC:5</availability>
+		</model>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>DTA:8,FWL:8,IS:4,RCM:8</availability>
+		</model>
+		<model name='PXH-7CS'>
+			<availability>CS:4</availability>
+		</model>
 		<model name='PXH-3PL'>
 			<availability>WOB:4,FS:5,MERC:4</availability>
 		</model>
@@ -11892,38 +11914,13 @@
 			<roles>recon</roles>
 			<availability>General:3-,BAN:6,Periphery:3-</availability>
 		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CLAN:3,FWL:3,WOB:4,RCM:3,CGS:5</availability>
+		</model>
 		<model name='PXH-3D'>
 			<roles>recon</roles>
 			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
-		<model name='PXH-5L'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>DTA:8,FWL:8,IS:4,RCM:8</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:1-,DC:2-</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>FRR:8,DC:8</availability>
-		</model>
-		<model name='PXH-1b (Special)'>
-			<roles>recon</roles>
-			<availability>CLAN:5,FWL:4,WOB:4,BAN:1</availability>
-		</model>
-		<model name='PXH-3S'>
-			<roles>recon</roles>
-			<availability>LA:6,MERC:5</availability>
-		</model>
-		<model name='PXH-7K'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='PXH-7CS'>
-			<availability>CS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -11931,17 +11928,17 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:4,CC:1-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:3-,WOB:4-,FS:3-,MERC:3-,CIR:3-,CWIE:6,Periphery:3-,TC:3-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:2-,CNC:5,FWL:2-,MH:5-,DC:3-</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:4,IS:4,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='(RAC) &apos;Assault Pike&apos;'>
 			<availability>CC:6,MOC:6,FS:6,MERC:6,TC:6</availability>
 		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
+		<model name='(Standard)'>
+			<availability>HL:4,IS:4,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -11949,6 +11946,9 @@
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,CS:4,MOC:3,MERC.WD:4,MERC.KH:4,CNC:6,CLAN:1,NIOPS:4,FS:2,MERC:4,TC:2</availability>
+		<model name='PLG-5Z'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
@@ -11959,19 +11959,16 @@
 		<model name='PLG-3Z'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PLG-5Z'>
-			<availability>CC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,FS:7</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -12017,9 +12014,6 @@
 	</chassis>
 	<chassis name='Plainsman Medium Hovertank' unitType='Tank'>
 		<availability>MERC.WD:3,HL:2,LA:5,FRR:6,FWL:4,IS:3,TC:8,Periphery:3</availability>
-		<model name='(Sealed)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>HL:2,IS:5,TC:6,Periphery:4</availability>
 		</model>
@@ -12029,6 +12023,9 @@
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
@@ -12062,38 +12059,38 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CSA:1,CS:1,CHH:1,CCC:2,CSR:5,CDS:5,CSV:2,NIOPS:1,CGS:3,CCO:2,CWIE:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CSL:4,CGS:7,CCO:6,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:6,CSV:6,General:8,CJF:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,General:2,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:6,CSV:6,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:3,General:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CSV:5,CLAN:4,General:2,CGB:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
@@ -12117,6 +12114,21 @@
 	</chassis>
 	<chassis name='Preta' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
+		<model name='C-PRT-OE Eminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-PRT-OD Luminos'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-PRT-O Invictus'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C-PRT-OU Exanimus'>
+			<availability>General:2</availability>
+		</model>
+		<model name='C-PRT-OS Caelestis'>
+			<availability>General:4</availability>
+		</model>
 		<model name='C-PRT-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
@@ -12127,28 +12139,16 @@
 		<model name='C-PRT-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-PRT-OU Exanimus'>
-			<availability>General:2</availability>
-		</model>
-		<model name='C-PRT-O Invictus'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C-PRT-OS Caelestis'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-PRT-OE Eminus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-PRT-OD Luminos'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:5,CBS:4,CSL:6,CCO:6</availability>
-		<model name='3'>
-			<availability>CCO:4</availability>
+		<model name='2'>
+			<availability>CHH:2,CCO:2</availability>
 		</model>
 		<model name='4'>
+			<availability>CCO:4</availability>
+		</model>
+		<model name='3'>
 			<availability>CCO:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -12156,9 +12156,6 @@
 		</model>
 		<model name='5'>
 			<availability>CCO:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:2,CCO:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -12184,10 +12181,6 @@
 			<roles>support</roles>
 			<availability>IS:4,Periphery:7</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8,General:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -12200,9 +12193,20 @@
 			<roles>apc</roles>
 			<availability>WOB:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:7,CLAN:7,IS:2+,MERC:2+,CCO:6,BAN:6,CWIE:8,CSA:8,MERC.WD:6,CDS:8,CW:8,CBS:6,CNC:8,CJF:5,CGB:6</availability>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CJF:6</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,CSV:5,General:4,CGB:3</availability>
 		</model>
@@ -12210,25 +12214,18 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CSV:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CJF:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,CSV:4,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CBS:6,CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CJF:6</availability>
+		<model name='E'>
+			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -12236,41 +12233,41 @@
 		<model name='PAT-005'>
 			<availability>CS:4,CHH:2,CW:2,FRR:8,NIOPS:8,WOB:8,CWIE:2</availability>
 		</model>
+		<model name='PAT-007'>
+			<availability>CS:7,WOB:6</availability>
+		</model>
 		<model name='PAT-008'>
 			<availability>WOB:5+</availability>
 		</model>
 		<model name='PAT-005b'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='PAT-007'>
-			<availability>CS:7,WOB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Purifier Adaptive Battle Armor' unitType='BattleArmor'>
 		<availability>WOB:6,MH:4,CIR:4,TC:4</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CS:7,WOB:7,Periphery:7</availability>
-		</model>
 		<model name='[PPC]' mechanized='true'>
 			<availability>CS:6,WOB:6,Periphery:6</availability>
-		</model>
-		<model name='[Narc]' mechanized='true'>
-			<availability>CS:4,WOB:4,Periphery:4</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:5,WOB:5,Periphery:5</availability>
 		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CS:7,WOB:7,Periphery:7</availability>
+		</model>
+		<model name='[Narc]' mechanized='true'>
+			<availability>CS:4,WOB:4,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Purifier Battle Armor Terra' unitType='BattleArmor'>
 		<availability>WOB:4</availability>
+		<model name='[MRR]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='[AP Gauss]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[SPL]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[MRR]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[ERSL]' mechanized='true'>
@@ -12291,8 +12288,11 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:4,CC:3,HL:3,FRR:7,Periphery.Deep:4,IS:4,WOB:3-,FS:4,CIR:3,CDP:4,Periphery:4,TC:4,CS:3-,DTA:6,OA:4,FVC:4,LA:4,FWL:7,NIOPS:3-,RCM:5,DC:5</availability>
-		<model name='QKD-4H'>
-			<availability>General:2-</availability>
+		<model name='QKD-5K2'>
+			<availability>MERC:1,DC:1</availability>
+		</model>
+		<model name='QKD-5K'>
+			<availability>FRR:5,MERC:5,DC:6</availability>
 		</model>
 		<model name='QKD-5A'>
 			<availability>MERC:2-,DC:2-,Periphery:2-</availability>
@@ -12300,23 +12300,20 @@
 		<model name='QKD-8K'>
 			<availability>FRR:5,MERC:3,DC:7</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>FRR:5,MERC:5,DC:6</availability>
-		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:4,FWL:6</availability>
-		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:6,FVC:6,Periphery.CM:6,Periphery.ME:6,FWL:8,IS:6,MH:6,TC:6,Periphery:2</availability>
-		</model>
-		<model name='QKD-5K2'>
-			<availability>MERC:1,DC:1</availability>
+		<model name='QKD-C'>
+			<availability>FRR:8,MERC:6,DC:8</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:4-,OA:4-,HL:2-,Periphery.Deep:8,FWL:3-,IS:3-,Periphery:4-,DC:3-,TC:4-</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>FRR:8,MERC:6,DC:8</availability>
+		<model name='QKD-4H'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:6,FVC:6,Periphery.CM:6,Periphery.ME:6,FWL:8,IS:6,MH:6,TC:6,Periphery:2</availability>
+		</model>
+		<model name='QKD-5Mr'>
+			<availability>General:4,FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
@@ -12328,43 +12325,43 @@
 	</chassis>
 	<chassis name='Rabid Coyote' unitType='Mek'>
 		<availability>CCC:3,CW:4,CCO:5-</availability>
-		<model name='2'>
-			<availability>CW:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCC:8,CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:8</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin II' unitType='Mek'>
 		<availability>WOB:6+</availability>
+		<model name='RJN-200-C'>
+			<availability>General:4</availability>
+		</model>
 		<model name='RJN-200-B'>
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='RJN-200-C'>
-			<availability>General:4</availability>
 		</model>
 		<model name='RJN-200-A'>
 			<availability>General:8</availability>
@@ -12381,8 +12378,8 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:4,FS:5,MERC:3</availability>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='MDG-1Ar'>
 			<availability>FS:3,MERC:3</availability>
@@ -12390,29 +12387,23 @@
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>CS:4,LA:3,FWL:3,MH:4,MERC:4,FS:3,DC:3</availability>
-		<model name='VV1'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='VV1 (MG)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='VV1'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:6,LA:4,CLAN:3,NIOPS:6,WOB:6</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:2-</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:3</availability>
@@ -12420,37 +12411,55 @@
 		<model name='RPR-100'>
 			<availability>CS:8,General:4,NIOPS:8,WOB:8</availability>
 		</model>
-		<model name='RPR-300'>
-			<availability>LA:5</availability>
-		</model>
 		<model name='RPR-200'>
 			<availability>CCC:1,CSR:1,CBS:1,CNC:2</availability>
+		</model>
+		<model name='RPR-102'>
+			<availability>LA:2-</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='RPR-300'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
 		<availability>WOB:5</availability>
-		<model name='RPT-2X1'>
-			<roles>specops</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='RPT-2X'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='RPT-2X1'>
+			<roles>specops</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:3,FS:4,DC:6</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:2+</availability>
 		</model>
-		<model name='RTX1-OU'>
-			<availability>General:2</availability>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
@@ -12459,59 +12468,47 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,MOC:4,FWL:4,FS:2,MERC:5,TC:4,DC:2</availability>
-		<model name='RVN-SR &apos;Shattered Raven&apos;'>
-			<availability>FS.CMM:2</availability>
-		</model>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:3</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:4,MOC:3,FWL:2,FS:1,MERC:3,DC:3,TC:3</availability>
-		</model>
-		<model name='RVN-SS &apos;Shattered Raven&apos;'>
-			<roles>spotter</roles>
-			<availability>FS.CMM:2</availability>
+		<model name='RVN-4X'>
+			<availability>CC:2</availability>
 		</model>
 		<model name='RVN-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3,FWL:4,FS:1,MERC:3,DC:1,TC:3</availability>
 		</model>
-		<model name='RVN-4L'>
+		<model name='RVN-4Lr'>
 			<roles>spotter</roles>
-			<availability>CC:7,MOC:7,TC:7</availability>
+			<availability>CC:3</availability>
 		</model>
-		<model name='RVN-4X'>
-			<availability>CC:2</availability>
+		<model name='RVN-SR &apos;Shattered Raven&apos;'>
+			<availability>FS.CMM:2</availability>
 		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,TC:2</availability>
 		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:4,MOC:3,FWL:2,FS:1,MERC:3,DC:3,TC:3</availability>
+		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:7,MOC:7,TC:7</availability>
+		</model>
+		<model name='RVN-SS &apos;Shattered Raven&apos;'>
+			<roles>spotter</roles>
+			<availability>FS.CMM:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>LA:6,FRR:5,MERC:4,FS:4</availability>
-		<model name='RZK-9S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RZK-10T'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='RZK-9S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
@@ -12526,6 +12523,11 @@
 	</chassis>
 	<chassis name='Red Shift' unitType='Mek'>
 		<availability>WOB:6</availability>
+		<model name='RDS-2A'>
+			<roles>spotter</roles>
+			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
+			<availability>General:8</availability>
+		</model>
 		<model name='RDS-2B'>
 			<roles>recon,spotter</roles>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
@@ -12534,11 +12536,6 @@
 		<model name='RDS-3A'>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
 			<availability>General:4</availability>
-		</model>
-		<model name='RDS-2A'>
-			<roles>spotter</roles>
-			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
@@ -12562,56 +12559,62 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,FRR:5,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 		</model>
-		<model name='(ML)'>
+		<model name='(MG)'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(ML)'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:3,CC:4,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,RCM:8,DC:4</availability>
+		<model name='F-700a'>
+			<availability>CC:7,DTA:6,FWL:7,WOB:7,FS:5,MERC:7,RCM:6</availability>
+		</model>
+		<model name='F-100b'>
+			<availability>FRR:3-,DC:3-</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>CC:2-,FWL:4-,MERC:4-</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:8,DTA:8,FWL:8,WOB:8,MERC:8,RCM:8</availability>
 		</model>
-		<model name='F-100b'>
-			<availability>FRR:3-,DC:3-</availability>
+		<model name='F-700b'>
+			<availability>DTA:8,FWL:5,WOB:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:2-,FVC:4-,HL:2-,LA:1,FRR:1,FWL:4-,Periphery.Deep:8,MERC:4-,DC:1,Periphery:4-</availability>
 		</model>
-		<model name='F-700a'>
-			<availability>CC:7,DTA:6,FWL:7,WOB:7,FS:5,MERC:7,RCM:6</availability>
-		</model>
-		<model name='F-700b'>
-			<availability>DTA:8,FWL:5,WOB:5,MERC:5,DC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:5,CLAN:2,CNC:5,IS:2,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:2,CNC:5,IS:2</availability>
+		<model name='5'>
+			<availability>CSA:5,CDS:3,SOC:4,IS:2,CLAN.HW:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:3,CLAN:2,CNC:3</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:6,CCC:5,CDS:4,CBS:5,CCO:4</availability>
 		</model>
 		<model name='6'>
 			<availability>CSA:5,CHH:3,CDS:3</availability>
@@ -12619,14 +12622,8 @@
 		<model name='3'>
 			<availability>CSA:5,CCC:6,CDS:4,CBS:4,CCO:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CDS:3,CLAN:2,CNC:3</availability>
-		</model>
-		<model name='5'>
-			<availability>CSA:5,CDS:3,SOC:4,IS:2,CLAN.HW:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:6,CCC:5,CDS:4,CBS:5,CCO:4</availability>
+		<model name='2'>
+			<availability>CLAN:2,CNC:5,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -12638,24 +12635,36 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,CCC:6,HL:3,FRR:7,CSV:6,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CJF:4</availability>
-		<model name='RFL-1N'>
-			<roles>fire_support</roles>
-			<availability>CC:3-,MOC:3-,PIR:3-,FWL:2-,MH:3-,FS:3-,MERC:2-,RCM:3-</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:1,CLAN:8,FS:1,BAN:2,DC:1</availability>
+		<model name='RFL-6D'>
+			<availability>FS:3</availability>
 		</model>
 		<model name='RFL-7M'>
 			<availability>DTA:6,FRR:4,FWL:6,WOB:5,RCM:6,DC:4</availability>
 		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:1</availability>
+		</model>
+		<model name='RFL-4D'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FVC:1-,FS:1-,MERC:1-</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 		<model name='RFL-5D'>
 			<availability>FVC:5,LA:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='RFL-3Cr'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RFL-1N'>
+			<roles>fire_support</roles>
+			<availability>CC:3-,MOC:3-,PIR:3-,FWL:2-,MH:3-,FS:3-,MERC:2-,RCM:3-</availability>
+		</model>
 		<model name='RFL-8D'>
 			<availability>LA:2,FS:5</availability>
-		</model>
-		<model name='RFL-6D'>
-			<availability>FS:3</availability>
 		</model>
 		<model name='RFL-9T'>
 			<availability>TC:4</availability>
@@ -12663,26 +12672,14 @@
 		<model name='RFL-8X'>
 			<availability>MERC:4</availability>
 		</model>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:1</availability>
+		<model name='RFL-6X'>
+			<availability>FVC:2,FS:3,MERC:2</availability>
 		</model>
 		<model name='RFL-5M'>
 			<availability>CC:4,MOC:4,FWL:4,IS:2,MERC:4,DC:4</availability>
 		</model>
-		<model name='RFL-3Cr'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RFL-4D'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FVC:1-,FS:1-,MERC:1-</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:2,FS:3,MERC:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='C'>
+			<availability>LA:1,CLAN:8,FS:1,BAN:2,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Riot Police' unitType='Infantry'>
@@ -12694,48 +12691,48 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CS:6,CHH:4,FVC:4,CSR:1,LA:5,FRR:5,CLAN:2,NIOPS:6,WOB:6,FS:5,DC:5</availability>
-		<model name='(SPL)'>
-			<roles>apc</roles>
-			<availability>FVC:4,IS:4</availability>
-		</model>
-		<model name='(ERML)'>
-			<roles>apc</roles>
-			<availability>CC:6,LA:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>DC:5</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8,BAN:2</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>DC:5</availability>
+		</model>
+		<model name='(ERML)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(Infantry)'>
+			<roles>apc</roles>
+			<availability>LA:5,FS:2</availability>
+		</model>
+		<model name='(SPL)'>
+			<roles>apc</roles>
+			<availability>FVC:4,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:4,CHH:4,CSR:7,CBS:7,SOC:8,CSV:4,CNC:7,CSL:4,CGS:6,CCO:8,CWIE:8</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CCC:6,CSR:8,CBS:8,CSV:6,CNC:6,CSL:6,CCO:8,CGS:6</availability>
+		</model>
 		<model name='3'>
 			<availability>CSR:6,CBS:6,CSV:5,CNC:4,CCO:4,CWIE:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CSR:5,CCO:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CCC:6,CSR:8,CBS:8,CSV:6,CNC:6,CSL:6,CCO:8,CGS:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
@@ -12746,33 +12743,33 @@
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:8</availability>
-		</model>
-		<model name='RGU-133L'>
-			<availability>CS:1,General:4,NIOPS:1,WOB:2</availability>
-		</model>
-		<model name='RGU-133F'>
-			<availability>CS:2,General:6,NIOPS:2,WOB:4</availability>
-		</model>
 		<model name='RGU-133Eb'>
 			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='RGU-133P'>
-			<availability>CS:1</availability>
 		</model>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
 		</model>
+		<model name='RGU-133L'>
+			<availability>CS:1,General:4,NIOPS:1,WOB:2</availability>
+		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:8</availability>
+		</model>
+		<model name='RGU-133F'>
+			<availability>CS:2,General:6,NIOPS:2,WOB:4</availability>
+		</model>
+		<model name='RGU-133P'>
+			<availability>CS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>OA:5,FVC:3,LA:6,FRR:4,FS:4,MERC:3,CWIE:6,TC:6</availability>
-		<model name='(Sealed)'>
-			<availability>LA:3,FS:3,CWIE:3</availability>
-		</model>
 		<model name='(Gauss)'>
 			<availability>OA:0,FRR:0,General:8</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>LA:3,FS:3,CWIE:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:4,TC:0,CWIE:0</availability>
@@ -12783,14 +12780,14 @@
 		<model name='NH-3X'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='NH-2'>
+			<availability>General:8</availability>
+		</model>
 		<model name='NH-1X &apos;Rook-X&apos;'>
 			<availability>FS:2-</availability>
 		</model>
 		<model name='NH-1A'>
 			<availability>General:3-</availability>
-		</model>
-		<model name='NH-2'>
-			<availability>General:8</availability>
 		</model>
 		<model name='NH-1B'>
 			<availability>MERC:6-,FS:6-</availability>
@@ -12809,16 +12806,16 @@
 			<roles>urban</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='(Firedrake)' mechanized='false'>
-			<roles>anti_infantry</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>LA:6</availability>
 		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='(Firedrake)' mechanized='false'>
+			<roles>anti_infantry</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -12831,7 +12828,7 @@
 	</chassis>
 	<chassis name='Rusalka' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:6</availability>
-		<model name='S-RSL-OD Luminos'>
+		<model name='S-RSL-OB Infernus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
@@ -12843,65 +12840,65 @@
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-RSL-OC Comminus'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='S-RSL-OA Dominus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-RSL-OB Infernus'>
+		<model name='S-RSL-OD Luminos'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='S-RSL-OC Comminus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CSR:7,CSV:6,CLAN:6,WOB:3+,MERC:2+,BAN:7,CWIE:7,MERC.WD:7,CDS:7,CBS:8,CNC:4,CJF:7,DC:3+</availability>
-		<model name='G'>
-			<availability>CHH:5,General:2</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
 		</model>
+		<model name='A'>
+			<availability>CDS:9,CW:6,CSV:8,General:6,CJF:5,CGB:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:5,CCC:5,CBS:4,CSV:5,CLAN:3,General:1</availability>
-		</model>
-		<model name='I'>
-			<availability>CLAN:3,General:1</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:9,CW:6,CSV:8,General:6,CJF:5,CGB:3</availability>
+		<model name='F'>
+			<availability>General:2,CJF:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CSV:6,CNC:6,General:5,CJF:4,CGB:3</availability>
-		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
+		<model name='I'>
+			<availability>CLAN:3,General:1</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CSR:6,CDS:6,CNC:4,General:5,CCO:7,CJF:4,CWIE:6</availability>
 		</model>
-		<model name='F'>
-			<availability>General:2,CJF:5</availability>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:6,CBS:6,General:5,CWIE:5,CGB:6</availability>
 		</model>
+		<model name='G'>
+			<availability>CHH:5,General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ryoken II' unitType='Mek'>
 		<availability>CGB:3</availability>
-		<model name='2'>
-			<availability>CGB:6</availability>
+		<model name='3'>
+			<availability>CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CGB:4</availability>
+		<model name='2'>
+			<availability>CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
@@ -12927,21 +12924,21 @@
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:7,CLAN:3,WOB:8</availability>
-		<model name='(WoB)'>
-			<roles>sr_fire_support,spotter</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:8,LA:8,FWL:8,IS:6,FS:8,DC:6,Periphery:6</availability>
+		<model name='(WoB)'>
+			<roles>sr_fire_support,spotter</roles>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='(C3)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:6,Periphery:3</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:8,LA:8,FWL:8,IS:6,FS:8,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -12964,32 +12961,23 @@
 		<model name='SB-29'>
 			<availability>MERC:5,DC:8</availability>
 		</model>
-		<model name='SB-27b'>
-			<availability>CC:8,MOC:6,CLAN:4,FS:8,MERC:5</availability>
-		</model>
 		<model name='SB-28'>
 			<availability>CS:6,LA:8,NIOPS:6,WOB:6,FS:5,MERC:5</availability>
+		</model>
+		<model name='SB-27b'>
+			<availability>CC:8,MOC:6,CLAN:4,FS:8,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
+		<model name='E'>
 			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='X'>
-			<availability>CSR:3,General:1,CJF:3</availability>
-		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CSR:5,General:2,CJF:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -12997,6 +12985,15 @@
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:5,General:2,CJF:5</availability>
+		</model>
+		<model name='X'>
+			<availability>CSR:3,General:1,CJF:3</availability>
+		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
@@ -13014,8 +13011,8 @@
 		<model name='S-4X'>
 			<availability>DC:1</availability>
 		</model>
-		<model name='S-7'>
-			<availability>CNC:5,DC:5</availability>
+		<model name='S-4C'>
+			<availability>CLAN:8,DC:4</availability>
 		</model>
 		<model name='S-3'>
 			<availability>DC:2-</availability>
@@ -13026,43 +13023,51 @@
 		<model name='S-4'>
 			<availability>FRR:6,FS:5,DC:6</availability>
 		</model>
-		<model name='S-4C'>
-			<availability>CLAN:8,DC:4</availability>
+		<model name='S-7'>
+			<availability>CNC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:6,Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:5,CS:5-,LA:6,FWL:6,CJF:4,DC:9</availability>
-		<model name='(Armor)'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='(Ultra)'>
+		<model name='(LB-X)'>
 			<availability>IS:6,DC:7</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
-		<model name='(LB-X)'>
+		<model name='(Armor)'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ultra)'>
 			<availability>IS:6,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>anti_infantry</roles>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='(Laser)' mechanized='true'>
 			<availability>CSR:6,CW:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>anti_infantry</roles>
+			<availability>CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>CS:5,LA:7,FS:5,MERC:5</availability>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
+		</model>
+		<model name='PPR-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
@@ -13071,31 +13076,23 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
-		<model name='PPR-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>CS:4,OA:1,LA:5,FRR:4,WOB:4,DC:1</availability>
+		<model name='SL-25'>
+			<roles>ground_support</roles>
+			<availability>OA:4,FRR:4-,DC:4</availability>
+		</model>
 		<model name='SL-27'>
 			<availability>IS:6,DC:2</availability>
 		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='SL-25'>
-			<roles>ground_support</roles>
-			<availability>OA:4,FRR:4-,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -13109,11 +13106,11 @@
 	</chassis>
 	<chassis name='Sasquatch' unitType='Mek'>
 		<availability>WOB:5</availability>
-		<model name='SQS-TH-001'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SQS-TH-002'>
 			<availability>General:6</availability>
+		</model>
+		<model name='SQS-TH-001'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sassanid' unitType='Dropship'>
@@ -13125,56 +13122,56 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:3,CSR:4,CBS:5,CSV:4,CNC:2,CGS:6,CCO:7,CWIE:7</availability>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CSR:4,CNC:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CSR:4,CNC:4</availability>
+		</model>
 		<model name='3'>
 			<roles>recon,raider</roles>
 			<availability>CGS:4,CWIE:4</availability>
 		</model>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CW:5,SOC:7,CCO:8</availability>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CLAN:6</availability>
+		</model>
+		<model name='J'>
+			<availability>CHH:4,CW:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
+		</model>
+		<model name='Z'>
+			<availability>SOC:10,CCO:4</availability>
 		</model>
 		<model name='W'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>CHH:3,CW:3</availability>
 		</model>
-		<model name='A'>
-			<availability>CSA:3,General:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
-		</model>
-		<model name='Z'>
-			<availability>SOC:10,CCO:4</availability>
-		</model>
-		<model name='J'>
-			<availability>CHH:4,CW:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
 		<availability>LA:5,FS:4,MERC:3,DC:3</availability>
-		<model name='(Interdictor)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>LA:2,FS:2</availability>
+		</model>
+		<model name='(Interdictor)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savior Repair Vehicle' unitType='Tank'>
@@ -13190,32 +13187,36 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MASH)'>
-			<roles>apc,support</roles>
-			<availability>General:4</availability>
+		<model name='(HQ)'>
+			<roles>apc,support,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(HQ)'>
-			<roles>apc,support,spotter</roles>
-			<availability>General:2</availability>
+		<model name='(MASH)'>
+			<roles>apc,support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>CS:4,LA:4,FS:6,MERC:4</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>LA:6,FS:3,MERC:5</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>LA:6,FS:3,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,FRR:4,FWL:4,WOB:4,FS:4,MERC:4,MERC.NH:4,DC:4</availability>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -13224,6 +13225,10 @@
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
@@ -13231,14 +13236,6 @@
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
@@ -13253,6 +13250,10 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>MOC:4,CC:2,HL:4,FRR:3,IS:4,Periphery.Deep:5,WOB:4,MERC:4,FS:4,CIR:5,Periphery:5,TC:4,CS:3,OA:5,LA:4,FWL:3,DC:2</availability>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -13260,10 +13261,6 @@
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>CNC:6,IS:4</availability>
@@ -13287,23 +13284,23 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,HL:6,LA:6,FRR:8,IS:7,Periphery.Deep:7,FWL:6,FS:6,CJF:4,Periphery:7,DC:6</availability>
-		<model name='(MRM)'>
-			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
+		<model name='(LRM)'>
+			<availability>General:3-</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5-</availability>
 		</model>
 		<model name='(LAC)'>
 			<availability>CC:4,MOC:3,LA:4,FWL:4,IS:3,MH:3,WOB:4,FS:4,MERC:4,DC:4,TC:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(SRM)'>
 			<availability>General:5-</availability>
 		</model>
 		<model name='(ML)'>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5-</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:3-</availability>
+		<model name='(MRM)'>
+			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -13311,8 +13308,8 @@
 		<model name='SCP-1N'>
 			<availability>HL:2-,FRR:4-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
 		</model>
-		<model name='SCP-12S'>
-			<availability>LA:4,MERC:2</availability>
+		<model name='SCP-12C'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
@@ -13321,11 +13318,11 @@
 		<model name='SCP-1O'>
 			<availability>IS:6,Periphery:2</availability>
 		</model>
+		<model name='SCP-12S'>
+			<availability>LA:4,MERC:2</availability>
+		</model>
 		<model name='SCP-1TB'>
 			<availability>MERC:4</availability>
-		</model>
-		<model name='SCP-12C'>
-			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -13358,33 +13355,33 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Se&apos;irim Medium Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:7</availability>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Capture Team)' mechanized='true'>
 			<availability>General:2</availability>
@@ -13421,14 +13418,14 @@
 		<model name='STN-3M'>
 			<availability>DC.GHO:3-,DC:1</availability>
 		</model>
-		<model name='STN-5WB'>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='STN-C'>
 			<availability>DC:7</availability>
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-5WB'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -13442,12 +13439,6 @@
 	</chassis>
 	<chassis name='Seraph' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='C-SRP-OE Eminus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-SRP-OD Luminos'>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-SRP-OA Dominus'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
@@ -13458,49 +13449,55 @@
 		<model name='C-SRP-O (Havalah)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='C-SRP-OS Caelestis'>
+			<availability>General:4</availability>
+		</model>
 		<model name='C-SRP-OC Comminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-SRP-OE Eminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-SRP-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-SRP-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-SRP-OS Caelestis'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,CC:2,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,FWL:3-,MH:2,DC:3-</availability>
-		<model name='SYD-21'>
+		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
-			<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,FS:1-,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>OA:4-,HL:4,FRR:4-,Periphery.Deep:4,FWL:4-,WOB:4-,Periphery:6,TC:4-,DC:4-</availability>
-		</model>
-		<model name='SYD-Z4'>
-			<availability>CC:8,OA:4,LA:6,FRR:2,MERC:5</availability>
-		</model>
-		<model name='SYD-45X &apos;Starling&apos;'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:2-,FS:1-</availability>
+			<availability>LA:3-,Periphery.Deep:8,FS:2-,Periphery:3-</availability>
 		</model>
 		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
 			<availability>LA:8,FRR:6,FS:8,MERC:6</availability>
 		</model>
-		<model name='SYD-Z2'>
+		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
-			<availability>LA:3-,Periphery.Deep:8,FS:2-,Periphery:3-</availability>
+			<availability>OA:4-,HL:4,FRR:4-,Periphery.Deep:4,FWL:4-,WOB:4-,Periphery:6,TC:4-,DC:4-</availability>
+		</model>
+		<model name='SYD-Z3A'>
+			<availability>LA:6,FRR:3,MERC:3,FS:2</availability>
+		</model>
+		<model name='SYD-45X &apos;Starling&apos;'>
+			<availability>LA:1</availability>
+		</model>
+		<model name='SYD-Z4'>
+			<availability>CC:8,OA:4,LA:6,FRR:2,MERC:5</availability>
+		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,FS:1-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='SYD-Z2B'>
 			<availability>OA:4,LA:4,FS:2,MERC:2</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>LA:6,FRR:3,MERC:3,FS:2</availability>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:2-,FS:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
@@ -13509,10 +13506,10 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='SYU-4B'>
+		<model name='SYU-6B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SYU-6B'>
+		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -13524,16 +13521,16 @@
 		<model name='S-HA-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-HA-OB Infernus'>
+		<model name='S-HA-OC Comminus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-HA-OD Luminos'>
+		<model name='S-HA-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-HA-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='S-HA-OC Comminus'>
+		<model name='S-HA-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -13555,107 +13552,107 @@
 			<roles>recon</roles>
 			<availability>CSR:8,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:3,General:8</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='J'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:3,CW:3,General:6</availability>
 		</model>
+		<model name='J'>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:3,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:6,FRR:3,CLAN:4,IS:1,FS:3,MERC:3,CWIE:6,DTA:3,CS:3,CDS:6,LA:3,CNC:6,FWL:3,RCM:3,CJF:2,DC:3,CGB:6</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3,CGB:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:4,CDS:5,CNC:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='5'>
-			<availability>CS:6,CDS:6,LA:6,FRR:5,FWL:6,IS:4,FS:6,MERC:6,DC:6</availability>
+		<model name='2'>
+			<availability>CSA:3,CCC:3,CGB:4</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:5</availability>
 		</model>
+		<model name='3'>
+			<availability>CSA:4,CDS:5,CNC:5</availability>
+		</model>
+		<model name='5'>
+			<availability>CS:6,CDS:6,LA:6,FRR:5,FWL:6,IS:4,FS:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:2,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:3</availability>
-		<model name='SHD-2D2'>
-			<availability>FVC:6,LA:6,FS:6</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,CLAN:4,FWL:4,MERC:4,BAN:2</availability>
-		</model>
-		<model name='SHD-7CS'>
-			<availability>CS:5,WOB:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:1,Periphery:4-</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FVC:2-,FS:2-</availability>
-		</model>
 		<model name='SHD-2K'>
 			<availability>FRR:2-,MERC:2-,DC:4-</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:8,CCC:8,LA:3,CSV:8,FS:3,CGS:8,DC:3</availability>
-		</model>
-		<model name='SHD-9D'>
-			<availability>WOB:4,FS:4</availability>
-		</model>
-		<model name='SHD-5M'>
-			<availability>CC:6,FRR:6,Periphery.MW:4,Periphery.ME:3,FWL:6,IS:2,MERC:6,DC:6</availability>
-		</model>
-		<model name='SHD-3K'>
-			<availability>FRR:3,DC:4</availability>
-		</model>
-		<model name='SHD-5D'>
-			<availability>LA:4,WOB:4,FS:5,MERC:4</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,DTA:5,FVC:2,FWL:5,MERC:3,RCM:5,CDP:2,TC:3</availability>
-		</model>
-		<model name='SHD-11CS'>
-			<availability>CS:6,WOB:5</availability>
+		<model name='SHD-2D2'>
+			<availability>FVC:6,LA:6,FS:6</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:3-,MOC:3-,FWL:3-,MERC:3-</availability>
 		</model>
+		<model name='SHD-2D'>
+			<availability>FVC:2-,FS:2-</availability>
+		</model>
+		<model name='SHD-11CS'>
+			<availability>CS:6,WOB:5</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,BAN:1,Periphery:4-</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,CLAN:4,FWL:4,MERC:4,BAN:2</availability>
+		</model>
+		<model name='SHD-5M'>
+			<availability>CC:6,FRR:6,Periphery.MW:4,Periphery.ME:3,FWL:6,IS:2,MERC:6,DC:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:8,CCC:8,LA:3,CSV:8,FS:3,CGS:8,DC:3</availability>
+		</model>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,DTA:5,FVC:2,FWL:5,MERC:3,RCM:5,CDP:2,TC:3</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>WOB:4,FS:4</availability>
+		</model>
+		<model name='SHD-7CS'>
+			<availability>CS:5,WOB:4</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:4,WOB:4,FS:5,MERC:4</availability>
+		</model>
+		<model name='SHD-3K'>
+			<availability>FRR:3,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CSA:5,CDS:5,CW:5,CBS:7,CLAN:3,CGS:5,CGB:5</availability>
+		<model name='(Flamer)'>
+			<availability>CDS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Interdictor)'>
 			<availability>CHH:3,CSR:3,CDS:3,CW:3,CNC:3,CJF:3,CGB:4,CWIE:3</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>CDS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Shedu Assault Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:2</availability>
-		<model name='(Capture Team)' mechanized='false'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Recon)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Capture Team)' mechanized='false'>
+			<availability>General:3</availability>
 		</model>
 		<model name='(PPC)' mechanized='false'>
 			<availability>General:4</availability>
@@ -13669,11 +13666,11 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
-		<model name='SL-17'>
-			<availability>HL:2-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
 		<model name='SL-18'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='SL-17'>
+			<availability>HL:2-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>OA:3,FRR:4,MERC:3,DC:4</availability>
@@ -13684,11 +13681,14 @@
 	</chassis>
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>FWL:4,WOB:4,FWL.KIS:6,FWL.FWG:5</availability>
-		<model name='SHV-OB'>
+		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
+		</model>
+		<model name='SHV-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -13696,21 +13696,18 @@
 		<model name='SHV-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SHV-OA'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,CDS:4,CW:3,CNC:5,CJF:3,DC:3</availability>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:5,DC:5</availability>
+		</model>
 		<model name='(Streak)'>
 			<availability>CW:6,CNC:6,CJF:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
@@ -13755,35 +13752,47 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverback Coastal Cutter' unitType='Naval'>
+		<availability>LA:7</availability>
+		<model name='(Standard)'>
+			<availability>LA:7</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:5,CCC:7,CCO:4</availability>
+		<model name='2'>
+			<availability>CSA:8,CCC:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSA:4,CCC:4,CCO:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CCC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,FWL:3,WOB:4,MERC:3</availability>
-		<model name='SRC-6C'>
-			<availability>DTA:4,FWL:4,WOB:4</availability>
-		</model>
 		<model name='SRC-5C'>
 			<availability>DTA:5,FWL:5,WOB:5</availability>
 		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
 		</model>
+		<model name='SRC-6C'>
+			<availability>DTA:4,FWL:4,WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,FWL:3,NIOPS:3-,DC:6</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:5-</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -13793,18 +13802,18 @@
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:5-</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,DC:7</availability>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,DC:1</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>OA:6,CSR:6,FRR:8,FS:6,MERC:6,CDP:4,DC:8,TC:4</availability>
-		</model>
-		<model name='SL-15'>
-			<availability>HL:2-,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>FRR:1,MERC:1,DC:1</availability>
@@ -13812,11 +13821,11 @@
 		<model name='SL-15K'>
 			<availability>FRR:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:2-,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,DC:1</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -13849,11 +13858,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CNC:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
@@ -13872,10 +13881,6 @@
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Space Marine' unitType='Infantry'>
 		<availability>CS:5,WOB:5</availability>
@@ -13886,11 +13891,11 @@
 	</chassis>
 	<chassis name='Spad' unitType='Aero'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
-		<model name='SPD-504'>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>WOB:5</availability>
 		</model>
 		<model name='SPD-503'>
 			<availability>CS:6,WOB:6,BAN:2</availability>
@@ -13898,19 +13903,19 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3</availability>
+		<model name='SPR-6D'>
+			<availability>FVC:7,LA:2,FRR:5,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
+		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:4-,General:2-,Periphery.Deep:8,FS:4-,MERC:4-,CDP:4-,TC:4-</availability>
 		</model>
-		<model name='SPR-H5K'>
-			<roles>interceptor</roles>
-			<availability>OA:1,FRR:2-,DC:2-</availability>
-		</model>
 		<model name='SPR-7D'>
 			<availability>FS:5,MERC:5</availability>
 		</model>
-		<model name='SPR-6D'>
-			<availability>FVC:7,LA:2,FRR:5,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
+		<model name='SPR-H5K'>
+			<roles>interceptor</roles>
+			<availability>OA:1,FRR:2-,DC:2-</availability>
 		</model>
 		<model name='SPR-DH'>
 			<availability>OA:3-,FVC:3-,MERC:3-</availability>
@@ -13949,73 +13954,73 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,FVC:4,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:2-</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='SDR-7M'>
-			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,DC:6</availability>
-		</model>
-		<model name='SDR-7K2'>
-			<availability>MERC:3,DC:4</availability>
-		</model>
-		<model name='SDR-7Kr'>
-			<availability>MERC:2,DC:2</availability>
-		</model>
-		<model name='SDR-8M'>
-			<availability>MOC:2,CC:2,FWL:8,MH:2,MERC:2</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:6</availability>
-		</model>
-		<model name='SDR-7K'>
-			<availability>MERC:4,DC:5</availability>
 		</model>
 		<model name='SDR-5K'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:3-,DC:3-</availability>
 		</model>
+		<model name='SDR-7Kr'>
+			<availability>MERC:2,DC:2</availability>
+		</model>
+		<model name='SDR-7K'>
+			<availability>MERC:4,DC:5</availability>
+		</model>
+		<model name='SDR-7M'>
+			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,DC:6</availability>
+		</model>
 		<model name='SDR-7KC'>
 			<availability>MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:2-</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:6</availability>
+		</model>
+		<model name='SDR-7K2'>
+			<availability>MERC:3,DC:4</availability>
+		</model>
+		<model name='SDR-8M'>
+			<availability>MOC:2,CC:2,FWL:8,MH:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
 		<availability>CGS:3-,CJF:5-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>LA:7,FRR:7,IS:6,FS:7,DC:7</availability>
-		<model name='(Interdictor)'>
-			<roles>spotter</roles>
-			<availability>LA:3,FWL:3,MERC:3,FS:3,DC:3</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>FRR:5,IS:4,DC:6</availability>
 		</model>
-		<model name='(Laser)'>
-			<roles>recon</roles>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(C3i)'>
 			<roles>recon</roles>
 			<availability>CS:5,WOB:6</availability>
 		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
+		<model name='(Laser)'>
+			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Interdictor)'>
+			<roles>spotter</roles>
+			<availability>LA:3,FWL:3,MERC:3,FS:3,DC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -14026,17 +14031,20 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:6,CC:5,HL:9,FRR:6,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,FWL:8,NIOPS:5,DC:5</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		<model name='STK-8S'>
+			<availability>LA:4</availability>
 		</model>
-		<model name='STK-7D'>
-			<availability>FS:4,MERC:2</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='STK-7D'>
+			<availability>FS:4,MERC:2</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:2-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
@@ -14044,30 +14052,27 @@
 		<model name='STK-3Fb'>
 			<availability>CC:2,MOC:2,CLAN:8,FWL:3,MERC:3,RCM:3,BAN:2</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-6M'>
 			<availability>CC:3,MOC:3,FWL:6,WOB:6,MERC:6,RCM:6</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
-		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,CSV:3,MERC:4,FS:5,CJF:3,TC:4</availability>
-		</model>
-		<model name='STK-8S'>
-			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:6+,CBS:3+</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
@@ -14097,12 +14102,12 @@
 			<roles>raider</roles>
 			<availability>MOC:6,LA:6,MERC:6</availability>
 		</model>
+		<model name='STY-3Dr'>
+			<availability>LA:4,MERC:2</availability>
+		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>LA:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
@@ -14111,21 +14116,21 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:2,FS:4,MERC:2</availability>
 		</model>
-		<model name='STH-3S'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='STH-1D'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>LA:2,FS:4,MERC:4</availability>
-		</model>
 		<model name='STH-2D'>
 			<roles>recon</roles>
 			<availability>LA:2,FS:6,MERC:4</availability>
+		</model>
+		<model name='STH-3S'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='STH-2D1'>
+			<roles>recon</roles>
+			<availability>LA:2,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stiletto' unitType='Mek'>
@@ -14133,113 +14138,113 @@
 		<model name='STO-4C'>
 			<availability>LA:3,MERC:3</availability>
 		</model>
-		<model name='STO-4A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='STO-4B'>
 			<availability>General:4</availability>
+		</model>
+		<model name='STO-4A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
-		<model name='STG-5R'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,PIR:4,WOB:4,CIR:4,CDP:4,TC:4</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:5,FVC:3,FWL:8,IS:3,WOB:8,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
-		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,CC:3,TC:3</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>HL:2-,IS:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
-		</model>
-		<model name='STG-6L'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:4</availability>
-		</model>
-		<model name='STG-7S'>
-			<roles>recon</roles>
-			<availability>LA:4,MERC:2</availability>
 		</model>
 		<model name='STG-5G'>
 			<roles>recon</roles>
 			<availability>CC:3,FWL:2,MERC:2,TC:3</availability>
 		</model>
+		<model name='STG-6S'>
+			<roles>recon</roles>
+			<availability>LA:5,MERC:5,FS:3</availability>
+		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CLAN:8,FWL:4,WOB:4,RCM:6,BAN:2</availability>
 		</model>
-		<model name='STG-3P'>
+		<model name='STG-5M'>
 			<roles>recon</roles>
-			<availability>LA:3,IS:3,WOB.PM:4,MERC:4,DC:3,Periphery:3,CGB:3</availability>
-		</model>
-		<model name='STG-6S'>
-			<roles>recon</roles>
-			<availability>LA:5,MERC:5,FS:3</availability>
+			<availability>CC:5,MOC:5,FVC:3,FWL:8,IS:3,WOB:8,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
 		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 		</model>
+		<model name='STG-6L'>
+			<roles>recon</roles>
+			<availability>CC:5,MOC:4</availability>
+		</model>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,CC:3,TC:3</availability>
+		</model>
+		<model name='STG-3P'>
+			<roles>recon</roles>
+			<availability>LA:3,IS:3,WOB.PM:4,MERC:4,DC:3,Periphery:3,CGB:3</availability>
+		</model>
+		<model name='STG-5R'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,PIR:4,WOB:4,CIR:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='STG-7S'>
+			<roles>recon</roles>
+			<availability>LA:4,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,DTA:6,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,RCM:6,DC:4</availability>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:4</availability>
+		</model>
+		<model name='F-95'>
+			<availability>CC:2,DTA:6,LA:2,FWL:5,MERC:2,RCM:6</availability>
+		</model>
 		<model name='F-94'>
 			<availability>IS:5</availability>
 		</model>
 		<model name='F-92'>
 			<availability>FWL:6,IS:4</availability>
 		</model>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='F-90'>
 			<availability>CS:3-,LA:2-,IS:4-,FS:3-,Periphery:4-</availability>
-		</model>
-		<model name='F-95'>
-			<availability>CC:2,DTA:6,LA:2,FWL:5,MERC:2,RCM:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>:0,CLAN:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='F'>
+		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>:0,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -14251,45 +14256,45 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:4,FWL:4,FS:4,MERC:4,DC:7</availability>
-		<model name='SR1-OA'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SR1-OD'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
+		<model name='SR1-OG'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SR1-OR'>
 			<availability>CLAN:6,General:2+</availability>
 		</model>
-		<model name='SR1-OG'>
-			<availability>General:4</availability>
-		</model>
 		<model name='SR1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OF'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Striga' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='S-STR-O Invictus'>
-			<availability>General:8</availability>
+		<model name='S-STR-OB Infernus'>
+			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OA Dominus'>
+		<model name='S-STR-OE Eminus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-STR-OC Comminus'>
@@ -14298,21 +14303,25 @@
 		<model name='S-STR-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OE Eminus'>
-			<availability>General:7</availability>
+		<model name='S-STR-O Invictus'>
+			<availability>General:8</availability>
 		</model>
-		<model name='S-STR-OB Infernus'>
+		<model name='S-STR-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,LA:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
+		<model name='(Narc)'>
+			<availability>LA:2,FS:2,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:5-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>FVC:4-,IS:3-</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,LA:6,FS:7,DC:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2</availability>
@@ -14323,30 +14332,26 @@
 		<model name='(SRM)'>
 			<availability>FVC:4-,IS:3-</availability>
 		</model>
-		<model name='(Narc)'>
-			<availability>LA:2,FS:2,DC:1</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>General:3</availability>
 		</model>
 		<model name='(3061 Upgrade)'>
 			<availability>LA:4,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:5-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,LA:6,FS:7,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:5,CS:4,MOC:5,MERC.WD:1-,LA:2-,NIOPS:4,WOB:4</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>CC:4-,General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -14354,17 +14359,17 @@
 		<model name='STU-K5'>
 			<availability>FVC:4-,HL:2-,IS:4-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:2,LA:2,FS.DMM:2-</availability>
-		</model>
-		<model name='STU-K15'>
-			<availability>OA:1,TC:1,Periphery:1</availability>
-		</model>
 		<model name='STU-D7'>
 			<availability>FS:6</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>CLAN:8,FS:3,BAN:2</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:2,LA:2,FS.DMM:2-</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:1,TC:1,Periphery:1</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,FS:6,MERC:6</availability>
@@ -14372,6 +14377,9 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:3,CDS:3,HL:2,LA:6,CNC:4,WOB:3,MERC:2,FS:4,CWIE:4</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:5,WOB:0</availability>
@@ -14380,22 +14388,19 @@
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
-		</model>
 		<model name='(Heavy Gauss)'>
 			<availability>LA:6,CNC:6,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,WOB:4</availability>
-		<model name='(Standard)'>
-			<roles>recon,fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(WOB)'>
 			<roles>recon,fire_support</roles>
@@ -14414,14 +14419,14 @@
 		<model name='E'>
 			<availability>CW:5,CLAN:2,CGB:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:6,CBS:6,General:2,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:6,General:2,CJF:6,CGB:6</availability>
@@ -14438,12 +14443,15 @@
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,FS:5,MERC:3,DC:7</availability>
-		<model name='SD1-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='SD1-OX'>
+			<availability>General:2</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='SD1-OR'>
 			<availability>General:2+,CLAN:6,DC:2+</availability>
@@ -14454,9 +14462,6 @@
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
-		</model>
-		<model name='SD1-OX'>
-			<availability>General:2</availability>
 		</model>
 		<model name='SD1-OC'>
 			<availability>General:6,DC:7</availability>
@@ -14473,11 +14478,11 @@
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='4'>
 			<availability>CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -14497,10 +14502,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:2,MOC:2,CDP:2,TC:2</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -14512,33 +14517,33 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:2</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,CLAN:5,NIOPS:8,WOB:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:9,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:9,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:2,CCC:6,CSR:4,CDS:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='XR' mechanized='true'>
 			<roles>recon</roles>
@@ -14569,11 +14574,11 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:4,MERC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(RL)'>
 			<availability>MOC:4</availability>
@@ -14584,42 +14589,42 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,CS:3,DTA:6,FVC:2,IS:2,FWL:6,WOB:4,MERC:4,DC:6</availability>
-		<model name='ZPH-3A'>
-			<roles>recon</roles>
-			<availability>DTA:6,FVC:4,FWL:6,IS:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='ZPH-2A'>
 			<roles>recon</roles>
 			<availability>CC:5,FVC:5,FWL:5,IS:6,MERC:5,DC:5</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:5,General:2,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:6,FVC:4,IS:4,MERC:5,DC:6</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:5,MOC:5,General:2,FWL:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='ZPH-3A'>
+			<roles>recon</roles>
+			<availability>DTA:6,FVC:4,FWL:6,IS:4,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>FRR:4,CNC:4,DC:5</availability>
+		<model name='MIK-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-OE'>
 			<availability>General:4</availability>
 		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-O'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsumaki Destroyer' unitType='Warship'>
@@ -14631,8 +14636,8 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>DTA:8,FWL.MM:8,FWL:8,WOB:6,MERC:4</availability>
-		<model name='TMP-3G'>
-			<availability>FWL:2,WOB:2,MERC:2</availability>
+		<model name='TMP-3M'>
+			<availability>HL:6,FWL:5,Periphery.Deep:6,WOB:5,MERC:5,Periphery:8</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>FWL:4,WOB:4,MERC:4</availability>
@@ -14640,8 +14645,8 @@
 		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
 			<availability>DTA:6,FWL:5,WOB:5</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>HL:6,FWL:5,Periphery.Deep:6,WOB:5,MERC:5,Periphery:8</availability>
+		<model name='TMP-3G'>
+			<availability>FWL:2,WOB:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
@@ -14652,9 +14657,8 @@
 		<model name='TLR1-OB'>
 			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OG'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OC'>
 			<availability>General:5</availability>
@@ -14663,25 +14667,25 @@
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='TLR1-OF'>
 			<roles>spotter</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='TLR1-OG'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-OA'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Tengu Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:5</availability>
-		<model name='(C3i)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Support)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(RL)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Plasma)' mechanized='true'>
 			<availability>General:8</availability>
@@ -14692,51 +14696,52 @@
 		<model name='(ML)' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(RL)' mechanized='true'>
-			<availability>General:4</availability>
+		<model name='(C3i)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
 		<availability>CS:6,WOB:5,DC:4</availability>
+		<model name='TSN-X-4'>
+			<roles>recon,spotter</roles>
+			<availability>CS:1</availability>
+		</model>
 		<model name='TSN-C3'>
 			<roles>recon,spotter</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='TSN-C3M'>
-			<roles>recon,spotter</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='TSN-1C'>
-			<roles>recon,spotter</roles>
-			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='TSN-1Cr'>
 			<roles>recon,spotter</roles>
 			<availability>CS:4,DC:4</availability>
 		</model>
-		<model name='TSN-X-4'>
+		<model name='TSN-1C'>
 			<roles>recon,spotter</roles>
-			<availability>CS:1</availability>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='TSN-C3M'>
+			<roles>recon,spotter</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
 		<availability>LA:5,FS:5,MERC:4</availability>
-		<model name='TNS-4T'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TNS-4T'>
+			<availability>IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tharkad Battlecruiser' unitType='Warship'>
@@ -14755,47 +14760,51 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CSR:4,CLAN:4,IS:2+,CCO:4,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CDS:4,CW:4,CNC:4,CJF:6,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
+		</model>
 		<model name='Z'>
 			<availability>SOC:10,CCO:4</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CGS:4,CWIE:6,CGB:8</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
-		<model name='G'>
-			<availability>CHH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
-		</model>
-		<model name='HH'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CSV:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CGS:4,CWIE:6,CGB:8</availability>
+		<model name='HH'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
 		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,CLAN:5,NIOPS:3,WOB:3,BAN:5</availability>
+		<model name='(C3i)'>
+			<roles>artillery</roles>
+			<availability>CS:6,WOB:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CS:4,NIOPS:8,WOB:4</availability>
@@ -14804,18 +14813,11 @@
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='(C3i)'>
-			<roles>artillery</roles>
-			<availability>CS:6,WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>MOC:1,CLAN:1,WOB:7,CCO:1,Periphery:1,TC:1,CS:5,DC.GHO:1,CSA:1,OA:1,CDS:1,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
 		<model name='THE-S'>
 			<availability>HL:6,Periphery.Deep:6,DC:2-,Periphery:8</availability>
-		</model>
-		<model name='THE-N1'>
-			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:1-</availability>
@@ -14826,49 +14828,52 @@
 		<model name='THE-N2'>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='THE-N1'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CSR:2,CLAN:1</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:4-,FVC:4-,HL:3-,General:2-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:5-</availability>
+		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:4-,FVC:4-,HL:3-,General:2-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:5-</availability>
-		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:3,CSV:6,CLAN:4,IS:3,WOB:7,FS:3,CWIE:5,DC.GHO:5,CS:8,DTA:2,OA:4,FVC:2,CDS:3,CW:5,CBS:3,LA:2,CNC:3,FWL:5,NIOPS:8,RCM:2,CJF:5,CGB:5</availability>
-		<model name='THG-11Eb'>
-			<availability>CLAN:4,FWL:5,WOB:5,MERC:5,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>DC.GHO:8,CS:4,OA:5,FRR:6,CLAN:6,IS:8,FWL:8,NIOPS:4,WOB:4,FS:8,BAN:8,DC:8</availability>
 		</model>
-		<model name='THG-13K'>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='THG-12K'>
-			<availability>WOB:4,DC:6</availability>
+		<model name='THG-11Eb'>
+			<availability>CLAN:4,FWL:5,WOB:5,MERC:5,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>FWL:4-,MERC:4-</availability>
 		</model>
 		<model name='THG-12E'>
 			<availability>CS:6,WOB:3</availability>
+		</model>
+		<model name='THG-13K'>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='THG-12K'>
+			<availability>WOB:4,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -14894,9 +14899,6 @@
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,CLAN:1,MERC:4</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:6</availability>
@@ -14906,6 +14908,9 @@
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -14922,9 +14927,6 @@
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,MERC:4,TC:4</availability>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
@@ -14932,71 +14934,68 @@
 		<model name='THR-1L'>
 			<availability>General:8</availability>
 		</model>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>MOC:4,LA:8,FRR:6,MH:4,MERC:6</availability>
-		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:4-</availability>
-		</model>
-		<model name='TRB-D36b'>
-			<roles>ground_support</roles>
-			<availability>CLAN:4,FS:4</availability>
-		</model>
 		<model name='TRB-D56'>
 			<availability>LA:5</availability>
 		</model>
 		<model name='TRB-D50'>
 			<availability>TC:5</availability>
 		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>MOC:4,LA:8,FRR:6,MH:4,MERC:6</availability>
+		</model>
+		<model name='TRB-D36b'>
+			<roles>ground_support</roles>
+			<availability>CLAN:4,FS:4</availability>
+		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:4-</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:6,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,TC:4,CS:3-,LA:6,NIOPS:3-,MH:4,DC:6</availability>
-		<model name='TDR-9NAIS'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>CLAN:1,TC:4</availability>
-		</model>
-		<model name='TDR-9M'>
-			<availability>MOC:3,DTA:4,CC:3,PIR:2,FWL:4,MH:3,WOB:3</availability>
-		</model>
-		<model name='TDR-9S'>
-			<availability>FVC:5,LA:6,FS:4,MERC:3</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>CC:3-,MOC:3-,LA:3-,MERC:3-,TC:3-</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
 		</model>
 		<model name='TDR-60-RLA'>
 			<availability>MERC:2,DC:2</availability>
 		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:4-,MERC:1-</availability>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,MERC.ELH:8,MERC:4,FS:4</availability>
 		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,MERC:6,FS:2</availability>
+		<model name='TDR-9S'>
+			<availability>FVC:5,LA:6,FS:4,MERC:3</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,FWL:2,WOB:4,MERC:4,FS:2</availability>
 		</model>
 		<model name='TDR-5S'>
 			<availability>CC:4-,HL:2-,LA:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,MERC.ELH:8,MERC:4,FS:4</availability>
+		<model name='TDR-7M'>
+			<availability>CS:6,CC:5,FWL:8,IS:2,WOB:6,MERC:5</availability>
+		</model>
+		<model name='TDR-9M'>
+			<availability>MOC:3,DTA:4,CC:3,PIR:2,FWL:4,MH:3,WOB:3</availability>
+		</model>
+		<model name='TDR-5SS'>
+			<availability>LA:4-,MERC:1-</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CCC:6,LA:1,CSV:6,FS:1,CGS:6,DC:1</availability>
 		</model>
-		<model name='TDR-7M'>
-			<availability>CS:6,CC:5,FWL:8,IS:2,WOB:6,MERC:5</availability>
+		<model name='TDR-5Sb'>
+			<availability>CLAN:1,TC:4</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,FWL:2,WOB:4,MERC:4,FS:2</availability>
+		<model name='TDR-7SE'>
+			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>WOB:2,FS:2,MERC:2</availability>
@@ -15004,18 +15003,24 @@
 		<model name='TDR-17S'>
 			<availability>LA:4</availability>
 		</model>
+		<model name='TDR-10SE'>
+			<availability>CC:2,MERC:6,FS:2</availability>
+		</model>
+		<model name='TDR-9NAIS'>
+			<availability>FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
 		<availability>CC:7,MOC:3,TC:3</availability>
 		<model name='TSG-9J'>
 			<availability>General:5</availability>
 		</model>
+		<model name='TSG-9C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
 		<model name='TSG-9H'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='TSG-9C'>
-			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat Pocket Warship' unitType='Dropship'>
@@ -15041,61 +15046,61 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:5,CLAN:4,NIOPS:3,WOB:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,FRR:6,CNC:6,DC:8</availability>
-		<model name='(C3)'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='TKG-150'>
-			<availability>FRR:3-,DC:3-</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>FRR:5-,DC:5-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>CDS:8,CNC:8,DC:5</availability>
+		<model name='(C3)'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>CDS:8,CNC:8,DC:5</availability>
 		</model>
 		<model name='(MRM)'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='TKG-150'>
+			<availability>FRR:3-,DC:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:5</availability>
-		<model name='CH'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='THK-63CS'>
-			<availability>CS:8,WOB:6</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:2,NIOPS:2,WOB:2</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:2,BAN:2</availability>
-		</model>
-		<model name='CX-11'>
-			<availability>CS:2</availability>
-		</model>
-		<model name='&apos;C&apos;'>
-			<availability>CW:6,CLAN:3</availability>
+		<model name='CH'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='&apos;C&apos;'>
+			<availability>CW:6,CLAN:3</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:2,BAN:2</availability>
+		</model>
+		<model name='THK-63CS'>
+			<availability>CS:8,WOB:6</availability>
+		</model>
+		<model name='CX-11'>
+			<availability>CS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
@@ -15106,10 +15111,10 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -15122,33 +15127,33 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>CS:2,FWL:2,WOB:2,MH:1</availability>
-		<model name='G13 [Grenade Launcher]' mechanized='true'>
+		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
+			<roles>specops</roles>
+			<availability>CS:8</availability>
+		</model>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
-		<model name='G13 [Machine Gun]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
+		<model name='G14' mechanized='true'>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='G12' mechanized='true'>
 			<roles>specops</roles>
 			<availability>FWL:8,WOB:8</availability>
 		</model>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
+		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
-		</model>
-		<model name='G13 [Flamer]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
-		</model>
-		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
-			<roles>specops</roles>
-			<availability>CS:8</availability>
-		</model>
-		<model name='G14' mechanized='true'>
-			<availability>WOB:3</availability>
 		</model>
 		<model name='G17' mechanized='true'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Machine Gun]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
 	</chassis>
@@ -15164,11 +15169,11 @@
 		<model name='TYM-1C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='TYM-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='TYM-1A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TYM-1B'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trajan Assault Infantry Fighting Vehicle' unitType='Tank'>
@@ -15186,39 +15191,36 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,PIR:2,FWL:3,MERC:3,RCM:3,TC:5</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:3-,FWL:2</availability>
-		</model>
-		<model name='TR-16'>
-			<availability>CC:7,MOC:5,MERC:5,RCM:8,TC:5</availability>
-		</model>
-		<model name='TR-13'>
-			<availability>CC:3-,HL:2-,IS:2-,MERC:3-,Periphery:4-</availability>
-		</model>
 		<model name='TR-13A'>
 			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:3-,FWL:2</availability>
 		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13'>
+			<availability>CC:3-,HL:2-,IS:2-,MERC:3-,Periphery:4-</availability>
+		</model>
+		<model name='TR-16'>
+			<availability>CC:7,MOC:5,MERC:5,RCM:8,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:5,MOC:5,General:6,TC:5</availability>
+		<model name='TR-11'>
+			<roles>recon</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='TR-12'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
-		<model name='TR-11'>
-			<roles>recon</roles>
-			<availability>General:2</availability>
+		<model name='TR-10'>
+			<availability>CC:5,MOC:5,General:6,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Transportable Field Repair Unit' unitType='Tank'>
@@ -15230,40 +15232,40 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:3,CC:3,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:3,LA:3,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:3-,DC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:2-,CS:2-,MOC:6-,LA:2-,FWL:2-,IS:4-,NIOPS:2-,WOB:2-,FS:2-,MERC:4-,DC:2-,Periphery:6-</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:4</availability>
+		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='TBT-9K'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:2-</availability>
 		</model>
 		<model name='TBT-5S'>
 			<availability>MOC:2-,IS:2-,Periphery.Deep:4,FWL:2-,MERC:2-,CDP:2,Periphery:2-,TC:2-</availability>
 		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>CC:4,FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
-		</model>
-		<model name='TBT-9K'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:4</availability>
-		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,CS:2-,MOC:6-,LA:2-,FWL:2-,IS:4-,NIOPS:2-,WOB:2-,FS:2-,MERC:4-,DC:2-,Periphery:6-</availability>
-		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
-		<model name='TRN-3T'>
-			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='TRN-3V'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='TRN-3T'>
+			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
@@ -15271,17 +15273,8 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6,MOC:6,MH:4,TC:6</availability>
-		<model name='(Theseus RL)[LRR]' mechanized='true'>
-			<availability>MOC:5</availability>
-		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='(Asterion)[PPC]' mechanized='true'>
-			<availability>MH:5,TC:5</availability>
-		</model>
-		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
-			<availability>MOC:5</availability>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Asterion)[MRR]' mechanized='true'>
 			<availability>MH:5,TC:5</availability>
@@ -15289,24 +15282,33 @@
 		<model name='(Ying Long)(Plasma)' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
+		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
+			<availability>MOC:5</availability>
+		</model>
 		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:4</availability>
 		</model>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
+		<model name='(Theseus RL)[LRR]' mechanized='true'>
+			<availability>MOC:5</availability>
+		</model>
+		<model name='(Asterion)[PPC]' mechanized='true'>
+			<availability>MH:5,TC:5</availability>
+		</model>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+			<availability>TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Triton' unitType='ProtoMek'>
 		<availability>CGS:5</availability>
+		<model name='3'>
+			<availability>General:4</availability>
+		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='3'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -15325,11 +15327,11 @@
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
 		<availability>CC:4,MOC:5,FVC:2,Periphery.CM:3,Periphery.ME:3,MERC:2,TC:6,Periphery:2</availability>
-		<model name='CMT-4U'>
-			<availability>General:5</availability>
-		</model>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
+		</model>
+		<model name='CMT-4U'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Trojan' unitType='Dropship'>
@@ -15341,23 +15343,23 @@
 	</chassis>
 	<chassis name='Tsunami' unitType='Mek'>
 		<availability>MERC:3</availability>
-		<model name='TS-P1D'>
+		<model name='TS-P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TS-P1'>
+		<model name='TS-P1D'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CW:4+</availability>
-		<model name='4'>
-			<availability>General:8</availability>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
 		</model>
 		<model name='3'>
 			<availability>CW:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
+		<model name='4'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
@@ -15369,58 +15371,39 @@
 			<roles>apc,urban</roles>
 			<availability>DC:4-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>:0,General:6</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>apc,urban,spotter</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>:0,General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:2,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>CLAN:2,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CGB:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>SOC:4,CNC:4,CJF:7,CLAN.HW:4</availability>
-		<model name='A'>
-			<availability>CHH:7,CW:7,CNC:7,CGS:7,CJF:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:7,CW:7,CNC:7,CJF:7,CGS:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CW:9,General:7,CGB:9</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
-		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='Z'>
 			<roles>spotter</roles>
 			<availability>SOC:10,CCO:4</availability>
@@ -15429,15 +15412,38 @@
 			<roles>fire_support</roles>
 			<availability>CJF:3</availability>
 		</model>
+		<model name='A'>
+			<availability>CHH:7,CW:7,CNC:7,CGS:7,CJF:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CW:8,CNC:8,CJF:8,CCO:8</availability>
+		</model>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:7,CW:7,CNC:7,CJF:7,CGS:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:9,General:7,CGB:9</availability>
+		</model>
+		<model name='H'>
+			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,FS:6,MERC:3</availability>
+		<model name='(RAC)'>
+			<roles>urban</roles>
+			<availability>General:4,FS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
@@ -15445,10 +15451,6 @@
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>urban</roles>
-			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -15460,53 +15462,26 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,FRR:2,CGB:5,DC:2</availability>
-		<model name='(Kurita)'>
-			<roles>apc</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>FRR:8,CLAN:8</availability>
 		</model>
+		<model name='(Kurita)'>
+			<roles>apc</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CSV:9,CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:8,CHH:3,CSR:6,CSV:4,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:2,CW:3,CBS:5,CNC:1,CJF:6,CGB:1</availability>
-		<model name='B'>
-			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:6,CSV:3,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:6,CSR:6,CBS:6,General:5,CCO:4</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
-		</model>
 		<model name='F'>
 			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
 		</model>
@@ -15514,8 +15489,35 @@
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:4,CW:2,CSV:3,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:6,CSV:3,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
+		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:6,CSR:6,CBS:6,General:5,CCO:4</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CDS:2,CW:4,CSV:2,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CSV:5,CLAN:4,IS:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
@@ -15540,24 +15542,24 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:2,LA.SR:4</availability>
-		<model name='(3065)'>
-			<roles>troop_carrier</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3071)'>
 			<roles>troop_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(3065)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:4,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>CS:8,LA:8,IS:6,WOB:8,FS:8</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:4,BAN:4</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:5</availability>
@@ -15576,6 +15578,10 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+		<model name='UM-R80'>
+			<roles>urban,spotter</roles>
+			<availability>CC:3,MOC:3,FWL:2,WOB:3,MERC:2</availability>
+		</model>
 		<model name='UM-R69'>
 			<roles>urban</roles>
 			<availability>FWL:6,IS:5,Periphery:5</availability>
@@ -15588,42 +15594,38 @@
 			<roles>urban</roles>
 			<availability>CC:3-,FVC:2,Periphery:3</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:5,IS:2,Periphery:2</availability>
-		</model>
-		<model name='UM-R80'>
-			<roles>urban,spotter</roles>
-			<availability>CC:3,MOC:3,FWL:2,WOB:3,MERC:2</availability>
-		</model>
-		<model name='UM-R63'>
+		<model name='UM-R60'>
 			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+			<availability>CC:4-,HL:2-,General:2-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>CC:2,MOC:2,FS.CMM:6,FS:4</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R63'>
 			<roles>urban</roles>
-			<availability>CC:4-,HL:2-,General:2-,Periphery.Deep:8,Periphery:4-</availability>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:5,IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
 		<availability>CGB:6</availability>
-		<model name='(Standard)'>
-			<deployedWith>IS</deployedWith>
-			<availability>General:8</availability>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:2</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:2</availability>
+		<model name='(Standard)'>
+			<deployedWith>IS</deployedWith>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -15641,41 +15643,41 @@
 	</chassis>
 	<chassis name='Valiant' unitType='Mek'>
 		<availability>LA:4,FS:4,MERC:3,DC:5</availability>
-		<model name='V4-LNT-J3'>
-			<availability>FS:8,MERC:6</availability>
+		<model name='V4-LNT-K7'>
+			<availability>General:8</availability>
 		</model>
 		<model name='VLN-3T'>
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='V4-LNT-K7'>
-			<availability>General:8</availability>
+		<model name='V4-LNT-J3'>
+			<availability>FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:3,WOB:4,FS:9,MERC:4,CDP:3,TC:3</availability>
-		<model name='VLK-QD2'>
+		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:3,FS:3</availability>
+			<availability>LA:2-,FS:2-,MERC:2-</availability>
 		</model>
 		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4-,FS:4-,MERC:4-,CDP:4-,TC:4-</availability>
-		</model>
 		<model name='VLK-QW5'>
 			<roles>recon,fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='VLK-QF'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:2-,FS:2-,MERC:2-</availability>
-		</model>
 		<model name='VLK-QD'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:5,LA:6,FS:8,MERC:6</availability>
+		</model>
+		<model name='VLK-QD2'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:3,FS:3</availability>
+		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4-,FS:4-,MERC:4-,CDP:4-,TC:4-</availability>
 		</model>
 		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
@@ -15695,27 +15697,27 @@
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:6,General:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:6,General:5</availability>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -15727,14 +15729,14 @@
 	</chassis>
 	<chassis name='Vanquisher' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='VQR-7U'>
-			<availability>WOB:3</availability>
+		<model name='VQR-5V'>
+			<availability>WOB:5</availability>
 		</model>
 		<model name='VQR-2A'>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='VQR-5V'>
-			<availability>WOB:5</availability>
+		<model name='VQR-7U'>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='VQR-2B'>
 			<availability>WOB:3</availability>
@@ -15745,32 +15747,32 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:5-,HL:9,IS:10,Periphery.Deep:8,WOB:4-,Periphery:10,CGB:2</availability>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(Liao)'>
 			<availability>CC:4-</availability>
-		</model>
-		<model name='V-G7X'>
-			<availability>LA:1</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>CC:7,MOC:8,FVC:4+,Periphery.CM:4+,Periphery.HR:4+,PIR:4+,MH:4+,CDP:4+,TC:8</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>IS:3,FS:6</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>CC:5,MOC:5,DTA:5,RCM:5,CDP:5,TC:5</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
+		<model name='(RAC)'>
+			<availability>IS:3,FS:6</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>CC:2-,General:2-</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='V-G7X'>
+			<availability>LA:1</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CC:2-,General:4-</availability>
-		</model>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>CC:3,LA:3,FWL:3,WOB:4,FS:3,MERC:4,DC:3</availability>
@@ -15778,73 +15780,45 @@
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,FWL:4,NIOPS:5,DC:4</availability>
-		<model name='(3056)'>
-			<roles>asf_carrier</roles>
-			<availability>IS:2,FS:8</availability>
-		</model>
 		<model name='(2682)'>
 			<roles>asf_carrier</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(3056)'>
+			<roles>asf_carrier</roles>
+			<availability>IS:2,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
 		<availability>CS:3,FRR:5,CNC:4,FWL:2,MERC:3,RCM:4,FS:2,DC:8</availability>
+		<model name='SDR-9KC'>
+			<availability>FWL:5,MERC:5,RCM:5,DC:5</availability>
+		</model>
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
-		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,RCM:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,RCM:5,DC:5</availability>
 		</model>
-		<model name='SDR-9KC'>
-			<availability>FWL:5,MERC:5,RCM:5,DC:5</availability>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,RCM:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:2,LA:2,CWIE:2</availability>
-		<model name='VR6-C'>
-			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:4</availability>
-		</model>
 		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='VR6-C'>
+			<deployedWith>Wolfhound</deployedWith>
+			<availability>MERC.KH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
-		<model name='VTR-C'>
-			<availability>CC:4,FRR:6,MERC:4,FS:4,DC:6</availability>
-		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='VTR-9B'>
 			<availability>HL:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-9D'>
-			<availability>CC:2,FVC:3,LA:2,FS:2,CDP:3</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-10D'>
-			<availability>FS:6,MERC:2</availability>
-		</model>
-		<model name='VTR-11D'>
-			<roles>urban</roles>
-			<availability>FS:2,MERC:1</availability>
-		</model>
-		<model name='VTR-Cr'>
-			<availability>FS:1,DC:2</availability>
-		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,MERC:2</availability>
 		</model>
 		<model name='VTR-9K'>
 			<availability>MOC:4,FVC:4,HL:2,FRR:8,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
@@ -15852,21 +15826,49 @@
 		<model name='VTR-9Ka'>
 			<availability>FS:2,MERC:2</availability>
 		</model>
+		<model name='VTR-Cr'>
+			<availability>FS:1,DC:2</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-C'>
+			<availability>CC:4,FRR:6,MERC:4,FS:4,DC:6</availability>
+		</model>
+		<model name='VTR-11D'>
+			<roles>urban</roles>
+			<availability>FS:2,MERC:1</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>FVC:1,Periphery:1</availability>
+		</model>
 		<model name='VTR-9S'>
 			<availability>LA:2-,CIR:2-</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='VTR-10D'>
+			<availability>FS:6,MERC:2</availability>
+		</model>
+		<model name='VTR-9D'>
+			<availability>CC:2,FVC:3,LA:2,FS:2,CDP:3</availability>
+		</model>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CS:6,FRR:7,WOB:4,CGB:5</availability>
-		<model name='VKG-2F'>
-			<roles>fire_support</roles>
-			<availability>General:8,WOB:2</availability>
-		</model>
 		<model name='VKG-2G'>
 			<availability>CS:5,FRR:6,CGB:6</availability>
 		</model>
 		<model name='VKG-3W'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='VKG-2F'>
+			<roles>fire_support</roles>
+			<availability>General:8,WOB:2</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
@@ -15886,29 +15888,29 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,FRR:1,MERC:4,TC:6</availability>
-		<model name='VND-1SIC'>
-			<availability>CC:1</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:6,MOC:5,TC:4</availability>
-		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='VND-3L'>
-			<availability>CC:7,MOC:4,General:4,TC:4</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>FRR:8,TC:2</availability>
 		</model>
 		<model name='VND-5L'>
 			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
 		</model>
-		<model name='VND-6L'>
-			<availability>CC:1+</availability>
+		<model name='VND-4L'>
+			<availability>CC:6,MOC:5,TC:4</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,General:4</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>FRR:8,TC:2</availability>
+		<model name='VND-3L'>
+			<availability>CC:7,MOC:4,General:4,TC:4</availability>
+		</model>
+		<model name='VND-1SIC'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='VND-6L'>
+			<availability>CC:1+</availability>
+		</model>
+		<model name='VND-3Lr'>
+			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -15928,29 +15930,35 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CSR:6,General:2,CJF:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:6,General:2,CJF:6</availability>
 		</model>
 		<model name='E'>
 			<availability>CSR:5,General:2,CJF:5</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CLAN:2,CGS:5,CJF:5</availability>
+		<model name='2'>
+			<availability>CLAN:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:3,CJF:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CHH:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:2</availability>
@@ -15958,24 +15966,18 @@
 		<model name='5'>
 			<availability>CHH:5</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:4,DC:5+</availability>
-		<model name='(Nova Cat)' mechanized='true'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Nova Cat)' mechanized='true'>
+			<availability>CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -15988,36 +15990,32 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CS:6,LA:1,FRR:4,PIR:2,WOB:6,MERC:1,FS:2,DC:3</availability>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
-		</model>
-		<model name='VNL-K70'>
-			<availability>FRR:1,DC:1</availability>
+		<model name='VNL-K100'>
+			<availability>FS:1</availability>
 		</model>
 		<model name='VNL-K75N'>
 			<availability>LA:8,FRR:6,FWL:8,FS:8,DC:8</availability>
 		</model>
-		<model name='VNL-K100'>
-			<availability>FS:1</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='VNL-K70'>
+			<availability>FRR:1,DC:1</availability>
+		</model>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>MERC:5,CDP:2,Periphery:2,TC:2</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-5N'>
 			<availability>General:2</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 		<model name='VLC-8N'>
 			<availability>General:3,FS:8,CDP:3</availability>
@@ -16025,42 +16023,51 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:3,CS:3,MOC:5,LA:6,FRR:4,IS:4,FWL:6,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
-		<model name='VT-6C'>
+		<model name='VT-6M'>
 			<roles>anti_infantry</roles>
-			<availability>WOB:8</availability>
+			<availability>WOB:6,RCM:4</availability>
 		</model>
 		<model name='VL-2T'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:3-,General:4-,FS:2-</availability>
 		</model>
+		<model name='VL-5T'>
+			<roles>anti_infantry</roles>
+			<availability>MOC:2,FVC:4,PIR:2,IS:2,FS:4-,CIR:2,Periphery:2,TC:2</availability>
+		</model>
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='VT-6C'>
+			<roles>anti_infantry</roles>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='VT-5Sr'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:4,LA:4,FRR:4,FS:4,MERC:4</availability>
 		</model>
-		<model name='VL-5T'>
-			<roles>anti_infantry</roles>
-			<availability>MOC:2,FVC:4,PIR:2,IS:2,FS:4-,CIR:2,Periphery:2,TC:2</availability>
-		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:5,LA:8,FRR:5,MH:3,FS:5,MERC:5</availability>
 		</model>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>WOB:6,RCM:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,MERC.WD:6,CW:2,CSV:6,CLAN:6,CNC:2,CCO:6,CJF:6,BAN:6,CWIE:6,CGB:7,DC:2+</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSV:6,CNC:7,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:5,CDS:7,CSV:8,CNC:7,General:5,CGB:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:5,CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
@@ -16070,15 +16077,6 @@
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:5,CDS:7,CSV:8,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CSV:5,CNC:5,CLAN:4,General:2</availability>
@@ -16102,67 +16100,46 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:7,IS:3</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:4,CLAN:2,IS:3</availability>
+		</model>
 		<model name='6'>
 			<availability>CSR:5,CGB:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:5,CHH:2,CDS:6,CSR:2,CNC:5,CCO:5,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='3'>
+			<availability>CCC:2,CDS:5,CLAN:2</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:1,IS:3</availability>
 		</model>
-		<model name='3'>
-			<availability>CCC:2,CDS:5,CLAN:2</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:4,CLAN:2,IS:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:5,CHH:2,CDS:6,CSR:2,CNC:5,CCO:5,CWIE:5,CGB:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:2-,General:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:1+,FS:1+,DC:1+</availability>
-		</model>
-		<model name='WHM-10T'>
-			<availability>TC:6</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:2-</availability>
+		</model>
+		<model name='WHM-9S'>
+			<availability>LA:5,WOB:3,MERC:4,CIR:3</availability>
+		</model>
+		<model name='WHM-8M'>
+			<availability>FWL:3,WOB:4</availability>
 		</model>
 		<model name='WHM-7K'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='WHM-8M'>
-			<availability>FWL:3,WOB:4</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2,TC:4</availability>
-		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:4,PIR:3,IS:3,FS:4,MERC:3,TC:4</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:5,LA:6,FS:5,MERC:4</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:6,CC:3,FVC:3,FRR:2,FWL:8,WOB:7,MERC:4,DC:2,Periphery:3</availability>
-		</model>
-		<model name='WHM-9S'>
-			<availability>LA:5,WOB:3,MERC:4,CIR:3</availability>
+		<model name='WHM-6R'>
+			<availability>HL:2-,General:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-,DC:1-</availability>
@@ -16170,17 +16147,38 @@
 		<model name='WHM-4L'>
 			<availability>CC:6</availability>
 		</model>
+		<model name='WHM-8K'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='WHM-6D'>
 			<availability>FVC:2-,FS:2-</availability>
+		</model>
+		<model name='WHM-7M'>
+			<availability>CS:6,CC:3,FVC:3,FRR:2,FWL:8,WOB:7,MERC:4,DC:2,Periphery:3</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:5,LA:6,FS:5,MERC:4</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='WHM-10T'>
+			<availability>TC:6</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:1+,FS:1+,DC:1+</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:5,FS:4</availability>
-		<model name='BLR-2G'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BLR-2D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BLR-2G'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
@@ -16192,61 +16190,53 @@
 			<roles>apc</roles>
 			<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
 		</model>
-		<model name='H-7C'>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
 		<model name='H-8'>
 			<availability>HL:4,LA:5,FS.CH:8,FRR:6,Periphery.Deep:4,FS:6,MERC:6,Periphery:6</availability>
-		</model>
-		<model name='H-9'>
-			<availability>LA:4</availability>
 		</model>
 		<model name='H-7A'>
 			<availability>IS:3-,Periphery:3-</availability>
 		</model>
+		<model name='H-7C'>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='H-9'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>HL:5,IS:8,Periphery.Deep:5,CIR:4,Periphery:6</availability>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:3-</availability>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,CC:3,TC:3</availability>
 		</model>
-		<model name='WSP-1D'>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>FVC:2,FS:2-</availability>
-		</model>
-		<model name='WSP-1'>
-			<roles>recon</roles>
-			<availability>CC:3-,MOC:3-,FWL:3-,RCM:3-</availability>
+			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='WSP-8T'>
 			<roles>recon</roles>
 			<availability>CC:3,MOC:3,WOB:4,TC:4</availability>
-		</model>
-		<model name='WSP-3L'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:3,PIR:3,WOB:3,TC:3</availability>
 		</model>
 		<model name='WSP-1W'>
 			<roles>recon</roles>
@@ -16256,29 +16246,37 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:5,FRR:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,CC:3,TC:3</availability>
+		<model name='WSP-1K'>
+			<roles>recon</roles>
+			<availability>FRR:2-,DC:2-</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:3-</availability>
 		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>FVC:5,LA:6,FS:5,MERC:3</availability>
 		</model>
-		<model name='WSP-3W'>
+		<model name='WSP-3M'>
 			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
+			<availability>CC:6,MOC:6,FWL:8,WOB:8,MH:6,MERC:6,DC:6</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:2-</availability>
 		</model>
-		<model name='WSP-3M'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,WOB:8,MH:6,MERC:6,DC:6</availability>
+			<availability>FVC:2,FS:2-</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1'>
 			<roles>recon</roles>
-			<availability>FRR:2-,DC:2-</availability>
+			<availability>CC:3-,MOC:3-,FWL:3-,RCM:3-</availability>
+		</model>
+		<model name='WSP-3L'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:3,PIR:3,WOB:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
@@ -16303,15 +16301,15 @@
 	</chassis>
 	<chassis name='White Flame' unitType='Mek'>
 		<availability>WOB.SD:6,WOB:4</availability>
+		<model name='WHF-3B'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='WHF-3C'>
 			<availability>WOB:4</availability>
 		</model>
 		<model name='WHF-4C'>
 			<roles>spotter</roles>
 			<availability>WOB:3</availability>
-		</model>
-		<model name='WHF-3B'>
-			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='White Tip Submarine' unitType='Naval'>
@@ -16325,46 +16323,46 @@
 		<model name='WTH-3'>
 			<availability>FS.CMM:4</availability>
 		</model>
+		<model name='WTH-2A'>
+			<availability>DC:1</availability>
+		</model>
+		<model name='WTH-1'>
+			<roles>fire_support</roles>
+			<availability>Periphery.Deep:8,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='WTH-2'>
+			<roles>fire_support</roles>
+			<availability>CS:8,OA:6,MH:6,FS:2,MERC:3,CDP:6,DC:2,TC:6</availability>
+		</model>
 		<model name='WTH-1H'>
 			<availability>Periphery.CM:3,Periphery.HR:3,PIR:5,Periphery.ME:3,MH:5</availability>
 		</model>
 		<model name='WTH-K'>
 			<availability>DC:4</availability>
 		</model>
-		<model name='WTH-1'>
-			<roles>fire_support</roles>
-			<availability>Periphery.Deep:8,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='WTH-2A'>
-			<availability>DC:1</availability>
-		</model>
-		<model name='WTH-2'>
-			<roles>fire_support</roles>
-			<availability>CS:8,OA:6,MH:6,FS:2,MERC:3,CDP:6,DC:2,TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:3,LA:3,CNC:2-,FWL:3,MERC:3,DC:6</availability>
-		<model name='WGT-3SC'>
-			<availability>CC:8,LA:4,FWL:4,MERC:4</availability>
-		</model>
-		<model name='WGT-1LAW/SC3'>
-			<availability>DC:6</availability>
+		<model name='WGT-2LAW'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='WGT-4NC &apos;Dezgra&apos;'>
 			<availability>CNC:8</availability>
 		</model>
+		<model name='WGT-1LAW/SC3'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='WGT-2LAWC3'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WGT-2LAW'>
-			<availability>DC:4</availability>
+		<model name='WGT-1LAW/SC'>
+			<availability>LA:6,FWL:6,MERC:6,DC:7</availability>
 		</model>
 		<model name='WGT-2SC'>
 			<availability>LA:6,FWL:6,MERC:6</availability>
 		</model>
-		<model name='WGT-1LAW/SC'>
-			<availability>LA:6,FWL:6,MERC:6,DC:7</availability>
+		<model name='WGT-3SC'>
+			<availability>CC:8,LA:4,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -16376,9 +16374,6 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>FRR:3,WOB:3,MERC:3,DC:5</availability>
-		<model name='WFT-C'>
-			<availability>FRR:4,DC:4</availability>
-		</model>
 		<model name='WFT-2'>
 			<availability>DC:4</availability>
 		</model>
@@ -16388,21 +16383,12 @@
 		<model name='WFT-1'>
 			<availability>General:4</availability>
 		</model>
+		<model name='WFT-C'>
+			<availability>FRR:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,MERC.KH:7,FRR:5,FS:3,MERC:4,CIR:4,CWIE:5,DTA:3,MERC.WD:5,FVC:3,LA:7,FWL:3,MH:4</availability>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:3,MERC:3,CWIE:5</availability>
-		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,FVC:2,LA:5,FRR:6,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-1A'>
-			<availability>MERC.KH:1</availability>
-		</model>
-		<model name='WLF-3M'>
-			<availability>DTA:8,FWL:8</availability>
-		</model>
 		<model name='WLF-4WA'>
 			<roles>ew_support</roles>
 			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:1,CWIE:2</availability>
@@ -16410,65 +16396,77 @@
 		<model name='WLF-1'>
 			<availability>MERC.KH:3,MERC.WD:1,HL:6,LA:3,Periphery.Deep:6,FS:2,MERC:3,Periphery:8</availability>
 		</model>
+		<model name='WLF-3M'>
+			<availability>DTA:8,FWL:8</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,FVC:2,LA:5,FRR:6,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:3,MERC:3,CWIE:5</availability>
+		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4,CWIE:2</availability>
 		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1</availability>
 		</model>
+		<model name='WLF-1A'>
+			<availability>MERC.KH:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
-		<model name='WVR-9K'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='WVR-6R'>
+		<model name='WVR-7M'>
 			<roles>recon</roles>
-			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>FVC:6,LA:6,WOB:4,FS:6</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>DC:5</availability>
+			<availability>CC:4,FWL:6,WOB:5,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-9D'>
 			<roles>spotter</roles>
 			<availability>FS:5,MERC:4</availability>
 		</model>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,FWL:6,WOB:5,MERC:6,DC:4</availability>
-		</model>
-		<model name='WVR-8D'>
-			<availability>FS:5</availability>
+		<model name='WVR-8K'>
+			<availability>FRR:5,CNC:6,MERC:3,DC:4</availability>
 		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>FRR:8,MERC:6,DC:6</availability>
 		</model>
+		<model name='WVR-8D'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='WVR-9W'>
 			<availability>CS:3,WOB:5</availability>
-		</model>
-		<model name='WVR-9M'>
-			<availability>FWL:4</availability>
 		</model>
 		<model name='WVR-6M'>
 			<roles>recon</roles>
 			<availability>Periphery.MW:5,PIR:4,Periphery.ME:5,FWL:3-,MH:4</availability>
 		</model>
-		<model name='WVR-8K'>
-			<availability>FRR:5,CNC:6,MERC:3,DC:4</availability>
+		<model name='WVR-8C'>
+			<availability>DC:5</availability>
+		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>HL:2-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='WVR-9M'>
+			<availability>FWL:4</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>FVC:6,LA:6,WOB:4,FS:6</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -16485,19 +16483,19 @@
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
 		<availability>CHH:4,CW:4,CLAN:2</availability>
+		<model name='2'>
+			<availability>CW:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>CW:4,CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CW:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:3,FRR:5,CLAN:2,IS:3,WOB:4-,FS:7,MERC:5,DC.GHO:5,CS:5,DTA:3,FVC:3,NIOPS:5,RCM:3,DC:6</availability>
-		<model name='WVE-9N'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CS:8,WOB:8</availability>
+			<availability>DC.GHO:3,CS:4,FRR:8,NIOPS:4,WOB:4,FS:8,MERC:8,BAN:2,DC:3</availability>
 		</model>
 		<model name='WVE-10N'>
 			<roles>urban</roles>
@@ -16507,9 +16505,9 @@
 			<roles>urban</roles>
 			<availability>CLAN:1,CGS:1</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-9N'>
 			<roles>urban</roles>
-			<availability>DC.GHO:3,CS:4,FRR:8,NIOPS:4,WOB:4,FS:8,MERC:8,BAN:2,DC:3</availability>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -16544,23 +16542,20 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CSR:6,CLAN:5</availability>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CSL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CSL:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>CS:6,FVC:8,HL:3,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
 		<model name='(RAC)'>
 			<availability>CS:4,IS:3,FS:5</availability>
-		</model>
-		<model name='(PPC)'>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2,FS:4</availability>
@@ -16572,15 +16567,18 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(PPC)'>
+			<availability>IS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
 		<availability>FWL.FWL:6,FWL:4,WOB:4,MH:3,MERC:3</availability>
-		<model name='YMN-10-OR'>
-			<availability>FWL:4,MERC:4</availability>
-		</model>
 		<model name='YMN-6Y'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='YMN-10-OR'>
+			<availability>FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ymir' unitType='Mek'>
@@ -16598,18 +16596,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='Y-H10G'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Y-H9G'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='Y-H10G'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zechetinu Corvette' unitType='Warship'>
@@ -16628,13 +16626,6 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:7,DC.GHO:2,FRR:5,CLAN:4,NIOPS:7,WOB:7,MERC:4,DC:2</availability>
-		<model name='(LRM)'>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='(C3i)'>
-			<roles>spotter</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
@@ -16645,50 +16636,57 @@
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,FRR:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='(C3i)'>
+			<roles>spotter</roles>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-115'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='ZRO-114'>
+			<availability>CS:3-,CLAN:1,NIOPS:3-,WOB:3-</availability>
 		</model>
 		<model name='ZRO-CX-3'>
 			<availability>CS:2</availability>
 		</model>
-		<model name='ZRO-114'>
-			<availability>CS:3-,CLAN:1,NIOPS:3-,WOB:3-</availability>
+		<model name='ZRO-115'>
+			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:3-</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='ZEU-X'>
 			<availability>LA:6</availability>
 		</model>
 		<model name='ZEU-9WD'>
 			<availability>General:4</availability>
 		</model>
-		<model name='ZEU-X2'>
-			<availability>LA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>HL:5,FRR:4,IS:1,WOB:3,FS:5-,MERC:5,CDP:4,Periphery:2,TC:4,Periphery.R:5,LA:10,PIR:4,MH:4</availability>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,WOB:8</availability>
-		</model>
-		<model name='ZEU-6S'>
-			<availability>HL:4,General:2-,Periphery.Deep:4,Periphery:6</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>FVC:5,LA:8,FRR:6,PIR:6,MH:2,FS:2,MERC:6,CDP:6,TC:6</availability>
 		</model>
-		<model name='ZEU-9S2'>
-			<availability>LA:4,FS:5,MERC:4</availability>
+		<model name='ZEU-6T'>
+			<availability>FVC:2-,LA:2-,FS:2-</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='ZEU-6T'>
-			<availability>FVC:2-,LA:2-,FS:2-</availability>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,WOB:8</availability>
+		</model>
+		<model name='ZEU-9S2'>
+			<availability>LA:4,FS:5,MERC:4</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:4,General:2-,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,MERC:4</availability>
@@ -16696,14 +16694,14 @@
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>
 		<availability>MOC:3,CC:6,HL:2,IS:2,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:4</availability>
-		<model name='(Liao)'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>WOB:6</availability>
 		</model>
 		<model name='(WoB)'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
@@ -16711,14 +16709,14 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,CBS:8,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(ATM)'>
 			<availability>CW:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3078.xml
+++ b/megamek/data/forcegenerator/3078.xml
@@ -1334,15 +1334,6 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(WoB) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(WoB) [Laser]' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
 		</model>
@@ -1350,21 +1341,30 @@
 			<roles>spotter</roles>
 			<availability>CS:5,WOB:5</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='(WoB) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(WoB) [Flamer]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
 		<model name='(WoB)' mechanized='true'>
 			<availability>CS:4,WOB:4</availability>
 		</model>
 		<model name='(WoB) [David]' mechanized='true'>
 			<availability>CS:5,WOB:5</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(WoB) [Flamer]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1409,17 +1409,17 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CSL:5,CJF:5</availability>
-		<model name='(Jade Falcon)' mechanized='true'>
-			<availability>CJF:8</availability>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Jade Falcon)' mechanized='true'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Agamemnon Heavy Cruiser' unitType='Warship'>
@@ -1431,9 +1431,6 @@
 	</chassis>
 	<chassis name='Ahab' unitType='Aero'>
 		<availability>CS:7,CLAN:1,FWL:1,NIOPS:4,WOB:7,DC:1</availability>
-		<model name='AHB-MD'>
-			<availability>WOB:3</availability>
-		</model>
 		<model name='AHB-643'>
 			<availability>WOB:5</availability>
 		</model>
@@ -1442,6 +1439,9 @@
 		</model>
 		<model name='AHB-443b'>
 			<availability>CLAN:1,WOB:4</availability>
+		</model>
+		<model name='AHB-MD'>
+			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ailette Rescue PA(L)' unitType='BattleArmor'>
@@ -1466,13 +1466,12 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>CS:3,ROS:4,FS:6</availability>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4</availability>
@@ -1480,17 +1479,15 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>CNC:4,WOB:4,DC:6</availability>
-		<model name='AKU-2X'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,WOB:4,DC:5</availability>
+		<model name='AKU-2XK'>
+			<availability>DC:3</availability>
 		</model>
 		<model name='AKU-1X'>
 			<availability>WOB:6,DC:5</availability>
@@ -1498,17 +1495,20 @@
 		<model name='AKU-2XC'>
 			<availability>DC:2</availability>
 		</model>
-		<model name='AKU-2XK'>
-			<availability>DC:3</availability>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,WOB:4,DC:5</availability>
+		</model>
+		<model name='AKU-2X'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CC:2,CS:7,CDS:4,LA:6,CNC:4,NIOPS:7,WOB:7,FS:5,MERC:3,CWIE:6,DC:3</availability>
-		<model name='Mk VII'>
-			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk VII'>
+			<availability>CS:4,LA:4,WOB:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
@@ -1516,20 +1516,20 @@
 		<model name='ALB-3U'>
 			<availability>FWL:8,WOB:8,MERC:8</availability>
 		</model>
-		<model name='ALB-3Ur'>
-			<availability>ROS:3,FWL:3,WOB:3,MERC:3</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,SC:6,DoO:6,MCM:6,FWL:6,WOB:6,DO:6,DGM:6,TP:6</availability>
+		</model>
+		<model name='ALB-3Ur'>
+			<availability>ROS:3,FWL:3,WOB:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CGS:5,CCO:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='XR'>
 			<availability>CDS:2</availability>
@@ -1553,11 +1553,14 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>MERC.KH:3,CHH:2,CSR:2,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CSA:2,MERC.WD:8,LA:4,ROS:5,CGB:2</availability>
-		<model name='ANH-4A'>
-			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:2,ROS:2,MERC:2,CWIE:5</availability>
+		<model name='C 2'>
+			<availability>MERC.WD:4,CLAN:6,IS:2,BAN:1</availability>
 		</model>
 		<model name='ANH-1A'>
 			<availability>CLAN:1-,MERC:1-</availability>
+		</model>
+		<model name='ANH-4A'>
+			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:2,ROS:2,MERC:2,CWIE:5</availability>
 		</model>
 		<model name='ANH-2A'>
 			<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
@@ -1567,9 +1570,6 @@
 		</model>
 		<model name='ANH-3A'>
 			<availability>MERC.WD:5,CHH:3,LA:4,ROS:4,MERC:4,CWIE:3</availability>
-		</model>
-		<model name='C 2'>
-			<availability>MERC.WD:4,CLAN:6,IS:2,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1588,11 +1588,11 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:4,MOC:6,PIR:2,TC:3</availability>
-		<model name='ABS-3T'>
-			<availability>CC:5,MOC:5,TC:5</availability>
-		</model>
 		<model name='ABS-3R'>
 			<availability>General:4</availability>
+		</model>
+		<model name='ABS-3T'>
+			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
@@ -1601,18 +1601,12 @@
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>CC:1,PR:6,DoO:6,WOB:2,DO:6,DGM:6,MERC:3,DTA:6,SC:6,MCM:6,ROS:4,PG:6,FWL:5,TP:6,DA:6,RFS:6</availability>
-		<model name='ANV-5M'>
-			<availability>DTA:5,DoO:5,FWL:6,WOB:6,DO:5,TP:5,DA:5</availability>
-		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>PR:5,DoO:5,WOB:4,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:2,TP:5,DA:5,RFS:5</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>CC:5,ROS:6,FWL:4,WOB:4,MERC:5</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,WOB:4,MERC:4</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:5,DoO:5,FWL:6,WOB:6,DO:5,TP:5,DA:5</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
@@ -1621,14 +1615,20 @@
 		<model name='ANV-5Q'>
 			<availability>DTA:4,SC:4,PR:4,MCM:4,PG:4,FWL:2,WOB:4,DGM:4,RFS:4</availability>
 		</model>
+		<model name='ANV-3R'>
+			<availability>FWL:4,WOB:4,MERC:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>CC:5,ROS:6,FWL:4,WOB:4,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,SC:8,LA:1,MCM:8,ROS:4,FWL:8,MH:2,DGM:8,MERC:4,FS:1,DC:6</availability>
-		<model name='APL-3T'>
+		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
-		<model name='APL-1R'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
 			<availability>FWL:4,DC:3</availability>
 		</model>
@@ -1658,14 +1658,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,CNC:4,MERC:2</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1698,127 +1698,118 @@
 	</chassis>
 	<chassis name='Archangel' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
-		<model name='C-ANG-O Invictus'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C-ANG-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-ANG-OE Eminus'>
-			<roles>fire_support</roles>
+		<model name='C-ANG-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OS Caelestis'>
 			<availability>General:4</availability>
 		</model>
-		<model name='C-ANG-OD Luminos'>
+		<model name='C-ANG-OC Comminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-ANG-O Invictus'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C-ANG-OE Eminus'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-ANG-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-ANG-OC Comminus'>
+		<model name='C-ANG-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,HL:3,FRR:4,CLAN:1,IS:3-,Periphery.Deep:5,WOB:2-,FS:3-,Periphery:4,CS:4-,LA:6,CGB.FRR:4,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
-		<model name='ARC-6W'>
+		<model name='ARC-7L'>
 			<roles>fire_support</roles>
-			<availability>FVC:3,TC:4,Periphery:3</availability>
+			<availability>CC:6</availability>
 		</model>
 		<model name='ARC-9W'>
 			<roles>fire_support</roles>
 			<availability>ROS:4,WOB:4</availability>
 		</model>
-		<model name='ARC-6S'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>LA:4,FRR:3,CGB.FRR:3,ROS:4,MERC:3</availability>
-		</model>
-		<model name='ARC-2S'>
-			<roles>fire_support</roles>
-			<availability>LA:1-</availability>
-		</model>
-		<model name='ARC-8M'>
-			<roles>fire_support</roles>
-			<availability>CC:1,MOC:3,DoO:5,FRR:3,WOB:3,DO:5,DGM:5,MERC:3,DTA:5,SC:5,MCM:5,CGB.FRR:3,ROS:4,PIR:3,FWL:2,TP:5,DC:1</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6,CWIE:1</availability>
-		</model>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:6</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>FRR:1-,CGB.FRR:2-,DC:3-</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,WOB:4</availability>
-		</model>
-		<model name='ARC-5R'>
-			<roles>fire_support</roles>
-			<availability>FRR:8,CGB.FRR:8,MERC:4,DC:1</availability>
-		</model>
-		<model name='ARC-9K'>
-			<roles>fire_support</roles>
-			<availability>CNC:2,DC:4</availability>
-		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:6,FS:1</availability>
-		</model>
-		<model name='ARC-9M'>
-			<roles>fire_support</roles>
-			<availability>LA:4,ROS:4,FWL:3,WOB:4,MERC:3,DC:3</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>HL:1-,LA:3-,FRR:2-,CGB.FRR:3-,IS:3-,Periphery.Deep:8,BAN:2,DC:3-,Periphery:4-</availability>
+			<availability>CLAN:4,FWL:4,BAN:2</availability>
 		</model>
 		<model name='ARC-5W'>
 			<roles>fire_support</roles>
 			<availability>MERC.WD:8,LA:4,MERC:4</availability>
 		</model>
-		<model name='ARC-2Rb'>
+		<model name='ARC-2W'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,BAN:2</availability>
+			<availability>MERC.WD:1-</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,FRR:3,CGB.FRR:3,ROS:4,MERC:3</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,WOB:4</availability>
+		</model>
+		<model name='ARC-2S'>
+			<roles>fire_support</roles>
+			<availability>LA:1-</availability>
+		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:3,TC:4,Periphery:3</availability>
+		</model>
+		<model name='ARC-9K'>
+			<roles>fire_support</roles>
+			<availability>CNC:2,DC:4</availability>
+		</model>
+		<model name='ARC-9M'>
+			<roles>fire_support</roles>
+			<availability>LA:4,ROS:4,FWL:3,WOB:4,MERC:3,DC:3</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:6,CCC:6,CW:1,LA:2+,FS:2+,CGS:6,CWIE:1,DC:2+</availability>
 		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:6,FS:1</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6,CWIE:1</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>FRR:8,CGB.FRR:8,MERC:4,DC:1</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>HL:1-,LA:3-,FRR:2-,CGB.FRR:3-,IS:3-,Periphery.Deep:8,BAN:2,DC:3-,Periphery:4-</availability>
+		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CS:6,CC:5,FVC:3,LA:1,PIR:4,FWL:6,WOB:6,MERC:5,FS:1,DC:5</availability>
 		</model>
-		<model name='ARC-2W'>
+		<model name='ARC-2K'>
 			<roles>fire_support</roles>
-			<availability>MERC.WD:1-</availability>
+			<availability>FRR:1-,CGB.FRR:2-,DC:3-</availability>
+		</model>
+		<model name='ARC-8M'>
+			<roles>fire_support</roles>
+			<availability>CC:1,MOC:3,DoO:5,FRR:3,WOB:3,DO:5,DGM:5,MERC:3,DTA:5,SC:5,MCM:5,CGB.FRR:3,ROS:4,PIR:3,FWL:2,TP:5,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1E'>
-			<availability>General:6</availability>
+		<model name='AF1C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
@@ -1826,6 +1817,15 @@
 		</model>
 		<model name='AF1B'>
 			<availability>General:5</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
@@ -1842,11 +1842,11 @@
 		<model name='A'>
 			<availability>General:3</availability>
 		</model>
-		<model name='J'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:5</availability>
+		</model>
+		<model name='J'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -1876,12 +1876,6 @@
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
 		<availability>FS:5</availability>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
@@ -1891,40 +1885,26 @@
 		<model name='AGS-6F'>
 			<availability>General:3</availability>
 		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1934,17 +1914,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1960,19 +1960,19 @@
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
 		<availability>MOC:3-,CC:3-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:3-,CS:3-,OA:1-,FVC:1,LA:1,CGB.FRR:1-,FS.CMM:1-</availability>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
+		<model name='ASN-99'>
+			<roles>spotter</roles>
+			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,FVC:4,Periphery.HR:3,PIR:2,MH:4,MERC:4,FS:4,RCM:4,DA:4,CDP:6,TC:6</availability>
 		</model>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
 		<model name='ASN-21'>
 			<availability>General:1-</availability>
-		</model>
-		<model name='ASN-99'>
-			<roles>spotter</roles>
-			<availability>CC:2,MOC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -2018,20 +2018,20 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,CCC:5,CSR:3,CDS:5,CW:5,CSL:8,CGS:5,CJF:3,CCO:2,CGB:6</availability>
-		<model name='(HAG)'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>LA:3,CLAN:1,WOB:3</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -2039,63 +2039,51 @@
 		<model name='AS7-Dr'>
 			<availability>LA:3,ROS:4,MERC:3</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>FRR:4,CGB.FRR:4,IS:4,DC:4</availability>
+		<model name='AS7-K'>
+			<availability>CC:1,MOC:3,FRR:5,WOB:3,MERC:4,CDP:3,TC:3,CS:3,OA:3,CGB.FRR:5,CNC:5,FWL:1,DC:7</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:5,ROS:4,MERC:2</availability>
+		</model>
+		<model name='AS7-K3'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
+		</model>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:3</availability>
+		</model>
+		<model name='AS7-D-DC'>
+			<availability>IS:1-,MERC:0,DC:1-</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:3,FS:4,DC:4</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>FRR:4,CGB.FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>FRR:2,CGB.FRR:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>FRR:5,CGB.FRR:5,MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
-		</model>
-		<model name='AS7-C'>
-			<availability>FRR:2,CGB.FRR:2,MERC:2,DC:2</availability>
-		</model>
 		<model name='AS7-S2'>
 			<availability>LA:3,ROS:3,MERC:2</availability>
 		</model>
-		<model name='AS7-D'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:5,ROS:4,MERC:2</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1-,MERC:0,DC:1-</availability>
-		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:3</availability>
-		</model>
-		<model name='AS7-K3'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>CC:1,MOC:3,FRR:5,WOB:3,MERC:4,CDP:3,TC:3,CS:3,OA:3,CGB.FRR:5,CNC:5,FWL:1,DC:7</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(CV)'>
@@ -2106,6 +2094,14 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Gunship)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
@@ -2113,6 +2109,10 @@
 		<model name='(Tanker)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -2124,24 +2124,24 @@
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:2,CW:4,CLAN:3,CNC:4,BAN:5,CWIE:4</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:4,General:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CSR:5,CDS:9,General:7,CGS:8,CCO:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5,CCO:6</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:4,General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
@@ -2152,34 +2152,34 @@
 		<model name='AV1-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
+		</model>
 		<model name='AV1-OI'>
 			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='AV1-OE'>
-			<availability>General:6</availability>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AV1-OR'>
 			<availability>General:2+,CLAN:6,DC:2+</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
@@ -2187,13 +2187,13 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:2,FRR:2,IS:2,FS:4,CIR:2,TC:2,Periphery:1,OA:2,LA:4,CGB.FRR:2,FWL:3,DC:3</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>LA:2-,General:4,FS:2-</availability>
+		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
@@ -2201,23 +2201,23 @@
 		<model name='AWS-8R'>
 			<availability>FWL:1-</availability>
 		</model>
+		<model name='AWS-10KM'>
+			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4,DC:4</availability>
+		</model>
 		<model name='AWS-8T'>
 			<availability>IS:1-,CIR:4</availability>
 		</model>
 		<model name='AWS-8Q'>
 			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
-		<model name='AWS-10KM'>
-			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4,DC:4</availability>
-		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:4,PIR:4,FWL:6,IS:5,MH:4,TC:4,Periphery:2</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:4,SC:4,LA:4,DoO:4,MCM:4,FWL:4,DO:4,DGM:4,TP:4,FS:4</availability>
-		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:4,HL:2,FWL:6,IS:4,MH:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='AWS-9Ma'>
+			<availability>DTA:4,SC:4,LA:4,DoO:4,MCM:4,FWL:4,DO:4,DGM:4,TP:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
@@ -2240,8 +2240,18 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:2,LA:3,FRR:2,CGB.FRR:2,ROS:4,FS:2,MERC:1</availability>
+		<model name='AXM-6T'>
+			<availability>LA:3</availability>
+		</model>
+		<model name='AXM-3S'>
+			<availability>LA:5,ROS:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='AXM-4D'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='AXM-2N'>
+			<roles>fire_support</roles>
+			<availability>FVC:1,LA:3,FS:1</availability>
 		</model>
 		<model name='AXM-1N'>
 			<availability>FVC:5,LA:5,FRR:5,CGB.FRR:5,MERC:5,FS:5</availability>
@@ -2249,19 +2259,13 @@
 		<model name='AXM-3Sr'>
 			<availability>LA:4,ROS:4,FS:5</availability>
 		</model>
-		<model name='AXM-6T'>
-			<availability>LA:3</availability>
-		</model>
-		<model name='AXM-3S'>
-			<availability>LA:5,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-2N'>
-			<roles>fire_support</roles>
-			<availability>FVC:1,LA:3,FS:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:4,CSR:3,CJF:5</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CSR:3</availability>
+		</model>
 		<model name='3 &apos;Devil&apos;'>
 			<availability>CSR:3</availability>
 		</model>
@@ -2269,14 +2273,30 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CSR:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CHH:2,MERC.WD:3,CW:3,CSL:2</availability>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:6,CLAN:5,General:3</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:6,General:3</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2288,38 +2308,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>CLAN:6,General:3</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:4</availability>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
@@ -2335,7 +2331,7 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
@@ -2343,15 +2339,13 @@
 			<roles>apc</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>OA:5,IS:5,CLAN.IS:5</availability>
-		<model name='(Hybrid)'>
-			<availability>CLAN:3,IS:3</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
@@ -2359,24 +2353,30 @@
 		<model name='(Standard)'>
 			<availability>CLAN:8,IS:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Hybrid)'>
+			<availability>CLAN:3,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:3+</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -2384,33 +2384,41 @@
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:3,ROS:3,FWL:3,WOB:3,FS:3,MERC:8</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:4</availability>
+		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
 		<model name='BNDR-01B'>
 			<availability>General:4,MERC:8</availability>
 		</model>
-		<model name='BNDR-01Ar'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:3,CLAN:1,CSL:3</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3,CCO:6</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
@@ -2420,16 +2428,8 @@
 			<roles>apc</roles>
 			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -2438,9 +2438,13 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:4,MERC:5</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -2450,9 +2454,9 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:6</availability>
+			<availability>General:5</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
@@ -2462,36 +2466,38 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:7-,CC:1-,PR:3-,HL:8-,FRR:2-,Periphery.Deep:9-,IS:1-,DGM:3-,FS:1-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,SC:3-,OA:7-,FVC:3-,LA:5-,MCM:3-,CGB.FRR:3-,PG:3-,FWL:3-,MH:7-,RFS:3-,DC:1-</availability>
+		<model name='BNC-3Mr'>
+			<availability>MOC:4,FWL:4,WOB:5,CDP:4,TC:4</availability>
+		</model>
 		<model name='BNC-3MC'>
 			<availability>MOC:5-</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>OA:1-,LA:3-,IS:1-,FS:1-,MERC:2-,CIR:3,CDP:2,TC:2-</availability>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
-		<model name='BNC-6S'>
-			<availability>LA:4</availability>
+		<model name='BNC-9S'>
+			<availability>LA:3</availability>
 		</model>
-		<model name='BNC-3Mr'>
-			<availability>MOC:4,FWL:4,WOB:5,CDP:4,TC:4</availability>
+		<model name='BNC-8S'>
+			<availability>LA:6,WOB:9</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:2-,FVC:2-,OA:2-,FWL:2-,MH:2-,MERC:2-,CDP:2-,TC:2-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>SC:2-,PR:2-,MCM:2-,PG:2-,FWL:1-,DGM:2-,RFS:2-</availability>
@@ -2499,36 +2505,30 @@
 		<model name='BNC-3E'>
 			<availability>HL:1-,General:1-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
 		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6,WOB:9</availability>
+		<model name='BNC-3S'>
+			<availability>OA:1-,LA:3-,IS:1-,FS:1-,MERC:2-,CIR:3,CDP:2,TC:2-</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:5,FRR:3,CGB.FRR:3,MH:2,FS:6,MERC:5</availability>
 		</model>
-		<model name='BNC-9S'>
-			<availability>LA:3</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:2-,FVC:2-,OA:2-,FWL:2-,MH:2-,MERC:2-,CDP:2-,TC:2-,Periphery:2-</availability>
+		<model name='BNC-6S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,FRR:4,CGB.FRR:4,MERC:4</availability>
+		<model name='BGS-1T'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BGS-3T'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
 		<model name='BGS-2T'>
 			<availability>LA:5,MERC:5</availability>
 		</model>
 		<model name='BGS-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BGS-1T'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BGS-3T'>
-			<availability>LA:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Barouche Military Transport' unitType='Tank'>
@@ -2540,24 +2540,24 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:4,CNC:6,CLAN:4,IS:2+,BAN:5</availability>
-		<model name='D'>
-			<availability>CSR:3,CNC:3,CLAN:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:5,CNC:8,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='Z'>
 			<availability>CCO:2</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:3,CNC:3,CLAN:2</availability>
+		</model>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
@@ -2566,67 +2566,67 @@
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CSA:4,CCC:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:1,CDS:1,CBS:4,CNC:1,CLAN.IS:1,CSL:4,CGS:7,CCO:3,CJF:6</availability>
+		<model name='C'>
+			<availability>General:6,CCO:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='F'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='F'>
-			<availability>General:5</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:6,CCO:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='IS'>
 		<availability>CS:5</availability>
-		<model name='BTL-C-2O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BTL-C-2OE'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='BTL-C-2OB'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='BTL-C-2OF'>
-			<roles>anti_infantry</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='BTL-C-2OA'>
 			<roles>ew_support,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='BTL-C-2OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='BTL-C-2OC'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='BTL-C-2OB'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='BTL-C-2O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='BTL-C-2OF'>
+			<roles>anti_infantry</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='BTL-C-2OD'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2652,51 +2652,41 @@
 		<model name='BKX-7K'>
 			<availability>FS:3-,MERC:5-</availability>
 		</model>
-		<model name='BKX-1X'>
-			<availability>LA:8-,FS:3-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='BKX-1X'>
+			<availability>LA:8-,FS:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:5,LA:6,CGB.FRR:4,ROS:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
-		<model name='BLR-4L'>
-			<availability>CC:3</availability>
+		<model name='BLR-1Gc'>
+			<availability>CLAN:1,WOB:2</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1-,MERC:0</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CS:6,CC:6,FVC:5,ROS:5,PIR:5,FWL:5,IS:1,WOB:7,MH:5,MERC:6</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:5,FRR:3,CGB.FRR:3,ROS:4,WOB:5,MERC:4,CJF:1</availability>
+		<model name='BLR-1Gb'>
+			<availability>CLAN:8,WOB:5,BAN:2</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>SC:2,MCM:2,CLAN:1,WOB:1,DGM:2</availability>
 		</model>
-		<model name='BLR-10S'>
-			<availability>LA:5,ROS:3,FS:3</availability>
+		<model name='BLR-1D'>
+			<availability>FVC:3-,FS:3-</availability>
 		</model>
-		<model name='BLR-10S2'>
-			<availability>LA:5,ROS:3,FS:3</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:7</availability>
+		<model name='BLR-4S'>
+			<availability>LA:5,FRR:3,CGB.FRR:3,ROS:4,WOB:5,MERC:4,CJF:1</availability>
 		</model>
 		<model name='BLR-2C'>
 			<availability>CS:1,DC.GHO:1,WOB:1</availability>
 		</model>
-		<model name='BLR-M3'>
-			<roles>spotter</roles>
-			<availability>DTA:4,DoO:4,ROS:4,FWL:2,WOB:4,DO:4,TP:4,DA:4,MERC:3</availability>
-		</model>
-		<model name='BLR-K4'>
-			<availability>FRR:4,CGB.FRR:4,ROS:3,WOB:3,DC:4</availability>
-		</model>
 		<model name='BLR-1S'>
 			<availability>LA:2-</availability>
+		</model>
+		<model name='BLR-10S'>
+			<availability>LA:5,ROS:3,FS:3</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1-,MERC:0</availability>
 		</model>
 		<model name='BLR-3S'>
 			<availability>LA:4,FS:1</availability>
@@ -2704,21 +2694,31 @@
 		<model name='BLR-1G'>
 			<availability>HL:1-,IS:3-,Periphery.Deep:8,FS:1-,BAN:8,Periphery:4-</availability>
 		</model>
-		<model name='BLR-1Gb'>
-			<availability>CLAN:8,WOB:5,BAN:2</availability>
+		<model name='BLR-10S2'>
+			<availability>LA:5,ROS:3,FS:3</availability>
 		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:3-,FS:3-</availability>
+		<model name='C'>
+			<availability>CLAN:7</availability>
 		</model>
-		<model name='BLR-1Gc'>
-			<availability>CLAN:1,WOB:2</availability>
+		<model name='BLR-M3'>
+			<roles>spotter</roles>
+			<availability>DTA:4,DoO:4,ROS:4,FWL:2,WOB:4,DO:4,TP:4,DA:4,MERC:3</availability>
 		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:2,WOB:3,DO:5,DGM:5,TP:5</availability>
 		</model>
+		<model name='BLR-K4'>
+			<availability>FRR:4,CGB.FRR:4,ROS:3,WOB:3,DC:4</availability>
+		</model>
 		<model name='BLR-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-3M'>
+			<availability>CS:6,CC:6,FVC:5,ROS:5,PIR:5,FWL:5,IS:1,WOB:7,MH:5,MERC:6</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='BLR-K3'>
 			<roles>spotter</roles>
@@ -2734,16 +2734,12 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CSA:6,CHH:6,CDS:6,CW:7,CNC:6,CSL:6,CGS:6,CCO:4,CJF:7,CWIE:4,CGB:6,DC:1+</availability>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
+		<model name='Z'>
+			<availability>CCO:2</availability>
 		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CNC:9,General:8,CGS:7</availability>
-		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,General:6,CGS:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CGS:8,CJF:6</availability>
@@ -2751,8 +2747,12 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
 		</model>
-		<model name='Z'>
-			<availability>CCO:2</availability>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,General:6,CGS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
@@ -2761,34 +2761,34 @@
 			<roles>spotter</roles>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='(Sealed)'>
-			<availability>CS:8,ROS:8,WOB:4</availability>
+		<model name='(C3i)'>
+			<roles>spotter</roles>
+			<availability>WOB:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(C3i)'>
-			<roles>spotter</roles>
-			<availability>WOB:7</availability>
+		<model name='(Sealed)'>
+			<availability>CS:8,ROS:8,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>CGB:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:6,CSR:2,CLAN:1,CGS:5</availability>
-		<model name='(Standard)'>
-			<availability>CSR:2,General:1</availability>
+		<model name='6'>
+			<availability>General:1</availability>
 		</model>
 		<model name='4'>
 			<availability>General:1</availability>
@@ -2799,27 +2799,27 @@
 		<model name='3'>
 			<availability>CHH:7</availability>
 		</model>
-		<model name='6'>
-			<availability>General:1</availability>
-		</model>
 		<model name='5'>
 			<availability>General:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSR:2,General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:3,HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:4,Periphery:4,CS:4-,OA:4,CDS:5,LA:3,CGB.FRR:4,PIR:3,CNC:4,FWL:2,DC:5</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:5,IS:5,DC:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>FVC:3,CDS:3,General:8,DC:3</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2,DC:1</availability>
 		</model>
-		<model name='(Kurita)'>
-			<availability>CLAN:5,IS:5,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>FVC:3,CDS:3,General:8,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2831,22 +2831,22 @@
 	</chassis>
 	<chassis name='Bellona Hover Tank' unitType='Tank'>
 		<availability>CHH:5</availability>
-		<model name='(Laser)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>CS:6,FRR:6,CGB.FRR:6,ROS:6,CNC:4,CGB:4</availability>
-		<model name='BEO-14'>
-			<roles>recon</roles>
-			<availability>CS:4</availability>
-		</model>
 		<model name='BEO-12'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='BEO-14'>
+			<roles>recon</roles>
+			<availability>CS:4</availability>
 		</model>
 		<model name='BEO-X-7a'>
 			<roles>recon,spotter</roles>
@@ -2855,14 +2855,14 @@
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>PR:4,LA:7,FRR:3,CGB.FRR:3,ROS:4,PG:4,FS:3,MERC:2,RFS:4</availability>
-		<model name='BRZ-B3'>
-			<availability>LA:3</availability>
+		<model name='BRZ-A3'>
+			<availability>PR:8,LA:5,FRR:8,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>PR:4,LA:5,ROS:5,PG:4,MERC:5,RFS:4</availability>
 		</model>
-		<model name='BRZ-A3'>
-			<availability>PR:8,LA:5,FRR:8,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2880,70 +2880,70 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CHH:3,CSR:2,CW:2,IS:3+,CGS:1,CCO:1,CJF:3,BAN:4,CWIE:3,CGB:3</availability>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:1</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:5,General:6,CJF:8,CGB:7</availability>
 		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:1</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:6,FRR:6,CGB.FRR:6,FS:4,MERC:4,DC:7</availability>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OX'>
+			<availability>DC:2</availability>
+		</model>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='BHKU-OX'>
-			<availability>DC:2</availability>
-		</model>
 		<model name='BHKU-OR'>
 			<availability>General:2+,DC:2+</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
@@ -2954,23 +2954,23 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:4,PR:5,DoO:5,FRR:4,CLAN:5,DO:5,FS:5,CDP:3,CWIE:6,DC.GHO:3,SC:5,OA:3,CDS:4,CBS:6,CGB.FRR:4,FWL:4,NIOPS:7,RFS:5,CGB:6,CSR:4,WOB:7,DGM:5,FWL.OH:3,MERC:4,CGS:6,Periphery:3,TC:4,CS:7,DTA:5,FVC:3,CW:6,LA:4,MCM:5,ROS:6,PG:5,CNC:6,TP:5,RCM:5,DA:5,CJF:4,DC:4</availability>
-		<model name='BL-12-KNT'>
-			<availability>ROS:6,FS:6</availability>
+		<model name='BL-6b-KNT'>
+			<availability>DoO:6,CLAN:5,DO:6,MERC:4,FS:4,CGS:6,BAN:2,DTA:6,CS:6,LA:4,ROS:6,FWL:6,TP:6,DA:6,DC:4</availability>
+		</model>
+		<model name='BL-9-KNT'>
+			<availability>CS:8,ROS:8,WOB:8</availability>
 		</model>
 		<model name='BL-6-KNT'>
 			<availability>FRR:6,CLAN:6,WOB:4,BAN:6,TC:5,Periphery:5,DC.GHO:4,CS:4,OA:5,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
 		</model>
-		<model name='BL-6b-KNT'>
-			<availability>DoO:6,CLAN:5,DO:6,MERC:4,FS:4,CGS:6,BAN:2,DTA:6,CS:6,LA:4,ROS:6,FWL:6,TP:6,DA:6,DC:4</availability>
-		</model>
-		<model name='BL-7-KNT-L'>
-			<availability>FWL:1-,TC:1-</availability>
-		</model>
 		<model name='BL-7-KNT'>
 			<availability>:0,LA:2-,FRR:2-,FWL:1-,MERC:2-,FS:2-,CIR:6,DC:2-</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>CS:8,ROS:8,WOB:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:6,FS:6</availability>
+		</model>
+		<model name='BL-7-KNT-L'>
+			<availability>FWL:1-,TC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -2978,19 +2978,15 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:6</availability>
 		</model>
 		<model name='X'>
 			<availability>CJF:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6,CCO:6</availability>
@@ -2998,6 +2994,10 @@
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -3016,36 +3016,42 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:5,MERC:3,MERC.NH:5</availability>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:4-,MOC:4,OA:4,FVC:6,HL:3,IS:1,FS:6,MERC:4,TC:4,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:3,FS:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:7,MERC:5</availability>
-		</model>
 		<model name='BJ-1'>
 			<availability>General:1-,Periphery.Deep:8,Periphery:3</availability>
+		</model>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:3,FS:3,MERC:3,Periphery:3</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>CC:1,CS:4,FVC:5,LA:4,PIR:2,WOB:4,FS:5,MERC:4</availability>
 		</model>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:7,MERC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,CS:3,MOC:4,FVC:3,ROS:4,FWL:5,IS:3,WOB:5,FS:5,MERC:3,DA:4,DC:6</availability>
-		<model name='BJ2-O'>
-			<availability>General:7</availability>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
 		</model>
-		<model name='BJ2-OX'>
-			<availability>General:1</availability>
+		<model name='BJ2-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:2+,DC:2+</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:6</availability>
@@ -3053,23 +3059,17 @@
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OC'>
+		<model name='BJ2-OD'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
+		<model name='BJ2-O'>
+			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:2+,DC:2+</availability>
+		<model name='BJ2-OX'>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
@@ -3083,39 +3083,39 @@
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MOC:3,WOB:5,MERC:5,TC:3</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Black Blizzard&apos;'>
 			<availability>CC:2,General:3,WOB:3</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,CHH:5,CCC:4,CBS:4,CSL:5</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='G'>
+		<model name='E'>
 			<availability>General:5</availability>
 		</model>
 		<model name='D'>
@@ -3124,33 +3124,33 @@
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
 		<availability>CSA:5,CCC:3,CBS:10</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3,CBS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CW:5</availability>
-		<model name='2'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='2'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
 		<availability>DTA:6,SC:6,DoO:6,MCM:6,FWL:6,WOB:4,DO:6,DGM:6,TP:6,DA:6</availability>
-		<model name='B3-HND'>
-			<roles>anti_infantry</roles>
-			<availability>:0,IS:2</availability>
+		<model name='B2-HND'>
+			<availability>General:4,RCM:0</availability>
 		</model>
 		<model name='B1-HND'>
 			<availability>:0,General:8</availability>
 		</model>
-		<model name='B2-HND'>
-			<availability>General:4,RCM:0</availability>
+		<model name='B3-HND'>
+			<roles>anti_infantry</roles>
+			<availability>:0,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blue Flame' unitType='Mek'>
@@ -3177,28 +3177,32 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank' unitType='Tank' omni='IS'>
 		<availability>WOB:4</availability>
-		<model name='Comminus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Infernus'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Invictus'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Dominus'>
 			<availability>General:7</availability>
 		</model>
+		<model name='Comminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='Infernus'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>CS:3,OA:5,FVC:4,CDS:4,CLAN:3,IS:1-,NIOPS:3,FWL:1-,WOB:5,DC:4</availability>
-		<model name='BMB-14C'>
+		<model name='BMB-12D'>
 			<roles>fire_support</roles>
-			<availability>CS:6,WOB:6</availability>
+			<availability>CS:4,OA:5,FVC:6,FRR:6,CGB.FRR:6,ROS:3,CLAN:8,NIOPS:4,WOB:4,MERC.SI:8,BAN:8</availability>
 		</model>
 		<model name='BMB-10D'>
 			<roles>fire_support</roles>
 			<availability>IS:1-,Periphery.Deep:8,Periphery:1-</availability>
+		</model>
+		<model name='BMB-14C'>
+			<roles>fire_support</roles>
+			<availability>CS:6,WOB:6</availability>
 		</model>
 		<model name='BMB-05A'>
 			<roles>missile_artillery,fire_support</roles>
@@ -3207,10 +3211,6 @@
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='BMB-12D'>
-			<roles>fire_support</roles>
-			<availability>CS:4,OA:5,FVC:6,FRR:6,CGB.FRR:6,ROS:3,CLAN:8,NIOPS:4,WOB:4,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -3229,22 +3229,22 @@
 			<roles>missile_artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
 		<availability>TC:4</availability>
-		<model name='BRM-5A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BRM-5B'>
 			<availability>TC:2</availability>
+		</model>
+		<model name='BRM-5A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bridge-builder Engineers' unitType='Infantry'>
@@ -3256,22 +3256,22 @@
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2,CIR:2,TC:2</availability>
-		<model name='LDT-5'>
-			<availability>PIR:6</availability>
-		</model>
 		<model name='LDT-X3'>
+			<availability>PIR:3</availability>
+		</model>
+		<model name='LDT-X4'>
 			<availability>PIR:3</availability>
 		</model>
 		<model name='LDT-1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='LDT-X4'>
-			<availability>PIR:3</availability>
-		</model>
-		<model name='LDT-X1'>
-			<availability>General:4</availability>
+		<model name='LDT-5'>
+			<availability>PIR:6</availability>
 		</model>
 		<model name='LDT-X2'>
+			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X1'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -3289,6 +3289,9 @@
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -3301,9 +3304,6 @@
 		<model name='(HPPC)'>
 			<availability>CC:4,MOC:3,FS:2</availability>
 		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
 		<availability>CS:3,HL:6,CLAN:3,IS:6,NIOPS:3,Periphery.Deep:6,WOB:3,MERC:5,BAN:5,Periphery:7</availability>
@@ -3314,9 +3314,6 @@
 	</chassis>
 	<chassis name='Buccaneer' unitType='Mek'>
 		<availability>SC:4,PR:4,MCM:4,PG:4,FWL:3,WOB:6,DGM:4,RFS:4</availability>
-		<model name='BCN-3R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BCN-6W'>
 			<roles>fire_support</roles>
 			<availability>WOB:4</availability>
@@ -3324,6 +3321,9 @@
 		<model name='BCN-5W'>
 			<roles>urban</roles>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='BCN-3R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VIII' unitType='Tank'>
@@ -3335,13 +3335,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CIR:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -3353,11 +3353,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:3,General:8,FS:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:3,General:8,FS:3,MERC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3368,11 +3368,11 @@
 	</chassis>
 	<chassis name='Burke Defense Tank' unitType='Tank'>
 		<availability>CS:7,CHH:4,ROS:6,NIOPS:7,WOB:7</availability>
-		<model name='(HPPC)'>
-			<availability>CS:9,WOB:9</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='(HPPC)'>
+			<availability>CS:9,WOB:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Burrock' unitType='Mek'>
@@ -3393,14 +3393,14 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,FS:5,MERC:3</availability>
+		<model name='BSW-S2r'>
+			<availability>General:2</availability>
+		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4,FS:2</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BSW-S2r'>
-			<availability>General:2</availability>
 		</model>
 		<model name='BSW-X2'>
 			<availability>LA:4,General:1,MERC:4</availability>
@@ -3411,17 +3411,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>CS:4,FVC:6,LA:4,FS:6,MERC:4</availability>
-		<model name='CES-3R'>
-			<availability>CS:8,FVC:8,FS:4,MERC:4</availability>
-		</model>
-		<model name='CES-4S'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='CES-4R'>
 			<availability>FS:5</availability>
 		</model>
 		<model name='CES-3S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='CES-3R'>
+			<availability>CS:8,FVC:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='CES-4S'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -3446,13 +3446,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CHH:1,CSR:2,CDS:3,CW:1,CNC:5,CCO:1,CGS:1,CJF:1,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3464,14 +3464,20 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:6,MOC:5,WOB:5,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:1,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2</availability>
-		<model name='CTF-1X'>
-			<availability>General:3-,Periphery:4-</availability>
-		</model>
 		<model name='CTF-2X'>
 			<availability>CC:2-,MOC:2,FVC:2,MERC:1,TC:2</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:5,LA:2,FS:5</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CTF-3LL'>
+			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FVC:4,FS:4</availability>
@@ -3479,50 +3485,48 @@
 		<model name='CTF-4L'>
 			<availability>CC:6,WOB:6</availability>
 		</model>
-		<model name='CTF-5D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
+		<model name='CTF-1X'>
+			<availability>General:3-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,DoO:2,FRR:5,DO:2,MERC:3,CIR:4,Periphery:2,TC:3,CS:4,LA:1,CGB.FRR:5,FWL:1,NIOPS:4,MH:5,TP:2,DA:2,RCM:2,DC:6</availability>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,FS:1,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-K2'>
+			<roles>fire_support</roles>
+			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:2,PIR:4,MH:7,Periphery:4</availability>
+		</model>
 		<model name='CPLT-K4'>
 			<roles>fire_support</roles>
 			<availability>WOB:4,DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:3-,Periphery.Deep:8,MERC:3-,BAN:4,Periphery:3-</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>FRR:6,CGB.FRR:6,DC:8</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,CS:3,MOC:3,FWL:2,WOB:3,MERC:2,FS:2,CDP:3,TC:3,DC:4</availability>
 		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:3-,Periphery.Deep:8,MERC:3-,BAN:4,Periphery:3-</availability>
-		</model>
 		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:2,MERC:2,TC:2</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,PIR:4,MH:7,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>FRR:6,CGB.FRR:6,DC:8</availability>
-		</model>
-		<model name='CPLT-A1'>
-			<roles>fire_support</roles>
-			<availability>CC:1-</availability>
-		</model>
-		<model name='CPLT-K2'>
-			<roles>fire_support</roles>
-			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
@@ -3536,28 +3540,18 @@
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:2,TC:4</availability>
-		</model>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,FS:1,MERC:3,CDP:3,TC:3</availability>
-		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:4,MOC:4,DoO:2,DO:2,TP:2,MERC:2,DA:2,RCM:2</availability>
 		</model>
+		<model name='CPLT-A1'>
+			<roles>fire_support</roles>
+			<availability>CC:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CCC:5,CSR:3,CDS:5,CW:1,CLAN:1,CNC:5,CGS:6,CJF:1,CGB:1,DC:3+</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:2</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
@@ -3567,9 +3561,8 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='X'>
+			<availability>CHH:1,CW:1</availability>
 		</model>
 		<model name='B'>
 			<roles>spotter</roles>
@@ -3578,29 +3571,42 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
-		<model name='X'>
-			<availability>CHH:1,CW:1</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>LA:1,FS:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
@@ -3610,20 +3616,14 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>CSR:1,CBS:5+</availability>
-		<model name='2'>
-			<availability>CSR:3,CBS:6</availability>
-		</model>
 		<model name='4'>
 			<availability>CBS:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSR:3,CBS:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:5,CBS:8</availability>
@@ -3638,11 +3638,11 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CSR:3,CBS:4,CNC:6,CSL:5,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,CNC:8,CSL:5,CJF:3</availability>
-		</model>
 		<model name='3'>
 			<availability>CSR:3,CBS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8,CNC:8,CSL:5,CJF:3</availability>
 		</model>
 		<model name='2'>
 			<availability>CSL:5</availability>
@@ -3650,13 +3650,13 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
@@ -3674,72 +3674,72 @@
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8,WOB:8</availability>
 		</model>
+		<model name='CNT-1A'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>DoO:2,FRR:1,DO:2,Periphery.OS:4,FS:8,CDP:3,SC:2,CGB.FRR:1,FWL:2,NIOPS:2-,MH:4,CC:2,IS:1,WOB:2-,DGM:2,MERC:2,Periphery:2,CS:2-,DTA:2,FVC:8,LA:4,MCM:2,Periphery.HR:4,ROS:3,TP:2,DC:1</availability>
-		<model name='CN9-D3'>
-			<availability>FVC:2,ROS:3,FS:3,MERC:3</availability>
-		</model>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:2-,FS:2-,MERC:2-</availability>
-		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:4,Periphery:2</availability>
-		</model>
-		<model name='CN9-H'>
-			<availability>MH:6</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:5,HL:2,LA:1,FWL:1,FS:3,MERC:6,CIR:3,Periphery:4</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:3-,Periphery.Deep:8,FS:2-,MERC:2-,Periphery:3-</availability>
 		</model>
+		<model name='CN9-D'>
+			<availability>FVC:5,HL:2,LA:1,FWL:1,FS:3,MERC:6,CIR:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:2,ROS:3,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:2-,FS:2-,MERC:2-</availability>
 		</model>
-		<model name='CN9-Da'>
-			<availability>SC:1,FVC:2,DoO:1,MCM:1,ROS:1,FWL:2,DO:1,DGM:1,TP:1,FS:1,MERC:1,Periphery:2</availability>
+		<model name='CN9-H'>
+			<availability>MH:6</availability>
 		</model>
 		<model name='CN9-D4D'>
 			<availability>DTA:2,SC:2,DoO:2,MCM:2,ROS:3,FWL:1,DO:2,DGM:2,TP:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='CN9-Ar'>
+			<availability>IS:4,Periphery:2</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FVC:2,ROS:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
+		</model>
+		<model name='CN9-Da'>
+			<availability>SC:1,FVC:2,DoO:1,MCM:1,ROS:1,FWL:2,DO:1,DGM:1,TP:1,FS:1,MERC:1,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
 		<availability>MOC:4,LA:5,IS:4,MH:4,FS:5,DC:6</availability>
-		<model name='MR-6B'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='MR-5M'>
 			<availability>CC:4,ROS:5,FWL:6,WOB:6</availability>
+		</model>
+		<model name='MR-V2'>
+			<availability>General:8</availability>
 		</model>
 		<model name='MR-V3'>
 			<availability>IS:6</availability>
 		</model>
-		<model name='MR-V2'>
-			<availability>General:8</availability>
+		<model name='MR-6B'>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3762,15 +3762,15 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
-		<model name='4'>
-			<roles>spotter</roles>
-			<availability>CSR:2</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<roles>spotter</roles>
+			<availability>CSR:2</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:3</availability>
@@ -3794,51 +3794,47 @@
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:5,CC:5,OA:5,HL:3,LA:6,IS:4,FWL:5,FS:5,TC:5,Periphery:4,DC:4</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:2-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6</availability>
 		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:4,IS:3,FS:4</availability>
 		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
 		<availability>CHH:2,PR:2,DoO:2,FRR:4,DO:2,FS:3,DC.GHO:5,SC:2,CGB.FRR:4,FWL:3,NIOPS:5,RFS:2,CGB:3,CC:4,IS:3,WOB:5,DGM:2,MERC:2,CS:5,DTA:2,FVC:2,LA:3,MCM:2,ROS:4,PG:2,TP:2,DA:2,RCM:2,DC:3</availability>
+		<model name='CHP-3P'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='CHP-2N'>
+			<availability>IS:1-,NIOPS:0</availability>
+		</model>
 		<model name='CHP-3N'>
 			<availability>CS:6,ROS:6,WOB:6</availability>
+		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,CS:4,LA:4,IS:1,MERC:4</availability>
 		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CC:1,CHH:2,WOB:4,FS:1,MERC:5,BAN:3,DC.GHO:3-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:1,CGB:2</availability>
 		</model>
-		<model name='CHP-2N'>
-			<availability>IS:1-,NIOPS:0</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,CS:4,LA:4,IS:1,MERC:4</availability>
-		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
-		</model>
-		<model name='CHP-3P'>
-			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CS:4,FRR:3+,CGB.FRR:3+,ROS:4,IS:3+,NIOPS:4,WOB:6,MERC:2+,BAN:4,Periphery:2+</availability>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:4,WOB:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
@@ -3847,22 +3843,36 @@
 			<roles>missile_artillery</roles>
 			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='(ERML)'>
+		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MG)'>
+		<model name='(CASE)'>
+			<roles>missile_artillery</roles>
+			<availability>General:4,WOB:4</availability>
+		</model>
+		<model name='(ERML)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:3-,MOC:2-,FRR:4-,MERC:2-,TC:2-,Periphery:2,OA:2-,FVC:2,LA:3-,CGB.FRR:4-,ROS:2-,FWL:1-,DC:4-</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5,Periphery:3</availability>
+		</model>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>LA:3,ROS:3,MERC:4,DC:4</availability>
+		</model>
 		<model name='CGR-3K'>
 			<availability>CC:1-,FRR:3-,CGB.FRR:3-,MERC:3-,DC:3-</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>CC:3-,FVC:4,HL:1,Periphery:4</availability>
+		<model name='CGR-3Kr'>
+			<availability>FRR:1,CGB.FRR:2,ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='CGR-C'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>FVC:4-,OA:4-</availability>
@@ -3874,74 +3884,64 @@
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,OA:10,FVC:5,PIR:5,MH:5,Periphery:3</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:3,ROS:3,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:2,MERC:4</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:3,ROS:3,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-C'>
-			<availability>DC:4</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>FRR:1,CGB.FRR:2,ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>LA:3,ROS:3,MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>CC:3-,FVC:4,HL:1,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>PR:8,HL:2,DoO:10,FRR:3,DO:10,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,RFS:8,MOC:5,CC:3,WOB:6,DGM:10,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,FVC:2,LA:1-,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10,DC:1-</availability>
-		<model name='F-11'>
-			<availability>CC:2,MOC:2,PR:8,DoO:8,FRR:6,WOB:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:2,PG:8,PIR:2,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='F-13'>
+			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,DO:4,DGM:4,TP:4,MERC:4</availability>
 		</model>
-		<model name='F-14-S'>
-			<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:3,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:3,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
-		<model name='OF-17A-R'>
-			<roles>recon</roles>
-			<availability>SC:4,MCM:4,ROS:3,DGM:4</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:3-,PR:2-,HL:1-,DoO:2-,Periphery.Deep:8,DO:2-,DGM:2-,MERC:3-,Periphery:3-,DTA:2-,SC:2-,MCM:2-,PG:2-,General:1-,FWL:3-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
+		<model name='F-12-S'>
+			<availability>FWL:2-,WOB:2-</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,PR:2,DoO:2,DO:2,DGM:2,MERC:2,DTA:2,SC:2,MCM:2,PG:2,FWL:2,TP:2,DA:2,RCM:2,RFS:2</availability>
 		</model>
-		<model name='F-13'>
-			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,DO:4,DGM:4,TP:4,MERC:4</availability>
-		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2-,FVC:1,FWL:2-,MERC:2-,Periphery:1</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:2-,WOB:2-</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:3-,PR:2-,HL:1-,DoO:2-,Periphery.Deep:8,DO:2-,DGM:2-,MERC:3-,Periphery:3-,DTA:2-,SC:2-,MCM:2-,PG:2-,General:1-,FWL:3-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:2,MOC:2,PR:8,DoO:8,FRR:6,WOB:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:2,PG:8,PIR:2,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
+		<model name='OF-17A-R'>
+			<roles>recon</roles>
+			<availability>SC:4,MCM:4,ROS:3,DGM:4</availability>
+		</model>
+		<model name='F-14-S'>
+			<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:3,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:3,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CS:5,CDS:2,LA:1,ROS:5,CNC:3,NIOPS:5,WOB:5,FS:1,DC:3</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>CS:4,WOB:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>CS:4,WOB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:4,LA:4,WOB:4,FS:4,RCM:4,DC:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3961,23 +3961,23 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,FWL:2,DC:1,CGB:3</availability>
-		<model name='CHP-W7T'>
-			<availability>TC:8</availability>
-		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,FRR:6,CGB.FRR:6,ROS:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,HL:1-,LA:3-,IS:1-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>FVC:4,FS:1-,CDP:4,TC:4,Periphery:1-</availability>
 		</model>
-		<model name='CHP-W8'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,HL:1-,LA:3-,IS:1-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
+		<model name='CHP-W7T'>
+			<availability>TC:8</availability>
+		</model>
+		<model name='CHP-W8'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='CHP-W7'>
+			<availability>LA:8,FRR:6,CGB.FRR:6,ROS:6,CLAN:6,WOB:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
@@ -3991,13 +3991,6 @@
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:4,IS:1,WOB:4-,DGM:6,FS:1,MERC:3,CDP:3,Periphery:3,CS:4-,SC:6,LA:1,MCM:6,PG:6,FWL:6,RFS:6,DC:3</availability>
-		<model name='CDA-3P'>
-			<availability>SC:4,PR:5,MCM:4,PG:5,FWL:7,WOB:6,DGM:4,RFS:5</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
-		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
 			<availability>CC:6,FRR:6,CGB.FRR:6,FWL:6,WOB:6,MERC:6,DC:6</availability>
@@ -4006,9 +3999,16 @@
 			<roles>recon</roles>
 			<availability>FWL:8,IS:6,MERC:6,Periphery:2</availability>
 		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:2,MOC:2,FWL:4,MERC:2</availability>
+		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:5,IS:4,WOB:5</availability>
+		</model>
+		<model name='CDA-3P'>
+			<availability>SC:4,PR:5,MCM:4,PG:5,FWL:7,WOB:6,DGM:4,RFS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -4032,20 +4032,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -4065,14 +4065,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -4080,29 +4077,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -4113,8 +4113,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -4122,18 +4125,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -4142,15 +4151,6 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -4171,14 +4171,14 @@
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -4186,8 +4186,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -4219,19 +4219,6 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,PR:3,FRR:1,IS:1,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,CGB.FRR:1,PG:3,ROS:3,FWL:1,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3,DC:1</availability>
-		<model name='CLNT-2-3UL'>
-			<availability>CC:8,MOC:3,TC:7</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:4,Periphery.HR:4,Periphery.CM:4,MH:4,CDP:4,TC:8</availability>
-		</model>
-		<model name='CLNT-5U'>
-			<roles>spotter</roles>
-			<availability>LA:8,General:4,MERC:8</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
-		</model>
 		<model name='CLNT-2-4T'>
 			<availability>CC:1,FS:1</availability>
 		</model>
@@ -4241,31 +4228,44 @@
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
 		</model>
+		<model name='CLNT-5U'>
+			<roles>spotter</roles>
+			<availability>LA:8,General:4,MERC:8</availability>
+		</model>
+		<model name='CLNT-2-3UL'>
+			<availability>CC:8,MOC:3,TC:7</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:4,Periphery.HR:4,Periphery.CM:4,MH:4,CDP:4,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>CS:6,WOB:6</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>CS:4,NIOPS:4,WOB:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>IS:2</availability>
+			<availability>CS:4,NIOPS:4,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra' unitType='Mek'>
 		<availability>LA:6,FRR:4,CGB.FRR:4,MERC:3</availability>
-		<model name='CBR-03'>
-			<roles>fire_support</roles>
-			<availability>LA:5</availability>
-		</model>
 		<model name='CBR-02'>
 			<roles>fire_support</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='CBR-03'>
+			<roles>fire_support</roles>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
@@ -4297,66 +4297,66 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:3,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
-		<model name='COM-1A'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>FVC:3-,LA:3-,Periphery:3-</availability>
+			<availability>MOC:4+,FVC:3,LA:8,FRR:6,CGB.FRR:6,MH:4+,FS:2,MERC:5,CDP:4+,TC:4+</availability>
+		</model>
+		<model name='COM-4H'>
+			<roles>recon</roles>
+			<availability>PIR:8,MH:10</availability>
 		</model>
 		<model name='COM-1B'>
 			<roles>recon</roles>
 			<availability>LA:1</availability>
 		</model>
-		<model name='COM-7B'>
-			<roles>recon</roles>
-			<availability>ROS:8,WOB:10</availability>
-		</model>
 		<model name='COM-2Dr'>
 			<roles>recon</roles>
 			<availability>HL:2,LA:4,MERC:4,Periphery:4</availability>
 		</model>
-		<model name='COM-7S'>
+		<model name='COM-7B'>
 			<roles>recon</roles>
-			<availability>LA:7,WOB:8,MERC:6</availability>
+			<availability>ROS:8,WOB:10</availability>
 		</model>
-		<model name='COM-5S'>
+		<model name='COM-1A'>
 			<roles>recon</roles>
-			<availability>MOC:4+,FVC:3,LA:8,FRR:6,CGB.FRR:6,MH:4+,FS:2,MERC:5,CDP:4+,TC:4+</availability>
+			<availability>FVC:3-,LA:3-,Periphery:3-</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
 			<availability>LA:2-,MERC:1-,Periphery:1</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>PIR:8,MH:10</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>HL:1-,LA:1-,General:3-,Periphery.Deep:8,TC:3-,Periphery:4-</availability>
 		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:7,WOB:8,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:5-</availability>
-		</model>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:8,FWL:6,MERC:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:2,LA:2,FS:2</availability>
-		</model>
-		<model name='(Upgrade) (Laser)'>
-			<availability>LA:6,IS:7</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:4-,FVC:4-,General:3-,FS:4-,Periphery:3-</availability>
 		</model>
 		<model name='(Davion)'>
 			<availability>FS:2-</availability>
 		</model>
+		<model name='(Upgrade) (Laser)'>
+			<availability>LA:6,IS:7</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CC:2,LA:2,FS:2</availability>
+		</model>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:8,FWL:6,MERC:6</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>LA:3,IS:3</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -4379,24 +4379,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CS:6,CLAN:4,NIOPS:6,WOB:6,BAN:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CS:2,CHH:1,MERC.WD:1,CSR:1,CW:1,NIOPS:2,CGS:2,CJF:2</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -4418,17 +4418,17 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Copperhead' unitType='Mek'>
@@ -4451,17 +4451,17 @@
 		<model name='CRX-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='CRX-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='CRX-OR'>
-			<availability>OA:2,CLAN:8</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='CRX-OD'>
+			<availability>General:5</availability>
+		</model>
 		<model name='CRX-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='CRX-OR'>
+			<availability>OA:2,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
@@ -4475,11 +4475,17 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:4,CGB.FRR:2,ROS:4,DC:2</availability>
-		<model name='CSR-V12M &apos;Regulus&apos;'>
-			<availability>FWL:1</availability>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FRR:6,FS:6,MERC:6</availability>
 		</model>
-		<model name='CSR-V18'>
-			<availability>FVC:5,ROS:4,FS:5</availability>
+		<model name='CSR-X12 Rigid Night'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='CSR-12D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>CLAN:6,FS:3,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>LA:1,FS.AH:2-,Periphery:1</availability>
@@ -4487,17 +4493,11 @@
 		<model name='CSR-V12'>
 			<availability>HL:1-,IS:3-,Periphery.Deep:8,BAN:4,Periphery:4-</availability>
 		</model>
-		<model name='CSR-X12 Rigid Night'>
-			<availability>FS:1</availability>
+		<model name='CSR-V12M &apos;Regulus&apos;'>
+			<availability>FWL:1</availability>
 		</model>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FRR:6,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>CLAN:6,FS:3,BAN:2</availability>
-		</model>
-		<model name='CSR-12D'>
-			<availability>FS:4</availability>
+		<model name='CSR-V18'>
+			<availability>FVC:5,ROS:4,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -4521,50 +4521,50 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='XR'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='G'>
 			<availability>CHH:6,General:4</availability>
+		</model>
+		<model name='XR'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
 		<availability>CJF:5,CCO:3</availability>
-		<model name='H'>
-			<availability>CSA:6,General:5</availability>
-		</model>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>CW:3,CJF:3,CWIE:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<availability>CW:3,CJF:3,CWIE:3</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,General:5</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -4573,9 +4573,9 @@
 			<roles>raider</roles>
 			<availability>CS:7,FRR:5,CGB.FRR:5,ROS:7,CLAN:4,WOB:7,CGS:6,BAN:2,DC:5</availability>
 		</model>
-		<model name='CRB-27'>
+		<model name='CRB-20'>
 			<roles>raider</roles>
-			<availability>DC.GHO:5-,CS:3,FRR:3,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
+			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
 		<model name='CRB-45'>
 			<availability>WOB:5</availability>
@@ -4583,12 +4583,12 @@
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='CRB-27'>
+			<roles>raider</roles>
+			<availability>DC.GHO:5-,CS:3,FRR:3,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,WOB:3,BAN:8,DC:8</availability>
+		</model>
 		<model name='CRB-30'>
 			<availability>CS:8,FRR:2,CGB.FRR:2,WOB:6</availability>
-		</model>
-		<model name='CRB-20'>
-			<roles>raider</roles>
-			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
@@ -4596,39 +4596,42 @@
 		<model name='(Standard)'>
 			<availability>CLAN.IS:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CDS:4,CBS:8</availability>
-		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:4,CBS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:2,CDS:3,CBS:6</availability>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CBS:8,General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:6,CSR:4,FRR:6,CLAN:5,WOB:8,CIR:4,CGS:4,CWIE:6,DC.GHO:3,CS:9,CDS:4,CW:6,CBS:6,CGB.FRR:6,ROS:5,NIOPS:9,CJF:4,CGB:6</availability>
-		<model name='CRK-5003-3'>
-			<availability>CS:8,FRR:4,CGB.FRR:4,ROS:8</availability>
+		<model name='CRK-5004-1'>
+			<availability>CS:6,FRR:4,CGB.FRR:4,ROS:6</availability>
+		</model>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:4,CGS:6,BAN:2</availability>
 		</model>
 		<model name='CRK-5005-1'>
 			<availability>ROS:8,WOB:8,CIR:6</availability>
@@ -4639,23 +4642,20 @@
 		<model name='CRK-5003-1'>
 			<availability>CS:4,ROS:4,FRR:4,CLAN:6,NIOPS:4,WOB:4,CIR:4,BAN:8</availability>
 		</model>
-		<model name='CRK-5004-1'>
-			<availability>CS:6,FRR:4,CGB.FRR:4,ROS:6</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:4,CGS:6,BAN:2</availability>
+		<model name='CRK-5003-3'>
+			<availability>CS:8,FRR:4,CGB.FRR:4,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
 		<availability>CS:3,HL:3,Periphery.MW:4,Periphery.ME:4,FWL:3,WOB:3,MERC:4,Periphery:4</availability>
-		<model name='CNS-5M'>
-			<availability>CS:0,PIR:4,IS:8</availability>
-		</model>
 		<model name='CNS-3M'>
 			<availability>General:4</availability>
 		</model>
 		<model name='CNS-TD9'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='CNS-5M'>
+			<availability>CS:0,PIR:4,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
@@ -4666,28 +4666,28 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CSR:3,CDS:4,CW:3,CBS:5,CLAN:3,CNC:4,CCO:3,CJF:3,CWIE:4,CGB:3</availability>
-		<model name='D'>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
 			<availability>General:4</availability>
 		</model>
 		<model name='U'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
-		<model name='C'>
+		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
+		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4697,50 +4697,17 @@
 			<roles>recon</roles>
 			<availability>DC:5</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>IS:4,DC:8</availability>
 		</model>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CS:6-,HL:5,CLAN:5,IS:7,NIOPS:6-,Periphery.Deep:5,WOB:4-,Periphery:6</availability>
-		<model name='CRD-4D'>
-			<availability>FVC:8,FS:8</availability>
-		</model>
-		<model name='CRD-2R'>
-			<availability>ROS:5,CLAN:4,FWL:4,IS:2,WOB:5,MERC:4,CGS:6,BAN:2</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>MERC:5</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>FRR:5,CGB.FRR:5,WOB:4,MERC:5,DC:6</availability>
-		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:4,WOB:4,MERC:4</availability>
-		</model>
-		<model name='CRD-7L'>
-			<availability>CC:6,WOB:4</availability>
-		</model>
-		<model name='CRD-5S'>
-			<availability>LA:6,FS:1,MERC:4</availability>
-		</model>
-		<model name='CRD-3R'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>DTA:5,SC:5,MCM:5,ROS:4,FWL:2,WOB:4,DGM:5,MERC:4,RCM:5</availability>
-		</model>
-		<model name='CRD-3K'>
-			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
-		</model>
 		<model name='CRD-8S'>
 			<availability>LA:5,FS:4</availability>
 		</model>
@@ -4748,56 +4715,89 @@
 			<roles>raider</roles>
 			<availability>CC:1-</availability>
 		</model>
+		<model name='CRD-7L'>
+			<availability>CC:6,WOB:4</availability>
+		</model>
+		<model name='CRD-3R'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
+		</model>
 		<model name='CRD-5M'>
 			<availability>CC:4,CS:4,FWL:8,IS:1,WOB:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='CRD-3D'>
-			<availability>FVC:1-,FS:1-</availability>
+		<model name='CRD-3K'>
+			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
+		</model>
+		<model name='CRD-7W'>
+			<availability>DTA:5,SC:5,MCM:5,ROS:4,FWL:2,WOB:4,DGM:5,MERC:4,RCM:5</availability>
 		</model>
 		<model name='CRD-4K'>
 			<availability>LA:1,FRR:7,CGB.FRR:7,MERC:1,FS:1,DC:6</availability>
 		</model>
+		<model name='CRD-4BR'>
+			<availability>MERC:5</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:6,FS:1,MERC:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>FRR:5,CGB.FRR:5,WOB:4,MERC:5,DC:6</availability>
+		</model>
+		<model name='CRD-2R'>
+			<availability>ROS:5,CLAN:4,FWL:4,IS:2,WOB:5,MERC:4,CGS:6,BAN:2</availability>
+		</model>
+		<model name='CRD-3D'>
+			<availability>FVC:1-,FS:1-</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:4,WOB:4,MERC:4</availability>
+		</model>
+		<model name='CRD-4D'>
+			<availability>FVC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,CGB.FRR:5,ROS:3,FWL:4,NIOPS:3,DC:5</availability>
-		<model name='CP-11-C'>
-			<roles>spotter</roles>
-			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,DC:5</availability>
-		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='CP-11-H'>
-			<availability>FVC:5,HL:3,PIR:6,MH:6,CIR:6,CDP:6,TC:6,Periphery:5</availability>
-		</model>
-		<model name='CP-10-Z'>
-			<availability>OA:1-,General:4-,IS:1-,FS:1-,MERC:1-,DC:1-,TC:1-</availability>
-		</model>
-		<model name='CP-11-C3'>
-			<roles>spotter</roles>
-			<availability>FS:1,DC:1</availability>
-		</model>
-		<model name='CP-11-A'>
-			<availability>CC:6,CS:4,MOC:4,LA:6,FWL:7,IS:6,WOB:6,MH:3,FS:7,CDP:4,DC:3,TC:4</availability>
-		</model>
 		<model name='CP-11-G'>
 			<availability>CS:8,MOC:3,FRR:8,CGB.FRR:8,IS:3,MERC:4,CDP:3,TC:3</availability>
 		</model>
 		<model name='CP-10-Q'>
 			<availability>IS:1-</availability>
 		</model>
-		<model name='CP-10-HQ'>
-			<availability>IS:2</availability>
+		<model name='CP-12-K'>
+			<availability>MERC:7,DC:7</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>CC:6,CS:4,MOC:4,LA:6,FWL:7,IS:6,WOB:6,MH:3,FS:7,CDP:4,DC:3,TC:4</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>OA:1-,General:4-,IS:1-,FS:1-,MERC:1-,DC:1-,TC:1-</availability>
 		</model>
 		<model name='CP-11-A-DC'>
 			<availability>CC:4,IS:2</availability>
 		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:7,DC:7</availability>
-		</model>
 		<model name='CP-11-B'>
 			<availability>CC:5,IS:2+,MERC:5,DC:5</availability>
+		</model>
+		<model name='CP-11-C'>
+			<roles>spotter</roles>
+			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,DC:5</availability>
+		</model>
+		<model name='CP-11-H'>
+			<availability>FVC:5,HL:3,PIR:6,MH:6,CIR:6,CDP:6,TC:6,Periphery:5</availability>
+		</model>
+		<model name='CP-11-C3'>
+			<roles>spotter</roles>
+			<availability>FS:1,DC:1</availability>
+		</model>
+		<model name='CP-10-HQ'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
@@ -4818,6 +4818,10 @@
 			<roles>recon,escort</roles>
 			<availability>HL:2,MERC:4,TC:2,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,escort</roles>
+			<availability>CS:4,General:4,NIOPS:4,WOB:4</availability>
+		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -4826,22 +4830,18 @@
 			<roles>recon,escort</roles>
 			<availability>TC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon,escort</roles>
-			<availability>CS:4,General:4,NIOPS:4,WOB:4</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:5</availability>
 		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dagger' unitType='Aero'>
@@ -4852,18 +4852,18 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>WOB:4,FS:6</availability>
-		<model name='DARO-1'>
-			<availability>General:6,FS:8</availability>
-		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='DARO-1C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1'>
+			<availability>General:6,FS:8</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1A'>
 			<availability>General:7</availability>
@@ -4871,12 +4871,12 @@
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01r'>
-			<availability>General:3</availability>
-		</model>
 		<model name='DAI-01'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='DAI-01r'>
+			<availability>General:3</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
@@ -4889,13 +4889,13 @@
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
 		<availability>FRR:3+,CGB.FRR:3+,DC:3+,CGB:1</availability>
-		<model name='67-K'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='67-K2'>
 			<roles>support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='67-K'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
@@ -4903,49 +4903,49 @@
 		<model name='DMO-4K'>
 			<availability>FRR:2,CGB.FRR:2,DC:7</availability>
 		</model>
-		<model name='DMO-5K'>
-			<roles>spotter</roles>
-			<availability>FRR:2,CGB.FRR:2,DC:3</availability>
+		<model name='DMO-2K'>
+			<availability>FRR:4,CGB.FRR:4,DC:6</availability>
 		</model>
 		<model name='DMO-1K'>
 			<availability>General:8,DC:5</availability>
 		</model>
-		<model name='DMO-2K'>
-			<availability>FRR:4,CGB.FRR:4,DC:6</availability>
+		<model name='DMO-5K'>
+			<roles>spotter</roles>
+			<availability>FRR:2,CGB.FRR:2,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,IS:2+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:2</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4,CGS:5,CCO:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4971,24 +4971,21 @@
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>CS:4,LA:5,ROS:4,MH:2,FS:6,MERC:4,CIR:4</availability>
-		<model name='DRT-3S'>
-			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='DRT-4S'>
-			<availability>LA:4,MH:3,FS:5,MERC:4,CIR:4</availability>
-		</model>
 		<model name='DRT-6T'>
 			<availability>CS:8,LA:4,ROS:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='DRT-3S'>
+			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:2</availability>
 		</model>
+		<model name='DRT-4S'>
+			<availability>LA:4,MH:3,FS:5,MERC:4,CIR:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:4,FS:7</availability>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5</availability>
@@ -4996,6 +4993,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -5005,13 +5006,18 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,CHH:5,CCC:3,MERC.WD:3,CDS:3,CLAN:3,IS:3+,CCO:2,CJF:3,BAN:3,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CDS:4,CBS:3,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -5019,27 +5025,21 @@
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
 		</model>
+		<model name='K'>
+			<availability>General:2,CGB:4</availability>
+		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CDS:4,CBS:3,General:4,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
-		</model>
-		<model name='K'>
-			<availability>General:2,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
@@ -5059,19 +5059,19 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:4+,MOC:3+,WOB:5+</availability>
-		<model name='DFC-OD'>
-			<roles>ground_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='DFC-OB'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='DFC-OD'>
+			<roles>ground_support</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OB'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -5082,11 +5082,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:4,MERC:3</availability>
-		<model name='DFN-3T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='DFN-3S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='DFN-3T'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -5104,24 +5104,24 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>CHH:5,HL:9,FRR:7,CLAN:4,Periphery.Deep:9,FS:9,CWIE:6,OA:9,CGB.FRR:7,FWL:8,NIOPS:6,MOC:10,CC:7,IS:7,WOB:6,CIR:9,Periphery:10,TC:9,CS:6,FVC:8,LA:5,ROS:8,CNC:5,CJF:2,DC:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:1,Periphery:1</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:3,IS:3,Periphery.Deep:6,Periphery:5</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:8,MOC:7,FRR:6,IS:7,WOB:8,FS:8,TC:7,CWIE:4,CS:8,LA:8,CGB.FRR:6,ROS:8,FWL:8,DC:8</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>FVC:3,DC:7,Periphery:3</availability>
+		<model name='(Defensive)'>
+			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
 		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:3,IS:3,Periphery.Deep:6,Periphery:5</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>FVC:3,DC:7,Periphery:3</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -5130,15 +5130,15 @@
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
 		<availability>LA:6,CWIE:4</availability>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MML)'>
 			<availability>LA:3,CWIE:3</availability>
 		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:2,CWIE:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -5161,11 +5161,11 @@
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
 		<availability>CS:8,FRR:6,CGB.FRR:6,ROS:7,CLAN:5,NIOPS:8,WOB:9,CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6</availability>
-		</model>
 		<model name='(HGR)'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<availability>CS:4,CHH:6,ROS:4,CLAN:4,NIOPS:4,WOB:4</availability>
@@ -5176,31 +5176,27 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:2,CC:2,HL:2,DoO:3,FRR:3,IS:2,Periphery.Deep:5,DO:3,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:1,FVC:5,LA:3,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:3</availability>
-		<model name='DV-1S'>
-			<availability>IS:3-</availability>
-		</model>
 		<model name='DV-8D'>
 			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='DV-6Mr'>
-			<availability>General:2</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:6,LA:6,FS:6,MERC:4,CDP:3,TC:3</availability>
-		</model>
-		<model name='DV-9D'>
-			<availability>ROS:4,FS:5,MERC:3</availability>
 		</model>
 		<model name='DV-6M'>
 			<availability>HL:2-,CLAN:4,IS:2-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
+		<model name='DV-9D'>
+			<availability>ROS:4,FS:5,MERC:3</availability>
+		</model>
+		<model name='DV-7D'>
+			<availability>FVC:6,LA:6,FS:6,MERC:4,CDP:3,TC:3</availability>
+		</model>
+		<model name='DV-6Mr'>
+			<availability>General:2</availability>
+		</model>
+		<model name='DV-1S'>
+			<availability>IS:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Deva' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='C-DVA-OE Eminus'>
-			<deployedWith>Grigori</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-DVA-OS Caelestis'>
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:4</availability>
@@ -5213,9 +5209,13 @@
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-O Invictus'>
+		<model name='C-DVA-OE Eminus'>
 			<deployedWith>Grigori</deployedWith>
-			<availability>General:8</availability>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-DVA-OA Dominus'>
+			<deployedWith>Grigori</deployedWith>
+			<availability>General:7</availability>
 		</model>
 		<model name='C-DVA-OU Exanimus'>
 			<deployedWith>Grigori</deployedWith>
@@ -5225,9 +5225,9 @@
 			<deployedWith>Grigori</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-DVA-OA Dominus'>
+		<model name='C-DVA-O Invictus'>
 			<deployedWith>Grigori</deployedWith>
-			<availability>General:7</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -5238,14 +5238,14 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:3,FVC:6,LA:6,FS:6,MERC:3,TC:4</availability>
-		<model name='DVS-1D'>
-			<availability>FVC:8,LA:1-,FS:1-,TC:8</availability>
+		<model name='DVS-3'>
+			<availability>LA:3,FS:3</availability>
 		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='DVS-3'>
-			<availability>LA:3,FS:3</availability>
+		<model name='DVS-1D'>
+			<availability>FVC:8,LA:1-,FS:1-,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -5256,28 +5256,25 @@
 	</chassis>
 	<chassis name='Djinn Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:5,PIR:1,WOB:1</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>WOB.SD:8</availability>
-		</model>
 		<model name='(Reflective)&apos;Terrorizer&apos; (Flamer)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Reflective)&apos;Terrorizer&apos; (SL)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Stealth)' mechanized='true'>
-			<availability>WOB:4</availability>
+		<model name='(Standard)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>WOB.SD:8</availability>
 		</model>
 		<model name='(Reflective)&apos;Terrorizer&apos; (MG)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Stealth)' mechanized='true'>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:5</availability>
@@ -5285,6 +5282,9 @@
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CSL:4,CGS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau Assault Interceptor' unitType='Dropship'>
@@ -5308,17 +5308,17 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,LA:1,FRR:6,CGB.FRR:6,MERC:3,DC:5</availability>
-		<model name='DRG-5N'>
-			<availability>FRR:5,CGB.FRR:5,MERC:5,DC:5,Periphery:3</availability>
-		</model>
 		<model name='DRG-7N'>
 			<availability>LA:1,MERC:5,DC:5</availability>
 		</model>
-		<model name='DRG-5Nr'>
-			<availability>FRR:2,CGB.FRR:2,MERC:2,DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>FRR:1-,CGB.FRR:1-,DC:1-,Periphery:3</availability>
+		</model>
+		<model name='DRG-5N'>
+			<availability>FRR:5,CGB.FRR:5,MERC:5,DC:5,Periphery:3</availability>
+		</model>
+		<model name='DRG-5Nr'>
+			<availability>FRR:2,CGB.FRR:2,MERC:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
@@ -5327,16 +5327,6 @@
 			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:7,CHH:7,CCC:7,CSR:4,CDS:8,CBS:7,General:6,CGS:7,CJF:8,CWIE:7,CGB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>General:2,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 		</model>
@@ -5344,22 +5334,32 @@
 			<roles>spotter</roles>
 			<availability>CCO:2</availability>
 		</model>
+		<model name='B'>
+			<availability>CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:1</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
 		</model>
-		<model name='I'>
-			<availability>General:2</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>General:2,CGB:5</availability>
 		</model>
-		<model name='U'>
+		<model name='D'>
+			<availability>CSA:7,CHH:7,CCC:7,CSR:4,CDS:8,CBS:7,General:6,CGS:7,CJF:8,CWIE:7,CGB:7</availability>
+		</model>
+		<model name='I'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5372,20 +5372,20 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:3-,Periphery:3-,CS:3,FVC:4-,LA:7,ROS:3,FWL:3-,CC.MAC:3-,DC:3-</availability>
-		<model name='(SRM)'>
-			<availability>CC:3-,General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:3-,General:3-</availability>
-		</model>
-		<model name='(Streak)'>
-			<availability>LA:8,WOB:7,FS:7</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>LA:2,ROS:2,WOB:2,FS:2</availability>
 		</model>
+		<model name='(SRM)'>
+			<availability>CC:3-,General:2</availability>
+		</model>
 		<model name='(ERLL)'>
 			<availability>WOB:2</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:8,WOB:7,FS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5413,17 +5413,11 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
-		<model name='EGL-R6'>
-			<availability>LA:1-,General:5-,FS:1-</availability>
-		</model>
-		<model name='EGL-R4'>
-			<availability>LA:1,FS:1</availability>
-		</model>
 		<model name='EGL-R6b'>
 			<availability>SC:4,DoO:4,MCM:4,DO:4,DGM:4,TP:4,RCM:4</availability>
 		</model>
-		<model name='EGL-R11'>
-			<availability>LA:4,MERC:4</availability>
+		<model name='EGL-R4'>
+			<availability>LA:1,FS:1</availability>
 		</model>
 		<model name='EGL-R9'>
 			<availability>LA:1-,FS:1-</availability>
@@ -5432,33 +5426,39 @@
 			<roles>ground_support</roles>
 			<availability>LA:1-,FS:1-</availability>
 		</model>
+		<model name='EGL-R11'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
+		<model name='EGL-R6'>
+			<availability>LA:1-,General:5-,FS:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,PR:6,DGM:7,MERC:4,DTA:6,SC:7,FWL.MM:7,MCM:7,PG:6,FWL:6,MH:4,FWL.FO:7,DA:5,RFS:6</availability>
-		<model name='EGL-3M'>
-			<availability>DTA:3,SC:3,MCM:3,FWL:3,DGM:3</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
-		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
+		</model>
+		<model name='EGL-3M'>
+			<availability>DTA:3,SC:3,MCM:3,FWL:3,DGM:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Ebony' unitType='Mek'>
 		<availability>MOC:3,CC:2</availability>
-		<model name='MEB-11'>
+		<model name='MEB-10'>
 			<roles>recon</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='MEB-9'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='MEB-10'>
+		<model name='MEB-11'>
 			<roles>recon</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Eidolon' unitType='Mek'>
@@ -5469,14 +5469,14 @@
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:4,MERC:3</availability>
+		<model name='EFT-7X'>
+			<availability>IS:8,MH:4</availability>
+		</model>
 		<model name='EFT-4J'>
 			<availability>LA:3-,MERC:2-</availability>
 		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
-		</model>
-		<model name='EFT-7X'>
-			<availability>IS:8,MH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5487,78 +5487,78 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:4,MERC:2+</availability>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
+		<model name='EST-OD'>
+			<availability>General:3</availability>
 		</model>
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='EST-OD'>
-			<availability>General:3</availability>
+		<model name='EST-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Eldingar Hover Sled' unitType='Tank'>
 		<availability>FRR:3,CGB.FRR:3,CGB:3</availability>
+		<model name='(Standard)'>
+			<availability>FRR:8,CGB.FRR:8,CGB:8</availability>
+		</model>
 		<model name='(Streak)'>
 			<roles>fire_support</roles>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>FRR:8,CGB.FRR:8,CGB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,MERC.WD:6,CW:6,CLAN:6,CNC:6+</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:2,CLAN:2</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [AP Gauss]' mechanized='true'>
 			<availability>CJF:4</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='(Fire) [MicroPL]' mechanized='true'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='[MicroPL]' mechanized='true'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:2,CLAN:2</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Space) [MicroPL]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:2,CLAN:2</availability>
 		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:2,CLAN:2</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Fire) [Flamer]' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:2,CLAN:2</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [MicroPL]' mechanized='true'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='[MicroPL]' mechanized='true'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5569,17 +5569,11 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,WOB:7,FS:5,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
-		<model name='EMP-6M'>
-			<availability>FWL:2,WOB:4</availability>
-		</model>
-		<model name='EMP-6D'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='EMP-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='EMP-6S'>
-			<availability>LA:7</availability>
+		<model name='EMP-7L'>
+			<availability>CC:5</availability>
 		</model>
 		<model name='EMP-6ME &apos;Mercury Elite&apos;'>
 			<availability>FWL:1</availability>
@@ -5587,8 +5581,14 @@
 		<model name='EMP-6A'>
 			<availability>CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='EMP-7L'>
-			<availability>CC:5</availability>
+		<model name='EMP-6M'>
+			<availability>FWL:2,WOB:4</availability>
+		</model>
+		<model name='EMP-6S'>
+			<availability>LA:7</availability>
+		</model>
+		<model name='EMP-6D'>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
@@ -5597,6 +5597,10 @@
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4,FS:4</availability>
 		</model>
+		<model name='END-6Q'>
+			<roles>urban</roles>
+			<availability>LA:5,General:1,MERC:5</availability>
+		</model>
 		<model name='END-6S'>
 			<roles>urban</roles>
 			<availability>LA:2,MERC:2</availability>
@@ -5604,21 +5608,17 @@
 		<model name='END-6Sr'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
-		<model name='END-6Q'>
-			<roles>urban</roles>
-			<availability>LA:5,General:1,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:6,FS:7,MERC:5</availability>
-		<model name='ENF-6Ma'>
-			<availability>FVC:2,FS:2</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='ENF-6Ma'>
+			<availability>FVC:2,FS:2</availability>
 		</model>
 		<model name='ENF-6T'>
 			<availability>FS:4</availability>
@@ -5629,17 +5629,17 @@
 		<model name='ENF-7C3BS'>
 			<availability>FS:1</availability>
 		</model>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,TC:2,Periphery:2,FVC:7,OA:1,LA:1,Periphery.HR:2,MH:2,DC:1</availability>
-		<model name='ENF-4R'>
-			<availability>FVC:4-,General:2-,FS:3-,TC:3-</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>FVC:8,LA:1,FS:8,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>FVC:4-,General:2-,FS:3-,TC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -5668,14 +5668,6 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CDS:4+,CW:4+,CNC:3+,CSL:6+,CGS:3+,CGB:3+,CWIE:4+</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>CHH:8</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
@@ -5684,13 +5676,21 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>CHH:8</availability>
+		</model>
 		<model name='C'>
 			<roles>apc,spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
+			<availability>General:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Erinyes' unitType='ProtoMek'>
@@ -5704,17 +5704,21 @@
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CS:4,CSR:1,CDS:2,FWL:1,WOB:2,CGS:1,CCO:1,DC:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CS:4,CLAN:8,DC:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,CGB.FRR:6,FWL:5,NIOPS:5,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:2,FS:6</availability>
@@ -5722,20 +5726,12 @@
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:5,FS:4,MERC:2</availability>
 		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
 		<availability>CS:5,ROS:4,CLAN:1,NIOPS:5,WOB:5,CIR:2+,DC:4</availability>
 		<model name='EXC-B2b'>
 			<roles>fire_support</roles>
 			<availability>ROS:6,CLAN:4,WOB:5,CGS:6,BAN:2</availability>
-		</model>
-		<model name='EXC-CS'>
-			<roles>fire_support</roles>
-			<availability>CS:8,ROS:6,WOB:8,DC:8</availability>
 		</model>
 		<model name='EXC-B2'>
 			<roles>fire_support</roles>
@@ -5748,6 +5744,10 @@
 		<model name='EXC-D1'>
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='EXC-CS'>
+			<roles>fire_support</roles>
+			<availability>CS:8,ROS:6,WOB:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -5763,14 +5763,14 @@
 	</chassis>
 	<chassis name='Exterminator' unitType='Mek'>
 		<availability>CS:4,CLAN:1,NIOPS:2,WOB:4,DC:1</availability>
-		<model name='EXT-6CS'>
-			<availability>CS:1</availability>
+		<model name='EXT-4D'>
+			<availability>CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:2,DC:8</availability>
 		</model>
 		<model name='EXT-5F'>
 			<availability>CS:6</availability>
 		</model>
-		<model name='EXT-4D'>
-			<availability>CS:5,CLAN:6,NIOPS:5,WOB:5,BAN:2,DC:8</availability>
+		<model name='EXT-6CS'>
+			<availability>CS:1</availability>
 		</model>
 		<model name='EXT-4C'>
 			<availability>BAN:1</availability>
@@ -5781,9 +5781,8 @@
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
 		<availability>MOC:7,CC:3</availability>
-		<model name='EYL-45A'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='EYL-4A'>
+			<availability>MOC:1</availability>
 		</model>
 		<model name='EYL-35A'>
 			<roles>spotter</roles>
@@ -5793,40 +5792,38 @@
 			<roles>spotter</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='EYL-4A'>
-			<availability>MOC:1</availability>
+		<model name='EYL-45A'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:7</availability>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CC:5</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='(Support) [King David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
 		<availability>LA:4,WOB:3</availability>
-		<model name='FNR-5X'>
-			<availability>General:2</availability>
-		</model>
 		<model name='FNR-5WB'>
 			<availability>WOB:8</availability>
 		</model>
@@ -5835,6 +5832,9 @@
 		</model>
 		<model name='FNR-6U'>
 			<roles>marine</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='FNR-5X'>
 			<availability>General:2</availability>
 		</model>
 		<model name='FNR-5'>
@@ -5846,12 +5846,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,WOB:6</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>SC:6,MCM:6,WOB:8,DGM:6</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5874,20 +5874,20 @@
 		<model name='FLC-6C'>
 			<availability>MERC.WD:6+</availability>
 		</model>
-		<model name='FLC-4Nb'>
-			<availability>CLAN:8,BAN:1</availability>
-		</model>
 		<model name='FLC-4Nb-PP2'>
 			<availability>BAN:2</availability>
+		</model>
+		<model name='FLC-4Nb'>
+			<availability>CLAN:8,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>CS:4,LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-8R'>
-			<availability>General:6</availability>
-		</model>
 		<model name='FLC-9R'>
 			<availability>General:5</availability>
+		</model>
+		<model name='FLC-8R'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -5899,11 +5899,11 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:3</availability>
-		<model name='(Upgrade)'>
+		<model name='(Standard)'>
 			<roles>cruiser</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Upgrade)'>
 			<roles>cruiser</roles>
 			<availability>General:6</availability>
 		</model>
@@ -5917,14 +5917,8 @@
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SRM]' mechanized='false'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[SL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='&apos;Longshot&apos;' mechanized='false'>
 			<availability>General:3</availability>
@@ -5932,54 +5926,60 @@
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:3</availability>
+		</model>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[SRM]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:3+,CHH:3,MERC.WD:6,CW:6,IS:2+,CJF:4,CWIE:6,CGB:3</availability>
-		<model name='B'>
-			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:3,CNC:5,General:4,CGS:4,CWIE:3</availability>
-		</model>
-		<model name='H'>
-			<availability>MERC.KH:2,MERC.WD:2,General:2,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
 		</model>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		<model name='A'>
+			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:2,MERC.WD:2,General:2,CWIE:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:3,CNC:5,General:4,CGS:4,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:4,HL:4,LA:5,ROS:3,Periphery.HR:4,Periphery.MW:4,Periphery.CM:4,FWL:3,FS:6</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='&apos;Fermi&apos;'>
+			<roles>apc</roles>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
@@ -5989,9 +5989,9 @@
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:5</availability>
 		</model>
-		<model name='&apos;Fermi&apos;'>
-			<roles>apc</roles>
-			<availability>FS:3</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -6018,63 +6018,15 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(LBX20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(UAC20)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
-		</model>
 		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -6082,9 +6034,57 @@
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(LBX2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LBX10)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
@@ -6093,70 +6093,70 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CNC:3,CJF:7,CLAN.HW:5</availability>
-		<model name='Prime'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CSA:7,CLAN:6,IS:3</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CSA:7,CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:3,CCO:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Fire Scorpion' unitType='Mek'>
 		<availability>CGS:8</availability>
-		<model name='(Standard)'>
+		<model name='2'>
 			<roles>urban</roles>
-			<availability>CLAN:8</availability>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='3'>
 			<roles>urban</roles>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='2'>
+		<model name='(Standard)'>
 			<roles>urban</roles>
-			<availability>CLAN:6</availability>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:6,MERC:6,FS:6</availability>
-		</model>
 		<model name='ALM-10D'>
 			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,LA:1,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -6178,11 +6178,14 @@
 	</chassis>
 	<chassis name='Firefly' unitType='Mek'>
 		<availability>CS:6,MERC.WD:1,CLAN:1,WOB:5,BAN:1</availability>
-		<model name='C'>
-			<availability>MERC.WD:2,CLAN:8,BAN:1</availability>
+		<model name='FFL-4D'>
+			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='FFL-4B'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:2,CLAN:8,BAN:1</availability>
 		</model>
 		<model name='FFL-4C'>
 			<availability>CS:8,WOB:8</availability>
@@ -6190,23 +6193,14 @@
 		<model name='FFL-4DA'>
 			<availability>MERC.WD:4</availability>
 		</model>
-		<model name='FFL-4D'>
-			<availability>MERC.WD:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>CS:3,HL:6,LA:6,IS:5,NIOPS:3,Periphery.Deep:6,WOB:3,Periphery:7</availability>
+		<model name='FS9-S2'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='FS9-B'>
 			<availability>WOB:6</availability>
-		</model>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>HL:1-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:3,CS:3,MOC:4,LA:5,FRR:4,CGB.FRR:4,General:4,FS:4,TC:3</availability>
 		</model>
 		<model name='FS9-M &apos;Mirage&apos;'>
 			<roles>recon</roles>
@@ -6215,14 +6209,20 @@
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,CIR:7,Periphery:3,TC:4</availability>
 		</model>
-		<model name='FS9-S2'>
-			<availability>LA:4</availability>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>HL:1-,General:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='FS9-P'>
 			<availability>FVC:3,Periphery:3</availability>
 		</model>
 		<model name='FS9-S3'>
 			<availability>LA:4,ROS:3,FWL:2,FS:2,MERC:2</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:3,CS:3,MOC:4,LA:5,FRR:4,CGB.FRR:4,General:4,FS:4,TC:3</availability>
 		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
@@ -6231,61 +6231,61 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CS:5,CC:4,FVC:4+,LA:5,IS:4,WOB:5,FS:5,MERC:4,DC:7</availability>
-		<model name='FS9-OE'>
+		<model name='FS9-OD'>
 			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OX'>
-			<availability>General:2</availability>
 		</model>
 		<model name='FS9-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='FS9-OH'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OA'>
+		<model name='FS9-OE'>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OR'>
 			<availability>CLAN:4,IS:1+,DC:1+</availability>
 		</model>
+		<model name='FS9-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OX'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:3</availability>
-		<model name='C'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
@@ -6293,8 +6293,11 @@
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:2,FRR:4,CLAN:3,WOB:5,DGM:5,CGS:2,CS:5,DC.GHO:5,SC:5,Periphery.R:1,CDS:2,LA:4,CBS:2,MCM:5,CGB.FRR:4,ROS:4,FWL:3,NIOPS:5,CJF:4,CGB:2,DC:4</availability>
-		<model name='FLS-9M'>
-			<availability>SC:8,MCM:8,FWL:6,DGM:8</availability>
+		<model name='FLS-9C'>
+			<availability>CS:6</availability>
+		</model>
+		<model name='FLS-7K'>
+			<availability>:0,MERC.KH:1-,LA:1-</availability>
 		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,CS:4,SC:6,LA:8,MCM:6,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
@@ -6302,11 +6305,8 @@
 		<model name='FLS-C'>
 			<availability>DC:1</availability>
 		</model>
-		<model name='FLS-9C'>
-			<availability>CS:6</availability>
-		</model>
-		<model name='FLS-7K'>
-			<availability>:0,MERC.KH:1-,LA:1-</availability>
+		<model name='FLS-9M'>
+			<availability>SC:8,MCM:8,FWL:6,DGM:8</availability>
 		</model>
 		<model name='FLS-9B'>
 			<availability>WOB:6</availability>
@@ -6314,46 +6314,46 @@
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,PR:3,WOB:4,MERC:4,CIR:4,Periphery:4,TC:4,MERC.WD:4,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:2,DA:3,RCM:3,RFS:3</availability>
-		<model name='FLE-20'>
-			<availability>CC:3</availability>
-		</model>
-		<model name='FLE-17'>
-			<availability>CC:7,PR:6,ROS:8,PG:6,FWL:5,MERC:5,RCM:6,DA:6,RFS:6,Periphery:5</availability>
-		</model>
 		<model name='FLE-19'>
 			<roles>urban</roles>
 			<availability>MOC:4-,CC:4-,PR:4-,HL:4-,WOB:4-,MERC:5-,Periphery:6-,TC:4-,FVC:4-,OA:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
 		</model>
+		<model name='FLE-20'>
+			<availability>CC:3</availability>
+		</model>
 		<model name='&apos;Fire Ant&apos;'>
 			<roles>urban</roles>
 			<availability>CC:1</availability>
+		</model>
+		<model name='FLE-17'>
+			<availability>CC:7,PR:6,ROS:8,PG:6,FWL:5,MERC:5,RCM:6,DA:6,RFS:6,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6364,20 +6364,18 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
@@ -6388,33 +6386,35 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
 		<availability>CS:4,LA:4,NIOPS:4,FS:4,Periphery:1</availability>
-		<model name='(2613)'>
-			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3058)'>
 			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
 			<availability>CS:8,LA:8,FS:8</availability>
 		</model>
+		<model name='(2613)'>
+			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Fortune Wheeled Assault Vehicle' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='(Thunderbolt)'>
-			<availability>LA:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>LA:3,ROS:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Thunderbolt)'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -6444,13 +6444,13 @@
 			<roles>spotter</roles>
 			<availability>LA:5,FS:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
@@ -6459,14 +6459,14 @@
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='CX-17'>
-			<availability>CS:8,ROS:4</availability>
+		<model name='(Royal)'>
+			<availability>ROS:3,CLAN:4,WOB:4,BAN:2</availability>
 		</model>
 		<model name='(C3S)'>
 			<availability>ROS:5,FS:5</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>ROS:3,CLAN:4,WOB:4,BAN:2</availability>
+		<model name='CX-17'>
+			<availability>CS:8,ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -6486,10 +6486,6 @@
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
 		<availability>CS:3,FRR:2,CGB.FRR:2,NIOPS:3,WOB:4,TC:4</availability>
-		<model name='(TDF)'>
-			<roles>recon</roles>
-			<availability>TC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
@@ -6497,53 +6493,43 @@
 		<model name='(ERSL)'>
 			<availability>TC:4</availability>
 		</model>
+		<model name='(TDF)'>
+			<roles>recon</roles>
+			<availability>TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:2,CW:4,CLAN:1</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CSA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CW:6,ROS:8,CLAN:2,CGS:6,CCO:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
 		<availability>LA:2,WOB:4</availability>
-		<model name='GLH-2D'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='GLH-3D'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='GLH-2D'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gallant' unitType='Mek'>
 		<availability>LA:3,ROS:3,WOB:5,FS:3,MERC:2</availability>
-		<model name='GLT-8-0'>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GLT-7-0'>
 			<availability>General:8,FS:4</availability>
+		</model>
+		<model name='GLT-8-0'>
+			<availability>FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:1,LA:1,FRR:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
-		</model>
-		<model name='GAL-104'>
-			<availability>WOB:5</availability>
-		</model>
-		<model name='GAL-103'>
-			<roles>recon</roles>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
-		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3</availability>
 		</model>
@@ -6551,33 +6537,50 @@
 			<roles>recon</roles>
 			<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,CGB.FRR:5,FWL:7,DC:4</availability>
 		</model>
+		<model name='GAL-104'>
+			<availability>WOB:5</availability>
+		</model>
+		<model name='GAL-200'>
+			<availability>MOC:1,LA:1,FRR:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
+		</model>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
+		<model name='GAL-103'>
+			<roles>recon</roles>
+			<availability>WOB:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>CC:1,MOC:1,MERC.WD:6,ROS:5,IS:2,FWL:1,MH:4,MERC:5,TC:1,CWIE:4</availability>
-		<model name='GAL-2GLS'>
-			<availability>HL:2-,IS:4-,Periphery:4-</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:5,Periphery:8</availability>
-		</model>
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:5</availability>
 		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2</availability>
 		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:5</availability>
+		<model name='GAL-2GLS'>
+			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8-,CWIE:8</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:5</availability>
+		</model>
 		<model name='GAL-4GLSA'>
 			<availability>MERC.WD:2</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:5,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:5,FS:6,MERC:4,CDP:4,TC:4</availability>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A2'>
 			<availability>FS:3</availability>
 		</model>
@@ -6586,9 +6589,6 @@
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
-		</model>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gazelle' unitType='Dropship'>
@@ -6604,53 +6604,53 @@
 	</chassis>
 	<chassis name='Ghost' unitType='Mek'>
 		<availability>CC:1,CS:1,LA:2,FWL:2,MERC:1,FS:1,DC:1</availability>
-		<model name='GST-11'>
-			<availability>General:4</availability>
-		</model>
 		<model name='GST-10'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GST-11'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,MERC.WD:1,CSR:1,CDS:5,CLAN:5,CNC:5,IS:1+,CJF:4,BAN:4,CWIE:1,CGB:9</availability>
-		<model name='Prime'>
-			<availability>CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
-		</model>
-		<model name='P'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7,CGB:4</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CGB:5</availability>
 		</model>
-		<model name='K'>
-			<availability>CHH:6,CDS:5,CW:5,General:2,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		</model>
+		<model name='P'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
 		<availability>CS:3,LA:2-,FWL:1-,MH:2-,MERC:2,DC:3-</availability>
-		<model name='GLD-5R'>
-			<availability>CS:8,MERC:7</availability>
-		</model>
 		<model name='GLD-1R'>
 			<availability>LA:3-,FWL:3-,MH:4-,MERC:3-,DA:5-,DC:3-</availability>
 		</model>
 		<model name='GLD-3R'>
 			<availability>MERC:1</availability>
+		</model>
+		<model name='GLD-5R'>
+			<availability>CS:8,MERC:7</availability>
 		</model>
 		<model name='GLD-4R'>
 			<availability>MERC:1</availability>
@@ -6658,22 +6658,22 @@
 	</chassis>
 	<chassis name='Gladius Medium Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:4,Periphery.CM:3,Periphery.ME:3,MH:6,CDP:4,TC:5,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk II'>
 			<availability>MH:5,TC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Glaive Medium Tank' unitType='Tank'>
 		<availability>LA:3,LA.SR:6</availability>
-		<model name='(MFB)'>
-			<roles>support</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MFB)'>
+			<roles>support</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
@@ -6682,31 +6682,31 @@
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>FS:8</availability>
 		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6747,25 +6747,25 @@
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CGB:6</availability>
-		<model name='(Fast Assault)' mechanized='false'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Rock Golem)' mechanized='false'>
-			<availability>CHH:8</availability>
+		<model name='(Fast Assault)' mechanized='false'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
 			<roles>urban,anti_infantry</roles>
 			<availability>CGB:4</availability>
 		</model>
+		<model name='(Rock Golem)' mechanized='false'>
+			<availability>CHH:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:3,HL:2,IS:1,FS:3,MERC:4,TC:3,Periphery:3,CS:1,OA:2,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-3L'>
+		<model name='GOL-4S'>
 			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3</availability>
+			<availability>LA:5</availability>
 		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
@@ -6775,21 +6775,25 @@
 			<roles>fire_support</roles>
 			<availability>WOB:6</availability>
 		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GOL-6M'>
 			<roles>fire_support</roles>
 			<availability>ROS:3,FWL:3,MERC:2</availability>
+		</model>
+		<model name='GOL-3L'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
 		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>Periphery.HR:4,Periphery.CM:4,Periphery.MW:4,Periphery.ME:4,MH:5,Periphery:3</availability>
 		</model>
-		<model name='GOL-4S'>
+		<model name='GOL-1H'>
 			<roles>fire_support</roles>
-			<availability>LA:5</availability>
+			<availability>CC:3-,LA:3-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 		</model>
 		<model name='GOL-2H'>
 			<roles>fire_support</roles>
@@ -6799,10 +6803,6 @@
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
 		</model>
-		<model name='GOL-1H'>
-			<roles>fire_support</roles>
-			<availability>CC:3-,LA:3-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
-		</model>
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CSA:7,CSR:3,CBS:4,CNC:4,CJF:5,CCO:4</availability>
@@ -6810,47 +6810,47 @@
 			<roles>anti_infantry</roles>
 			<availability>CSA:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:5,CSR:3,CBS:5,CNC:5,CJF:3</availability>
+		<model name='2'>
+			<availability>CSA:8,CJF:5,CCO:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CSR:3,CBS:6</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CJF:5,CCO:8</availability>
+		<model name='(Standard)'>
+			<availability>CSA:5,CSR:3,CBS:5,CNC:5,CJF:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
 		<availability>CLAN:1</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>DoO:7,CLAN:4,WOB:9,DO:7,DGM:7,MERC:4-,CS:8,DTA:7,SC:7,CDS:5,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,TP:7</availability>
-		<model name='GTHA-600'>
-			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:6,FWL:3,WOB:5,DO:6,DGM:6,TP:6</availability>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:5,MERC:4,BAN:2</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CS:6,CDS:4,HL:4,ROS:6,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:5,MERC:4,BAN:2</availability>
-		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
+		</model>
+		<model name='GTHA-600'>
+			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:6,FWL:3,WOB:5,DO:6,DGM:6,TP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Crusader II' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='GRN-D-03'>
-			<availability>General:6</availability>
-		</model>
 		<model name='GRN-D-04'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GRN-D-03'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Crusader' unitType='Mek'>
@@ -6864,6 +6864,15 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>FRR:6,CGB.FRR:6,CNC:6,WOB:5,DC:8</availability>
+		<model name='DRG-1G'>
+			<availability>FRR:2-,CGB.FRR:3-,DC:3-</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:4</availability>
+		</model>
+		<model name='DRG-5K'>
+			<availability>FRR:6,CGB.FRR:6,ROS:6,CNC:8,WOB:8,MERC:5,DC:5</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>FRR:3,CGB.FRR:3,ROS:4,DC:6</availability>
 		</model>
@@ -6871,53 +6880,44 @@
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:4</availability>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='DRG-7K'>
 			<availability>ROS:6,MERC:3,DC:5</availability>
 		</model>
-		<model name='DRG-1G'>
-			<availability>FRR:2-,CGB.FRR:3-,DC:3-</availability>
-		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-5K'>
-			<availability>FRR:6,CGB.FRR:6,ROS:6,CNC:8,WOB:8,MERC:5,DC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>PR:7,DoO:7,DO:7,FWL.KIS:8,FS:5,SC:7,Periphery.MW:4,FWL:7,MH:4,RFS:7,CC:5,MOC:5,IS:1,WOB:5,DGM:7,MERC:5,CS:3,DTA:7,FVC:5,MCM:7,ROS:6,PG:7,Periphery.ME:2,TP:7,DA:7,RCM:7,DC:5</availability>
-		<model name='T-IT-N10M'>
-			<availability>HL:4,ROS:5,General:1,FWL:6,Periphery.Deep:2,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='T-IT-N11M'>
 			<availability>DTA:5,CC:5,MOC:5,SC:4,MCM:4,ROS:5,FWL:3,WOB:6,DGM:4,MERC:4,FS:5,DC:5</availability>
+		</model>
+		<model name='T-IT-N10M'>
+			<availability>HL:4,ROS:5,General:1,FWL:6,Periphery.Deep:2,MERC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>CS:4-,MOC:6,OA:6,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:5,TC:6</availability>
-		<model name='GHR-5J'>
-			<availability>CS:2-,IS:5,WOB:2-,Periphery:3</availability>
-		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:5</availability>
 		</model>
-		<model name='GHR-5H'>
-			<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='GHR-C'>
-			<availability>IS:3,DC:3</availability>
-		</model>
-		<model name='GHR-5N'>
-			<availability>General:2-</availability>
+		<model name='GHR-5J'>
+			<availability>CS:2-,IS:5,WOB:2-,Periphery:3</availability>
 		</model>
 		<model name='GHR-6K'>
 			<availability>FRR:5,CGB.FRR:5,ROS:4,MERC:3,FS:3,DC:5</availability>
 		</model>
+		<model name='GHR-5H'>
+			<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 		<model name='GHR-7P'>
 			<availability>LA:4,MERC:3</availability>
+		</model>
+		<model name='GHR-5N'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Scout Suit' unitType='BattleArmor'>
@@ -6935,14 +6935,14 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Strike Armor' unitType='BattleArmor'>
@@ -6955,20 +6955,26 @@
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
 		<availability>CSA:4,CCC:4,CHH:4,CLAN:1,CCO:4,CGB:4</availability>
-		<model name='2'>
-			<availability>CHH:7,CGB:7</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:7,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:3</availability>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[MagShot]' mechanized='false'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:3</availability>
@@ -6976,12 +6982,6 @@
 		<model name='[TAG]' mechanized='false'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='[MagShot]' mechanized='false'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
@@ -6992,8 +6992,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
@@ -7004,23 +7010,26 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3,CCO:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:4</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:5,CDS:6,CW:3,LA:2,CLAN:2,CNC:7,CCO:6,CJF:3,CWIE:4,CGB:3,DC:4</availability>
+		<model name='4'>
+			<availability>CSA:6,CDS:6,CNC:8,CLAN:2</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:8,CNC:5,CLAN:2,CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>MERC.WD:8,CNC:3,CLAN:1</availability>
+		</model>
 		<model name='6'>
 			<availability>ROS:4,CNC:5,DC:5</availability>
 		</model>
-		<model name='4'>
-			<availability>CSA:6,CDS:6,CNC:8,CLAN:2</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CLAN:1-,CNC:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CNC:4</availability>
@@ -7031,60 +7040,59 @@
 		<model name='5'>
 			<availability>CDS:4,CNC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CLAN:1-,CNC:4</availability>
-		</model>
-		<model name='2'>
-			<availability>MERC.WD:8,CNC:3,CLAN:1</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:8,CNC:5,CLAN:2,CCO:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:4,CS:2,OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-3M'>
-			<availability>PR:6,DoO:5,IS:6,DO:5,DGM:5,FS:5,DTA:5,SC:5,LA:6,MCM:5,PG:6,FWL:6,TP:5,RCM:6,DA:6,RFS:6,DC:3</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:5,FRR:3,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
+		<model name='GRF-1S'>
+			<availability>LA:3-,MERC:3-</availability>
 		</model>
 		<model name='GRF-6CS'>
 			<availability>CS:5,WOB:4</availability>
 		</model>
-		<model name='GRF-4N'>
-			<availability>TC:3</availability>
-		</model>
-		<model name='GRF-4R'>
-			<availability>CS:5,ROS:5,FRR:4,CGB.FRR:4,CNC:2,FWL:2,WOB:4,FS:2,CGB:4,DC:2</availability>
-		</model>
 		<model name='GRF-2N'>
 			<availability>CC:3,DoO:4,CLAN:6,WOB:5,DO:4,DGM:4,FS:3,MERC:3,BAN:4,SC:4,MCM:4,FWL:2,TP:4,RCM:4,DC:3</availability>
-		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:5,FWL:3,WOB:5,DO:6,DGM:6,TP:6,MERC:5</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
 		</model>
 		<model name='GRF-1A'>
 			<availability>LA:3-,MERC:3-,TC:3-</availability>
 		</model>
-		<model name='GRF-1S'>
-			<availability>LA:3-,MERC:3-</availability>
+		<model name='GRF-5M'>
+			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:5,FWL:3,WOB:5,DO:6,DGM:6,TP:6,MERC:5</availability>
 		</model>
-		<model name='GRF-5K'>
-			<availability>CNC:5,DC:5</availability>
+		<model name='GRF-3M'>
+			<availability>PR:6,DoO:5,IS:6,DO:5,DGM:5,FS:5,DTA:5,SC:5,LA:6,MCM:5,PG:6,FWL:6,TP:5,RCM:6,DA:6,RFS:6,DC:3</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CS:5,ROS:5,FRR:4,CGB.FRR:4,CNC:2,FWL:2,WOB:4,FS:2,CGB:4,DC:2</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>FVC:6,LA:4,FRR:4,CGB.FRR:4,ROS:4,FS:6,MERC:4,DC:5</availability>
 		</model>
+		<model name='GRF-5K'>
+			<availability>CNC:5,DC:5</availability>
+		</model>
+		<model name='GRF-4N'>
+			<availability>TC:3</availability>
+		</model>
 		<model name='GRF-5L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:2,Periphery:4-</availability>
+		</model>
+		<model name='GRF-6S'>
+			<availability>LA:5,FRR:3,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grigori' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:7,WOB:2+</availability>
+		<model name='C-GRG-OS Caelestis'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:4</availability>
+		</model>
+		<model name='C-GRG-OC Comminus'>
+			<deployedWith>Deva</deployedWith>
+			<availability>General:7</availability>
+		</model>
 		<model name='C-GRG-OB Infernus'>
 			<roles>fire_support</roles>
 			<deployedWith>Deva</deployedWith>
@@ -7094,10 +7102,6 @@
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-GRG-OS Caelestis'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:4</availability>
-		</model>
 		<model name='C-GRG-OD Luminos'>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
@@ -7106,86 +7110,70 @@
 			<deployedWith>Deva</deployedWith>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-GRG-OC Comminus'>
+		<model name='C-GRG-OU Exanimus'>
 			<deployedWith>Deva</deployedWith>
-			<availability>General:7</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='C-GRG-O Invictus'>
 			<roles>fire_support</roles>
 			<deployedWith>Deva</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='C-GRG-OU Exanimus'>
-			<deployedWith>Deva</deployedWith>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>CS:5,ROS:6,WOB:6,MERC:5,DC:5</availability>
-		<model name='GRM-R-PR30'>
-			<availability>ROS:4,WOB:6+,MERC:3</availability>
-		</model>
 		<model name='GRM-R (Einar)'>
 			<roles>spotter</roles>
 			<availability>CS:1</availability>
-		</model>
-		<model name='GRM-R-PR29'>
-			<availability>CS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='GRM-R-PR31'>
 			<roles>fire_support</roles>
 			<availability>WOB:6+,MERC:4</availability>
 		</model>
+		<model name='GRM-R-PR30'>
+			<availability>ROS:4,WOB:6+,MERC:3</availability>
+		</model>
+		<model name='GRM-R-PR29'>
+			<availability>CS:8,MERC:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CCC:3,CSR:2,CBS:3,CLAN:2,CCO:3,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:2,PR:3,IS:1,MERC:2,TC:2,Periphery:1,FVC:1,ROS:3,PG:3,FWL:2,RCM:3,RFS:3</availability>
-		<model name='D'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CC:1,FWL:1,Periphery:1</availability>
-		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CC:1,FWL:1,Periphery:1</availability>
+		</model>
+		<model name='D'>
+			<availability>CC:3,MOC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>CHH:3-,CW:3,CLAN:1-,CNC:3-,CCO:3,CWIE:3</availability>
-		<model name='2'>
-			<availability>CW:4,CCO:6,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:4,CCO:6,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:3,CSR:2,FRR:1,IS:1,WOB:7,DGM:5,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:3,SC:5,MCM:5,CGB.FRR:1,ROS:6,FWL:5,NIOPS:7,DC:1</availability>
-		<model name='GLT-3N'>
-			<roles>raider</roles>
-			<availability>CS:8,ROS:6,FRR:8,CGB.FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
-		</model>
-		<model name='GLT-6WB'>
-			<roles>raider</roles>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='GLT-6WB2'>
-			<roles>raider</roles>
-			<availability>WOB:5</availability>
-		</model>
 		<model name='GLT-6WB3'>
 			<roles>raider</roles>
 			<availability>SC:6,MCM:6,ROS:3,DGM:6,MERC:3</availability>
@@ -7202,19 +7190,31 @@
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:5,MERC:4</availability>
 		</model>
+		<model name='GLT-6WB2'>
+			<roles>raider</roles>
+			<availability>WOB:5</availability>
+		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>CS:8,ROS:6,FRR:8,CGB.FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
+		</model>
+		<model name='GLT-6WB'>
+			<roles>raider</roles>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
 		<availability>FVC:5,LA:8,FRR:5,CGB.FRR:5,IS:5,FS:5,DC:7</availability>
-		<model name='GUN-2ERDr'>
-			<roles>spotter</roles>
-			<availability>FS:3,DC:3</availability>
-		</model>
 		<model name='GUN-2ERD'>
 			<roles>spotter</roles>
 			<availability>LA:5,WOB:4,FS:4,DC:4</availability>
 		</model>
 		<model name='GUN-1ERD'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GUN-2ERDr'>
+			<roles>spotter</roles>
+			<availability>FS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gurkha' unitType='Mek'>
@@ -7223,6 +7223,10 @@
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:8</availability>
 		</model>
+		<model name='GUR-8G'>
+			<deployedWith>Vanquisher</deployedWith>
+			<availability>WOB:3</availability>
+		</model>
 		<model name='GUR-6G'>
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:3</availability>
@@ -7230,10 +7234,6 @@
 		<model name='GUR-4G'>
 			<deployedWith>Vanquisher</deployedWith>
 			<availability>WOB:4</availability>
-		</model>
-		<model name='GUR-8G'>
-			<deployedWith>Vanquisher</deployedWith>
-			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
@@ -7251,27 +7251,27 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,CBS:3,LA:4,CNC:5,DC:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>LA:3+,CLAN:6,DC:3+</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4</availability>
-		</model>
 		<model name='HKO-1C'>
 			<roles>fire_support</roles>
 			<availability>LA:7,DC:7</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>LA:3+,CLAN:6,DC:3+</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:7,OA:3,CBS:6,CLAN:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(AAA)'>
 			<roles>fire_support</roles>
 			<availability>OA:7,CSR:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hamilcar' unitType='Dropship'>
@@ -7305,8 +7305,8 @@
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>FS:4,MERC:2</availability>
-		<model name='HMH-6E'>
-			<availability>General:4,MERC:4</availability>
+		<model name='HMH-6D'>
+			<availability>General:6</availability>
 		</model>
 		<model name='HMH-3D'>
 			<availability>General:3-,MERC:3-</availability>
@@ -7314,17 +7314,17 @@
 		<model name='HMH-5D'>
 			<availability>General:3,MERC:4</availability>
 		</model>
-		<model name='HMH-6D'>
-			<availability>General:6</availability>
+		<model name='HMH-6E'>
+			<availability>General:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>CS:7,ROS:6,CLAN:3,CNC:4,FWL:2,NIOPS:7,WOB:7,DC:1</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>CS:8,ROS:4,NIOPS:8,WOB:4</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:4</availability>
 		</model>
 		<model name='HMR-HF'>
 			<availability>WOB:6</availability>
@@ -7338,30 +7338,30 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CDS:4,CNC:5,CLAN:1,IS:2+,CJF:4,CCO:3,CGB:3</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='E'>
-			<roles>anti_infantry</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>CSA:8,General:7</availability>
+		</model>
+		<model name='E'>
+			<roles>anti_infantry</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -7380,16 +7380,16 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>PR:5,HL:3-,DoO:5,FRR:5-,Periphery.Deep:4,DO:5,SC:5,FWL.pm:6-,CGB.FRR:5-,Periphery.CM:5-,Periphery.MW:5-,FWL:6-,MH:4-,RFS:5,MOC:4-,CC:4-,IS:4-,WOB:4-,DGM:5,MERC:4-,Periphery:3-,CS:4-,DTA:5,LA:4-,MCM:5,PG:5,Periphery.ME:5-,TP:5,DA:5,RCM:5,DC:4-</availability>
+		<model name='(LRM)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>FWL:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<deployedWith>Galleon</deployedWith>
 			<availability>General:3-</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(LRM)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>FWL:4</availability>
 		</model>
 		<model name='&apos;Mini-Peggy&apos;'>
 			<roles>recon</roles>
@@ -7401,29 +7401,29 @@
 		<model name='(Standard)'>
 			<availability>CSA:4,CHH:4,CBS:4,CSL:4,CJF:2</availability>
 		</model>
+		<model name='2'>
+			<availability>CHH:8,CBS:8,CSL:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6,CHH:1</availability>
 		</model>
 		<model name='4'>
 			<availability>CHH:5,CSL:5</availability>
 		</model>
-		<model name='2'>
-			<availability>CHH:8,CBS:8,CSL:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>FRR:4,CGB.FRR:4,ROS:5,WOB:5,MERC:3,DC:7</availability>
-		<model name='HTM-28T'>
-			<availability>ROS:4,WOB:6,DC:4</availability>
-		</model>
-		<model name='HTM-27T'>
-			<availability>FRR:7,CGB.FRR:7,MERC:5,DC:6</availability>
-		</model>
 		<model name='HTM-26T'>
 			<availability>DC:1-</availability>
 		</model>
+		<model name='HTM-28T'>
+			<availability>ROS:4,WOB:6,DC:4</availability>
+		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:5,WOB:6,DC:3</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>FRR:7,CGB.FRR:7,MERC:5,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -7465,36 +7465,36 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>MERC.KH:4,TC.PL:3,FRR:3,WOB:4,FS:5,MERC:3,Periphery:2,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,DC:4</availability>
-		<model name='HCT-5DD'>
-			<availability>ROS:6,FS:5,MERC:5</availability>
+		<model name='HCT-6S'>
+			<availability>LA:6,MERC:6</availability>
+		</model>
+		<model name='HCT-3NH'>
+			<availability>DC:1-</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>ROS:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='HCT-6D'>
-			<availability>ROS:5,FS:5,MERC:6</availability>
-		</model>
 		<model name='HCT-6M'>
 			<availability>DTA:8,SC:8,MCM:8,FWL:8,DGM:8</availability>
-		</model>
-		<model name='HCT-7S'>
-			<availability>LA:5</availability>
 		</model>
 		<model name='HCT-5S'>
 			<availability>FVC:5,LA:5,FRR:4,CGB.FRR:4,FS:5,MERC:4,DC:2,Periphery:2</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>WOB:8,DC:8</availability>
+		<model name='HCT-5DD'>
+			<availability>ROS:6,FS:5,MERC:5</availability>
 		</model>
-		<model name='HCT-3NH'>
-			<availability>DC:1-</availability>
+		<model name='HCT-7S'>
+			<availability>LA:5</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:2-,LA:2-,TC.PL:3-,MERC:2-,FS:1-,Periphery:2-</availability>
 		</model>
-		<model name='HCT-6S'>
-			<availability>LA:6,MERC:6</availability>
+		<model name='HCT-6D'>
+			<availability>ROS:5,FS:5,MERC:6</availability>
+		</model>
+		<model name='HCT-5K'>
+			<availability>WOB:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
@@ -7512,24 +7512,24 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:5</availability>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OB'>
-			<availability>General:7</availability>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='HA1-OC'>
+		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OD'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OC'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
@@ -7566,25 +7566,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7624,8 +7624,8 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:4,CC:3,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CIR:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
@@ -7633,14 +7633,14 @@
 		<model name='Meteor-U'>
 			<availability>ROS:2,FS:3,MERC:1</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:4,CC:3,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CIR:4,TC:1</availability>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
 		</model>
 		<model name='Meteor-G'>
 			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7651,10 +7651,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7662,6 +7658,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7670,6 +7670,18 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(WoB)'>
+			<roles>apc,support</roles>
+			<availability>ROS:4,WOB:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7678,21 +7690,13 @@
 			<roles>apc,support</roles>
 			<availability>General:8,WOB:4</availability>
 		</model>
-		<model name='(WoB)'>
-			<roles>apc,support</roles>
-			<availability>ROS:4,WOB:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:2,CSR:1,CNC:2,CSL:4,CWIE:5</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -7700,44 +7704,43 @@
 		<model name='Prime'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
 		<availability>CC:2,MOC:2,MERC:2</availability>
-		<model name='HEP-4H'>
-			<roles>artillery</roles>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='HEP-1H'>
 			<roles>artillery</roles>
 			<availability>CC:3-,MOC:3-,MERC:3-</availability>
 		</model>
+		<model name='HEP-4H'>
+			<roles>artillery</roles>
+			<availability>MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
 		<availability>CC:5,CS:4,MOC:5,WOB:3,FS:3,MERC:3,DC:3,TC:5</availability>
+		<model name='HEL-4A'>
+			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
+		</model>
+		<model name='HEL-C'>
+			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
+		</model>
 		<model name='HEL-3D'>
 			<availability>CC:8,CS:8,MOC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 		<model name='HEL-6X'>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='HEL-C'>
-			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
-		</model>
-		<model name='HEL-4A'>
-			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
 		<availability>CS:6,LA:1,ROS:4,CNC:2,NIOPS:6,WOB:6,FS:1,DC:1</availability>
 		<model name='HCT-212'>
 			<availability>LA:5,FS:5</availability>
+		</model>
+		<model name='HCT-215'>
+			<availability>CS:4,ROS:4</availability>
 		</model>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -7746,36 +7749,33 @@
 		<model name='HCT-214'>
 			<availability>CS:8,NIOPS:5,WOB:8</availability>
 		</model>
-		<model name='HCT-215'>
-			<availability>CS:4,ROS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,OA:5,FVC:3,CSR:2,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
-		<model name='HCT-213D'>
+		<model name='HCT-213S'>
 			<availability>LA:1,FS:1</availability>
+		</model>
+		<model name='HCT-313'>
+			<availability>OA:8,FVC:7,CSR:5,CDP:7</availability>
 		</model>
 		<model name='HCT-213R'>
 			<roles>recon</roles>
 			<availability>LA:1,FS:1</availability>
 		</model>
-		<model name='HCT-213S'>
-			<availability>LA:1,FS:1</availability>
-		</model>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
 		</model>
-		<model name='HCT-313'>
-			<availability>OA:8,FVC:7,CSR:5,CDP:7</availability>
+		<model name='HCT-213D'>
+			<availability>LA:1,FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
 		<availability>CSA:5,CCC:4,CHH:4</availability>
-		<model name='(Standard)'>
-			<availability>CSA:8,CCC:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
@@ -7783,8 +7783,8 @@
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:2,CHH:3,CDS:3,DC.AL:2,CLAN:1,CNC:6,CJF:3</availability>
-		<model name='2'>
-			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
+		<model name='5'>
+			<availability>ROS:5,CNC:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
@@ -7792,15 +7792,27 @@
 		<model name='4'>
 			<availability>CNC:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CHH:7,CLAN:1,CJF:7</availability>
-		</model>
-		<model name='5'>
-			<availability>ROS:5,CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CDS:5,CBS:2,CLAN:1,CNC:5,CSL:5,CGS:4,CCO:5,CJF:2</availability>
+		<model name='B'>
+			<availability>CSA:8,General:7,CJF:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:4,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:3,General:7,CJF:3</availability>
+		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -7809,58 +7821,58 @@
 			<roles>fire_support</roles>
 			<availability>CSA:3,General:6,CJF:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:8,General:7,CJF:3</availability>
-		</model>
 		<model name='F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:3,General:7,CJF:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:4,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>FS:6,MERC:4</availability>
+		<model name='HSN-9F'>
+			<roles>fire_support</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='HSN-10SR'>
 			<roles>spotter</roles>
 			<availability>FS:3</availability>
 		</model>
-		<model name='HSN-7D'>
-			<roles>fire_support</roles>
-			<availability>FS:8,MERC:8</availability>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-9F'>
+		<model name='HSN-7D'>
 			<roles>fire_support</roles>
-			<availability>FS:4</availability>
+			<availability>FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellstar' unitType='Mek'>
 		<availability>CHH:4,CWIE:4</availability>
+		<model name='2'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:4+,CSL:4+</availability>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>recon,apc,fire_support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -7868,18 +7880,6 @@
 		<model name='Prime'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon,apc,fire_support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -7904,6 +7904,10 @@
 			<roles>recon</roles>
 			<availability>FWL:3</availability>
 		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>SC:4,DoO:4,MCM:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4</availability>
+		</model>
 		<model name='HER-6D'>
 			<roles>recon</roles>
 			<availability>FS.LG:10</availability>
@@ -7911,10 +7915,6 @@
 		<model name='HER-5C'>
 			<roles>recon</roles>
 			<availability>WOB:10</availability>
-		</model>
-		<model name='HER-5Sr'>
-			<roles>recon</roles>
-			<availability>MOC:3,IS:3</availability>
 		</model>
 		<model name='HER-5SA'>
 			<roles>training</roles>
@@ -7928,56 +7928,59 @@
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:4,WOB:8,FS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>SC:4,DoO:4,MCM:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4</availability>
+			<availability>MOC:3,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
 		<availability>CHH:1,DoO:8,FRR:3,WOB:3,DO:8,DGM:8,CS:3,DC.GHO:5,SC:8,MCM:8,CGB.FRR:3,FWL:7,NIOPS:3,TP:8,CGB:1,DC:6</availability>
-		<model name='HER-4WB'>
-			<roles>recon</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='HER-3S2'>
 			<roles>recon,spotter</roles>
 			<availability>FWL:3</availability>
-		</model>
-		<model name='HER-4K'>
-			<roles>recon</roles>
-			<availability>SC:6,DoO:6,MCM:6,DO:6,DGM:6,TP:6,DC:7</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:5</availability>
-		</model>
-		<model name='HER-3S'>
-			<roles>recon</roles>
-			<availability>FWL:5,WOB:5</availability>
 		</model>
 		<model name='HER-1S'>
 			<roles>recon</roles>
 			<availability>DC.GHO:3-,CS:4,CLAN:6,NIOPS:4,BAN:8</availability>
 		</model>
-		<model name='HER-4S'>
+		<model name='HER-3S'>
 			<roles>recon</roles>
-			<availability>CS:3,SC:4,DoO:4,MCM:4,FRR:3,CGB.FRR:3,FWL:5,WOB:3,DO:4,DGM:4,TP:4</availability>
+			<availability>FWL:5,WOB:5</availability>
 		</model>
 		<model name='HER-4M'>
 			<roles>recon</roles>
 			<availability>FWL:3,WOB:6</availability>
 		</model>
+		<model name='HER-4WB'>
+			<roles>recon</roles>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='HER-4K'>
+			<roles>recon</roles>
+			<availability>SC:6,DoO:6,MCM:6,DO:6,DGM:6,TP:6,DC:7</availability>
+		</model>
+		<model name='HER-4S'>
+			<roles>recon</roles>
+			<availability>CS:3,SC:4,DoO:4,MCM:4,FRR:3,CGB.FRR:3,FWL:5,WOB:3,DO:4,DGM:4,TP:4</availability>
+		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:8,IS:4-,Periphery.Deep:6,WOB:2-,MERC:1,Periphery:1,CWIE:3,CS:2-,CDS:3,Periphery.CM:7,CGB.FRR:2,CNC:3,CGB:2</availability>
-		<model name='(SRM)'>
-			<availability>IS:2,Periphery:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6-</availability>
 		</model>
-		<model name='(AC10)'>
-			<availability>IS:1,Periphery:1</availability>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:2,Periphery:2</availability>
@@ -7985,14 +7988,11 @@
 		<model name='(LB-X)'>
 			<availability>CC:8,MOC:5,PR:4,PG:4,DA:4,CDP:4,RFS:4,TC:6</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:2,IS:2,Periphery:2</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
-		</model>
-		<model name='(Sealed)'>
-			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -8009,18 +8009,21 @@
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>MERC.WD:1,CHH:4,CDS:4,CW:6,CLAN:1,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CDS:5,CW:5,CLAN:3,CNC:5,IS:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:5,CW:2,CJF:5,CGB:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:5,CW:5,CLAN:3,CNC:5,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>MOC:2,CC:3,CS:9,LA:6,CLAN:5,IS:2,NIOPS:9,WOB:9,MERC:4,FS:5,CJF:6,DC:2</availability>
+		<model name='HGN-734'>
+			<availability>LA:6,ROS:6,MERC:6</availability>
+		</model>
 		<model name='HGN-736'>
 			<availability>CS:8,WOB:6</availability>
 		</model>
@@ -8033,26 +8036,23 @@
 		<model name='HGN-641-X-2'>
 			<availability>CS:1</availability>
 		</model>
-		<model name='HGN-734'>
-			<availability>LA:6,ROS:6,MERC:6</availability>
-		</model>
-		<model name='HGN-738'>
-			<availability>LA:5,ROS:5</availability>
+		<model name='HGN-733'>
+			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>MOC:6,CC:4,CLAN:6,IS:6,WOB:3,MERC:6,FS:6,BAN:8,DC.GHO:8,CS:3,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6</availability>
 		</model>
-		<model name='HGN-733'>
-			<availability>CC:2-,:0,LA:2-,DC:2-</availability>
+		<model name='HGN-738'>
+			<availability>LA:5,ROS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:3</availability>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8078,11 +8078,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F5'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BZK-F7'>
 			<availability>General:6</availability>
+		</model>
+		<model name='BZK-F5'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -8096,17 +8096,17 @@
 	</chassis>
 	<chassis name='Hoplite' unitType='Mek'>
 		<availability>CHH:1,MERC.WD:1,CLAN:1,CGS:1</availability>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
-		</model>
-		<model name='HOP-4Cb'>
-			<availability>CHH:2,CLAN:1</availability>
-		</model>
 		<model name='HOP-4Bb'>
 			<availability>CLAN:1</availability>
 		</model>
 		<model name='HOP-4D'>
 			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
+		</model>
+		<model name='HOP-4Cb'>
+			<availability>CHH:2,CLAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
@@ -8114,16 +8114,16 @@
 		<model name='HNT-161'>
 			<availability>MERC.WD:1-</availability>
 		</model>
+		<model name='HNT-152'>
+			<roles>recon,urban</roles>
+			<availability>FVC:2-,IS:1-</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:3-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='HNT-152'>
-			<roles>recon,urban</roles>
-			<availability>FVC:2-,IS:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -8140,13 +8140,13 @@
 	</chassis>
 	<chassis name='Huitzilopochtli Assault Tank &apos;Huey&apos;' unitType='Tank'>
 		<availability>CLAN:5,CNC:1,CWIE:1</availability>
-		<model name='(AAA)'>
-			<roles>missile_artillery,anti_aircraft</roles>
-			<availability>CGB:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>missile_artillery,anti_aircraft</roles>
+			<availability>CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Humming Bird VTOL' unitType='VTOL'>
@@ -8158,9 +8158,6 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:5,CDS:7,CSR:6,CW:6,CLAN:1,IS:2,CJF:6,CGB:6,CWIE:5</availability>
-		<model name='3'>
-			<availability>CSR:5,CCO:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:8,CBS:8</availability>
 		</model>
@@ -8170,14 +8167,20 @@
 		<model name='(Standard)'>
 			<availability>CSR:2,General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CSR:5,CCO:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:2,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:3</availability>
+		<model name='HBK-5SS'>
+			<availability>LA:5</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 		<model name='HBK-6S'>
 			<availability>LA:5,ROS:4,MERC:5</availability>
-		</model>
-		<model name='HBK-4N'>
-			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:2-,FWL:2-,MERC:2-,Periphery:2-</availability>
@@ -8185,35 +8188,32 @@
 		<model name='HBK-5P'>
 			<availability>ROS:5,FWL:5,WOB:5,MERC:4</availability>
 		</model>
-		<model name='HBK-4SP'>
-			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
-		</model>
-		<model name='HBK-5M'>
-			<availability>CS:4,CC:1,MOC:1,FRR:1,CGB.FRR:1,FWL:1,WOB:4,MERC:1,CDP:1,TC:1</availability>
-		</model>
-		<model name='HBK-5SS'>
-			<availability>LA:5</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='HBK-4P'>
-			<availability>IS:1-,Periphery:2-</availability>
-		</model>
-		<model name='HBK-5S'>
-			<availability>LA:5,FRR:3,CGB.FRR:3,ROS:3,MERC:3,FS:2</availability>
-		</model>
-		<model name='HBK-6N'>
-			<availability>ROS:3,FWL:4,MERC:5</availability>
-		</model>
 		<model name='HBK-4H'>
 			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-5H'>
 			<availability>MH:6,Periphery:3</availability>
 		</model>
+		<model name='HBK-4SP'>
+			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
+		</model>
 		<model name='HBK-5N'>
 			<availability>MOC:5,CC:5,CS:5,FRR:5,CGB.FRR:5,FWL:6,WOB:5,MERC:5,CDP:5,TC:5</availability>
+		</model>
+		<model name='HBK-4P'>
+			<availability>IS:1-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-5M'>
+			<availability>CS:4,CC:1,MOC:1,FRR:1,CGB.FRR:1,FWL:1,WOB:4,MERC:1,CDP:1,TC:1</availability>
+		</model>
+		<model name='HBK-5S'>
+			<availability>LA:5,FRR:3,CGB.FRR:3,ROS:3,MERC:3,FS:2</availability>
+		</model>
+		<model name='HBK-4N'>
+			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-6N'>
+			<availability>ROS:3,FWL:4,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -8227,50 +8227,50 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:2,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:8,CGB.FRR:5,ROS:3,FWL:5,DC:4</availability>
-		<model name='&apos;Assault Hunter&apos;'>
-			<availability>LA:2,FS:2</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:1-</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:3-</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:4-</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:3</availability>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>PR:5,LA:8,ROS:5,PG:5,FS:6,RCM:5,MERC:5,DA:5,RFS:5</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
+		<model name='(LRM15)'>
 			<roles>fire_support</roles>
-			<availability>PR:5,LA:8,ROS:5,PG:5,FS:6,RCM:5,MERC:5,DA:5,RFS:5</availability>
+			<availability>General:3-</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:1-</availability>
+		</model>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='&apos;Assault Hunter&apos;'>
+			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,WOB:3,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4O'>
+			<availability>CC:8,MOC:8,FWL:4,MERC:5,TC:4</availability>
+		</model>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:4,MOC:4,FWL:5</availability>
 		</model>
 		<model name='HUR-WO-R4N'>
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
-		</model>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4O'>
-			<availability>CC:8,MOC:8,FWL:4,MERC:5,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
@@ -8282,51 +8282,51 @@
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>CS:3,FRR:5,CGB.FRR:5,CNC:4,CGB:4</availability>
-		<model name='HSCL-1-OD'>
-			<availability>General:4</availability>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:2+</availability>
 		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HSCL-1-OA'>
+		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OB'>
+		<model name='HSCL-1-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:2+</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>CS:4,DC.GHO:3,LA:3,FRR:1,CGB.FRR:2,ROS:3,CLAN:4,NIOPS:4,WOB:4,MERC:3,DC:1</availability>
-		<model name='HSR-200-Db'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='HSR-350-D'>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='HSR-900-D'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='HSR-400-D'>
-			<availability>CS:8,LA:8,ROS:8,WOB:8,MERC:8</availability>
+		<model name='HSR-500-D'>
+			<availability>CS:4,WOB:8</availability>
 		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>CS:4,General:8,CLAN:6,NIOPS:4,MERC.SI:4,WOB:4,BAN:8</availability>
 		</model>
+		<model name='HSR-900-D'>
+			<availability>WOB:6</availability>
+		</model>
+		<model name='HSR-350-D'>
+			<availability>DC:1-</availability>
+		</model>
 		<model name='HSR-300-D'>
 			<availability>DC:1-</availability>
 		</model>
-		<model name='HSR-500-D'>
-			<availability>CS:4,WOB:8</availability>
-		</model>
 		<model name='HSR-950-D'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='HSR-200-Db'>
+			<availability>CLAN:1</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>CS:8,LA:8,ROS:8,WOB:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -8338,11 +8338,11 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CCC:6,CSR:3,CLAN:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Algar)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
@@ -8350,19 +8350,19 @@
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
 		<availability>CHH:5,CBS:2,CSL:5</availability>
+		<model name='2'>
+			<availability>CHH:6,CSL:6</availability>
+		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CBS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CHH:6,CBS:6,CSL:6</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:6,CSL:6</availability>
-		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CBS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:6,CBS:6,CSL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hyena' unitType='Mek'>
@@ -8374,35 +8374,35 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:4,MOC:8,LA:3,ROS:4,FWL:3,IS:8,WOB:3,MH:8,FS:1,DC:2,TC:8</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Level I) [MG]' mechanized='true'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='(Level I) [Laser]' mechanized='true'>
+			<availability>CS:6,WOB:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Level I) [SRM]' mechanized='true'>
+			<availability>CS:7,WOB:7</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='(Level I) [Flamer]' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
 		<model name='(Level I) [LRR]' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Level I) [MG]' mechanized='true'>
-			<availability>CS:8,WOB:8</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [Laser]' mechanized='true'>
-			<availability>CS:6,WOB:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Level I) [SRM]' mechanized='true'>
-			<availability>CS:7,WOB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -8436,10 +8436,10 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
+		<model name='IMP-4E'>
 			<availability>MERC.WD:6</availability>
 		</model>
-		<model name='IMP-4E'>
+		<model name='IMP-3E'>
 			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
@@ -8459,11 +8459,11 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,CNC:1,CWIE:1</availability>
-		<model name='(BA)'>
-			<availability>CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(BA)'>
+			<availability>CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
@@ -8479,14 +8479,14 @@
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:3,TC:3</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
+		<model name='&apos;Puma&apos;' mechanized='true'>
+			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
 		</model>
-		<model name='&apos;Puma&apos;' mechanized='true'>
-			<availability>FS:8,TC:8</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Initiate' unitType='Mek'>
@@ -8506,6 +8506,10 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>WOB:6</availability>
+		<model name='(Standard)'>
+			<roles>assault</roles>
+			<availability>FWL:8,WOB:6</availability>
+		</model>
 		<model name='(SCC)'>
 			<roles>assault</roles>
 			<availability>WOB:4</availability>
@@ -8513,10 +8517,6 @@
 		<model name='(Sub-Capital)'>
 			<roles>assault</roles>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>assault</roles>
-			<availability>FWL:8,WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -8532,16 +8532,16 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,FRR:9,CLAN:9,IS:7,Periphery.Deep:7,WOB:9,FS:9,CIR:8,BAN:6,Periphery:8,TC:8,CS:9,OA:8,LA:9,CGB.FRR:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
@@ -8553,11 +8553,11 @@
 	</chassis>
 	<chassis name='Ironsides' unitType='Aero'>
 		<availability>CS:6,CLAN:1,CNC:1,NIOPS:3,WOB:6,DC:1</availability>
-		<model name='IRN-SD1'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='IRN-SD3'>
 			<availability>WOB:5</availability>
+		</model>
+		<model name='IRN-SD1'>
+			<availability>General:8,CNC:4</availability>
 		</model>
 		<model name='IRN-SD1b'>
 			<availability>CSR:6,CLAN:4,BAN:2</availability>
@@ -8597,15 +8597,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -8626,29 +8626,29 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>FS.DLC:4-,PR:1-,DC.LV:4-,HL:2-,DoO:2-,FRR:2-,Periphery.Deep:5,DO:2-,FS:3-,SC:2-,OA:2-,CGB.FRR:3-,FWL:2-,NIOPS:2-,RFS:1-,MOC:3-,CC:1-,DC.GR:3-,FS.AH:3-,IS:3-,WOB:3-,DGM:2-,CIR:4-,Periphery:3-,TC:4-,CS:2-,DTA:1-,LA:3-,MCM:2-,PG:1-,TP:2-,RCM:1-,DA:1-,DC:3-</availability>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>FVC:3,IS:4,TC:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Kurita)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>DC:8,TC:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Kurita)'>
-			<roles>recon,raider</roles>
-			<availability>DC:8,TC:4</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
+		</model>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
@@ -8718,27 +8718,27 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:2,CW:5,General:2</availability>
 		</model>
-		<model name='E'>
-			<availability>CSR:3,CW:4,CLAN:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CSR:3,CW:4,CLAN:2</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8752,35 +8752,16 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:3,CC:4-,FRR:3,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,CGB.FRR:3,Periphery.CM:2,Periphery.HR:3,ROS:3,PIR:3,Periphery.ME:2,FWL:1,NIOPS:3,MH:4,DC:3</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>MOC:2,FVC:6,OA:6,LA:6,FRR:6,CGB.FRR:6,FS:6,MERC:6,CDP:2,DC:6,TC:2</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='JM7-C3BS'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>CC:3-,FRR:1-,CGB.FRR:2-,IS:3-,FS:3-,Periphery:6</availability>
 		</model>
-		<model name='JM6-DGr'>
-			<roles>anti_aircraft</roles>
-			<availability>FVC:3,LA:3,ROS:2,FRR:2,CGB.FRR:3,FS:3,MERC:3,CDP:2,DC:3</availability>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:4,FS:5,MERC:6</availability>
-		</model>
-		<model name='JM7-F'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
 		</model>
 		<model name='JM6-DDa'>
 			<roles>anti_aircraft</roles>
@@ -8790,32 +8771,51 @@
 			<roles>anti_aircraft</roles>
 			<availability>FVC:1,PIR:2,MH:5,Periphery:1</availability>
 		</model>
+		<model name='JM7-F'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:4,FS:4</availability>
+		</model>
+		<model name='JM6-DGr'>
+			<roles>anti_aircraft</roles>
+			<availability>FVC:3,LA:3,ROS:2,FRR:2,CGB.FRR:3,FS:3,MERC:3,CDP:2,DC:3</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM7-G'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>MOC:2,FVC:6,OA:6,LA:6,FRR:6,CGB.FRR:6,FS:6,MERC:6,CDP:2,DC:6,TC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:4,HL:3,IS:1,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:1,LA:2,Periphery.HR:5,ROS:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+		<model name='JVN-10P'>
 			<roles>recon</roles>
-			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3</availability>
+			<availability>MOC:5,LA:6,Periphery.HR:5,PIR:5,FS:5,MERC:6,CDP:5,TC:5</availability>
 		</model>
 		<model name='JVN-11F'>
 			<roles>recon</roles>
 			<availability>FS:5</availability>
 		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
+		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>HL:1-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
-			<availability>MOC:5,LA:6,Periphery.HR:5,PIR:5,FS:5,MERC:6,CDP:5,TC:5</availability>
+			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>ROS:6,FS:6</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -8824,14 +8824,14 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:3,General:2,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>CSR:3,General:2,CJF:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -8842,67 +8842,59 @@
 		<model name='C'>
 			<availability>General:4,CGS:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CSR:3,General:2,CJF:5</availability>
+		<model name='B'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CDS:6,CW:5,ROS:4,CNC:8,CLAN:1,CGS:5,CCO:5,DC:3</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>CCC:6,CNC:6</availability>
 		</model>
-		<model name='3'>
+		<model name='(Standard)'>
+			<availability>CW:4,CLAN:2,CNC:4</availability>
+		</model>
+		<model name='2'>
 			<availability>CCC:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:6,CNC:8,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CW:4,CLAN:2,CNC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
-		<model name='JR7-K'>
+		<model name='JR7-C4'>
 			<roles>raider</roles>
-			<availability>MOC:4,OA:4,FRR:8,CGB.FRR:8,MERC:4,DC:4,TC:4</availability>
-		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>HL:1-,General:2-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>DC:5</availability>
-		</model>
-		<model name='JR7-C3'>
-			<roles>raider</roles>
-			<availability>ROS:3,MERC:3,DC:4</availability>
+			<availability>DC:2</availability>
 		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>HL:1-,General:2-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='JR7-C3'>
+			<roles>raider</roles>
+			<availability>ROS:3,MERC:3,DC:4</availability>
+		</model>
+		<model name='JR7-K'>
+			<roles>raider</roles>
+			<availability>MOC:4,OA:4,FRR:8,CGB.FRR:8,MERC:4,DC:4,TC:4</availability>
+		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
 			<availability>MERC:5,FS:5,DC:6</availability>
 		</model>
-		<model name='JR7-C4'>
+		<model name='JR7-C2'>
 			<roles>raider</roles>
-			<availability>DC:2</availability>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:5,TC:4</availability>
-		<model name='JI-50 (Q-Vehicle)'>
-			<roles>support</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='JI-50'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='JI-50 (ML)'>
+		<model name='JI-50 (Hoist)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8910,21 +8902,29 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='JI-50 (Hoist)'>
+		<model name='JI-50'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Q-Vehicle)'>
+			<roles>support</roles>
+			<availability>TC:2</availability>
+		</model>
+		<model name='JI-50 (ML)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:5,MOC:4,TC:4</availability>
-		<model name='JN-G8A'>
-			<availability>General:8</availability>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
+		<model name='JN-G8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Joust Medium Tank' unitType='Tank'>
@@ -8943,11 +8943,11 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
@@ -8959,8 +8959,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -8980,29 +8980,28 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='KBO-7B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='KBO-7A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='KBO-7B'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:2,DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+		<model name='C' mechanized='true'>
+			<availability>DC:2</availability>
 		</model>
-		<model name='(DEST)' mechanized='true'>
+		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
@@ -9010,28 +9009,29 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C' mechanized='true'>
-			<availability>DC:2</availability>
+		<model name='[MG]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
+		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='(Space)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='(Vibro-Claw)' mechanized='true'>
+		<model name='[ECM]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
+			<availability>MERC:2,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -9043,6 +9043,13 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Salvage Arm]' mechanized='false'>
+			<roles>support</roles>
+			<availability>DC.SL:6,General:6</availability>
+		</model>
 		<model name='[Industrial Drill]' mechanized='false'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -9050,23 +9057,16 @@
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Salvage Arm]' mechanized='false'>
-			<roles>support</roles>
-			<availability>DC.SL:6,General:6</availability>
-		</model>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>CGB:4</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
@@ -9088,38 +9088,38 @@
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(AC)'>
+			<availability>MH:6,MERC:6</availability>
+		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:4,OA:5,FVC:4,HL:3,PIR:7,MH:6,CIR:6,DA:4,Periphery:5,TC:5</availability>
+		</model>
+		<model name='(Heavy Stealth)'>
+			<availability>PIR:2</availability>
+		</model>
 		<model name='(3055 Upgrade)'>
 			<roles>cargo</roles>
 			<availability>HL:3,IS:8,Periphery:5</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:6,MERC:6</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>CS:5,FWL:5,IS:6,WOB:5</availability>
 		</model>
-		<model name='(Heavy Stealth)'>
-			<availability>PIR:2</availability>
-		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:4,OA:5,FVC:4,HL:3,PIR:7,MH:6,CIR:6,DA:4,Periphery:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,FRR:2,CGB.FRR:2,DC:6</availability>
+		<model name='CRK-5003-2'>
+			<availability>FRR:8,CGB.FRR:8,DC:3-</availability>
+		</model>
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:5,DC:5</availability>
 		</model>
-		<model name='CRK-5003-2'>
-			<availability>FRR:8,CGB.FRR:8,DC:3-</availability>
+		<model name='CRK-5003-C'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CRK-5003-CM'>
 			<roles>spotter</roles>
 			<availability>DC:7</availability>
-		</model>
-		<model name='CRK-5003-C'>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
@@ -9128,21 +9128,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
@@ -9150,8 +9150,20 @@
 		<model name='KGC-001'>
 			<availability>CS:8,FVC:8,LA:5,IS:5,WOB:5,MH:6,CIR:6,MERC:6</availability>
 		</model>
+		<model name='KGC-000b'>
+			<availability>CS:5,FRR:4,CGB.FRR:4,CLAN:4,WOB:4,CGS:6,BAN:2,DC:4</availability>
+		</model>
+		<model name='KGC-007'>
+			<availability>LA:7,ROS:7,FS:7,MERC:7</availability>
+		</model>
+		<model name='KGC-0000'>
+			<availability>IS:3-,CIR:5</availability>
+		</model>
 		<model name='KGC-008B'>
 			<availability>ROS:4,WOB.PM:8</availability>
+		</model>
+		<model name='KGC-000'>
+			<availability>CS:4,FRR:8,CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
 		</model>
 		<model name='KGC-005r'>
 			<availability>CS:2,ROS:2,WOB:2</availability>
@@ -9159,20 +9171,8 @@
 		<model name='KGC-005'>
 			<availability>CS:5,WOB:4</availability>
 		</model>
-		<model name='KGC-000b'>
-			<availability>CS:5,FRR:4,CGB.FRR:4,CLAN:4,WOB:4,CGS:6,BAN:2,DC:4</availability>
-		</model>
 		<model name='KGC-008'>
 			<availability>WOB:8</availability>
-		</model>
-		<model name='KGC-0000'>
-			<availability>IS:3-,CIR:5</availability>
-		</model>
-		<model name='KGC-000'>
-			<availability>CS:4,FRR:8,CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
-		</model>
-		<model name='KGC-007'>
-			<availability>LA:7,ROS:7,FS:7,MERC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
@@ -9180,41 +9180,38 @@
 		<model name='C'>
 			<availability>General:5,CGB:3</availability>
 		</model>
-		<model name='X'>
-			<availability>CGB:1</availability>
+		<model name='E'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6,CGB:5</availability>
 		</model>
-		<model name='E'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
-		</model>
 		<model name='B'>
 			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='X'>
+			<availability>CGB:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>CS:7,DC.GHO:6,CHH:1,CDS:1,FRR:4,CGB.FRR:4,ROS:6,NIOPS:7,WOB:7,FS:3,MERC:5,DC:4</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:7</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:4,CS:4,DC.SL:4,ROS:4,CLAN:6,NIOPS:4,WOB:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-21'>
-			<availability>CS:6,WOB:5</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>ROS:6,CLAN:4,WOB:6,FS:5,CGS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:3-,MERC:3-,DC:1-</availability>
@@ -9225,29 +9222,32 @@
 		<model name='KTO-20'>
 			<availability>CS:4,FRR:4,CGB.FRR:4,WOB:4,MERC:5,DC:5</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:7</availability>
+		<model name='KTO-19b'>
+			<availability>ROS:6,CLAN:4,WOB:6,FS:5,CGS:6,BAN:2</availability>
+		</model>
+		<model name='KTO-21'>
+			<availability>CS:6,WOB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,CGS:7,BAN:7,CWIE:6,CGB:7</availability>
-		<model name='C'>
-			<availability>General:5,CGS:6</availability>
-		</model>
 		<model name='E'>
 			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5,CGS:6</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -9270,46 +9270,49 @@
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
 		<availability>CS:5,FRR:5,CGB.FRR:5</availability>
-		<model name='[GL/Flamer]' mechanized='true'>
-			<availability>FRR:6,CGB.FRR:6</availability>
+		<model name='[GL]' mechanized='true'>
+			<availability>FRR:4,CGB.FRR:4</availability>
 		</model>
-		<model name='[SL/Flamer]' mechanized='true'>
-			<availability>FRR:6,CGB.FRR:6</availability>
-		</model>
-		<model name='X-C3' mechanized='true'>
-			<availability>CS:2</availability>
-		</model>
-		<model name='(CS) [GL/Flamer]' mechanized='true'>
+		<model name='(CS) [GL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
 			<availability>CS:6</availability>
 		</model>
 		<model name='[SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>FRR:8,CGB.FRR:8</availability>
 		</model>
-		<model name='[GL]' mechanized='true'>
-			<availability>FRR:4,CGB.FRR:4</availability>
+		<model name='X-C3' mechanized='true'>
+			<availability>CS:2</availability>
+		</model>
+		<model name='[SL/Flamer]' mechanized='true'>
+			<availability>FRR:6,CGB.FRR:6</availability>
+		</model>
+		<model name='(CS) [GL/Flamer]' mechanized='true'>
+			<availability>CS:6</availability>
 		</model>
 		<model name='(CS) [GL]' mechanized='true'>
 			<availability>CS:4</availability>
 		</model>
-		<model name='(CS) [GL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CS:6</availability>
-		</model>
 		<model name='(CS) [SL/Flamer]' mechanized='true'>
 			<availability>CS:6</availability>
-		</model>
-		<model name='[GL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>FRR:6,CGB.FRR:6</availability>
 		</model>
 		<model name='(CS) [SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:8</availability>
 		</model>
+		<model name='[GL/Flamer]' mechanized='true'>
+			<availability>FRR:6,CGB.FRR:6</availability>
+		</model>
+		<model name='[GL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>FRR:6,CGB.FRR:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CHH:1,CCC:3,CSR:3,CNC:1,CLAN:1,CGS:4,CCO:3,CGB:8</availability>
+		<model name='5'>
+			<availability>CGB:4</availability>
+		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
 			<availability>CSR:3</availability>
@@ -9318,9 +9321,6 @@
 			<availability>CGB:5</availability>
 		</model>
 		<model name='4'>
-			<availability>CGB:4</availability>
-		</model>
-		<model name='5'>
 			<availability>CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -9333,9 +9333,6 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='KIM-2'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>General:8,DC:5</availability>
@@ -9344,27 +9341,23 @@
 			<roles>spotter</roles>
 			<availability>DC:3</availability>
 		</model>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:3</availability>
-		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Anti-Infantry)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,WOB:4,MERC:4</availability>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
-			<availability>MERC:3</availability>
-		</model>
 		<model name='KSC-4I'>
-			<availability>MERC:3</availability>
-		</model>
-		<model name='KSC-4L'>
 			<availability>MERC:3</availability>
 		</model>
 		<model name='KSC-5I'>
@@ -9373,12 +9366,51 @@
 		<model name='KSC-5MC'>
 			<availability>MOC:8,CC:8</availability>
 		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:3</availability>
+		</model>
+		<model name='KSC-4L'>
+			<availability>MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CSR:6,CLAN:1,IS:3+,CCO:2,CGS:5,BAN:6,CSA:6,MERC.WD:6,CDS:6,CW:6,CBS:6,CJF:5</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>CDS:3,CW:7,General:4,CGB:8</availability>
+		</model>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CLAN:5,IS:2</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
+		</model>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
+		</model>
+		<model name='Z'>
+			<roles>recon</roles>
+			<availability>CCO:2</availability>
+		</model>
+		<model name='G'>
+			<roles>recon,anti_infantry</roles>
+			<availability>CLAN:2,IS:1</availability>
+		</model>
+		<model name='B'>
+			<roles>recon</roles>
+			<availability>CSA:6,CDS:6,CW:6,General:5,CGS:6,CCO:4,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='D'>
 			<roles>recon</roles>
@@ -9387,38 +9419,6 @@
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CLAN:5,IS:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CLAN:5,IS:2</availability>
-		</model>
-		<model name='G'>
-			<roles>recon,anti_infantry</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='Z'>
-			<roles>recon</roles>
-			<availability>CCO:2</availability>
-		</model>
-		<model name='B'>
-			<roles>recon</roles>
-			<availability>CSA:6,CDS:6,CW:6,General:5,CGS:6,CCO:4,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='P'>
-			<roles>recon</roles>
-			<availability>CLAN:2,IS:1</availability>
-		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
@@ -9435,9 +9435,6 @@
 	</chassis>
 	<chassis name='Kraken (Bane)' unitType='Mek'>
 		<availability>CSR:2,ROS:2,CLAN:1,CJF:4</availability>
-		<model name='2'>
-			<availability>CLAN:1,CJF:1</availability>
-		</model>
 		<model name='4'>
 			<availability>ROS:8,CJF:6</availability>
 		</model>
@@ -9448,15 +9445,18 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:1,CJF:2</availability>
 		</model>
+		<model name='2'>
+			<availability>CLAN:1,CJF:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CSR:3,CDS:3,CW:4,CLAN:1,CNC:3,CGS:6,CJF:4,CGB:6,CWIE:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(IFV) &apos;Turhan II&apos;'>
 			<roles>apc</roles>
 			<availability>CHH:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kuan Ti' unitType='Dropship'>
@@ -9505,6 +9505,12 @@
 	</chassis>
 	<chassis name='Lancelot' unitType='Mek'>
 		<availability>CS:6,FRR:3,ROS:5,CGB.FRR:3,CLAN:4,NIOPS:6,WOB:6,CGS:5,BAN:7,DC:5</availability>
+		<model name='LNC25-06'>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='LNC25-04'>
+			<availability>CS:8,WOB:8</availability>
+		</model>
 		<model name='LNC25-02'>
 			<roles>fire_support</roles>
 			<availability>:0,FRR:2-,CGB.FRR:3-,DC:3-</availability>
@@ -9512,53 +9518,47 @@
 		<model name='LNC25-03'>
 			<availability>DC:1-</availability>
 		</model>
-		<model name='LNC25-01'>
-			<roles>anti_aircraft</roles>
-			<availability>CS:4,ROS:4,FRR:6,CGB.FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:5</availability>
-		</model>
-		<model name='LNC25-08'>
-			<availability>WOB:4</availability>
-		</model>
 		<model name='LNC25-05'>
 			<roles>anti_infantry</roles>
 			<availability>CS:2,NIOPS:1,WOB:2</availability>
 		</model>
-		<model name='LNC25-04'>
-			<availability>CS:8,WOB:8</availability>
+		<model name='LNC25-08'>
+			<availability>WOB:4</availability>
 		</model>
-		<model name='LNC25-06'>
-			<availability>WOB:8</availability>
+		<model name='LNC25-01'>
+			<roles>anti_aircraft</roles>
+			<availability>CS:4,ROS:4,FRR:6,CGB.FRR:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>PR:5,DoO:5,WOB:3,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,TP:5,DA:5,RCM:5,RFS:5</availability>
-		<model name='LX-2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LX-2A'>
 			<availability>PR:5,DoO:5,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,TP:5,RCM:5,DA:5,RFS:5</availability>
 		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
+		<model name='LX-2'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:7,MOC:5,FS:3,TC:4</availability>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3B'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:6</availability>
-		</model>
 		<model name='LHU-4E'>
 			<availability>CC:3</availability>
 		</model>
 		<model name='LHU-3L'>
 			<availability>CC:5,MOC:6,FS:8</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-3B'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -9570,15 +9570,12 @@
 	</chassis>
 	<chassis name='Legacy' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='LGC-04-WVR'>
-			<availability>WOB:2</availability>
-		</model>
 		<model name='LGC-02'>
 			<roles>fire_support</roles>
 			<availability>WOB:3</availability>
 		</model>
-		<model name='LGC-03'>
-			<availability>WOB:4</availability>
+		<model name='LGC-04-WVR'>
+			<availability>WOB:2</availability>
 		</model>
 		<model name='LGC-01'>
 			<availability>WOB:8</availability>
@@ -9586,45 +9583,48 @@
 		<model name='LGC-05'>
 			<availability>WOB:2</availability>
 		</model>
+		<model name='LGC-03'>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>FS:6</availability>
-		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGN-2F'>
 			<availability>FS:6</availability>
 		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
+		</model>
+		<model name='LGN-2XU'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-2XA'>
 			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>CC:8,PR:8,DoO:8,WOB:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:5-</availability>
 		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>CC:8,PR:8,DoO:8,WOB:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
 		<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
-		<model name='&apos;Pocket Warship&apos;'>
-			<availability>FWL:2,WOB:6</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,DA:8,RCM:8,RFS:8</availability>
+		</model>
+		<model name='&apos;Pocket Warship&apos;'>
+			<availability>FWL:2,WOB:6</availability>
 		</model>
 		<model name='(2537)'>
 			<roles>mech_carrier</roles>
@@ -9667,30 +9667,30 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
-		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:2,FWL:7,IS:2</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:2</availability>
+		<model name='Owl'>
+			<availability>LA:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,Periphery.ME:3,FWL:3,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='Andurien'>
-			<availability>FWL:2</availability>
+		<model name='Comet'>
+			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:4,HL:4,LA:4</availability>
 		</model>
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
+		</model>
+		<model name='Andurien'>
+			<availability>FWL:2</availability>
+		</model>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:2,FWL:7,IS:2</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -9701,6 +9701,13 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CS:2,CLAN:4,NIOPS:2,WOB:7,CJF:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8,CLAN:6,WOB:4</availability>
+		</model>
+		<model name='(Royal)'>
+			<roles>spotter</roles>
+			<availability>CLAN:8,BAN:2</availability>
+		</model>
 		<model name='(ERSL)'>
 			<availability>ROS:4,WOB:4</availability>
 		</model>
@@ -9710,62 +9717,55 @@
 		<model name='(RL)'>
 			<availability>WOB:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8,CLAN:6,WOB:4</availability>
-		</model>
 		<model name='CX-3'>
 			<availability>CS:8</availability>
-		</model>
-		<model name='(Royal)'>
-			<roles>spotter</roles>
-			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='LTN-G15b'>
-			<availability>CC:4,MOC:4,CLAN:3,MERC:3</availability>
-		</model>
-		<model name='LTN-G16L'>
-			<availability>CC:5,MOC:5,MERC:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:5-</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='LTN-G16S'>
-			<availability>LA:5</availability>
+		<model name='LTN-G15b'>
+			<availability>CC:4,MOC:4,CLAN:3,MERC:3</availability>
 		</model>
 		<model name='LTN-G16D'>
 			<availability>FS:5,MERC:4</availability>
 		</model>
+		<model name='LTN-G16L'>
+			<availability>CC:5,MOC:5,MERC:4</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:5</availability>
+		</model>
 		<model name='LTN-G16O'>
 			<availability>OA:5,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G16S'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Lightray' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='LGH-4Y'>
+		<model name='LGH-5W'>
 			<roles>recon</roles>
-			<availability>WOB:3</availability>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='LGH-7W'>
 			<roles>recon</roles>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='LGH-6W'>
+		<model name='LGH-4Y'>
 			<roles>recon</roles>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='LGH-5W'>
-			<roles>recon</roles>
-			<availability>WOB:4</availability>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='LGH-4W'>
 			<roles>recon</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='LGH-6W'>
+			<roles>recon</roles>
+			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
@@ -9773,11 +9773,14 @@
 		<model name='B'>
 			<availability>CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:4,CW:4,CBS:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
@@ -9785,29 +9788,26 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CW:4,CBS:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
+		<model name='D'>
+			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lineholder' unitType='Mek'>
 		<availability>CC:4,ROS:4,FWL:4,IS:3,WOB:5,FS:5,CIR:6,TC:6,Periphery:2</availability>
-		<model name='KW2-LHW'>
-			<availability>WOB:8</availability>
-		</model>
-		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
-			<availability>WOB:5,FS:7</availability>
-		</model>
 		<model name='KW1-LH3'>
 			<availability>General:2,WOB:3,FS:3</availability>
 		</model>
 		<model name='KW1-LH2'>
 			<availability>General:6,WOB:2,FS:2</availability>
+		</model>
+		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
+			<availability>WOB:5,FS:7</availability>
+		</model>
+		<model name='KW2-LHW'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -9841,80 +9841,75 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CS:3,CHH:6,CW:7,LA:1,ROS:3,CLAN:2,IS:1,CJF:6,DC:3,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CW:4,General:1</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:4,CS:6,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
+		<model name='3'>
+			<availability>General:1</availability>
 		</model>
 		<model name='6'>
 			<availability>CW:4,CGB:4</availability>
 		</model>
-		<model name='5'>
-			<availability>CHH:4,CW:4,ROS:4,CCO:4,CGB:4</availability>
-		</model>
-		<model name='7'>
-			<availability>CHH:3</availability>
+		<model name='(Standard)'>
+			<availability>CW:4,General:1</availability>
 		</model>
 		<model name='8'>
 			<availability>CGB:5</availability>
 		</model>
+		<model name='7'>
+			<availability>CHH:3</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:4,CS:6,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
 		<model name='2'>
 			<availability>CCC:2,CJF:2</availability>
 		</model>
-		<model name='3'>
-			<availability>General:1</availability>
+		<model name='5'>
+			<availability>CHH:4,CW:4,ROS:4,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CS:2-,HL:5,CLAN:2-,IS:8,NIOPS:2-,Periphery.Deep:5,WOB:3-,Periphery:5</availability>
-		<model name='LCT-3M'>
+		<model name='LCT-6M'>
 			<roles>recon</roles>
-			<availability>MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:6,DTA:5,SC:5,MCM:5,PG:5,FWL:6,TP:5,RCM:5,DA:5,RFS:5</availability>
-		</model>
-		<model name='LCT-1L'>
-			<roles>recon</roles>
-			<availability>CC:1-</availability>
-		</model>
-		<model name='LCT-5W'>
-			<roles>recon,spotter</roles>
-			<availability>WOB:6</availability>
+			<availability>SC:4,MCM:4,ROS:2,FWL:3,WOB:3,DGM:4</availability>
 		</model>
 		<model name='LCT-5T'>
 			<roles>recon,anti_infantry</roles>
 			<availability>MOC:4,CC:4,FVC:3,TC:5</availability>
 		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:4,ROS:4,PIR:4,FWL:5,IS:2,WOB:4,FS:4,MERC:4</availability>
+		<model name='LCT-5M3'>
+			<availability>SC:3,MCM:3,ROS:3,DGM:3</availability>
 		</model>
-		<model name='LCT-6M'>
+		<model name='LCT-1L'>
 			<roles>recon</roles>
-			<availability>SC:4,MCM:4,ROS:2,FWL:3,WOB:3,DGM:4</availability>
-		</model>
-		<model name='LCT-5W2'>
-			<roles>recon,spotter</roles>
-			<availability>CS:4,LA:3,ROS:4,CLAN:2,IS:2,FS:3,DC:3</availability>
+			<availability>CC:1-</availability>
 		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CC:4,CLAN:6,BAN:2</availability>
 		</model>
-		<model name='LCT-5V'>
+		<model name='LCT-3V'>
 			<roles>recon</roles>
-			<availability>MOC:4,CC:3,FVC:3,PIR:4,TC:4</availability>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:4,ROS:4,PIR:4,FWL:5,IS:2,WOB:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='LCT-1V2'>
+			<roles>recon</roles>
+			<availability>PIR:4,MH:4</availability>
+		</model>
+		<model name='LCT-5W2'>
+			<roles>recon,spotter</roles>
+			<availability>CS:4,LA:3,ROS:4,CLAN:2,IS:2,FS:3,DC:3</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:3-,General:3-,FS:3-</availability>
 		</model>
-		<model name='LCT-3V'>
+		<model name='LCT-5V'>
 			<roles>recon</roles>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>MOC:4,CC:3,FVC:3,PIR:4,TC:4</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -9924,25 +9919,30 @@
 			<roles>recon</roles>
 			<availability>LA:8,FRR:6,CGB.FRR:6,MERC:6</availability>
 		</model>
+		<model name='LCT-5W'>
+			<roles>recon,spotter</roles>
+			<availability>WOB:6</availability>
+		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:6,DTA:5,SC:5,MCM:5,PG:5,FWL:6,TP:5,RCM:5,DA:5,RFS:5</availability>
+		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:3-,MERC:3-</availability>
 		</model>
-		<model name='LCT-5M3'>
-			<availability>SC:3,MCM:3,ROS:3,DGM:3</availability>
-		</model>
-		<model name='LCT-1V2'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>PIR:4,MH:4</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CDS:1,CW:4,CBS:4,CLAN:1,IS:2+,CJF:2,BAN:5,CWIE:5,CGB:1</availability>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
@@ -9953,15 +9953,15 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:2,CJF:5</availability>
-		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -9977,6 +9977,10 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6</availability>
+		<model name='LGB-7V'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,FVC:4,FWL:5,IS:4</availability>
+		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
 			<availability>General:3-</availability>
@@ -9985,41 +9989,34 @@
 			<roles>missile_artillery,fire_support</roles>
 			<availability>LA:3,FRR:3,CGB.FRR:3,FWL:3,IS:2,FS:4,MERC:3</availability>
 		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:4,CS:4,LA:4,IS:2,FS:4,MERC:4,DC:4,Periphery:2</availability>
-		</model>
-		<model name='LGB-13NAIS'>
-			<availability>WOB:3,FS:4</availability>
-		</model>
 		<model name='LGB-12R'>
 			<roles>fire_support</roles>
 			<availability>DTA:3,LA:3,ROS:8,FS:3,DC:2</availability>
-		</model>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,FVC:4,FWL:5,IS:4</availability>
-		</model>
-		<model name='LGB-12C'>
-			<roles>fire_support</roles>
-			<availability>CC:5,MOC:5,LA:3,FWL:3,IS:3,MH:4,FS:3,MERC:3,CDP:2,TC:2</availability>
-		</model>
-		<model name='LGB-13C'>
-			<roles>fire_support</roles>
-			<availability>CC:5,MOC:3,DoO:4,DO:4,DGM:4,FS:5,MERC:5,SC:4,MCM:4,ROS:5,FWL:2,TP:4,DA:5,RCM:5,DC:5</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:3-,OA:3-,General:3-,TC:3-,Periphery:3-</availability>
 		</model>
+		<model name='LGB-12C'>
+			<roles>fire_support</roles>
+			<availability>CC:5,MOC:5,LA:3,FWL:3,IS:3,MH:4,FS:3,MERC:3,CDP:2,TC:2</availability>
+		</model>
+		<model name='LGB-13NAIS'>
+			<availability>WOB:3,FS:4</availability>
+		</model>
+		<model name='LGB-13C'>
+			<roles>fire_support</roles>
+			<availability>CC:5,MOC:3,DoO:4,DO:4,DGM:4,FS:5,MERC:5,SC:4,MCM:4,ROS:5,FWL:2,TP:4,DA:5,RCM:5,DC:5</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CS:4,LA:4,IS:2,FS:4,MERC:4,DC:4,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>PR:8,DoO:8,WOB:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:5,TP:8,RCM:8,DA:8,RFS:8</availability>
-		<model name='(Magnetic)' mechanized='true'>
-			<availability>FWL:5</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -10027,14 +10024,8 @@
 		<model name='[MG] (WoB)' mechanized='true'>
 			<availability>CS:8,WOB:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[David] (WoB)' mechanized='true'>
-			<availability>CS:5,WOB:5</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='(Magnetic)' mechanized='true'>
+			<availability>FWL:5</availability>
 		</model>
 		<model name='[Laser] (WoB)' mechanized='true'>
 			<availability>CS:6,WOB:6</availability>
@@ -10042,47 +10033,56 @@
 		<model name='[Flamer] (WoB)' mechanized='true'>
 			<availability>CS:7,WOB:7</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[David] (WoB)' mechanized='true'>
+			<availability>CS:5,WOB:5</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Magnetic) (WOB)' mechanized='true'>
 			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>FRR:4,CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
-		<model name='LCF-R16K'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>FRR:6,CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:2,HL:4,FRR:3,FS:2,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:1,FVC:2,LA:7,Periphery.MW:3</availability>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:2,FS:1,MERC:6</availability>
+		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:3-,FS:3-</availability>
 		</model>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:2,FS:1,MERC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM5/M'>
-			<availability>LA:2-</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='LM5/M'>
+			<availability>LA:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -10119,17 +10119,17 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3,WOB:3</availability>
-		<model name='W1'>
-			<roles>missile_artillery,escort</roles>
-			<availability>WOB:6</availability>
+		<model name='M1'>
+			<roles>escort</roles>
+			<availability>FWL:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='M1'>
-			<roles>escort</roles>
-			<availability>FWL:6</availability>
+		<model name='W1'>
+			<roles>missile_artillery,escort</roles>
+			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -10154,20 +10154,23 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>LA:2-,FWL:2-</availability>
-		<model name='MSK-5S'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>PR:8,PG:8,FWL:8,RFS:8</availability>
 		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
 		</model>
+		<model name='MSK-5S'>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:1,MERC.WD:7,CDS:5,CW:7,CBS:3,CLAN:3,CCO:5,CJF:5,BAN:2,CWIE:7</availability>
-		<model name='Prime'>
-			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,CW:5,CLAN:4,General:2,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -10177,56 +10180,53 @@
 			<roles>spotter</roles>
 			<availability>CHH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:3,General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='Z'>
 			<availability>CCO:2</availability>
 		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:3,General:4</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,CW:5,CLAN:4,General:2,CJF:6,CWIE:5,CGB:5</availability>
+		<model name='Prime'>
+			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CGS:7,CCO:6,CJF:8,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,CW:4,LA:3,CNC:6,FS:3,CWIE:4,DC:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CDS:3</availability>
 		</model>
 		<model name='2'>
 			<availability>CDS:4,CW:4,LA:4,CNC:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
 		<availability>LA:6,FS:4,MERC:3,DC:6</availability>
-		<model name='MTR-6E'>
-			<roles>recon,spotter</roles>
-			<availability>DC:1</availability>
+		<model name='MTR-5K'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:4</availability>
 		</model>
-		<model name='MTR-5K'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='MTR-6E'>
+			<roles>recon,spotter</roles>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Magellan Jumpship' unitType='Jumpship'>
@@ -10237,28 +10237,28 @@
 	</chassis>
 	<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
 		<availability>CS:5,FRR:1,CGB.FRR:1,NIOPS:3,WOB:5,WOB.PM:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UCSV)'>
 			<roles>apc,urban</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>PR:8,DoO:8,WOB:3,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(XL)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Malaika' unitType='Aero'>
@@ -10269,27 +10269,27 @@
 	</chassis>
 	<chassis name='Malak' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='C-MK-OC Comminus'>
-			<roles>spotter</roles>
+		<model name='C-MK-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-MK-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-MK-OA Dominus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-MK-O Invictus'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C-MK-OD Luminos'>
 			<availability>General:7</availability>
+		</model>
+		<model name='C-MK-OS Caelestis'>
+			<availability>General:5</availability>
 		</model>
 		<model name='C-MK-OE Eminus'>
 			<availability>General:5</availability>
 		</model>
-		<model name='C-MK-OS Caelestis'>
-			<availability>General:5</availability>
+		<model name='C-MK-O Invictus'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C-MK-OC Comminus'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mammoth' unitType='Dropship'>
@@ -10301,9 +10301,6 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,MERC.WD:7,CDS:7,CW:7,CBS:5,CLAN:1,CNC:3,IS:1+,CJF:7,BAN:5,CWIE:7,CGB:1</availability>
-		<model name='E'>
-			<availability>CLAN:6,General:2,CCO:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:2</availability>
 		</model>
@@ -10314,17 +10311,20 @@
 		<model name='G'>
 			<availability>General:2</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:2,CCO:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
@@ -10347,25 +10347,37 @@
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='C'>
-			<roles>spotter</roles>
-			<availability>General:7,FS:5</availability>
-		</model>
 		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7,FS:6</availability>
+		</model>
+		<model name='C'>
+			<roles>spotter</roles>
+			<availability>General:7,FS:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,TC:7,CS:7,OA:7,LA:7,CGB.FRR:8,ROS:7,FWL:6,NIOPS:7,DC:9</availability>
+		<model name='(LB-X)'>
+			<availability>LA:7,ROS:7,WOB:6,FS:7</availability>
+		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,PR:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:3,LA:2-,General:3-,Periphery.Deep:6,FS:2-,DC:2-,Periphery:5</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -10373,18 +10385,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>ROS:4,FS:4,DC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>LA:7,ROS:7,WOB:6,FS:7</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,PR:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:3,LA:2-,General:3-,Periphery.Deep:6,FS:2-,DC:2-,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
@@ -10398,26 +10398,26 @@
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:7,MERC.WD:6,CSR:3,CW:6,LA:1,CLAN:1,CNC:6,CJF:7,CWIE:6,CGB:7</availability>
-		<model name='3'>
-			<availability>CSA:3,CLAN:1,CJF:5,CGB:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CW:4,CJF:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:8,CLAN:1,CJF:4,CGB:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:5,CCC:3,CDS:1,CSR:1,CGS:3,CJF:3,CWIE:1,CGB:3</availability>
 		</model>
 		<model name='5'>
 			<availability>CW:1,LA:5,CJF:4,CWIE:5,CGB:1</availability>
 		</model>
-		<model name='4'>
-			<availability>CNC:5,CGB:4</availability>
+		<model name='6'>
+			<availability>CW:4,CJF:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:3,CLAN:1,CJF:5,CGB:5</availability>
 		</model>
 		<model name='7'>
 			<availability>CGB:3</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:5,CCC:3,CDS:1,CSR:1,CGS:3,CJF:3,CWIE:1,CGB:3</availability>
+		</model>
+		<model name='4'>
+			<availability>CNC:5,CGB:4</availability>
 		</model>
 		<model name='8'>
 			<availability>CLAN:1,CJF:5,CGB:5</availability>
@@ -10425,94 +10425,70 @@
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,FRR:5,WOB:2,FS:6,MERC:6,TC:4,CS:3,MERC.WD:6,LA:4,CGB.FRR:5,ROS:6,PIR:4,CNC:1,FWL:5,MH:4,DC:5</availability>
-		<model name='MAD-4H'>
-			<availability>PIR:7,MH:7,TC:7</availability>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:3</availability>
 		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
 		</model>
-		<model name='MAD-5W'>
-			<availability>CC:3,CS:4,WOB:8</availability>
-		</model>
 		<model name='MAD-6M'>
 			<availability>ROS:4,FWL:4,MERC:4</availability>
-		</model>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:3</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:4</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>CS:8,LA:8,FRR:6,CGB.FRR:6,ROS:6,CNC:8,FWL:3,FS:7,MERC:6,DC:4</availability>
 		</model>
-		<model name='MAD-4K'>
-			<availability>DC:7</availability>
+		<model name='MAD-4A'>
+			<availability>MERC:1</availability>
 		</model>
 		<model name='MAD-5C'>
 			<availability>MERC.WD:2</availability>
 		</model>
-		<model name='MAD-4A'>
-			<availability>MERC:1</availability>
+		<model name='MAD-5W'>
+			<availability>CC:3,CS:4,WOB:8</availability>
+		</model>
+		<model name='MAD-4K'>
+			<availability>DC:7</availability>
+		</model>
+		<model name='MAD-4H'>
+			<availability>PIR:7,MH:7,TC:7</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,CGB.FRR:4,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:2,DO:5,DGM:5,WOB:4,TP:5,MERC:3,DA:5</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:5,FRR:6,CGB.FRR:6,WOB:4,FS:4,MERC:4,DC:7</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>LA:5,FRR:4,CGB.FRR:4,ROS:4,MERC:3</availability>
+		<model name='MAD-3D'>
+			<availability>FVC:3-,MH:3-,FS:3-</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>PR:4,DoO:4,ROS:4,PG:4,FWL:2,WOB:4,DO:4,TP:4,MERC:4,DA:4,RFS:4</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:4,ROS:3,FS:4,MERC:3,DC:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:1,LA:1+,CNC:1,FS:1+,CJF:1,DC:1+,CGB:1,CWIE:1</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>FVC:4,LA:5,FRR:3,CGB.FRR:3,FS:4,MERC:4</availability>
-		</model>
-		<model name='MAD-9W'>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:2,DO:5,DGM:5,WOB:4,TP:5,MERC:3,DA:5</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:3-,Periphery.MW:3-,PIR:3-,Periphery.ME:3-,FWL:2-,MH:3-,MERC:3-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:5,FRR:6,CGB.FRR:6,WOB:4,FS:4,MERC:4,DC:7</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>CS:6,MOC:3,ROS:4,FWL:8,IS:1,WOB:7,MERC:4</availability>
 		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
+		<model name='MAD-6L'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:3-,MH:3-,FS:3-</availability>
+		<model name='C'>
+			<availability>CW:1,LA:1+,CNC:1,FS:1+,CJF:1,DC:1+,CGB:1,CWIE:1</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>CS:2-,HL:1-,IS:3-,Periphery.Deep:8,WOB:2-,Periphery:4-,TC:4-</availability>
 		</model>
+		<model name='MAD-9S'>
+			<availability>LA:5,FRR:4,CGB.FRR:4,ROS:4,MERC:3</availability>
+		</model>
 		<model name='MAD-3L'>
 			<availability>CC:1-</availability>
-		</model>
-		<model name='MAD-5L'>
-			<availability>CC:5,MOC:4,WOB:3,CIR:3,TC:1</availability>
 		</model>
 		<model name='MAD-2R'>
 			<availability>CLAN:1,CGS:1,BAN:1,TC:3</availability>
@@ -10520,31 +10496,55 @@
 		<model name='MAD-1R'>
 			<availability>CS:4-,NIOPS:2-,WOB:4-,MERC:0,BAN:1</availability>
 		</model>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
+		</model>
+		<model name='MAD-9W'>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:3-,Periphery.MW:3-,PIR:3-,Periphery.ME:3-,FWL:2-,MH:3-,MERC:3-</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:5,MOC:4,WOB:3,CIR:3,TC:1</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>FVC:4,LA:5,FRR:3,CGB.FRR:3,FS:4,MERC:4</availability>
+		</model>
+		<model name='MAD-9W2'>
+			<availability>LA:4,ROS:3,FS:4,MERC:3,DC:4</availability>
+		</model>
+		<model name='MAD-7D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
 		<availability>LA:5</availability>
-		<model name='(Light PPC)'>
-			<roles>artillery</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CHH:8,BAN:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>artillery</roles>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>CLAN:7</availability>
-		<model name='(HAG)'>
-			<availability>CGB:3</availability>
-		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CCO:6,CJF:2</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CSA:4,CHH:4,CCC:3,CSL:4,CGS:3,CCO:3,CGB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ATM)'>
+			<availability>General:5,CCO:6,CJF:2</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CGB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -10555,11 +10555,11 @@
 	</chassis>
 	<chassis name='Marshal' unitType='Mek'>
 		<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,Periphery:2,TC:7</availability>
-		<model name='MHL-6MC'>
-			<availability>MOC:3</availability>
-		</model>
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:3</availability>
 		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,PIR:4,TC:4</availability>
@@ -10567,36 +10567,36 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSR:2,CLAN:1,IS:1+,MERC:2+,CGS:7,BAN:3,CWIE:1,CSA:3,MERC.WD:3,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CLAN:4,General:2</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:8,General:5</availability>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:5,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:8,General:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
@@ -10604,20 +10604,17 @@
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CSR:1,CLAN.IS:1,CJF:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
 		<availability>LA:1,FRR:5,CGB.FRR:5,MERC:4,FS:1,DC:7</availability>
 		<model name='MAL-1R'>
 			<availability>FRR:8,CGB.FRR:8,MERC:6,DC:2</availability>
-		</model>
-		<model name='MAL-1K'>
-			<availability>DC:4</availability>
 		</model>
 		<model name='MAL-2R'>
 			<availability>LA:5,FS:5,MERC:5</availability>
@@ -10628,32 +10625,35 @@
 		<model name='MAL-3R'>
 			<availability>DC:6</availability>
 		</model>
+		<model name='MAL-1K'>
+			<availability>DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:4,CLAN:2,MH:4,FS:1,TC:6</availability>
-		<model name='(Intermediate)'>
+		<model name='(Fusion)'>
 			<roles>apc</roles>
-			<availability>TC:1</availability>
-		</model>
-		<model name='(Basic)'>
-			<roles>apc</roles>
-			<availability>FS:5,TC:2-</availability>
-		</model>
-		<model name='(BA)'>
-			<roles>apc</roles>
-			<availability>TC:5</availability>
+			<availability>TC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
+		<model name='(Intermediate)'>
+			<roles>apc</roles>
+			<availability>TC:1</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>TC:5</availability>
 		</model>
-		<model name='(Fusion)'>
+		<model name='(BA)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:5</availability>
+		</model>
+		<model name='(Basic)'>
+			<roles>apc</roles>
+			<availability>FS:5,TC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -10673,59 +10673,59 @@
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Company Command)'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,TC:2,CS:2-,OA:1,LA:3,CGB.FRR:3,ROS:2,FWL:2,NIOPS:2-,DC:2</availability>
+		<model name='(SRM2)'>
+			<roles>apc</roles>
+			<availability>IS:1-,Periphery:2</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>MERC.WD:8,CLAN:8</availability>
+		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>IS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='(BA Field Upgrade)'>
 			<roles>apc,spotter</roles>
 			<availability>FRR:3,CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
 		</model>
-		<model name='(3052 Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>DC:1</availability>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
 		</model>
 		<model name='(BA Factory Upgrade)'>
 			<roles>apc</roles>
 			<availability>CC:5,FRR:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
 		</model>
-		<model name='(SRM2)'>
-			<roles>apc</roles>
-			<availability>IS:1-,Periphery:2</availability>
+		<model name='(C3S)'>
+			<roles>apc,spotter</roles>
+			<availability>IS:4</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:2-,Periphery:2</availability>
+		<model name='(3052 Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>DC:1</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<roles>apc,spotter,anti_infantry</roles>
 			<availability>IS:2,DC:3</availability>
 		</model>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
-		</model>
-		<model name='(Clan)'>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(C3S)'>
-			<roles>apc,spotter</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Standard)'>
+		<model name='(SRM4)'>
 			<roles>apc</roles>
-			<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
+			<availability>IS:2-,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -10749,12 +10749,12 @@
 			<roles>interceptor</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<roles>interceptor</roles>
 			<availability>FVC:1,FRR:1,CGB.FRR:1,MERC:1,Periphery:1,DC:1</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Assault XCT' unitType='Infantry'>
@@ -10776,8 +10776,11 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -10786,11 +10789,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -10798,35 +10798,35 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -10839,11 +10839,11 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -10878,11 +10878,11 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5+</availability>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -10890,21 +10890,21 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='MS1-OU'>
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='MS1-OA'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
@@ -10930,17 +10930,17 @@
 			<roles>recon</roles>
 			<availability>CS:4,ROS:4,CLAN:8,NIOPS:4,WOB:4,MERC.SI:4,BAN:6</availability>
 		</model>
-		<model name='MCY-104'>
-			<roles>recon,spotter</roles>
-			<availability>WOB:4</availability>
+		<model name='MCY-97'>
+			<roles>recon</roles>
+			<availability>CS:4,ROS:4</availability>
 		</model>
 		<model name='MCY-102'>
 			<roles>recon</roles>
 			<availability>WOB:6</availability>
 		</model>
-		<model name='MCY-97'>
-			<roles>recon</roles>
-			<availability>CS:4,ROS:4</availability>
+		<model name='MCY-104'>
+			<roles>recon,spotter</roles>
+			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Merkava Heavy Tank' unitType='Tank'>
@@ -10958,14 +10958,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>OA:8,CSR:2,HL:3,MERC:6,Periphery:4</availability>
-		<model name='MLN-1C'>
-			<availability>OA:6,FVC:4,CSR:3,MERC:4</availability>
-		</model>
 		<model name='MLN-1A'>
 			<availability>General:4-</availability>
 		</model>
 		<model name='MLN-1B'>
 			<availability>OA:8,HL:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='MLN-1C'>
+			<availability>OA:6,FVC:4,CSR:3,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -10974,6 +10974,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,WOB:6</availability>
+		</model>
+		<model name='(Gauss) &apos;Sandblaster&apos;'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
@@ -10985,28 +10990,23 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Gauss) &apos;Sandblaster&apos;'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CSA:6,CHH:8,CCC:8,CSR:2,CBS:4,CSL:8,CGS:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='P2'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CBS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='XP'>
 			<availability>CHH:3</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CHH:8,CCC:6,CSL:8,CGS:6</availability>
+		</model>
+		<model name='P2'>
+			<availability>CHH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -11041,34 +11041,34 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:4,FS:2,MERC:2</availability>
-		<model name='MLR-BX'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='MLR-B2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MLR-BX'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -11098,15 +11098,15 @@
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
 		<availability>FWL:2</availability>
-		<model name='M2'>
-			<availability>General:6</availability>
-		</model>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
 			<availability>FWL:4</availability>
+		</model>
+		<model name='M2'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>
@@ -11122,32 +11122,32 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:3,ROS:3</availability>
 		</model>
-		<model name='MON-266'>
-			<roles>recon</roles>
-			<availability>CS:8,LA:1</availability>
-		</model>
 		<model name='MON-267'>
 			<roles>recon</roles>
 			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
+		<model name='MON-266'>
+			<roles>recon</roles>
+			<availability>CS:8,LA:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>CHH:1,FRR:3,CLAN:1,WOB:3,MERC:2,FS:2,DC.GHO:2,CS:5,CDS:1,CBS:1,CGB.FRR:3,NIOPS:1,CJF:1,CGB:1,DC:2</availability>
+		<model name='MON-66b'>
+			<roles>recon</roles>
+			<availability>CLAN:2,CGS:3,BAN:1</availability>
+		</model>
 		<model name='MON-76'>
 			<roles>recon</roles>
 			<availability>CS:4,FRR:5,CGB.FRR:5,ROS:5,MERC:5,FS:5,DC:5</availability>
-		</model>
-		<model name='MON-86'>
-			<roles>recon</roles>
-			<availability>CS:3,FRR:3,CGB.FRR:3,ROS:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='MON-66'>
 			<roles>recon</roles>
 			<availability>CS:8,CLAN:3,NIOPS:5,WOB:8,BAN:5</availability>
 		</model>
-		<model name='MON-66b'>
+		<model name='MON-86'>
 			<roles>recon</roles>
-			<availability>CLAN:2,CGS:3,BAN:1</availability>
+			<availability>CS:3,FRR:3,CGB.FRR:3,ROS:3,MERC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Monitor Naval Vessel' unitType='Naval'>
@@ -11160,9 +11160,6 @@
 		<availability>CLAN:2,IS:2</availability>
 		<model name='(2839)'>
 			<availability>CLAN:8</availability>
-		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(2776)'>
 			<availability>General:8</availability>
@@ -11219,33 +11216,33 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Motorized XCT Infantry' unitType='Infantry'>
@@ -11274,42 +11271,42 @@
 	</chassis>
 	<chassis name='Mule' unitType='Dropship'>
 		<availability>HL:7,CLAN:5,IS:7,Periphery.Deep:7,BAN:4,Periphery:8</availability>
-		<model name='(2737)'>
-			<roles>cargo,civilian</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:6</availability>
 		</model>
 		<model name='(Armored Pocket Warship)'>
 			<availability>WOB:5</availability>
 		</model>
+		<model name='(2737)'>
+			<roles>cargo,civilian</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>FS:6</availability>
-		<model name='(Armor)'>
+		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
-			<availability>FS:4</availability>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(3080 Upgrade)'>
+		<model name='(Armor)'>
 			<roles>spotter</roles>
-			<availability>General:5</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:4,OA:2,LA:5,WOB:4,FS:4,MERC:4,CIR:4,TC:2,Periphery:2,DC:4</availability>
-		<model name='Type 2'>
-			<availability>CC:7</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>FS:3,MERC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Naga' unitType='Mek' omni='Clan'>
@@ -11318,36 +11315,36 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>WOB:4,DC:6</availability>
-		<model name='NG-C3A'>
-			<roles>fire_support,spotter</roles>
-			<availability>WOB:8,DC:8</availability>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+		<model name='NG-C3A'>
+			<roles>fire_support,spotter</roles>
+			<availability>WOB:8,DC:8</availability>
 		</model>
 		<model name='NG-C3B'>
 			<roles>spotter</roles>
@@ -11373,22 +11370,22 @@
 	</chassis>
 	<chassis name='Nephilim Assault Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:2</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Seeker) [MG]' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Narc)' mechanized='false'>
 			<availability>General:3</availability>
 		</model>
 		<model name='(Gauss)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Capture Team)[HMG]' mechanized='false'>
-			<availability>General:3</availability>
+		<model name='(Seeker) [MG]' mechanized='false'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
+			<availability>General:3</availability>
+		</model>
+		<model name='(Capture Team)[HMG]' mechanized='false'>
 			<availability>General:3</availability>
 		</model>
 	</chassis>
@@ -11397,11 +11394,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -11423,20 +11420,26 @@
 	</chassis>
 	<chassis name='Nexus' unitType='Mek'>
 		<availability>CS:6,WOB:3</availability>
-		<model name='NXS1-A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='NXS1-B'>
 			<availability>WOB:4</availability>
+		</model>
+		<model name='NXS1-A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CGS:3,CJF:5</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:7,CLAN:5,IS:3</availability>
@@ -11444,28 +11447,22 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='F'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>OA:3,FVC:3,CW:5,LA:5,CLAN:2,FWL:1,MERC:3,FS:1,CGS:3,CGB:5</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nighthawk PA(L)' unitType='BattleArmor'>
@@ -11493,40 +11490,40 @@
 		<model name='(Standard)'>
 			<availability>General:8,WOB:2</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,WOB:4</availability>
+		</model>
+		<model name='(Light PPC)'>
+			<availability>WOB:6</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>apc</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Light PPC)'>
-			<availability>WOB:6</availability>
-		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>PR:4,DoO:4,WOB:3,DO:4,FS:7,MERC:5,CIR:2,Periphery.R:2,LA:8,ROS:5,PG:4,TP:4,RFS:4</availability>
-		<model name='NGS-4T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-4S'>
 			<availability>:0,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 		</model>
-		<model name='NGS-5T'>
-			<availability>PR:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
+		<model name='NGS-4T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6T'>
 			<availability>PR:6,LA:5,ROS:6,PG:6,WOB:8,MERC:5,FS:5,RFS:6</availability>
 		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
+		<model name='NGS-5T'>
+			<availability>PR:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
 		</model>
 		<model name='NGS-6S'>
 			<availability>LA:6,ROS:6,MERC:2</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -11534,11 +11531,11 @@
 		<model name='NSR-9FC'>
 			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
-		<model name='NSR-9SS'>
-			<availability>LA:4,MERC:2,FS:4</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9SS'>
+			<availability>LA:4,MERC:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nike Air Defense Platform' unitType='Tank'>
@@ -11552,11 +11549,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-4'>
-			<availability>DC:3</availability>
-		</model>
 		<model name='NJT-3'>
 			<availability>General:2</availability>
+		</model>
+		<model name='NJT-4'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -11568,31 +11565,40 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:7,DC.SL:2,LA:2,FRR:4,CGB.FRR:4,WOB:3,MERC:2,DC:6,CGB:3</availability>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
-		</model>
-		<model name='NDA-2KC'>
-			<availability>MERC:5,DC:7</availability>
+		<model name='NDA-2KO'>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>MERC:6,DC:6</availability>
 		</model>
+		<model name='NDA-2KC'>
+			<availability>MERC:5,DC:7</availability>
+		</model>
 		<model name='NDA-1K'>
 			<availability>FRR:6,CGB.FRR:6,WOB:8,MERC:6,DC:6,CGB:4</availability>
 		</model>
-		<model name='NDA-2KO'>
-			<availability>MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,CDS:1,CNC:8</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,CNC:4</availability>
+		</model>
+		<model name='N'>
+			<availability>CDS:4,CNC:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:4,CNC:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -11601,18 +11607,9 @@
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,CNC:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -11624,6 +11621,15 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CDS:6,ROS:4+,CNC:9,CLAN:3,CWIE:4</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -11632,33 +11638,20 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>CS:2,MERC:2,DC:3</availability>
-		<model name='NX-80C'>
-			<roles>recon</roles>
-			<availability>DC:3</availability>
-		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -11666,6 +11659,10 @@
 		<model name='NX-90'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='NX-80C'>
+			<roles>recon</roles>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='O-66 &apos;Oppie&apos; Hazardous Materials Recovery Vehicle' unitType='Tank'>
@@ -11677,26 +11674,26 @@
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>CS:2,DC:3</availability>
-		<model name='OBK-M12'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>DC:2</availability>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
+		<model name='OBK-M12'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ocelot' unitType='Mek'>
 		<availability>CNC:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:4</availability>
@@ -11704,13 +11701,13 @@
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
 		<availability>CLAN:5,CJF:2</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>recon,spotter</roles>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Odyssey Jumpship' unitType='Jumpship'>
@@ -11728,50 +11725,50 @@
 	</chassis>
 	<chassis name='Oni' unitType='Aero'>
 		<availability>FRR:3,CGB.FRR:3,CNC:3,DC:4</availability>
-		<model name='ON-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ON-2'>
 			<availability>DC:3</availability>
+		</model>
+		<model name='ON-1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:7,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,CGB.FRR:4,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5,DC:4</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:7,CNC:8,IS:7</availability>
-		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:7,MOC:6,IS:6,FWL:7</availability>
+		<model name='(Fusion)'>
+			<availability>CC:2,FVC:2,LA:2,ROS:2,FWL:2,FS:2</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:4,IS:4</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:7,MOC:6,IS:6,FWL:7</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:2,LA:2,ROS:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:2,FVC:2,LA:2,ROS:2,FWL:2,FS:2</availability>
+		<model name='(MML)'>
+			<availability>MOC:4,IS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,General:3,Periphery.Deep:8,Periphery:5</availability>
 		</model>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:7,CNC:8,IS:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:5,CSL:5,CGS:3,CCO:3</availability>
+		<model name='3'>
+			<availability>CHH:4,CSL:4</availability>
+		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:4,CSL:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<availability>CHH:4,CSL:4</availability>
 		</model>
 	</chassis>
@@ -11783,38 +11780,38 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:2,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:3,CWIE:2,CS:4-,OA:2,CW:2,LA:2,CGB.FRR:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
-		<model name='ON1-MD'>
-			<availability>MOC:3,CC:3,PR:4,WOB:4,DGM:4,MERC:2,FS:2,SC:4,MCM:4,ROS:4,PG:4,FWL:4,RFS:4</availability>
-		</model>
 		<model name='ON1-MA'>
 			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2,MOC:2,DoO:4,WOB:4,DO:4,DGM:4,FS:1,MERC:2,SC:4,MCM:4,ROS:4,FWL:4,TP:4,DA:4,RCM:4,DC:2</availability>
-		</model>
-		<model name='ON2-M'>
-			<availability>MOC:2,FWL:4,IS:2,MH:2,WOB:4,MERC:3</availability>
-		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1-</availability>
 		</model>
 		<model name='ON1-MC'>
 			<availability>FRR:4,CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
 		</model>
+		<model name='ON1-V'>
+			<availability>IS:2-,MH:2-,CDP:2-,TC:2-</availability>
+		</model>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1-</availability>
+		</model>
+		<model name='ON1-MB'>
+			<availability>CC:2,MOC:2,DoO:4,WOB:4,DO:4,DGM:4,FS:1,MERC:2,SC:4,MCM:4,ROS:4,FWL:4,TP:4,DA:4,RCM:4,DC:2</availability>
+		</model>
+		<model name='ON1-K'>
+			<availability>HL:1-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 		<model name='ON1-M'>
 			<availability>CS:6,MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,WOB:6,MH:6,DC:6</availability>
 		</model>
-		<model name='ON1-V'>
-			<availability>IS:2-,MH:2-,CDP:2-,TC:2-</availability>
+		<model name='ON1-MD'>
+			<availability>MOC:3,CC:3,PR:4,WOB:4,DGM:4,MERC:2,FS:2,SC:4,MCM:4,ROS:4,PG:4,FWL:4,RFS:4</availability>
 		</model>
 		<model name='ON1-VA'>
 			<availability>IS:2-</availability>
 		</model>
+		<model name='ON2-M'>
+			<availability>MOC:2,FWL:4,IS:2,MH:2,WOB:4,MERC:3</availability>
+		</model>
 		<model name='ON1-M-DC'>
 			<availability>IS:5,DC:7</availability>
-		</model>
-		<model name='ON1-K'>
-			<availability>HL:1-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -11828,14 +11825,14 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,LA:1,FS:6,MERC:4</availability>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='OSR-5D'>
 			<availability>FS:4</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -11843,19 +11840,24 @@
 		<model name='OSP-26'>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='OSP-25'>
-			<availability>General:6</availability>
-		</model>
 		<model name='OSP-15'>
 			<roles>fire_support,urban</roles>
 			<availability>CC:3</availability>
 		</model>
+		<model name='OSP-25'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,TC:4,Periphery:2,CS:3-,LA:4,CGB.FRR:5,ROS:4,NIOPS:3-,DC:5</availability>
-		<model name='OSR-5W'>
-			<roles>urban</roles>
-			<availability>WOB:3</availability>
+		<model name='OSR-3C'>
+			<availability>FVC:2-,IS:1-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='OSR-4K'>
+			<availability>ROS:4,DC:4</availability>
+		</model>
+		<model name='OSR-5C'>
+			<availability>TC:3</availability>
 		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
@@ -11864,15 +11866,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2</availability>
-		</model>
-		<model name='OSR-5C'>
-			<availability>TC:3</availability>
-		</model>
-		<model name='OSR-4K'>
-			<availability>ROS:4,DC:4</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>FVC:2-,IS:1-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='OSR-2L'>
 			<availability>IS:1-</availability>
@@ -11883,20 +11876,24 @@
 		<model name='OSR-4C'>
 			<availability>CIR:8,TC:6,Periphery:3</availability>
 		</model>
+		<model name='OSR-2M'>
+			<availability>FWL:1-</availability>
+		</model>
 		<model name='OSR-4L'>
 			<availability>CC:6,MOC:4</availability>
 		</model>
-		<model name='OSR-2M'>
-			<availability>FWL:1-</availability>
+		<model name='OSR-5W'>
+			<roles>urban</roles>
+			<availability>WOB:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>CGB:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
@@ -11907,17 +11904,9 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,PR:4,DoO:4,FRR:3,CLAN:1-,IS:1,WOB:3,DO:4,FS:2,MERC:3,CS:3,FVC:2,LA:2,CGB.FRR:3,ROS:4,PG:4,FWL:2,NIOPS:3,TP:4,RFS:4,DC:3</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='OTT-10CS'>
-			<roles>recon</roles>
-			<availability>CS:6,WOB:4</availability>
-		</model>
-		<model name='OTT-9CS'>
+		<model name='OTT-7K'>
 			<roles>recon,spotter</roles>
-			<availability>CS:5,WOB:4</availability>
+			<availability>FVC:8,IS:8,DC:8</availability>
 		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
@@ -11931,9 +11920,17 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:6,ROS:5,MERC:4</availability>
 		</model>
-		<model name='OTT-7K'>
+		<model name='OTT-10CS'>
+			<roles>recon</roles>
+			<availability>CS:6,WOB:4</availability>
+		</model>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='OTT-9CS'>
 			<roles>recon,spotter</roles>
-			<availability>FVC:8,IS:8,DC:8</availability>
+			<availability>CS:5,WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -11941,17 +11938,17 @@
 		<model name='OTL-7M'>
 			<availability>DTA:7,SC:6,DoO:6,MCM:6,ROS:6,FWL:6,WOB:4,DO:6,DGM:6,TP:6,MERC:4</availability>
 		</model>
-		<model name='OTL-5D'>
-			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:4</availability>
-		</model>
 		<model name='OTL-9M'>
 			<availability>FWL:3</availability>
 		</model>
+		<model name='OTL-8D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='OTL-4D'>
+			<availability>IS:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
+		</model>
 		<model name='OTL-6D'>
 			<availability>FS:4,MERC:1,DC:1</availability>
-		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:5,ROS:5,MERC:4</availability>
 		</model>
 		<model name='OTL-5M'>
 			<availability>CS:4,FWL:5,WOB:6,MERC:4</availability>
@@ -11959,32 +11956,32 @@
 		<model name='OTL-8M'>
 			<availability>DTA:5,SC:5,PR:5,MCM:5,PG:5,FWL:2,WOB:3,DGM:5,MERC:3,RFS:5</availability>
 		</model>
-		<model name='OTL-8D'>
-			<availability>FS:5</availability>
+		<model name='OTL-9R'>
+			<availability>DTA:5,ROS:5,MERC:4</availability>
+		</model>
+		<model name='OTL-5D'>
+			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:4</availability>
 		</model>
 		<model name='OTL-4F'>
 			<availability>FVC:1-,FS:1-</availability>
 		</model>
-		<model name='OTL-4D'>
-			<availability>IS:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
-		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>MOC:2-,LA:2-,FWL:3,MERC:2-,DC:2-</availability>
-		<model name='OWR-2M'>
-			<availability>General:8,FWL:3-</availability>
-		</model>
 		<model name='OWR-3M'>
 			<availability>FWL:3</availability>
+		</model>
+		<model name='OWR-2M'>
+			<availability>General:8,FWL:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:7,CW:4,CSL:6</availability>
-		<model name='(3063)'>
+		<model name='(3070)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(3070)'>
+		<model name='(3063)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:6</availability>
 		</model>
@@ -12002,41 +11999,37 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='A3A'>
-			<availability>LA:1,FS:1</availability>
-		</model>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:4,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:6,IS:2,FS:6</availability>
+		</model>
+		<model name='A3A'>
+			<availability>LA:1,FS:1</availability>
 		</model>
 		<model name='A3'>
 			<roles>assault</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:4,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:3,CS:3,CNC:4,FWL:3,WOB:3,FS:3,MERC:3,DC:5</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='OW-1C'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -12044,28 +12037,32 @@
 			<roles>recon,spotter</roles>
 			<availability>General:2+,CLAN:6</availability>
 		</model>
-		<model name='OW-1A'>
+		<model name='OW-1E'>
 			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='OW-1F'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Pack Hunter II' unitType='Mek'>
 		<availability>CWIE:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CWIE:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:3,CHH:3,CCC:3,MERC.KH:1,CDS:3,CSR:1,CNC:3,CLAN:1,CCO:3,CWIE:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CWIE:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CWIE:4</availability>
@@ -12073,16 +12070,12 @@
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,CGB.FRR:3-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -12091,13 +12084,17 @@
 			<roles>recon,raider</roles>
 			<availability>CC:2,MERC.KH:1,FRR:2,IS:1,Periphery.Deep:6,MERC:2,FS:1,Periphery:3,CGB.FRR:2,PIR:2,General:2,FWL:1,DC:2</availability>
 		</model>
-		<model name='&apos;Gespenst&apos;'>
-			<roles>recon,specops</roles>
-			<availability>LA:2</availability>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
 			<availability>FWL.pm:4,SC:3-,MCM:3-,DGM:3-,DA:3-</availability>
+		</model>
+		<model name='&apos;Gespenst&apos;'>
+			<roles>recon,specops</roles>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -12113,17 +12110,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:2,WOB:3</availability>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>LA:3,ROS:3,WOB:3,FS:3,DC:3</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>LA:3,ROS:3,WOB:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Palmoni Assault Infantry Fighting Vehicle' unitType='Tank'>
@@ -12149,82 +12146,82 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>CC:1,Periphery.DD:5,FS.RR:5,HL:2,FRR:7,WOB:4,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CS:2,LA:1,CGB.FRR:7,ROS:4,FS.DMM:5,CNC:2,FWL:1,NIOPS:2,DC:9</availability>
-		<model name='PNT-16K'>
+		<model name='PNT-10KA'>
 			<roles>fire_support</roles>
-			<availability>DC:6</availability>
+			<availability>FS.RR:2,FRR:2,CGB.FRR:2,CNC:8,FS.DMM:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='PNT-14S'>
 			<roles>fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='PNT-10KA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:2,CGB.FRR:2,CNC:8,FS.DMM:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,FVC:2,FRR:5,CGB.FRR:5,PIR:2,CNC:4,FS.DMM:4,WOB:6,MERC:4,DC:5,TC:2</availability>
-		</model>
-		<model name='PNT-10K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:2,CGB.FRR:2,ROS:2,FS.DMM:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FRR:1,CGB.FRR:1,FS.DMM:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='PNT-13K'>
-			<roles>fire_support</roles>
-			<availability>FRR:3,CGB.FRR:3,DC:4</availability>
-		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>ROS:4,DC:4</availability>
-		</model>
-		<model name='PNT-C'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,FRR:2,CGB.FRR:3,FS.DMM:3,MERC:3,DC:3</availability>
-		</model>
-		<model name='PNT-9R'>
-			<roles>fire_support</roles>
-			<availability>HL:1-,IS:3-,Periphery.Deep:8,MERC:3-,Periphery:4-,DC:3-</availability>
-		</model>
-		<model name='PNT-12K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,FRR:2,CGB.FRR:3,FS.DMM:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='PNT-12K2'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4</availability>
 		</model>
+		<model name='PNT-CA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FRR:1,CGB.FRR:1,FS.DMM:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='PNT-10K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FRR:2,CGB.FRR:2,ROS:2,FS.DMM:2,MERC:2,DC:4</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:4,FVC:2,FRR:5,CGB.FRR:5,PIR:2,CNC:4,FS.DMM:4,WOB:6,MERC:4,DC:5,TC:2</availability>
+		</model>
+		<model name='PNT-12K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,FRR:2,CGB.FRR:3,FS.DMM:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='PNT-16K'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PNT-9R'>
+			<roles>fire_support</roles>
+			<availability>HL:1-,IS:3-,Periphery.Deep:8,MERC:3-,Periphery:4-,DC:3-</availability>
+		</model>
+		<model name='PNT-13K'>
+			<roles>fire_support</roles>
+			<availability>FRR:3,CGB.FRR:3,DC:4</availability>
+		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,FRR:2,CGB.FRR:3,FS.DMM:3,MERC:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
 		<availability>FWL:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MFB)'>
 			<roles>support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,HL:3,FRR:4,IS:5,WOB:6,FS:8,Periphery:4,CWIE:5,CS:6,LA:7,CGB.FRR:4,CNC:5,DC:6</availability>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:4,FS:5</availability>
-		</model>
 		<model name='(Quad RAC)'>
 			<roles>anti_aircraft</roles>
 			<availability>WOB:3,FS:4</availability>
 		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:3,Periphery:3</availability>
 		</model>
-		<model name='(Company Command)'>
+		<model name='(Lance Command)'>
 			<roles>spotter,anti_aircraft</roles>
-			<availability>WOB:2,FS:2</availability>
+			<availability>WOB:4,FS:5</availability>
 		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
@@ -12233,31 +12230,31 @@
 		<model name='(Cell)'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>WOB:2,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:4-,CC:2-,HL:3-,FRR:1-,IS:3-,Periphery.Deep:9,WOB:4-,FS:4-,CIR:3-,Periphery:4-,TC:4-,CS:4-,OA:2-,CDS:2,LA:3-,CGB.FRR:1-,FWL:3-,DC:2-</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:3,Periphery:3</availability>
-		</model>
-		<model name='(C3)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:3,Periphery:3</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:2-,Periphery:3</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -12296,38 +12293,22 @@
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
 		<availability>FVC:4,PR:4,LA:7,FRR:4,CGB.FRR:4,ROS:4,PG:4,FS:5,MERC:4,RFS:4,CWIE:5</availability>
-		<model name='(Standard)'>
-			<availability>HL:3,IS:3-,Periphery:5</availability>
-		</model>
 		<model name='(Ultra)'>
 			<availability>LA:8,General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:3,IS:3-,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:1,CC:1,FRR:1,IS:1,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,TC:1,CWIE:1,CS:5-,OA:1,LA:6,CGB.FRR:1,ROS:6,FWL:2,DC:6</availability>
-		<model name='(Sensors)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
-		<model name='(Unarmed)'>
-			<roles>recon</roles>
-			<availability>FVC:1,IS:1</availability>
-		</model>
-		<model name='(Missile)'>
-			<roles>recon</roles>
-			<availability>IS:1</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,WOB:4,FS:4,DC:7</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Unarmed)'>
 			<roles>recon</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='(3058 Upgrade)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,WOB:8,FS:8,DC:7</availability>
+			<availability>FVC:1,IS:1</availability>
 		</model>
 		<model name='(MRM)'>
 			<roles>recon</roles>
@@ -12337,23 +12318,39 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
+		<model name='(Missile)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Sensors)'>
+			<roles>recon</roles>
+			<availability>IS:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='(3058 Upgrade)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,WOB:8,FS:8,DC:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='PTR-6T'>
-			<availability>FS.DBG:8,FS:4</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-6T'>
+			<availability>FS.DBG:8,FS:4</availability>
+		</model>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pentagon' unitType='Dropship'>
@@ -12364,18 +12361,18 @@
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
 		<availability>CLAN:1,CGB:4</availability>
-		<model name='5'>
-			<availability>CGS:9</availability>
-		</model>
-		<model name='4'>
-			<availability>CSR:5,CBS:7,CGS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='5'>
+			<availability>CGS:9</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='4'>
+			<availability>CSR:5,CBS:7,CGS:6</availability>
 		</model>
 		<model name='3'>
 			<roles>anti_infantry</roles>
@@ -12384,11 +12381,11 @@
 	</chassis>
 	<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
 		<availability>CC:1-,LA:1-,FRR:1-,CGB.FRR:1-,FWL:1-,IS:1-,FS:1-,MERC:1-,DC:1-</availability>
-		<model name='(Cargo)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Kurita)'>
 			<availability>IS:4,DC:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,DC:2</availability>
@@ -12396,31 +12393,31 @@
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,SC:6,DoO:6,MCM:6,FWL:6,WOB:5,DO:6,DGM:6,TP:6</availability>
-		<model name='P1E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='P1D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1'>
-			<availability>General:8</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='P1B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1W'>
 			<availability>General:2,WOB:6</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -12434,14 +12431,14 @@
 		<model name='(C)' mechanized='true'>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='(B)' mechanized='true'>
-			<availability>FWL:1</availability>
-		</model>
 		<model name='(WoB-A)' mechanized='true'>
 			<availability>WOB:8</availability>
 		</model>
 		<model name='(WoB-B)' mechanized='true'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='(B)' mechanized='true'>
+			<availability>FWL:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
@@ -12453,91 +12450,90 @@
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CSR:3,CW:8,CSL:7,CGS:8,CCO:4,CJF:7,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,General:8,CCO:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:7,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,General:8,CCO:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CSA:3,CCC:5,CSR:3,CDS:5,CBS:3,CLAN:3,CCO:5</availability>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:6,CLAN:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCC:2,CSR:2,CDS:4,CLAN:1,CNC:4,CCO:3,DC:2</availability>
+		</model>
+		<model name='7'>
+			<availability>CDS:4,CGB:5,DC:3</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CLAN:1</availability>
 		</model>
+		<model name='3'>
+			<availability>CDS:6,CLAN:1</availability>
+		</model>
 		<model name='6'>
 			<availability>CDS:5,CGB:5</availability>
-		</model>
-		<model name='7'>
-			<availability>CDS:4,CGB:5,DC:3</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CCC:2,CSR:3,CDS:2,CNC:2,CCO:2</availability>
 		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK1R'>
-            <availability>IS:2</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-        <model name='PHX-HK1RB'>
-            <availability>WOB:2</availability>
-        </model>
-    </chassis>
+		<availability>IS:2</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK1R'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK1RB'>
+			<availability>WOB:2</availability>
+		</model>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>CS:5,HL:5,CLAN:1,IS:8,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:3,Periphery:6,CGB:2</availability>
-		<model name='PXH-6D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>SC:4,DoO:3,MCM:4,CLAN:3,FWL:3,WOB:4,DO:3,DGM:4,TP:3,DA:3,RCM:3,CGS:5</availability>
+		<model name='PXH-7K'>
+			<availability>DC:3</availability>
 		</model>
 		<model name='PXH-7S'>
 			<availability>LA:5,ROS:4,MERC:4</availability>
+		</model>
+		<model name='PXH-4W'>
+			<availability>MOC:3,WOB:3,TC:3</availability>
 		</model>
 		<model name='PXH-4L'>
 			<availability>CC:6,MOC:4,MH:4,WOB:4,CIR:3,TC:4</availability>
@@ -12546,51 +12542,52 @@
 			<roles>recon</roles>
 			<availability>FVC:2-,PIR:3-,FS:2-,MERC:2-</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,WOB:4,FS:5,MERC:4</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:3-,BAN:6,Periphery:3-</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>CS:3,ROS:2,DC:2</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
 		<model name='PXH-5L'>
 			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>FRR:1-,CGB.FRR:1-,DC:2-</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>FRR:8,CGB.FRR:8,DC:8</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>SC:5,MCM:5,CLAN:5,FWL:4,WOB:4,DGM:5,BAN:1</availability>
 		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>FRR:1-,CGB.FRR:1-,DC:2-</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>FRR:8,CGB.FRR:8,DC:8</availability>
+		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:6,MERC:5</availability>
 		</model>
-		<model name='PXH-7K'>
-			<availability>DC:3</availability>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 		<model name='PXH-7CS'>
 			<availability>CS:4</availability>
 		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:3,WOB:3,TC:3</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,WOB:4,FS:5,MERC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>CS:3,ROS:2,DC:2</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:3-,BAN:6,Periphery:3-</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>SC:4,DoO:3,MCM:4,CLAN:3,FWL:3,WOB:4,DO:3,DGM:4,TP:3,DA:3,RCM:3,CGS:5</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -12598,17 +12595,17 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:3,CC:1-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:3-,WOB:4-,FS:3-,MERC:3-,CIR:3-,CWIE:6,Periphery:3-,TC:3-,CS:4-,OA:2-,MERC.WD:5,CDS:6,LA:2-,CGB.FRR:3-,CNC:5,FWL:2-,MH:5-,DC:3-</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:3,IS:3,Periphery.Deep:2,Periphery:5</availability>
 		</model>
 		<model name='(RAC) &apos;Assault Pike&apos;'>
 			<availability>CC:7,MOC:6,FS:6,MERC:7,DA:7,TC:6</availability>
 		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
+		<model name='(Standard)'>
+			<availability>HL:3,IS:3,Periphery.Deep:2,Periphery:5</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -12616,6 +12613,9 @@
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,CS:4,MOC:3,MERC.WD:4,MERC.KH:4,CNC:6,CLAN:1,NIOPS:4,FS:1,MERC:4,TC:1</availability>
+		<model name='PLG-5Z'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
@@ -12626,19 +12626,16 @@
 		<model name='PLG-3Z'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PLG-5Z'>
-			<availability>CC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,FS:7</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -12684,9 +12681,6 @@
 	</chassis>
 	<chassis name='Plainsman Medium Hovertank' unitType='Tank'>
 		<availability>MERC.WD:3,HL:2,LA:5,FRR:6,CGB.FRR:6,FWL:4,IS:3,TC:8,Periphery:3</availability>
-		<model name='(Sealed)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>HL:2,IS:5,TC:6,Periphery:4</availability>
 		</model>
@@ -12696,6 +12690,9 @@
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:4,IS:6,Periphery.Deep:2,Periphery:6</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
@@ -12732,38 +12729,38 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CSA:1,CS:1,CHH:1,CCC:2,CSR:3,CDS:5,NIOPS:1,CGS:3,CCO:2,CWIE:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CSL:4,CGS:7,CCO:6,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:6,General:8,CJF:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:2,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:6,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:3,General:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:2,CGB:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:2</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
@@ -12787,6 +12784,21 @@
 	</chassis>
 	<chassis name='Preta' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:5,WOB:1+</availability>
+		<model name='C-PRT-OE Eminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-PRT-OD Luminos'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-PRT-O Invictus'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C-PRT-OU Exanimus'>
+			<availability>General:2</availability>
+		</model>
+		<model name='C-PRT-OS Caelestis'>
+			<availability>General:4</availability>
+		</model>
 		<model name='C-PRT-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
@@ -12797,28 +12809,19 @@
 		<model name='C-PRT-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-PRT-OU Exanimus'>
-			<availability>General:2</availability>
-		</model>
-		<model name='C-PRT-O Invictus'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C-PRT-OS Caelestis'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C-PRT-OE Eminus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-PRT-OD Luminos'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:5,CBS:4,CSL:6,CCO:6</availability>
-		<model name='3'>
-			<availability>CCO:4</availability>
+		<model name='(Quad)'>
+			<availability>CHH:4+</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:2,CCO:2</availability>
 		</model>
 		<model name='4'>
+			<availability>CCO:4</availability>
+		</model>
+		<model name='3'>
 			<availability>CCO:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -12826,12 +12829,6 @@
 		</model>
 		<model name='5'>
 			<availability>CCO:4</availability>
-		</model>
-		<model name='(Quad)'>
-			<availability>CHH:4+</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:2,CCO:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -12857,10 +12854,6 @@
 			<roles>support</roles>
 			<availability>IS:3,Periphery:7</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>CS:8,CLAN:8,General:8</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -12873,9 +12866,20 @@
 			<roles>apc</roles>
 			<availability>WOB:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CS:8,CLAN:8,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CLAN:7,IS:1+,MERC:2+,CCO:6,BAN:6,CWIE:8,CSA:8,MERC.WD:6,CDS:8,CW:8,CBS:6,CNC:8,CJF:5,CGB:6</availability>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CJF:6</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,General:4,CGB:3</availability>
 		</model>
@@ -12883,25 +12887,18 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CBS:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:2,CJF:6</availability>
+		<model name='E'>
+			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -12909,54 +12906,54 @@
 		<model name='PAT-005'>
 			<availability>CS:2,CHH:2,CW:2,FRR:8,CGB.FRR:8,ROS:2,NIOPS:8,WOB:8,CWIE:2</availability>
 		</model>
+		<model name='PAT-007'>
+			<availability>CS:7,WOB:6</availability>
+		</model>
 		<model name='PAT-008'>
 			<availability>ROS:6,WOB:5+</availability>
 		</model>
 		<model name='PAT-005b'>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='PAT-007'>
-			<availability>CS:7,WOB:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Purifier Adaptive Battle Armor' unitType='BattleArmor'>
 		<availability>WOB:6,MH:4,CIR:4,TC:4</availability>
-		<model name='[Laser] (RAF)' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[TAG] (RAF)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CS:7,WOB:7,Periphery:7</availability>
+		<model name='[PPC] (RAF)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[PPC]' mechanized='true'>
 			<availability>CS:6,WOB:6,Periphery:6</availability>
-		</model>
-		<model name='[Narc]' mechanized='true'>
-			<availability>CS:4,WOB:4,Periphery:4</availability>
-		</model>
-		<model name='[PPC] (RAF)' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CS:5,WOB:5,Periphery:5</availability>
 		</model>
+		<model name='[TAG] (RAF)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='[Laser] (RAF)' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CS:7,WOB:7,Periphery:7</availability>
+		</model>
+		<model name='[Narc]' mechanized='true'>
+			<availability>CS:4,WOB:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Purifier Battle Armor Terra' unitType='BattleArmor'>
 		<availability>WOB:4</availability>
+		<model name='[MRR]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='[AP Gauss]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[SPL]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[MRR]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[ERSL]' mechanized='true'>
@@ -12964,11 +12961,11 @@
 		</model>
 	</chassis>
 	<chassis name='Pwwka' unitType='Mek'>
-        <availability>WOB:3</availability>
-        <model name='S-PW-1LAM'>
-            <availability>WOB:3</availability>
-        </model>
-    </chassis>
+		<availability>WOB:3</availability>
+		<model name='S-PW-1LAM'>
+			<availability>WOB:3</availability>
+		</model>
+	</chassis>
 	<chassis name='Quasit MilitiaMech' unitType='Mek'>
 		<availability>Periphery:2-</availability>
 		<model name='QUA-51T'>
@@ -12983,8 +12980,11 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>PR:6,HL:3,DoO:6,FRR:7,Periphery.Deep:4,DO:6,FS:4,CDP:4,SC:6,OA:4,CGB.FRR:7,FWL:7,NIOPS:3-,RFS:6,MOC:4,CC:3,IS:4,WOB:3-,DGM:6,CIR:3,Periphery:4,TC:4,CS:3-,DTA:6,FVC:4,LA:4,MCM:6,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
-		<model name='QKD-4H'>
-			<availability>General:2-</availability>
+		<model name='QKD-5K2'>
+			<availability>MERC:1,DC:1</availability>
+		</model>
+		<model name='QKD-5K'>
+			<availability>FRR:5,CGB.FRR:5,MERC:5,DC:6</availability>
 		</model>
 		<model name='QKD-5A'>
 			<availability>MERC:2-,DC:2-,Periphery:2-</availability>
@@ -12992,23 +12992,20 @@
 		<model name='QKD-8K'>
 			<availability>FRR:5,CGB.FRR:5,ROS:5,MERC:3,DC:7</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>FRR:5,CGB.FRR:5,MERC:5,DC:6</availability>
-		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:4,FWL:6</availability>
-		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:6,FVC:6,Periphery.CM:6,Periphery.ME:6,FWL:8,IS:6,MH:6,TC:6,Periphery:2</availability>
-		</model>
-		<model name='QKD-5K2'>
-			<availability>MERC:1,DC:1</availability>
+		<model name='QKD-C'>
+			<availability>FRR:8,CGB.FRR:8,MERC:6,DC:8</availability>
 		</model>
 		<model name='QKD-4G'>
 			<availability>MOC:4-,OA:4-,HL:1-,Periphery.Deep:8,FWL:3-,IS:3-,Periphery:4-,DC:3-,TC:4-</availability>
 		</model>
-		<model name='QKD-C'>
-			<availability>FRR:8,CGB.FRR:8,MERC:6,DC:8</availability>
+		<model name='QKD-4H'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:6,FVC:6,Periphery.CM:6,Periphery.ME:6,FWL:8,IS:6,MH:6,TC:6,Periphery:2</availability>
+		</model>
+		<model name='QKD-5Mr'>
+			<availability>General:4,FWL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Quixote Frigate' unitType='Warship'>
@@ -13020,43 +13017,43 @@
 	</chassis>
 	<chassis name='Rabid Coyote' unitType='Mek'>
 		<availability>CCC:3,CW:4,CCO:5-</availability>
-		<model name='2'>
-			<availability>CW:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCC:8,CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:8</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raijin II' unitType='Mek'>
 		<availability>WOB:6+</availability>
+		<model name='RJN-200-C'>
+			<availability>General:4</availability>
+		</model>
 		<model name='RJN-200-B'>
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='RJN-200-C'>
-			<availability>General:4</availability>
 		</model>
 		<model name='RJN-200-A'>
 			<availability>General:8</availability>
@@ -13073,8 +13070,8 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:4,ROS:3,FS:5,MERC:3</availability>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='MDG-1Ar'>
 			<availability>ROS:8,FS:3,MERC:3</availability>
@@ -13082,32 +13079,23 @@
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>CS:4,LA:3,ROS:4,ROS.pm:4,FWL:3,MH:5,MERC:5,FS:3,DC:3</availability>
-		<model name='VV1'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='VV1 (MG)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='VV1'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>CS:6,LA:4,ROS:5,CLAN:3,NIOPS:6,WOB:6</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:4,BAN:2</availability>
-		</model>
-		<model name='RPR-300S'>
-			<availability>LA:3</availability>
-		</model>
-		<model name='RPR-102'>
-			<availability>LA:1-</availability>
-		</model>
 		<model name='RPR-101'>
 			<roles>ground_support</roles>
 			<availability>CS:2</availability>
@@ -13115,37 +13103,58 @@
 		<model name='RPR-100'>
 			<availability>CS:8,General:4,NIOPS:8,WOB:8</availability>
 		</model>
-		<model name='RPR-300'>
-			<availability>LA:5</availability>
+		<model name='RPR-300S'>
+			<availability>LA:3</availability>
 		</model>
 		<model name='RPR-200'>
 			<availability>CCC:1,CSR:1,CBS:1,CNC:1</availability>
 		</model>
+		<model name='RPR-102'>
+			<availability>LA:1-</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
+		<model name='RPR-300'>
+			<availability>LA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
 		<availability>ROS:4,WOB:5</availability>
-		<model name='RPT-2X1'>
-			<roles>specops</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='RPT-2X'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='RPT-2X1'>
+			<roles>specops</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>CS:3,FS:4,DC:6</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:2+</availability>
 		</model>
-		<model name='RTX1-OU'>
-			<availability>General:2</availability>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
@@ -13154,65 +13163,53 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:8,MOC:4,FWL:4,FS:2,MERC:5,DA:4,TC:4,DC:2</availability>
-		<model name='RVN-SR &apos;Shattered Raven&apos;'>
-			<availability>FS.CMM:1</availability>
-		</model>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:4</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:4,MOC:3,FWL:1,FS:1,MERC:3,DC:3,TC:3</availability>
-		</model>
-		<model name='RVN-SS &apos;Shattered Raven&apos;'>
-			<roles>spotter</roles>
-			<availability>FS.CMM:1</availability>
+		<model name='RVN-4X'>
+			<availability>CC:1</availability>
 		</model>
 		<model name='RVN-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:3,MOC:3,FWL:4,FS:1,MERC:3,DC:1,TC:3</availability>
 		</model>
-		<model name='RVN-4L'>
+		<model name='RVN-4Lr'>
 			<roles>spotter</roles>
-			<availability>CC:7,MOC:7,DA:6,TC:7</availability>
+			<availability>CC:4</availability>
 		</model>
-		<model name='RVN-4X'>
-			<availability>CC:1</availability>
+		<model name='RVN-SR &apos;Shattered Raven&apos;'>
+			<availability>FS.CMM:1</availability>
 		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
 		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:4,MOC:3,FWL:1,FS:1,MERC:3,DC:3,TC:3</availability>
+		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:7,MOC:7,DA:6,TC:7</availability>
+		</model>
+		<model name='RVN-SS &apos;Shattered Raven&apos;'>
+			<roles>spotter</roles>
+			<availability>FS.CMM:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>LA:6,FRR:5,CGB.FRR:5,MERC:4,FS:4</availability>
-		<model name='RZK-9S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RZK-10T'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='RZK-10S'>
-			<availability>LA:3</availability>
+		<model name='RZK-9S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10S'>
+			<availability>LA:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Recon Infantry' unitType='Infantry'>
@@ -13224,6 +13221,11 @@
 	</chassis>
 	<chassis name='Red Shift' unitType='Mek'>
 		<availability>WOB:6</availability>
+		<model name='RDS-2A'>
+			<roles>spotter</roles>
+			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
+			<availability>General:8</availability>
+		</model>
 		<model name='RDS-2B'>
 			<roles>recon,spotter</roles>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
@@ -13232,11 +13234,6 @@
 		<model name='RDS-3A'>
 			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
 			<availability>General:4</availability>
-		</model>
-		<model name='RDS-2A'>
-			<roles>spotter</roles>
-			<deployedWith>Padilla Heavy Artillery Tank</deployedWith>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Regulator Hovertank' unitType='Tank'>
@@ -13260,77 +13257,77 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,FRR:5,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 		</model>
-		<model name='(ML)'>
+		<model name='(MG)'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(ML)'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>PR:7,DoO:8,FRR:5,DO:8,FS:3,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,RFS:7,MOC:3,CC:3,WOB:6,DGM:8,MERC:2,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:1,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:4</availability>
+		<model name='F-700a'>
+			<availability>CC:7,PR:6,DoO:6,WOB:7,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,TP:6,DA:6,RCM:6,RFS:6</availability>
+		</model>
+		<model name='F-100b'>
+			<availability>FRR:2-,CGB.FRR:2-,DC:2-</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>CC:1-,FWL:3-,MERC:3-</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:8,PR:8,DoO:8,WOB:8,DO:8,DGM:8,MERC:8,DTA:8,SC:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
-		<model name='F-100b'>
-			<availability>FRR:2-,CGB.FRR:2-,DC:2-</availability>
+		<model name='F-700b'>
+			<availability>DTA:8,SC:8,DoO:8,MCM:8,ROS:6,FWL:5,WOB:5,DO:8,DGM:8,TP:8,MERC:5,DC:5</availability>
 		</model>
 		<model name='F-100'>
 			<availability>CC:1-,FVC:4-,HL:1-,LA:1,FRR:1,CGB.FRR:1,FWL:3-,Periphery.Deep:8,MERC:3-,DC:1,Periphery:4-</availability>
 		</model>
-		<model name='F-700a'>
-			<availability>CC:7,PR:6,DoO:6,WOB:7,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,TP:6,DA:6,RCM:6,RFS:6</availability>
-		</model>
-		<model name='F-700b'>
-			<availability>DTA:8,SC:8,DoO:8,MCM:8,ROS:6,FWL:5,WOB:5,DO:8,DGM:8,TP:8,MERC:5,DC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:3,CLAN:1,CNC:5,IS:2,CGB:5</availability>
-		<model name='2'>
-			<availability>CLAN:1,CNC:5,IS:1</availability>
-		</model>
-		<model name='6'>
-			<availability>CSA:5,CHH:3,CDS:3</availability>
-		</model>
 		<model name='8'>
 			<availability>CC:2,DoO:2,DO:2,DGM:2,FS:2,MERC:2,SC:2,CDS:3,LA:2,MCM:2,TP:2,DC:2,CGB:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:5,CCC:6,CDS:4,CBS:2,CCO:2</availability>
-		</model>
-		<model name='7'>
-			<availability>CNC:5,DC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:3,CLAN:2,CNC:3</availability>
 		</model>
 		<model name='5'>
 			<availability>CSA:5,CDS:3,IS:3,CLAN.HW:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:3,CLAN:2,CNC:3</availability>
+		</model>
+		<model name='7'>
+			<availability>CNC:5,DC:4</availability>
+		</model>
 		<model name='4'>
 			<availability>CSA:6,CCC:5,CDS:2,CBS:5,CCO:2</availability>
+		</model>
+		<model name='6'>
+			<availability>CSA:5,CHH:3,CDS:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:5,CCC:6,CDS:4,CBS:2,CCO:2</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:1,CNC:5,IS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman II' unitType='Mek'>
@@ -13342,24 +13339,39 @@
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:6,CCC:6,HL:3,FRR:7,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:4</availability>
-		<model name='RFL-1N'>
-			<roles>fire_support</roles>
-			<availability>CC:3-,MOC:3-,DoO:3-,PIR:3-,FWL:1-,MH:3-,DO:3-,TP:3-,FS:3-,DA:3-,MERC:1-,RCM:3-</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:1,CLAN:5,FS:1,BAN:1,DC:1</availability>
+		<model name='RFL-6D'>
+			<availability>FS:2</availability>
 		</model>
 		<model name='RFL-7M'>
 			<availability>PR:6,DoO:6,FRR:4,WOB:5,DO:6,DGM:6,DTA:6,SC:6,MCM:6,CGB.FRR:4,PG:6,FWL:6,TP:6,DA:6,RCM:6,RFS:6,DC:4</availability>
 		</model>
+		<model name='RFL-3C'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FS:1</availability>
+		</model>
+		<model name='RFL-4D'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FVC:1-,FS:1-,MERC:1-</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
 		<model name='RFL-5D'>
 			<availability>FVC:5,LA:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='RFL-3Cr'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='RFL-1N'>
+			<roles>fire_support</roles>
+			<availability>CC:3-,MOC:3-,DoO:3-,PIR:3-,FWL:1-,MH:3-,DO:3-,TP:3-,FS:3-,DA:3-,MERC:1-,RCM:3-</availability>
+		</model>
+		<model name='C 2'>
+			<availability>CJF:3</availability>
+		</model>
 		<model name='RFL-8D'>
 			<availability>LA:1,FS:5</availability>
-		</model>
-		<model name='RFL-6D'>
-			<availability>FS:2</availability>
 		</model>
 		<model name='RFL-9T'>
 			<availability>TC:4</availability>
@@ -13367,33 +13379,18 @@
 		<model name='RFL-8X'>
 			<availability>ROS:4,MERC:4</availability>
 		</model>
-		<model name='RFL-3C'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FS:1</availability>
+		<model name='RFL-6X'>
+			<availability>FVC:2,FS:3,MERC:2</availability>
 		</model>
 		<model name='RFL-7X'>
 			<roles>fire_support</roles>
 			<availability>ROS:3,MERC:3</availability>
 		</model>
-		<model name='C 2'>
-			<availability>CJF:3</availability>
-		</model>
 		<model name='RFL-5M'>
 			<availability>CC:4,MOC:4,FWL:4,IS:1,MERC:4,DC:4</availability>
 		</model>
-		<model name='RFL-3Cr'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RFL-4D'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FVC:1-,FS:1-,MERC:1-</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:2,FS:3,MERC:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='C'>
+			<availability>LA:1,CLAN:5,FS:1,BAN:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Riot Police' unitType='Infantry'>
@@ -13405,89 +13402,89 @@
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,CSR:1,FRR:5,CLAN:2,WOB:6,FS:5,CS:6,FVC:4,LA:5,CGB.FRR:5,ROS:6,NIOPS:6,DC:5</availability>
-		<model name='(SPL)'>
-			<roles>apc</roles>
-			<availability>FVC:4,IS:4</availability>
-		</model>
-		<model name='(ERML)'>
-			<roles>apc</roles>
-			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>DC:5</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8,BAN:2</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>DC:5</availability>
+		</model>
+		<model name='(ERML)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(Infantry)'>
+			<roles>apc</roles>
+			<availability>LA:5,ROS:4,FS:2</availability>
+		</model>
+		<model name='(SPL)'>
+			<roles>apc</roles>
+			<availability>FVC:4,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:4,CHH:4,CSR:4,CBS:7,CNC:7,CSL:4,CGS:6,CCO:8,CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CCC:6,CSR:5,CBS:8,CNC:6,CSL:6,CCO:8,CGS:6</availability>
+		</model>
 		<model name='3'>
 			<availability>CSR:3,CBS:6,CNC:4,CCO:4,CWIE:3</availability>
 		</model>
 		<model name='4'>
 			<availability>CSR:3,CCO:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CCC:6,CSR:5,CBS:8,CNC:6,CSL:6,CCO:8,CGS:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CGB:5-</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HR' mechanized='true'>
 			<roles>recon</roles>
 			<availability>CGB:2</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Rogue' unitType='Aero'>
 		<availability>CS:4,CLAN:1,NIOPS:2,WOB:4</availability>
-		<model name='RGU-133LP'>
-			<roles>interceptor</roles>
-			<availability>CS:8</availability>
-		</model>
-		<model name='RGU-133L'>
-			<availability>CS:1,General:4,NIOPS:1,WOB:2</availability>
-		</model>
-		<model name='RGU-133F'>
-			<availability>CS:2,General:6,NIOPS:2,WOB:4</availability>
-		</model>
 		<model name='RGU-133Eb'>
 			<availability>CLAN:5,BAN:2</availability>
-		</model>
-		<model name='RGU-133P'>
-			<availability>CS:1</availability>
 		</model>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
 		</model>
+		<model name='RGU-133L'>
+			<availability>CS:1,General:4,NIOPS:1,WOB:2</availability>
+		</model>
+		<model name='RGU-133LP'>
+			<roles>interceptor</roles>
+			<availability>CS:8</availability>
+		</model>
+		<model name='RGU-133F'>
+			<availability>CS:2,General:6,NIOPS:2,WOB:4</availability>
+		</model>
+		<model name='RGU-133P'>
+			<availability>CS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>PR:3,FRR:4,FS:4,MERC:3,CWIE:6,TC:6,OA:5,FVC:3,LA:6,CGB.FRR:4,ROS:3,PG:3,RFS:3</availability>
-		<model name='(Sealed)'>
-			<availability>LA:3,ROS:3,FS:3,CWIE:3</availability>
-		</model>
 		<model name='(Gauss)'>
 			<availability>OA:0,FRR:0,General:8</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>LA:3,ROS:3,FS:3,CWIE:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>ROS:0,General:3,TC:0,CWIE:0</availability>
@@ -13498,14 +13495,14 @@
 		<model name='NH-3X'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='NH-2'>
+			<availability>General:8</availability>
+		</model>
 		<model name='NH-1X &apos;Rook-X&apos;'>
 			<availability>FS:2-</availability>
 		</model>
 		<model name='NH-1A'>
 			<availability>General:3-</availability>
-		</model>
-		<model name='NH-2'>
-			<availability>General:8</availability>
 		</model>
 		<model name='NH-1B'>
 			<availability>ROS:5-,MERC:5-,FS:5-</availability>
@@ -13524,16 +13521,16 @@
 			<roles>urban</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='(Firedrake)' mechanized='false'>
-			<roles>anti_infantry</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>LA:6</availability>
 		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='(Firedrake)' mechanized='false'>
+			<roles>anti_infantry</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -13546,7 +13543,7 @@
 	</chassis>
 	<chassis name='Rusalka' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:6</availability>
-		<model name='S-RSL-OD Luminos'>
+		<model name='S-RSL-OB Infernus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
@@ -13558,65 +13555,65 @@
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-RSL-OC Comminus'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='S-RSL-OA Dominus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-RSL-OB Infernus'>
+		<model name='S-RSL-OD Luminos'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='S-RSL-OC Comminus'>
 			<roles>interceptor</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,CSR:4,CLAN:6,WOB:3+,MERC:2+,BAN:7,CWIE:7,MERC.WD:7,CDS:6,CBS:7,CNC:2,CJF:6,DC:3+</availability>
-		<model name='G'>
-			<availability>CHH:5,General:2</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
 		</model>
+		<model name='A'>
+			<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:5,CCC:5,CBS:4,CLAN:3,General:1</availability>
-		</model>
-		<model name='I'>
-			<availability>CLAN:3,General:1</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
+		<model name='F'>
+			<availability>General:2,CJF:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
-		</model>
-		<model name='Z'>
-			<availability>CCO:2</availability>
+		<model name='I'>
+			<availability>CLAN:3,General:1</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CSR:3,CDS:6,CNC:4,General:5,CCO:7,CJF:4,CWIE:6</availability>
 		</model>
-		<model name='F'>
-			<availability>General:2,CJF:5</availability>
+		<model name='Z'>
+			<availability>CCO:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CSR:3,CBS:6,General:5,CWIE:5,CGB:6</availability>
 		</model>
+		<model name='G'>
+			<availability>CHH:5,General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Ryoken II' unitType='Mek'>
 		<availability>CGB:3</availability>
-		<model name='2'>
-			<availability>CGB:6</availability>
+		<model name='3'>
+			<availability>CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CGB:4</availability>
+		<model name='2'>
+			<availability>CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
@@ -13642,21 +13639,21 @@
 	</chassis>
 	<chassis name='SRM Carrier' unitType='Tank'>
 		<availability>General:7,CLAN:3,WOB:8</availability>
-		<model name='(WoB)'>
-			<roles>sr_fire_support,spotter</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:8,LA:8,FWL:8,IS:7,FS:8,DC:6,Periphery:6</availability>
+		<model name='(WoB)'>
+			<roles>sr_fire_support,spotter</roles>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='(C3)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:4,CS:5,LA:5,FWL:4,IS:2,FS:5,DC:7,Periphery:3</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:8,LA:8,FWL:8,IS:7,FS:8,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -13679,36 +13676,27 @@
 		<model name='SB-29'>
 			<availability>MERC:5,DC:8</availability>
 		</model>
-		<model name='SB-31D'>
-			<roles>escort</roles>
-			<availability>DC:4</availability>
+		<model name='SB-28'>
+			<availability>CS:6,LA:8,ROS:4,NIOPS:6,WOB:6,FS:5,MERC:5</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:5</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>CS:6,LA:8,ROS:4,NIOPS:6,WOB:6,FS:5,MERC:5</availability>
+		<model name='SB-31D'>
+			<roles>escort</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
+		<model name='E'>
 			<availability>CSR:3,General:2,CJF:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='X'>
-			<availability>CSR:2,General:1,CJF:3</availability>
-		</model>
-		<model name='Z'>
-			<availability>CCO:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CSR:3,General:2,CJF:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -13716,6 +13704,15 @@
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:3,General:2,CJF:5</availability>
+		</model>
+		<model name='X'>
+			<availability>CSR:2,General:1,CJF:3</availability>
+		</model>
+		<model name='Z'>
+			<availability>CCO:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
@@ -13733,8 +13730,8 @@
 		<model name='S-4X'>
 			<availability>DC:1</availability>
 		</model>
-		<model name='S-7'>
-			<availability>ROS:6,CNC:5,DC:5</availability>
+		<model name='S-4C'>
+			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
 		<model name='S-3'>
 			<availability>DC:2-</availability>
@@ -13745,43 +13742,51 @@
 		<model name='S-4'>
 			<availability>FRR:6,CGB.FRR:6,ROS:6,FS:5,DC:6</availability>
 		</model>
-		<model name='S-4C'>
-			<availability>ROS:4,CLAN:8,DC:4</availability>
+		<model name='S-7'>
+			<availability>ROS:6,CNC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:6,Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:4,CS:5-,LA:6,CGB.FRR:7,FWL:6,CJF:4,DC:9</availability>
-		<model name='(Armor)'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>IS:7,DC:7</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
+		<model name='(LB-X)'>
+			<availability>IS:6,DC:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:5-,Periphery:5-</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>IS:6,DC:7</availability>
+		<model name='(Armor)'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:7,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>anti_infantry</roles>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='(Laser)' mechanized='true'>
 			<availability>CSR:3,CW:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>anti_infantry</roles>
+			<availability>CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>CS:5,LA:7,ROS:4,FS:5,MERC:5</availability>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
+		</model>
+		<model name='PPR-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
@@ -13790,31 +13795,23 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
-		<model name='PPR-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
 		<availability>CS:4,OA:1,LA:5,FRR:4,CGB.FRR:4,ROS:5,WOB:4,DC:1</availability>
+		<model name='SL-25'>
+			<roles>ground_support</roles>
+			<availability>OA:2,FRR:2-,DC:2</availability>
+		</model>
 		<model name='SL-27'>
 			<availability>IS:6,DC:3</availability>
 		</model>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
 			<availability>CLAN:8,BAN:2</availability>
-		</model>
-		<model name='SL-25'>
-			<roles>ground_support</roles>
-			<availability>OA:2,FRR:2-,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
@@ -13834,11 +13831,11 @@
 	</chassis>
 	<chassis name='Sasquatch' unitType='Mek'>
 		<availability>WOB:5</availability>
-		<model name='SQS-TH-001'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SQS-TH-002'>
 			<availability>General:6</availability>
+		</model>
+		<model name='SQS-TH-001'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sassanid' unitType='Dropship'>
@@ -13850,13 +13847,17 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:3,CSR:2,CBS:5,CNC:2,CGS:6,CCO:7,CWIE:4</availability>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CSR:2,CNC:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CSR:2,CNC:4</availability>
 		</model>
 		<model name='XP'>
 			<availability>CNC:4</availability>
@@ -13865,44 +13866,40 @@
 			<roles>recon,raider</roles>
 			<availability>CGS:4,CWIE:2</availability>
 		</model>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CW:5,CCO:9</availability>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:8,CLAN:6</availability>
+		</model>
+		<model name='J'>
+			<availability>CHH:4,CW:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
+		</model>
+		<model name='Z'>
+			<availability>CCO:2</availability>
 		</model>
 		<model name='W'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>CHH:3,CW:3</availability>
 		</model>
-		<model name='A'>
-			<availability>CSA:3,General:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
-		</model>
-		<model name='Z'>
-			<availability>CCO:2</availability>
-		</model>
-		<model name='J'>
-			<availability>CHH:4,CW:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
 		<availability>LA:5,FS:4,MERC:3,DC:3</availability>
-		<model name='(Interdictor)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>LA:1,FS:1</availability>
+		</model>
+		<model name='(Interdictor)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savior Repair Vehicle' unitType='Tank'>
@@ -13918,32 +13915,36 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MASH)'>
-			<roles>apc,support</roles>
-			<availability>General:4</availability>
+		<model name='(HQ)'>
+			<roles>apc,support,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(HQ)'>
-			<roles>apc,support,spotter</roles>
-			<availability>General:2</availability>
+		<model name='(MASH)'>
+			<roles>apc,support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>CS:4,PR:5,LA:4,ROS:5,PG:5,FS:6,MERC:4,DA:5,RFS:5</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>PR:5,LA:6,ROS:4,PG:5,FS:3,MERC:5,DA:5,RFS:5</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>PR:5,LA:6,ROS:4,PG:5,FS:3,MERC:5,DA:5,RFS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,DoO:4,FRR:4,CGB.FRR:4,FWL:4,WOB:4,DO:4,TP:4,FS:4,MERC:4,MERC.NH:4,DC:4</availability>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -13952,6 +13953,10 @@
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
@@ -13959,14 +13964,6 @@
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
@@ -13981,6 +13978,10 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:2,HL:4,FRR:2,IS:3,Periphery.Deep:5,WOB:4,MERC:3,FS:3,CIR:5,Periphery:5,TC:3,CS:3,OA:3,LA:3,CGB.FRR:3,FWL:3,DC:2</availability>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -13988,10 +13989,6 @@
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>CNC:6,IS:4</availability>
@@ -14015,23 +14012,23 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,FS:6,Periphery:7,FVC:6,LA:6,CGB.FRR:8,FWL:6,CJF:4,DC:6</availability>
-		<model name='(MRM)'>
-			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
+		<model name='(LRM)'>
+			<availability>General:3-</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5-</availability>
 		</model>
 		<model name='(LAC)'>
 			<availability>CC:4,MOC:3,LA:4,ROS:4,IS:3,FWL:4,WOB:4,MH:3,FS:4,MERC:4,TC:3,DC:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(SRM)'>
 			<availability>General:5-</availability>
 		</model>
 		<model name='(ML)'>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5-</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:3-</availability>
+		<model name='(MRM)'>
+			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -14039,11 +14036,8 @@
 		<model name='SCP-1N'>
 			<availability>HL:1-,FRR:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
 		</model>
-		<model name='SCP-10M'>
-			<availability>CS:3,CC:3,FRR:2,CGB.FRR:3,FWL:5,MERC:3,DC:3</availability>
-		</model>
-		<model name='SCP-12S'>
-			<availability>LA:4,ROS:2,MERC:2</availability>
+		<model name='SCP-12C'>
+			<availability>WOB:4</availability>
 		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
@@ -14052,11 +14046,14 @@
 		<model name='SCP-1O'>
 			<availability>IS:5,Periphery:3</availability>
 		</model>
+		<model name='SCP-12S'>
+			<availability>LA:4,ROS:2,MERC:2</availability>
+		</model>
+		<model name='SCP-10M'>
+			<availability>CS:3,CC:3,FRR:2,CGB.FRR:3,FWL:5,MERC:3,DC:3</availability>
+		</model>
 		<model name='SCP-1TB'>
 			<availability>ROS:4,MERC:4</availability>
-		</model>
-		<model name='SCP-12C'>
-			<availability>WOB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scout Infantry' unitType='Infantry'>
@@ -14092,33 +14089,33 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Se&apos;irim Medium Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:7</availability>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Anti-Infantry)' mechanized='true'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Capture Team)' mechanized='true'>
 			<availability>General:2</availability>
@@ -14126,6 +14123,9 @@
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
+		</model>
 		<model name='(SRM6)'>
 			<availability>General:3</availability>
 		</model>
@@ -14134,9 +14134,6 @@
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:3</availability>
-		</model>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SeaBuster Strike Fighter' unitType='Conventional Fighter'>
@@ -14164,14 +14161,14 @@
 		<model name='STN-3M'>
 			<availability>DC.GHO:2-,DC:1</availability>
 		</model>
-		<model name='STN-5WB'>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='STN-C'>
 			<availability>DC:7</availability>
 		</model>
 		<model name='STN-4D'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='STN-5WB'>
+			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sentry' unitType='Mek'>
@@ -14185,12 +14182,6 @@
 	</chassis>
 	<chassis name='Seraph' unitType='Mek' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='C-SRP-OE Eminus'>
-			<availability>General:7</availability>
-		</model>
-		<model name='C-SRP-OD Luminos'>
-			<availability>General:7</availability>
-		</model>
 		<model name='C-SRP-OA Dominus'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
@@ -14201,49 +14192,55 @@
 		<model name='C-SRP-O (Havalah)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='C-SRP-OS Caelestis'>
+			<availability>General:4</availability>
+		</model>
 		<model name='C-SRP-OC Comminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-SRP-OE Eminus'>
+			<availability>General:7</availability>
+		</model>
+		<model name='C-SRP-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C-SRP-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C-SRP-OS Caelestis'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,CC:3,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,CGB.FRR:2,ROS:4,FWL:3-,MH:2,DC:3-</availability>
-		<model name='SYD-21'>
+		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
-			<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,FS:1-,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>OA:2-,HL:4,FRR:2-,ROS:2-,Periphery.Deep:2,FWL:2-,WOB:2-,Periphery:6,TC:3-,DC:2-</availability>
-		</model>
-		<model name='SYD-Z4'>
-			<availability>CC:8,OA:5,LA:6,FRR:2,CGB.FRR:2,ROS:4,MERC:5</availability>
-		</model>
-		<model name='SYD-45X &apos;Starling&apos;'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:2-,FS:1-</availability>
+			<availability>LA:3-,Periphery.Deep:8,FS:1-,Periphery:3-</availability>
 		</model>
 		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
 			<availability>LA:8,FRR:6,CGB.FRR:6,ROS:4,FS:8,MERC:6</availability>
 		</model>
-		<model name='SYD-Z2'>
+		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
-			<availability>LA:3-,Periphery.Deep:8,FS:1-,Periphery:3-</availability>
+			<availability>OA:2-,HL:4,FRR:2-,ROS:2-,Periphery.Deep:2,FWL:2-,WOB:2-,Periphery:6,TC:3-,DC:2-</availability>
+		</model>
+		<model name='SYD-Z3A'>
+			<availability>LA:6,FRR:3,CGB.FRR:3,ROS:2,MERC:3,FS:2</availability>
+		</model>
+		<model name='SYD-45X &apos;Starling&apos;'>
+			<availability>LA:1</availability>
+		</model>
+		<model name='SYD-Z4'>
+			<availability>CC:8,OA:5,LA:6,FRR:2,CGB.FRR:2,ROS:4,MERC:5</availability>
+		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,FS:1-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='SYD-Z2B'>
 			<availability>OA:4,LA:4,ROS:4,FS:3,MERC:3</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>LA:6,FRR:3,CGB.FRR:3,ROS:2,MERC:3,FS:2</availability>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:2-,FS:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
@@ -14252,10 +14249,10 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='SYU-4B'>
+		<model name='SYU-6B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SYU-6B'>
+		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -14267,16 +14264,16 @@
 		<model name='S-HA-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-HA-OB Infernus'>
+		<model name='S-HA-OC Comminus'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-HA-OD Luminos'>
+		<model name='S-HA-OB Infernus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-HA-O Invictus'>
 			<availability>General:8</availability>
 		</model>
-		<model name='S-HA-OC Comminus'>
+		<model name='S-HA-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -14298,119 +14295,119 @@
 			<roles>recon</roles>
 			<availability>CSR:5,CW:3,General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:2,General:8</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='J'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:2,CW:3,General:6</availability>
 		</model>
+		<model name='J'>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:2,General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>PR:3,CHH:6,DoO:3,FRR:3,CLAN:2,DO:3,FS:3,CWIE:6,SC:3,OA:3,CDS:6,CGB.FRR:3,FWL:3,RFS:3,CGB:6,IS:1,DGM:3,MERC:3,DTA:3,CS:3,LA:3,MCM:3,ROS:3,PG:3,CNC:6,TP:3,RCM:3,DA:2,CJF:1,DC:3</availability>
-		<model name='2'>
-			<availability>CSA:3,CCC:3,CGB:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:4,CDS:5,CNC:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:5</availability>
-		</model>
-		<model name='7'>
-			<availability>OA:2,CSR:2</availability>
+		<model name='8'>
+			<availability>CDS:3,LA:3,CNC:4,CWIE:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:1</availability>
 		</model>
-		<model name='5'>
-			<availability>CS:6,CDS:7,LA:7,FRR:5,CGB.FRR:5,FWL:7,IS:5,FS:7,MERC:7,DC:7</availability>
+		<model name='2'>
+			<availability>CSA:3,CCC:3,CGB:4</availability>
+		</model>
+		<model name='7'>
+			<availability>OA:2,CSR:2</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:5</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:3,LA:3,CNC:4,CWIE:4</availability>
+		<model name='3'>
+			<availability>CSA:4,CDS:5,CNC:5</availability>
+		</model>
+		<model name='5'>
+			<availability>CS:6,CDS:7,LA:7,FRR:5,CGB.FRR:5,FWL:7,IS:5,FS:7,MERC:7,DC:7</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:3</availability>
-		<model name='SHD-2D2'>
-			<availability>FVC:6,LA:3,FS:6</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,SC:4,MCM:4,ROS:4,CLAN:4,FWL:2,DGM:4,MERC:4,DA:4,BAN:2</availability>
-		</model>
-		<model name='SHD-7CS'>
-			<availability>CS:5,WOB:4</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:1,Periphery:4-</availability>
-		</model>
-		<model name='SHD-2D'>
-			<availability>FVC:1-,FS:1-</availability>
-		</model>
 		<model name='SHD-2K'>
 			<availability>FRR:1-,CGB.FRR:1-,MERC:2-,DC:3-</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:5,CCC:5,LA:2,FS:2,CGS:5,DC:2</availability>
-		</model>
-		<model name='SHD-9D'>
-			<availability>WOB:4,FS:4</availability>
-		</model>
-		<model name='SHD-5M'>
-			<availability>CC:6,FRR:6,CGB.FRR:6,Periphery.MW:4,Periphery.ME:3,FWL:6,IS:1,MERC:6,DC:6</availability>
-		</model>
-		<model name='SHD-3K'>
-			<availability>FRR:3,CGB.FRR:3,DC:5</availability>
-		</model>
-		<model name='SHD-5D'>
-			<availability>LA:4,ROS:4,WOB:4,FS:5,MERC:4</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,DoO:5,DO:5,DGM:5,MERC:3,CDP:2,TC:3,DTA:5,SC:5,FVC:2,MCM:5,ROS:4,FWL:3,TP:5,RCM:5</availability>
-		</model>
-		<model name='SHD-11CS'>
-			<availability>CS:6,WOB:5</availability>
-		</model>
-		<model name='SHD-12C'>
-			<availability>FRR:2,CGB.FRR:5</availability>
+		<model name='SHD-2D2'>
+			<availability>FVC:6,LA:3,FS:6</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:3-,MOC:3-,FWL:3-,MERC:3-</availability>
 		</model>
+		<model name='SHD-2D'>
+			<availability>FVC:1-,FS:1-</availability>
+		</model>
+		<model name='SHD-11CS'>
+			<availability>CS:6,WOB:5</availability>
+		</model>
+		<model name='SHD-2H'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:1,Periphery:4-</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,SC:4,MCM:4,ROS:4,CLAN:4,FWL:2,DGM:4,MERC:4,DA:4,BAN:2</availability>
+		</model>
+		<model name='SHD-12C'>
+			<availability>FRR:2,CGB.FRR:5</availability>
+		</model>
+		<model name='SHD-5M'>
+			<availability>CC:6,FRR:6,CGB.FRR:6,Periphery.MW:4,Periphery.ME:3,FWL:6,IS:1,MERC:6,DC:6</availability>
+		</model>
 		<model name='SHD-8L'>
 			<availability>CC:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:5,CCC:5,LA:2,FS:2,CGS:5,DC:2</availability>
+		</model>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,DoO:5,DO:5,DGM:5,MERC:3,CDP:2,TC:3,DTA:5,SC:5,FVC:2,MCM:5,ROS:4,FWL:3,TP:5,RCM:5</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>WOB:4,FS:4</availability>
+		</model>
+		<model name='SHD-7CS'>
+			<availability>CS:5,WOB:4</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:4,ROS:4,WOB:4,FS:5,MERC:4</availability>
+		</model>
+		<model name='SHD-3K'>
+			<availability>FRR:3,CGB.FRR:3,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CSA:5,CDS:5,CW:5,CBS:7,CLAN:3,CGS:5,CGB:5</availability>
+		<model name='(Flamer)'>
+			<availability>CDS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Interdictor)'>
 			<availability>CHH:3,CSR:2,CDS:3,CW:3,CNC:3,CJF:3,CGB:5,CWIE:3</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>CDS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Shedu Assault Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:2</availability>
-		<model name='(Capture Team)' mechanized='false'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Recon)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Capture Team)' mechanized='false'>
+			<availability>General:3</availability>
 		</model>
 		<model name='(PPC)' mechanized='false'>
 			<availability>General:4</availability>
@@ -14424,11 +14421,11 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
-		<model name='SL-17'>
-			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
 		<model name='SL-18'>
 			<availability>ROS:6,DC:7</availability>
+		</model>
+		<model name='SL-17'>
+			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>OA:2,FRR:2,CGB.FRR:3,ROS:3,MERC:3,DC:3</availability>
@@ -14445,11 +14442,14 @@
 	</chassis>
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>FWL:4,WOB:4,FWL.KIS:6,FWL.FWG:5</availability>
-		<model name='SHV-OB'>
+		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
+		</model>
+		<model name='SHV-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -14457,21 +14457,18 @@
 		<model name='SHV-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SHV-OA'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,CDS:4,CW:3,CNC:5,CJF:2,DC:3</availability>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:5,DC:5</availability>
+		</model>
 		<model name='(Streak)'>
 			<availability>CW:6,CNC:6,CJF:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Shogun' unitType='Mek'>
@@ -14516,35 +14513,47 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverback Coastal Cutter' unitType='Naval'>
+		<availability>LA:7</availability>
+		<model name='(Standard)'>
+			<availability>LA:7</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:5,CCC:7,CCO:4</availability>
+		<model name='2'>
+			<availability>CSA:8,CCC:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSA:4,CCC:4,CCO:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CCC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,SC:5,DoO:5,MCM:5,FWL:2,WOB:4,DO:5,DGM:5,TP:5,MERC:3</availability>
-		<model name='SRC-6C'>
-			<availability>DTA:4,SC:4,DoO:4,MCM:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4</availability>
-		</model>
 		<model name='SRC-5C'>
 			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:5,WOB:5,DO:5,DGM:5,TP:5</availability>
 		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
 		</model>
+		<model name='SRC-6C'>
+			<availability>DTA:4,SC:4,DoO:4,MCM:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,CGB.FRR:5-,ROS:3-,FWL:3,NIOPS:3-,DC:6</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>IS.pm:4</availability>
+			<availability>General:5-</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -14554,18 +14563,18 @@
 			<roles>recon</roles>
 			<availability>IS.pm:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:5-</availability>
+			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,CGB.FRR:7,ROS:4,DC:7</availability>
+		<model name='SL-15A'>
+			<availability>OA:1,FRR:1,CGB.FRR:1,DC:1</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>OA:6,CSR:3,FRR:8,CGB.FRR:8,ROS:6,FS:6,MERC:6,CDP:4,DC:8,TC:4</availability>
-		</model>
-		<model name='SL-15'>
-			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 		</model>
 		<model name='SL-15B'>
 			<availability>FRR:1,CGB.FRR:1,MERC:1,DC:1</availability>
@@ -14573,11 +14582,11 @@
 		<model name='SL-15K'>
 			<availability>FRR:4,CGB.FRR:4,ROS:4,DC:4</availability>
 		</model>
+		<model name='SL-15'>
+			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
+		</model>
 		<model name='SL-15C'>
 			<availability>FRR:1,CGB.FRR:1,DC:1</availability>
-		</model>
-		<model name='SL-15A'>
-			<availability>OA:1,FRR:1,CGB.FRR:1,DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -14610,20 +14619,20 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CNC:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
 		<availability>CCC:3,CDS:6+,CGB:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -14631,10 +14640,6 @@
 		<model name='(2742)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='(2845)'>
 			<roles>cruiser</roles>
@@ -14650,11 +14655,11 @@
 	</chassis>
 	<chassis name='Spad' unitType='Aero'>
 		<availability>CS:6,OA:2,ROS:5,NIOPS:6,WOB:6</availability>
-		<model name='SPD-504'>
-			<availability>ROS:4,WOB:5</availability>
-		</model>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4,WOB:5</availability>
 		</model>
 		<model name='SPD-503'>
 			<availability>CS:6,ROS:6,WOB:6,BAN:2</availability>
@@ -14662,19 +14667,19 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+		<model name='SPR-6D'>
+			<availability>FVC:7,LA:3,FRR:5,CGB.FRR:5,ROS:3,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
+		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:3-,General:1-,Periphery.Deep:8,FS:3-,MERC:3-,CDP:3-,TC:3-</availability>
 		</model>
-		<model name='SPR-H5K'>
-			<roles>interceptor</roles>
-			<availability>OA:1,FRR:1-,CGB.FRR:1-,DC:1-</availability>
-		</model>
 		<model name='SPR-7D'>
 			<availability>ROS:5,FS:5,MERC:5</availability>
 		</model>
-		<model name='SPR-6D'>
-			<availability>FVC:7,LA:3,FRR:5,CGB.FRR:5,ROS:3,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
+		<model name='SPR-H5K'>
+			<roles>interceptor</roles>
+			<availability>OA:1,FRR:1-,CGB.FRR:1-,DC:1-</availability>
 		</model>
 		<model name='SPR-DH'>
 			<availability>OA:3-,FVC:3-,MERC:3-</availability>
@@ -14722,27 +14727,40 @@
 	</chassis>
 	<chassis name='Spider' unitType='Mek'>
 		<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,FVC:4,LA:1,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
-		<model name='SDR-5D'>
-			<roles>anti_infantry</roles>
-			<availability>FS:1-</availability>
-		</model>
 		<model name='SDR-5V'>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='SDR-5K'>
+			<roles>anti_infantry</roles>
+			<availability>FRR:2-,CGB.FRR:3-,DC:3-</availability>
+		</model>
+		<model name='SDR-7Kr'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='SDR-7K'>
+			<availability>ROS:4,MERC:4,DC:5</availability>
 		</model>
 		<model name='SDR-7M'>
 			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,DC:6</availability>
 		</model>
-		<model name='SDR-7K2'>
-			<availability>ROS:3,MERC:3,DC:4</availability>
+		<model name='SDR-7KC'>
+			<availability>ROS:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-5D'>
+			<roles>anti_infantry</roles>
+			<availability>FS:1-</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:6</availability>
 		</model>
 		<model name='SDR-8K'>
 			<availability>DC:3</availability>
 		</model>
+		<model name='SDR-7K2'>
+			<availability>ROS:3,MERC:3,DC:4</availability>
+		</model>
 		<model name='SDR-8R'>
 			<availability>ROS:3,MERC:3</availability>
-		</model>
-		<model name='SDR-7Kr'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='SDR-8M'>
 			<availability>MOC:2,CC:2,FWL:8,MH:2,MERC:2</availability>
@@ -14750,54 +14768,41 @@
 		<model name='SDR-8X'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='SDR-C'>
-			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:6</availability>
-		</model>
-		<model name='SDR-7K'>
-			<availability>ROS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='SDR-5K'>
-			<roles>anti_infantry</roles>
-			<availability>FRR:2-,CGB.FRR:3-,DC:3-</availability>
-		</model>
-		<model name='SDR-7KC'>
-			<availability>ROS:5,MERC:5,DC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
 		<availability>CGS:3-,CJF:5-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>LA:7,FRR:7,CGB.FRR:7,ROS:7,IS:6,FS:7,DC:7</availability>
-		<model name='(Interdictor)'>
-			<roles>spotter</roles>
-			<availability>LA:3,FWL:3,MERC:3,FS:3,DC:3</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>FRR:5,CGB.FRR:5,IS:4,DC:6</availability>
 		</model>
-		<model name='(Laser)'>
-			<roles>recon</roles>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(C3i)'>
 			<roles>recon</roles>
 			<availability>CS:5,WOB:6</availability>
 		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
+		<model name='(Laser)'>
+			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Interdictor)'>
+			<roles>spotter</roles>
+			<availability>LA:3,FWL:3,MERC:3,FS:3,DC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -14808,17 +14813,20 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:6,CC:5,HL:9,FRR:6,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,CGB.FRR:6,ROS:4,FWL:8,NIOPS:5,DC:5</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		<model name='STK-8S'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-7D'>
-			<availability>ROS:4,FS:4,MERC:2</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
+		<model name='STK-4P'>
+			<availability>IS:1,MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='STK-7D'>
+			<availability>ROS:4,FS:4,MERC:2</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
@@ -14826,30 +14834,27 @@
 		<model name='STK-3Fb'>
 			<availability>CC:2,MOC:2,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,CIR:3+,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-6M'>
 			<availability>CC:4,MOC:4,PR:6,DoO:6,WOB:6,DO:6,MERC:6,ROS:6,PG:6,FWL:6,TP:6,DA:4,RCM:6,RFS:6</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>IS:1,MERC:1,Periphery:1</availability>
-		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CJF:3,TC:4</availability>
-		</model>
-		<model name='STK-8S'>
-			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:6+,CBS:3+</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
@@ -14879,12 +14884,12 @@
 			<roles>raider</roles>
 			<availability>MOC:6,LA:6,MERC:6</availability>
 		</model>
+		<model name='STY-3Dr'>
+			<availability>LA:4,MERC:3</availability>
+		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>LA:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
@@ -14893,21 +14898,21 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:1,FS:4,MERC:1</availability>
 		</model>
-		<model name='STH-3S'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='STH-1D'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>LA:1,FS:4,MERC:4</availability>
-		</model>
 		<model name='STH-2D'>
 			<roles>recon</roles>
 			<availability>LA:1,FS:6,MERC:4</availability>
+		</model>
+		<model name='STH-3S'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='STH-2D1'>
+			<roles>recon</roles>
+			<availability>LA:1,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stiletto' unitType='Mek'>
@@ -14915,113 +14920,113 @@
 		<model name='STO-4C'>
 			<availability>LA:3,MERC:3</availability>
 		</model>
-		<model name='STO-4A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='STO-4B'>
 			<availability>General:4</availability>
+		</model>
+		<model name='STO-4A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,CGB.FRR:4,NIOPS:2-,DC:5,CGB:2-</availability>
-		<model name='STG-5R'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,PIR:4,WOB:4,CIR:4,CDP:4,TC:4</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:5,FVC:3,FWL:8,IS:2,WOB:8,FS:5,MERC:5,CDP:3,DC:5,TC:2</availability>
-		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,CC:3,TC:3</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>HL:1-,IS:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
-		</model>
-		<model name='STG-6L'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:4,DA:4</availability>
-		</model>
-		<model name='STG-7S'>
-			<roles>recon</roles>
-			<availability>LA:4,ROS:4,MERC:2</availability>
 		</model>
 		<model name='STG-5G'>
 			<roles>recon</roles>
 			<availability>CC:3,FWL:2,MERC:2,TC:3</availability>
 		</model>
+		<model name='STG-6S'>
+			<roles>recon</roles>
+			<availability>LA:5,ROS:5,MERC:5,FS:3</availability>
+		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>SC:6,DoO:6,MCM:6,CLAN:8,FWL:4,WOB:4,DGM:6,DO:6,TP:6,RCM:6,DA:6,BAN:2</availability>
 		</model>
-		<model name='STG-3P'>
+		<model name='STG-5M'>
 			<roles>recon</roles>
-			<availability>LA:3,ROS:5,IS:3,WOB.PM:4,MERC:4,DC:3,Periphery:3,CGB:3</availability>
-		</model>
-		<model name='STG-6S'>
-			<roles>recon</roles>
-			<availability>LA:5,ROS:5,MERC:5,FS:3</availability>
+			<availability>CC:5,MOC:5,FVC:3,FWL:8,IS:2,WOB:8,FS:5,MERC:5,CDP:3,DC:5,TC:2</availability>
 		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 		</model>
+		<model name='STG-6L'>
+			<roles>recon</roles>
+			<availability>CC:5,MOC:4,DA:4</availability>
+		</model>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,CC:3,TC:3</availability>
+		</model>
+		<model name='STG-3P'>
+			<roles>recon</roles>
+			<availability>LA:3,ROS:5,IS:3,WOB.PM:4,MERC:4,DC:3,Periphery:3,CGB:3</availability>
+		</model>
+		<model name='STG-5R'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,PIR:4,WOB:4,CIR:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='STG-7S'>
+			<roles>recon</roles>
+			<availability>LA:4,ROS:4,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:2,RFS:5,MOC:2,CC:5,IS:3,WOB:3,DGM:6,MERC:5,CIR:2,Periphery:1,TC:2,CS:3,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
+		<model name='F-90S'>
+			<roles>ground_support</roles>
+			<availability>LA:2</availability>
+		</model>
+		<model name='F-95'>
+			<availability>CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:3,PG:6,FWL:5,TP:6,RCM:6,DA:6,RFS:6</availability>
+		</model>
 		<model name='F-94'>
 			<availability>IS:5</availability>
 		</model>
 		<model name='F-92'>
 			<availability>FWL:6,IS:4</availability>
 		</model>
-		<model name='F-90S'>
-			<roles>ground_support</roles>
-			<availability>LA:2</availability>
-		</model>
 		<model name='F-90'>
 			<availability>CS:2-,LA:2-,IS:4-,FS:2-,Periphery:4-</availability>
-		</model>
-		<model name='F-95'>
-			<availability>CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:3,PG:6,FWL:5,TP:6,RCM:6,DA:6,RFS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>:0,CLAN:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='F'>
+		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>:0,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -15033,45 +15038,45 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>LA:4,FWL:4,FS:5,MERC:4,DC:7</availability>
-		<model name='SR1-OA'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SR1-OD'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
+		<model name='SR1-OG'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SR1-OR'>
 			<availability>CLAN:6,General:2+</availability>
 		</model>
-		<model name='SR1-OG'>
-			<availability>General:4</availability>
-		</model>
 		<model name='SR1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OF'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Striga' unitType='Aero' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
-		<model name='S-STR-O Invictus'>
-			<availability>General:8</availability>
+		<model name='S-STR-OB Infernus'>
+			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OA Dominus'>
+		<model name='S-STR-OE Eminus'>
 			<availability>General:7</availability>
 		</model>
 		<model name='S-STR-OC Comminus'>
@@ -15080,21 +15085,25 @@
 		<model name='S-STR-OD Luminos'>
 			<availability>General:7</availability>
 		</model>
-		<model name='S-STR-OE Eminus'>
-			<availability>General:7</availability>
+		<model name='S-STR-O Invictus'>
+			<availability>General:8</availability>
 		</model>
-		<model name='S-STR-OB Infernus'>
+		<model name='S-STR-OA Dominus'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,LA:4,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
+		<model name='(Narc)'>
+			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:5-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>FVC:3-,IS:3-</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,LA:6,ROS:6,FS:7,DC:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2</availability>
@@ -15105,30 +15114,26 @@
 		<model name='(SRM)'>
 			<availability>FVC:3-,IS:3-</availability>
 		</model>
-		<model name='(Narc)'>
-			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>General:3</availability>
 		</model>
 		<model name='(3061 Upgrade)'>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:5-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,LA:6,ROS:6,FS:7,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:5,CS:4,MOC:5,MERC.WD:1-,LA:2-,NIOPS:4,WOB:4</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>CC:3-,General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -15136,17 +15141,17 @@
 		<model name='STU-K5'>
 			<availability>FVC:4-,HL:1-,IS:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:1,LA:1,FS.DMM:1-</availability>
-		</model>
-		<model name='STU-K15'>
-			<availability>OA:1,TC:1,Periphery:1</availability>
-		</model>
 		<model name='STU-D7'>
 			<availability>ROS:5,FS:6</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>ROS:6,CLAN:8,FS:3,BAN:2</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:1,LA:1,FS.DMM:1-</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:1,TC:1,Periphery:1</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,ROS:6,FS:6,MERC:6</availability>
@@ -15154,6 +15159,9 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>PR:4,HL:2,WOB:3,MERC:2,FS:4,CWIE:4,Periphery.R:3,CDS:3,LA:6,ROS:4,PG:4,CNC:4,RFS:4</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:5,WOB:0</availability>
@@ -15162,22 +15170,19 @@
 			<roles>spotter</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
-		</model>
 		<model name='(Heavy Gauss)'>
 			<availability>PR:3,LA:6,PG:3,CNC:6,RFS:3,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,WOB:4</availability>
-		<model name='(Standard)'>
-			<roles>recon,fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(WOB)'>
 			<roles>recon,fire_support</roles>
@@ -15196,14 +15201,14 @@
 		<model name='E'>
 			<availability>CW:5,CLAN:2,CGB:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:6,CBS:6,General:2,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:6,General:2,CJF:6,CGB:6</availability>
@@ -15220,12 +15225,15 @@
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,FS:5,MERC:3,DC:7</availability>
-		<model name='SD1-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='SD1-OX'>
+			<availability>General:2</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='SD1-OR'>
 			<availability>General:2+,CLAN:6,DC:2+</availability>
@@ -15236,9 +15244,6 @@
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
-		</model>
-		<model name='SD1-OX'>
-			<availability>General:2</availability>
 		</model>
 		<model name='SD1-OC'>
 			<availability>General:6,DC:7</availability>
@@ -15255,11 +15260,11 @@
 		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='4'>
 			<availability>CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -15279,10 +15284,10 @@
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:2,MOC:2,CDP:2,TC:2</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -15294,33 +15299,33 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:2</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>CS:8,ROS:6,CLAN:5,NIOPS:8,WOB:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:5,CLAN:8</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>CS:4,ROS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:5,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:2,CCC:6,CSR:2,CDS:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='XR' mechanized='true'>
 			<roles>recon</roles>
@@ -15358,11 +15363,11 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:4,MERC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(RL)'>
 			<availability>MOC:4</availability>
@@ -15373,42 +15378,42 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,DoO:6,IS:1,WOB:4,DO:6,DGM:6,MERC:4,CS:3,DTA:6,SC:6,FVC:1,MCM:6,ROS:4,FWL:6,TP:6,DC:6</availability>
-		<model name='ZPH-3A'>
-			<roles>recon</roles>
-			<availability>DoO:6,IS:2,DGM:6,DO:6,MERC:4,DTA:7,SC:6,FVC:2,MCM:6,ROS:5,FWL:7,TP:6,DC:4</availability>
-		</model>
 		<model name='ZPH-2A'>
 			<roles>recon</roles>
 			<availability>CC:5,FVC:3,ROS:5,FWL:5,IS:3,MERC:5,DC:5</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:5,MOC:5,ROS:5,General:1,FWL:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:7,SC:6,FVC:2,DoO:6,MCM:6,ROS:6,IS:2,DO:6,DGM:6,TP:6,MERC:5,DC:7</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:5,MOC:5,ROS:5,General:1,FWL:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='ZPH-3A'>
+			<roles>recon</roles>
+			<availability>DoO:6,IS:2,DGM:6,DO:6,MERC:4,DTA:7,SC:6,FVC:2,MCM:6,ROS:5,FWL:7,TP:6,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>FRR:4,CGB.FRR:4,CNC:4,DC:5</availability>
+		<model name='MIK-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-OE'>
 			<availability>General:4</availability>
 		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-O'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsumaki Destroyer' unitType='Warship'>
@@ -15420,8 +15425,8 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>PR:8,DoO:8,WOB:6,DO:8,DGM:8,MERC:4,DTA:8,SC:8,FWL.MM:8,MCM:8,ROS:5,PG:8,FWL:8,TP:8,RFS:8</availability>
-		<model name='TMP-3G'>
-			<availability>ROS:2,FWL:2,WOB:2,MERC:2</availability>
+		<model name='TMP-3M'>
+			<availability>HL:6,ROS:4,FWL:5,Periphery.Deep:6,WOB:5,MERC:5,Periphery:8</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>SC:4,PR:4,MCM:4,ROS:4,PG:4,FWL:2,WOB:4,DGM:4,MERC:4,RFS:4</availability>
@@ -15429,8 +15434,8 @@
 		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
 			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:6,FWL:3,WOB:5,DO:6,DGM:6,TP:6</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>HL:6,ROS:4,FWL:5,Periphery.Deep:6,WOB:5,MERC:5,Periphery:8</availability>
+		<model name='TMP-3G'>
+			<availability>ROS:2,FWL:2,WOB:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
@@ -15438,48 +15443,47 @@
 		<model name='TLR1-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OH'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OB'>
 			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OG'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OI'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OE'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
+		<model name='TLR1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OF'>
 			<roles>spotter</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OI'>
-			<availability>General:5</availability>
+		<model name='TLR1-OG'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OU'>
-			<availability>General:2</availability>
+		<model name='TLR1-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Tengu Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>WOB.SD:5</availability>
-		<model name='(C3i)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Support)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(RL)' mechanized='true'>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Plasma)' mechanized='true'>
 			<availability>General:8</availability>
@@ -15490,54 +15494,55 @@
 		<model name='(ML)' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(RL)' mechanized='true'>
-			<availability>General:4</availability>
+		<model name='(C3i)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
 		<availability>CS:6,WOB:5,DC:4</availability>
+		<model name='TSN-X-4'>
+			<roles>recon,spotter</roles>
+			<availability>CS:1</availability>
+		</model>
 		<model name='TSN-C3'>
 			<roles>recon,spotter</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='TSN-C3M'>
-			<roles>recon,spotter</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='TSN-1C'>
-			<roles>recon,spotter</roles>
-			<availability>CS:8,WOB:8</availability>
 		</model>
 		<model name='TSN-1Cr'>
 			<roles>recon,spotter</roles>
 			<availability>CS:4,DC:4</availability>
 		</model>
-		<model name='TSN-X-4'>
+		<model name='TSN-1C'>
 			<roles>recon,spotter</roles>
-			<availability>CS:1</availability>
+			<availability>CS:8,WOB:8</availability>
+		</model>
+		<model name='TSN-C3M'>
+			<roles>recon,spotter</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CCO:1,CJF:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
 		<availability>LA:5,FS:5,MERC:4</availability>
-		<model name='TNS-4T'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='TNS-6S'>
 			<availability>LA:4,IS:3</availability>
+		</model>
+		<model name='TNS-4T'>
+			<availability>IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tharkad Battlecruiser' unitType='Warship'>
@@ -15556,50 +15561,54 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CSR:2,CLAN:3,IS:1+,CCO:3,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CDS:3,CW:3,CNC:4,CJF:6,CGB:3</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
+		</model>
 		<model name='Z'>
 			<availability>CCO:2</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CGS:4,CWIE:6,CGB:8</availability>
+		</model>
+		<model name='F'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
-		<model name='G'>
-			<availability>CHH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
-		</model>
-		<model name='HH'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
-		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CGS:4,CWIE:6,CGB:8</availability>
+		<model name='HH'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
 		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CGS:5,CCO:6,CWIE:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
 		<availability>CS:3,ROS:4,CLAN:5,NIOPS:3,WOB:3,BAN:5</availability>
+		<model name='(C3i)'>
+			<roles>artillery</roles>
+			<availability>CS:6,WOB:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CS:4,ROS:8,NIOPS:8,WOB:4</availability>
@@ -15608,18 +15617,11 @@
 			<roles>artillery</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
-		<model name='(C3i)'>
-			<roles>artillery</roles>
-			<availability>CS:6,WOB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>MOC:1,CLAN:1,WOB:7,CCO:1,Periphery:1,TC:1,CS:5,DC.GHO:1,CSA:1,OA:1,CDS:1,ROS:6,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
 		<model name='THE-S'>
 			<availability>HL:3,Periphery.Deep:3,DC:1-,Periphery:5</availability>
-		</model>
-		<model name='THE-N1'>
-			<availability>CS:8,ROS:8,WOB:8</availability>
 		</model>
 		<model name='THE-T'>
 			<availability>DC:1-</availability>
@@ -15630,49 +15632,52 @@
 		<model name='THE-N2'>
 			<availability>ROS:8,WOB:8</availability>
 		</model>
+		<model name='THE-N1'>
+			<availability>CS:8,ROS:8,WOB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CSR:1,CLAN:1</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:3-,FVC:4-,HL:3-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:5-</availability>
+		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:3</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:3-,FVC:4-,HL:3-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:5-</availability>
-		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:3,PR:5,DoO:2,CLAN:4,DO:2,FS:3,CWIE:5,DC.GHO:5,SC:5,OA:4,CDS:3,CBS:3,FWL:5,NIOPS:8,MH:2,RFS:5,CGB:5,MOC:2,IS:3,WOB:7,DGM:5,CS:8,DTA:1,FVC:1,CW:5,LA:1,MCM:5,ROS:6,PG:5,CNC:3,TP:2,DA:5,RCM:1,CJF:5</availability>
-		<model name='THG-11Eb'>
-			<availability>SC:5,MCM:5,ROS:5,CLAN:4,FWL:5,WOB:5,DGM:5,MERC:5,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>FRR:6,CLAN:6,IS:8,WOB:4,FS:8,BAN:8,DC.GHO:8,CS:4,OA:6,CGB.FRR:6,ROS:8,PG:8,FWL:8,NIOPS:4,DC:8</availability>
 		</model>
-		<model name='THG-13K'>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='THG-12K'>
-			<availability>ROS:5,WOB:4,DC:7</availability>
+		<model name='THG-11Eb'>
+			<availability>SC:5,MCM:5,ROS:5,CLAN:4,FWL:5,WOB:5,DGM:5,MERC:5,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>SC:3-,MOC:3-,PR:3-,MCM:3-,PG:3-,PIR:3-,FWL:3-,MH:3-,MERC:3-,DA:3-</availability>
 		</model>
 		<model name='THG-12E'>
 			<availability>CS:6,WOB:3</availability>
+		</model>
+		<model name='THG-13K'>
+			<availability>WOB:4</availability>
+		</model>
+		<model name='THG-12K'>
+			<availability>ROS:5,WOB:4,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -15698,9 +15703,6 @@
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,CLAN:1,MERC:4</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:6</availability>
@@ -15710,6 +15712,9 @@
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -15726,69 +15731,57 @@
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,PR:4,PG:4,MERC:4,DA:4,RFS:4,TC:4</availability>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-C4'>
-			<availability>CC:2,MOC:2,CC.LCC:3</availability>
-		</model>
 		<model name='THR-1L'>
 			<availability>General:7</availability>
+		</model>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='THR-C4'>
+			<availability>CC:2,MOC:2,CC.LCC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:1,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>MOC:4,LA:8,FRR:6,CGB.FRR:6,MH:4,MERC:6</availability>
-		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:4-</availability>
-		</model>
-		<model name='TRB-D36b'>
-			<roles>ground_support</roles>
-			<availability>CLAN:4,FS:4</availability>
-		</model>
 		<model name='TRB-D56'>
 			<availability>LA:5</availability>
 		</model>
 		<model name='TRB-D50'>
 			<availability>TC:5</availability>
 		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>MOC:4,LA:8,FRR:6,CGB.FRR:6,MH:4,MERC:6</availability>
+		</model>
+		<model name='TRB-D36b'>
+			<roles>ground_support</roles>
+			<availability>CLAN:4,FS:4</availability>
+		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:4-</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:6,HL:3,CLAN:1,IS:5,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,TC:4,CS:3-,LA:6,ROS:5,NIOPS:3-,MH:4,DC:5</availability>
-		<model name='TDR-9NAIS'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>CLAN:1,TC:4</availability>
-		</model>
-		<model name='TDR-9M'>
-			<availability>MOC:3,CC:3,DoO:4,WOB:3,DO:4,DGM:4,DTA:4,SC:4,MCM:4,PIR:2,FWL:4,MH:3,TP:4,DA:4</availability>
-		</model>
-		<model name='TDR-9S'>
-			<availability>FVC:5,LA:6,FS:4,MERC:3</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>CC:3-,MOC:3-,LA:3-,MERC:3-,TC:3-</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
 		</model>
 		<model name='TDR-60-RLA'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:3-,MERC:1-</availability>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,MERC.ELH:8,ROS:6,MERC:4,FS:4</availability>
 		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MERC:6,FS:2</availability>
+		<model name='TDR-9S'>
+			<availability>FVC:5,LA:6,FS:4,MERC:3</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,WOB:4,MERC:4,FS:2</availability>
 		</model>
 		<model name='TDR-9T'>
 			<availability>TC:3</availability>
@@ -15796,26 +15789,38 @@
 		<model name='TDR-5S'>
 			<availability>CC:3-,HL:1-,LA:2-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,MERC.ELH:8,ROS:6,MERC:4,FS:4</availability>
+		<model name='TDR-7M'>
+			<availability>CS:6,CC:5,FWL:7,IS:1,WOB:6,MERC:5</availability>
 		</model>
-		<model name='TDR-10M'>
-			<availability>ROS:6,FWL:3</availability>
+		<model name='TDR-9M'>
+			<availability>MOC:3,CC:3,DoO:4,WOB:3,DO:4,DGM:4,DTA:4,SC:4,MCM:4,PIR:2,FWL:4,MH:3,TP:4,DA:4</availability>
+		</model>
+		<model name='TDR-5SS'>
+			<availability>LA:3-,MERC:1-</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CCC:6,LA:1,FS:1,CGS:6,DC:1</availability>
 		</model>
-		<model name='TDR-7M'>
-			<availability>CS:6,CC:5,FWL:7,IS:1,WOB:6,MERC:5</availability>
+		<model name='TDR-5Sb'>
+			<availability>CLAN:1,TC:4</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,WOB:4,MERC:4,FS:2</availability>
+		<model name='TDR-7SE'>
+			<availability>CC:3,PIR:2,MH:2,MERC:3,FS:4</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>WOB:2,FS:2,MERC:2</availability>
 		</model>
+		<model name='TDR-10M'>
+			<availability>ROS:6,FWL:3</availability>
+		</model>
 		<model name='TDR-17S'>
 			<availability>LA:4</availability>
+		</model>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MERC:6,FS:2</availability>
+		</model>
+		<model name='TDR-9NAIS'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
@@ -15823,24 +15828,24 @@
 		<model name='TSG-9J'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TSG-9H'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='TSG-9DDC'>
+			<availability>CC.WHO:5</availability>
 		</model>
 		<model name='TSG-9C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
-		<model name='TSG-9DDC'>
-			<availability>CC.WHO:5</availability>
+		<model name='TSG-9H'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat Pocket Warship' unitType='Dropship'>
 		<availability>WOB:5</availability>
-		<model name='(CASPAR II Drone)'>
-			<availability>WOB:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(CASPAR II Drone)'>
+			<availability>WOB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -15860,61 +15865,61 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CS:3,CSR:3,CLAN:4,NIOPS:3,WOB:3</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,FRR:3,CGB.FRR:3,CNC:6,DC:8</availability>
-		<model name='(C3)'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='TKG-150'>
-			<availability>FRR:2-,CGB.FRR:3-,DC:3-</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>FRR:5-,CGB.FRR:5-,DC:5-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>CDS:8,CNC:8,DC:5</availability>
+		<model name='(C3)'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>CDS:8,CNC:8,DC:5</availability>
 		</model>
 		<model name='(MRM)'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
+		<model name='TKG-150'>
+			<availability>FRR:2-,CGB.FRR:3-,DC:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
 		<availability>CS:9,CW:4,ROS:7,CLAN:3,NIOPS:9,WOB:8,DC:5</availability>
-		<model name='CH'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='THK-63CS'>
-			<availability>CS:8,ROS:8,WOB:6</availability>
-		</model>
 		<model name='THK-53'>
 			<roles>escort</roles>
 			<availability>CS:2,NIOPS:1,WOB:2</availability>
 		</model>
-		<model name='THK-63b'>
-			<availability>CLAN:1,BAN:1</availability>
-		</model>
-		<model name='CX-11'>
-			<availability>CS:2</availability>
-		</model>
-		<model name='&apos;C&apos;'>
-			<availability>CW:6,CLAN:2</availability>
+		<model name='CH'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='THK-63'>
 			<roles>escort</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='&apos;C&apos;'>
+			<availability>CW:6,CLAN:2</availability>
+		</model>
+		<model name='THK-63b'>
+			<availability>CLAN:1,BAN:1</availability>
+		</model>
+		<model name='THK-63CS'>
+			<availability>CS:8,ROS:8,WOB:6</availability>
+		</model>
+		<model name='CX-11'>
+			<availability>CS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
@@ -15925,10 +15930,10 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -15941,33 +15946,33 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>CS:2,FWL:2,WOB:2,MH:1</availability>
-		<model name='G13 [Grenade Launcher]' mechanized='true'>
+		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
+			<roles>specops</roles>
+			<availability>CS:8</availability>
+		</model>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
-		<model name='G13 [Machine Gun]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
+		<model name='G14' mechanized='true'>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='G12' mechanized='true'>
 			<roles>specops</roles>
 			<availability>FWL:8,WOB:8</availability>
 		</model>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
+		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
-		</model>
-		<model name='G13 [Flamer]' mechanized='true'>
-			<availability>WOB:4,MH:4</availability>
-		</model>
-		<model name='P12 &apos;Hurricane&apos;' mechanized='true'>
-			<roles>specops</roles>
-			<availability>CS:8</availability>
-		</model>
-		<model name='G14' mechanized='true'>
-			<availability>WOB:3</availability>
 		</model>
 		<model name='G17' mechanized='true'>
 			<availability>WOB:4</availability>
 		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Machine Gun]' mechanized='true'>
+			<availability>WOB:4,MH:4</availability>
+		</model>
+		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>WOB:4,MH:4</availability>
 		</model>
 	</chassis>
@@ -15983,22 +15988,22 @@
 		<model name='TYM-1C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='TYM-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='TYM-1A'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TYM-1B'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trajan Assault Infantry Fighting Vehicle' unitType='Tank'>
 		<availability>WOB:5,WOB.PM:8</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>WOB:2</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>apc</roles>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>WOB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -16009,43 +16014,40 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,PR:3,Periphery.CM:2,PG:3,PIR:1,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:3-,FWL:1</availability>
-		</model>
-		<model name='TR-16'>
-			<availability>CC:7,MOC:5,PR:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
-		</model>
-		<model name='TR-13'>
-			<availability>CC:3-,HL:1-,IS:1-,MERC:3-,Periphery:4-</availability>
-		</model>
 		<model name='TR-13A'>
 			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:3-,FWL:1</availability>
 		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13'>
+			<availability>CC:3-,HL:1-,IS:1-,MERC:3-,Periphery:4-</availability>
+		</model>
+		<model name='TR-16'>
+			<availability>CC:7,MOC:5,PR:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:4,MOC:5,General:6,TC:5</availability>
-		</model>
-		<model name='TR-12'>
-			<availability>CC:6,MOC:3</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='TR-12'>
+			<availability>CC:6,MOC:3</availability>
+		</model>
 		<model name='TR-13G'>
 			<roles>ground_support,assault</roles>
 			<availability>CC:3</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>CC:4,MOC:5,General:6,TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Transportable Field Repair Unit' unitType='Tank'>
@@ -16066,44 +16068,44 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>MOC:3,CC:3,PR:6,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:2,LA:3,CGB.FRR:4,Periphery.MW:5,ROS:4,PG:6,Periphery.ME:5,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
+		<model name='TBT-5N'>
+			<roles>fire_support</roles>
+			<availability>CC:2-,CS:2-,MOC:5-,LA:2-,FWL:2-,IS:3-,NIOPS:2-,WOB:2-,FS:2-,MERC:3-,DC:2-,Periphery:5-</availability>
+		</model>
+		<model name='TBT-3C'>
+			<roles>fire_support</roles>
+			<availability>CS:5,SC:4,PR:4,MCM:4,ROS:5,PG:4,FWL:2,NIOPS:5,WOB:5,DGM:4,MERC:4,RFS:4</availability>
+		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,FRR:4,CGB.FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>SC:4,MCM:4,ROS:4,WOB:4,DGM:4</availability>
+		</model>
+		<model name='TBT-9K'>
+			<roles>fire_support</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='TBT-XK7'>
+			<roles>fire_support</roles>
+			<availability>TC:3</availability>
+		</model>
 		<model name='TBT-5J'>
 			<availability>FWL:2-</availability>
 		</model>
 		<model name='TBT-5S'>
 			<availability>MOC:1-,IS:1-,Periphery.Deep:4,FWL:1-,MERC:1-,CDP:2,Periphery:1-,TC:2-</availability>
 		</model>
-		<model name='TBT-7M'>
-			<roles>fire_support</roles>
-			<availability>CC:4,FRR:4,CGB.FRR:4,FWL:6,WOB:4,MH:4,FS:4,MERC:4,TC:4,DC:4</availability>
-		</model>
-		<model name='TBT-9K'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>SC:4,MCM:4,ROS:4,WOB:4,DGM:4</availability>
-		</model>
-		<model name='TBT-3C'>
-			<roles>fire_support</roles>
-			<availability>CS:5,SC:4,PR:4,MCM:4,ROS:5,PG:4,FWL:2,NIOPS:5,WOB:5,DGM:4,MERC:4,RFS:4</availability>
-		</model>
-		<model name='TBT-XK7'>
-			<roles>fire_support</roles>
-			<availability>TC:3</availability>
-		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,CS:2-,MOC:5-,LA:2-,FWL:2-,IS:3-,NIOPS:2-,WOB:2-,FS:2-,MERC:3-,DC:2-,Periphery:5-</availability>
-		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
-		<model name='TRN-3T'>
-			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
-		</model>
 		<model name='TRN-3V'>
 			<availability>WOB:3</availability>
+		</model>
+		<model name='TRN-3T'>
+			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
 		</model>
 		<model name='TRN-3Tb'>
 			<availability>CSR:3,CLAN:4,BAN:2</availability>
@@ -16111,17 +16113,8 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:7,MOC:7,MH:4,TC:7</availability>
-		<model name='(Theseus RL)[LRR]' mechanized='true'>
-			<availability>MOC:5</availability>
-		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='(Asterion)[PPC]' mechanized='true'>
-			<availability>MH:5,TC:5</availability>
-		</model>
-		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
-			<availability>MOC:5</availability>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Asterion)[MRR]' mechanized='true'>
 			<availability>MH:5,TC:5</availability>
@@ -16129,24 +16122,33 @@
 		<model name='(Ying Long)(Plasma)' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
+		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
+			<availability>MOC:5</availability>
+		</model>
 		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:4</availability>
 		</model>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
+		<model name='(Theseus RL)[LRR]' mechanized='true'>
+			<availability>MOC:5</availability>
+		</model>
+		<model name='(Asterion)[PPC]' mechanized='true'>
+			<availability>MH:5,TC:5</availability>
+		</model>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+			<availability>TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Triton' unitType='ProtoMek'>
 		<availability>CGS:5</availability>
+		<model name='3'>
+			<availability>General:4</availability>
+		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='3'>
-			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
@@ -16165,14 +16167,14 @@
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
 		<availability>CC:4,MOC:5,FVC:2,Periphery.CM:3,Periphery.ME:3,MERC:2,DA:2,TC:6,Periphery:2</availability>
+		<model name='CMT-3T'>
+			<availability>CC:8,MOC:8,TC:8</availability>
+		</model>
 		<model name='CMT-4U'>
 			<availability>General:5</availability>
 		</model>
 		<model name='CMT-6T'>
 			<availability>MOC:4,CC:4,MERC:3,DA:3</availability>
-		</model>
-		<model name='CMT-3T'>
-			<availability>CC:8,MOC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Trojan' unitType='Dropship'>
@@ -16184,10 +16186,10 @@
 	</chassis>
 	<chassis name='Tsunami' unitType='Mek'>
 		<availability>MERC:3</availability>
-		<model name='TS-P1D'>
+		<model name='TS-P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TS-P1'>
+		<model name='TS-P1D'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -16200,14 +16202,14 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CW:4+,CWIE:2</availability>
-		<model name='4'>
-			<availability>General:8</availability>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
 		</model>
 		<model name='3'>
 			<availability>CW:3,ROS:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
+		<model name='4'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
@@ -16219,58 +16221,39 @@
 			<roles>apc,urban</roles>
 			<availability>DC:3-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>:0,General:5</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>apc,urban,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>:0,General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:3,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:2,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>CLAN:2,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CGB:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
 		<availability>CNC:4,CJF:7,CLAN.HW:4</availability>
-		<model name='A'>
-			<availability>CHH:7,CW:7,CNC:7,CGS:7,CJF:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:7,CW:7,CNC:7,CJF:7,CGS:7</availability>
-		</model>
-		<model name='B'>
-			<availability>CW:9,General:7,CGB:9</availability>
-		</model>
-		<model name='H'>
-			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
-		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
 		<model name='Z'>
 			<roles>spotter</roles>
 			<availability>CCO:2</availability>
@@ -16279,15 +16262,38 @@
 			<roles>fire_support</roles>
 			<availability>CJF:2</availability>
 		</model>
+		<model name='A'>
+			<availability>CHH:7,CW:7,CNC:7,CGS:7,CJF:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CHH:8,CW:8,CNC:8,CJF:8,CCO:8</availability>
+		</model>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:7,CW:7,CNC:7,CJF:7,CGS:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:9,General:7,CGB:9</availability>
+		</model>
+		<model name='H'>
+			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,FS:6,MERC:3</availability>
+		<model name='(RAC)'>
+			<roles>urban</roles>
+			<availability>General:4,FS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
@@ -16295,10 +16301,6 @@
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>urban</roles>
-			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -16310,53 +16312,26 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,FRR:2,CGB.FRR:2,CGB:5,DC:2</availability>
-		<model name='(Kurita)'>
-			<roles>apc</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>FRR:8,CGB.FRR:8,CLAN:8</availability>
 		</model>
+		<model name='(Kurita)'>
+			<roles>apc</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:8,CHH:3,CSR:3,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:1,CW:3,CBS:5,CNC:1,CJF:6,CGB:1</availability>
-		<model name='B'>
-			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:6,CSR:3,CBS:6,General:5,CCO:4</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
-		</model>
 		<model name='F'>
 			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
 		</model>
@@ -16364,8 +16339,35 @@
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
+		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:6,CSR:3,CBS:6,General:5,CCO:4</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
@@ -16390,24 +16392,24 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:2,LA.SR:4</availability>
-		<model name='(3065)'>
+		<model name='(3071)'>
 			<roles>troop_carrier</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(3071)'>
+		<model name='(3065)'>
 			<roles>troop_carrier</roles>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:4,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>CS:8,LA:8,IS:6,WOB:8,FS:8</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:4,BAN:4</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>WOB:5</availability>
@@ -16426,6 +16428,10 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+		<model name='UM-R80'>
+			<roles>urban,spotter</roles>
+			<availability>CC:3,MOC:3,FWL:2,WOB:3,MERC:2</availability>
+		</model>
 		<model name='UM-R69'>
 			<roles>urban</roles>
 			<availability>FWL:6,IS:5,Periphery:5</availability>
@@ -16438,26 +16444,22 @@
 			<roles>urban</roles>
 			<availability>CC:3-,FVC:2,Periphery:3</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:5,IS:2,Periphery:2</availability>
-		</model>
-		<model name='UM-R80'>
-			<roles>urban,spotter</roles>
-			<availability>CC:3,MOC:3,FWL:2,WOB:3,MERC:2</availability>
-		</model>
-		<model name='UM-R63'>
+		<model name='UM-R60'>
 			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+			<availability>CC:3-,HL:2-,General:1-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>CC:2,MOC:2,SC:2,MCM:2,FS.CMM:6,DGM:2,FS:4</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R63'>
 			<roles>urban</roles>
-			<availability>CC:3-,HL:2-,General:1-,Periphery.Deep:8,Periphery:4-</availability>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:5,IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus II' unitType='Mek'>
@@ -16468,23 +16470,23 @@
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
 		<availability>CGB:6</availability>
-		<model name='(Standard)'>
+		<model name='3'>
+			<roles>anti_infantry,specops</roles>
 			<deployedWith>IS</deployedWith>
-			<availability>General:8</availability>
+			<availability>CGB:2</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:2</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:2</availability>
-		</model>
-		<model name='3'>
-			<roles>anti_infantry,specops</roles>
+		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
-			<availability>CGB:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -16502,41 +16504,41 @@
 	</chassis>
 	<chassis name='Valiant' unitType='Mek'>
 		<availability>LA:5,FS:5,MERC:4,DC:5</availability>
-		<model name='V4-LNT-J3'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
+		<model name='V4-LNT-K7'>
+			<availability>General:8</availability>
 		</model>
 		<model name='VLN-3T'>
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='V4-LNT-K7'>
-			<availability>General:8</availability>
+		<model name='V4-LNT-J3'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:3,ROS:4,WOB:4,FS:9,MERC:4,CDP:3,TC:3</availability>
-		<model name='VLK-QD2'>
+		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:3,FS:3</availability>
+			<availability>LA:1-,FS:2-,MERC:2-</availability>
 		</model>
 		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4-,FS:3-,MERC:3-,CDP:4-,TC:3-</availability>
-		</model>
 		<model name='VLK-QW5'>
 			<roles>recon,fire_support</roles>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='VLK-QF'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:1-,FS:2-,MERC:2-</availability>
-		</model>
 		<model name='VLK-QD'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:5,LA:6,ROS:6,FS:7,MERC:6</availability>
+		</model>
+		<model name='VLK-QD2'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:3,FS:3</availability>
+		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4-,FS:3-,MERC:3-,CDP:4-,TC:3-</availability>
 		</model>
 		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
@@ -16560,27 +16562,27 @@
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:3,General:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:3,General:5</availability>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -16592,14 +16594,14 @@
 	</chassis>
 	<chassis name='Vanquisher' unitType='Mek'>
 		<availability>WOB:6</availability>
-		<model name='VQR-7U'>
-			<availability>WOB:3</availability>
+		<model name='VQR-5V'>
+			<availability>WOB:5</availability>
 		</model>
 		<model name='VQR-2A'>
 			<availability>WOB:8</availability>
 		</model>
-		<model name='VQR-5V'>
-			<availability>WOB:5</availability>
+		<model name='VQR-7U'>
+			<availability>WOB:3</availability>
 		</model>
 		<model name='VQR-2B'>
 			<availability>WOB:3</availability>
@@ -16610,32 +16612,32 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CS:5-,HL:9,IS:10,Periphery.Deep:8,WOB:4-,Periphery:10,CGB:1</availability>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(Liao)'>
 			<availability>CC:3-</availability>
-		</model>
-		<model name='V-G7X'>
-			<availability>LA:2</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>CC:7,MOC:8,FVC:4+,Periphery.CM:4+,Periphery.HR:4+,PIR:4+,MH:4+,CDP:4+,TC:8</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>IS:3,FS:6</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>CC:5,MOC:5,DTA:5,PR:5,PG:5,DA:5,RCM:5,CDP:5,RFS:5,TC:5</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
+		<model name='(RAC)'>
+			<availability>IS:3,FS:6</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>CC:2-,General:2-</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='V-G7X'>
+			<availability>LA:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CC:1-,General:3-</availability>
-		</model>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>CC:4,LA:3,FWL:4,WOB:4,FS:3,MERC:4,DC:3</availability>
@@ -16643,6 +16645,10 @@
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:2,CC:2</availability>
 		</model>
@@ -16650,73 +16656,41 @@
 			<roles>asf_carrier</roles>
 			<availability>IS:2,FS:8</availability>
 		</model>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
 		<availability>CS:3,FRR:5,CGB.FRR:5,ROS:4,CNC:3,FWL:1,MERC:3,RCM:4,FS:1,DC:8</availability>
+		<model name='SDR-9KC'>
+			<availability>ROS:5,FWL:5,MERC:5,RCM:5,DC:5</availability>
+		</model>
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
-		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,RCM:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,RCM:5,DC:5</availability>
 		</model>
-		<model name='SDR-9KC'>
-			<availability>ROS:5,FWL:5,MERC:5,RCM:5,DC:5</availability>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,RCM:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:2,LA:2,ROS:2,CWIE:2</availability>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:2</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,CGB.FRR:6,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
-		<model name='VTR-C'>
-			<availability>CC:4,FRR:6,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
-		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='VTR-9B'>
 			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-9D'>
-			<availability>CC:2,FVC:3,LA:2,FS:2,CDP:3</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-10D'>
-			<availability>ROS:5,FS:6,MERC:2</availability>
-		</model>
-		<model name='VTR-11D'>
-			<roles>urban</roles>
-			<availability>ROS:2,FS:2,MERC:1</availability>
-		</model>
-		<model name='VTR-Cr'>
-			<availability>FS:1,DC:2</availability>
-		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,ROS:3,MERC:2</availability>
 		</model>
 		<model name='VTR-9K'>
 			<availability>MOC:4,FVC:4,HL:2,FRR:8,CGB.FRR:8,ROS:4,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
@@ -16724,21 +16698,49 @@
 		<model name='VTR-9Ka'>
 			<availability>ROS:3,FS:2,MERC:2</availability>
 		</model>
+		<model name='VTR-Cr'>
+			<availability>FS:1,DC:2</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-C'>
+			<availability>CC:4,FRR:6,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
+		</model>
+		<model name='VTR-11D'>
+			<roles>urban</roles>
+			<availability>ROS:2,FS:2,MERC:1</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>FVC:1,Periphery:1</availability>
+		</model>
 		<model name='VTR-9S'>
 			<availability>LA:2-,CIR:2-</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='VTR-10D'>
+			<availability>ROS:5,FS:6,MERC:2</availability>
+		</model>
+		<model name='VTR-9D'>
+			<availability>CC:2,FVC:3,LA:2,FS:2,CDP:3</availability>
+		</model>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,ROS:3,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CS:6,FRR:7,CGB.FRR:7,WOB:4,CGB:5</availability>
-		<model name='VKG-2F'>
-			<roles>fire_support</roles>
-			<availability>General:8,WOB:2</availability>
-		</model>
 		<model name='VKG-2G'>
 			<availability>CS:5,FRR:6,CGB.FRR:6,CGB:6</availability>
 		</model>
 		<model name='VKG-3W'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='VKG-2F'>
+			<roles>fire_support</roles>
+			<availability>General:8,WOB:2</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
@@ -16758,29 +16760,29 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,FRR:1,CGB.FRR:1,MERC:4,TC:6</availability>
-		<model name='VND-1SIC'>
-			<availability>CC:1</availability>
-		</model>
-		<model name='VND-4L'>
-			<availability>CC:7,MOC:5,TC:2</availability>
-		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='VND-3L'>
-			<availability>CC:6,MOC:4,General:4,TC:4</availability>
+		<model name='VND-1AA &apos;Avenging Angel&apos;'>
+			<availability>FRR:5,CGB.FRR:5,TC:1</availability>
 		</model>
 		<model name='VND-5L'>
 			<availability>CC:4,MOC:3,MERC:3,TC:2</availability>
 		</model>
-		<model name='VND-6L'>
-			<availability>CC:1+</availability>
+		<model name='VND-4L'>
+			<availability>CC:7,MOC:5,TC:2</availability>
 		</model>
 		<model name='VND-1R'>
 			<availability>FRR:0,CGB.FRR:0,General:3</availability>
 		</model>
-		<model name='VND-1AA &apos;Avenging Angel&apos;'>
-			<availability>FRR:5,CGB.FRR:5,TC:1</availability>
+		<model name='VND-3L'>
+			<availability>CC:6,MOC:4,General:4,TC:4</availability>
+		</model>
+		<model name='VND-1SIC'>
+			<availability>CC:1</availability>
+		</model>
+		<model name='VND-6L'>
+			<availability>CC:1+</availability>
+		</model>
+		<model name='VND-3Lr'>
+			<availability>CC:3,MOC:3,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -16797,29 +16799,35 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8,BAN:7</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CSR:3,General:2,CJF:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>CSR:3,General:2,CJF:6</availability>
 		</model>
 		<model name='E'>
 			<availability>CSR:3,General:2,CJF:5</availability>
 		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
 		<availability>CSA:5,CHH:6,CCC:6,CLAN:1,CGS:5,CJF:5</availability>
+		<model name='2'>
+			<availability>CLAN:1</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:2,CJF:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CHH:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CLAN:1</availability>
@@ -16827,28 +16835,22 @@
 		<model name='5'>
 			<availability>CHH:5</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:1</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:4,DC:5+</availability>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='(Nova Cat)' mechanized='true'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Nova Cat)' mechanized='true'>
+			<availability>CNC:8</availability>
+		</model>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -16861,36 +16863,32 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CS:6,LA:1,FRR:4,CGB.FRR:4,PIR:2,WOB:6,MERC:1,FS:2,DC:3</availability>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
-		</model>
-		<model name='VNL-K70'>
-			<availability>FRR:1,CGB.FRR:1,DC:1</availability>
+		<model name='VNL-K100'>
+			<availability>FS:1</availability>
 		</model>
 		<model name='VNL-K75N'>
 			<availability>LA:8,FRR:6,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
 		</model>
-		<model name='VNL-K100'>
-			<availability>FS:1</availability>
-		</model>
 		<model name='VNL-K65N'>
 			<availability>IS:1</availability>
+		</model>
+		<model name='VNL-K70'>
+			<availability>FRR:1,CGB.FRR:1,DC:1</availability>
+		</model>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
 		<availability>MERC:5,CDP:2,Periphery:3,TC:2</availability>
-		<model name='VLC-6N'>
-			<availability>MERC:8</availability>
-		</model>
 		<model name='VLC-5N'>
 			<availability>General:1</availability>
+		</model>
+		<model name='VLC-6N'>
+			<availability>MERC:8</availability>
 		</model>
 		<model name='VLC-8N'>
 			<availability>General:3,FS:8,CDP:3</availability>
@@ -16898,42 +16896,51 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:3,MOC:5,FRR:4,IS:4,WOB:3,CIR:5,Periphery:5,TC:5,CS:3,LA:6,CGB.FRR:4,FWL:6,NIOPS:3</availability>
-		<model name='VT-6C'>
+		<model name='VT-6M'>
 			<roles>anti_infantry</roles>
-			<availability>WOB:8</availability>
+			<availability>DoO:4,WOB:6,DO:4,TP:4,DA:5,RCM:5</availability>
 		</model>
 		<model name='VL-2T'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:3-,General:4-,FS:2-</availability>
 		</model>
+		<model name='VL-5T'>
+			<roles>anti_infantry</roles>
+			<availability>MOC:2,FVC:3,PIR:2,IS:2,FS:3-,CIR:2,Periphery:2,TC:2</availability>
+		</model>
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
 			<availability>FRR:3,CGB.FRR:3,FWL:8,WOB:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='VT-6C'>
+			<roles>anti_infantry</roles>
+			<availability>WOB:8</availability>
 		</model>
 		<model name='VT-5Sr'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:4,LA:4,FRR:4,CGB.FRR:4,ROS:6,FS:4,MERC:4</availability>
 		</model>
-		<model name='VL-5T'>
-			<roles>anti_infantry</roles>
-			<availability>MOC:2,FVC:3,PIR:2,IS:2,FS:3-,CIR:2,Periphery:2,TC:2</availability>
-		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:5,LA:8,FRR:5,CGB.FRR:5,MH:3,FS:5,MERC:5</availability>
 		</model>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>DoO:4,WOB:6,DO:4,TP:4,DA:5,RCM:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,MERC.WD:6,CW:1,CLAN:6,CNC:1,CCO:6,CJF:6,BAN:6,CWIE:6,CGB:7,DC:2+</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CNC:7,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:3,CDS:5,General:4,CGS:5,CCO:6,CGB:5</availability>
@@ -16943,15 +16950,6 @@
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CNC:5,CLAN:4,General:2</availability>
@@ -16965,11 +16963,11 @@
 		</model>
 	</chassis>
 	<chassis name='Waneta' unitType='Mek'>
-        <availability>WOB:3</availability>
-        <model name='S-WN-2LAM'>
-            <availability>WOB:3</availability>
-        </model>
-    </chassis>
+		<availability>WOB:3</availability>
+		<model name='S-WN-2LAM'>
+			<availability>WOB:3</availability>
+		</model>
+	</chassis>
 	<chassis name='War Dog' unitType='Mek'>
 		<availability>CS:5,MOC:1,FVC:6,LA:7,ROS:5,IS:1,WOB:1,FS:7,MERC:7</availability>
 		<model name='WR-DG-03FC'>
@@ -16981,15 +16979,8 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>CLAN:7,IS:3</availability>
-		<model name='6'>
-			<availability>CSR:3,CGB:5</availability>
-		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CLAN:1,IS:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CCC:1,CDS:5,CLAN:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:1</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,CLAN:1,IS:3</availability>
@@ -16997,60 +16988,43 @@
 		<model name='8'>
 			<availability>MOC:3,CLAN:3,IS:3,TC:3</availability>
 		</model>
+		<model name='6'>
+			<availability>CSR:3,CGB:5</availability>
+		</model>
 		<model name='7'>
 			<availability>CSR:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:1</availability>
 		</model>
 		<model name='4'>
 			<availability>CSA:5,CHH:3,CDS:6,CSR:1,CNC:5,CCO:5,CWIE:5,CGB:5</availability>
 		</model>
+		<model name='3'>
+			<availability>CCC:1,CDS:5,CLAN:1</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CLAN:1,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
-		</model>
-		<model name='C'>
-			<availability>LA:1+,FS:1+,DC:1+</availability>
-		</model>
-		<model name='WHM-10T'>
-			<availability>TC:6</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:2-</availability>
+		</model>
+		<model name='WHM-9S'>
+			<availability>LA:5,ROS:4,WOB:3,MERC:4,CIR:3</availability>
+		</model>
+		<model name='WHM-8M'>
+			<availability>PR:5,PG:5,FWL:3,WOB:4,RFS:5</availability>
 		</model>
 		<model name='WHM-7K'>
 			<roles>spotter</roles>
 			<availability>DC:7</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:5</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='WHM-8M'>
-			<availability>PR:5,PG:5,FWL:3,WOB:4,RFS:5</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>CLAN:4,BAN:2,TC:4</availability>
-		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:4,PIR:3,IS:3,FS:4,MERC:3,TC:4</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:5,LA:6,FS:5,MERC:4</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CS:6,CC:3,FVC:3,FRR:1,CGB.FRR:2,ROS:4,FWL:7,WOB:7,MERC:4,DC:2,Periphery:3</availability>
-		</model>
-		<model name='WHM-9S'>
-			<availability>LA:5,ROS:4,WOB:3,MERC:4,CIR:3</availability>
+		<model name='WHM-6R'>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,BAN:8,Periphery:4-</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-,DC:1-</availability>
@@ -17058,17 +17032,41 @@
 		<model name='WHM-4L'>
 			<availability>CC:6</availability>
 		</model>
+		<model name='WHM-8K'>
+			<availability>DC:5</availability>
+		</model>
+		<model name='WHM-5L'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='WHM-6D'>
 			<availability>FVC:2-,FS:2-</availability>
+		</model>
+		<model name='WHM-7M'>
+			<availability>CS:6,CC:3,FVC:3,FRR:1,CGB.FRR:2,ROS:4,FWL:7,WOB:7,MERC:4,DC:2,Periphery:3</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:5,LA:6,FS:5,MERC:4</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:5</availability>
+		</model>
+		<model name='WHM-10T'>
+			<availability>TC:6</availability>
+		</model>
+		<model name='C'>
+			<availability>LA:1+,FS:1+,DC:1+</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>CLAN:4,BAN:2,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:5,FS:4</availability>
-		<model name='BLR-2G'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BLR-2D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BLR-2G'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:4</availability>
@@ -17083,61 +17081,53 @@
 			<roles>apc</roles>
 			<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
 		</model>
-		<model name='H-7C'>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
 		<model name='H-8'>
 			<availability>HL:4,LA:5,FS.CH:8,FRR:6,CGB.FRR:6,ROS:6,Periphery.Deep:4,FS:6,MERC:6,Periphery:6</availability>
-		</model>
-		<model name='H-9'>
-			<availability>LA:4</availability>
 		</model>
 		<model name='H-7A'>
 			<availability>IS:3-,Periphery:3-</availability>
 		</model>
+		<model name='H-7C'>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='H-9'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>HL:5,IS:8,Periphery.Deep:5,CIR:4,Periphery:6</availability>
-		<model name='WSP-1A'>
-			<roles>recon</roles>
-			<availability>General:3-</availability>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:4,CC:3,DA:3,TC:3</availability>
 		</model>
-		<model name='WSP-1D'>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>FVC:2,FS:2-</availability>
-		</model>
-		<model name='WSP-1'>
-			<roles>recon</roles>
-			<availability>CC:3-,MOC:3-,FWL:3-,RCM:3-</availability>
+			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='WSP-8T'>
 			<roles>recon</roles>
 			<availability>CC:3,MOC:3,WOB:4,TC:5</availability>
-		</model>
-		<model name='WSP-3L'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:3,PIR:3,WOB:3,DA:3,TC:3</availability>
 		</model>
 		<model name='WSP-1W'>
 			<roles>recon</roles>
@@ -17147,33 +17137,41 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:5,FRR:3,CGB.FRR:3,ROS:5,FS:3,MERC:3</availability>
 		</model>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:4,CC:3,DA:3,TC:3</availability>
-		</model>
-		<model name='WSP-3A'>
+		<model name='WSP-1K'>
 			<roles>recon</roles>
-			<availability>OA:2</availability>
+			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
+		</model>
+		<model name='WSP-1A'>
+			<roles>recon</roles>
+			<availability>General:3-</availability>
 		</model>
 		<model name='WSP-1S'>
 			<roles>recon</roles>
 			<availability>FVC:5,LA:6,FS:5,MERC:3</availability>
 		</model>
-		<model name='WSP-3W'>
+		<model name='WSP-3M'>
 			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
+			<availability>CC:6,MOC:6,FWL:8,WOB:8,MH:6,MERC:6,DC:6</availability>
 		</model>
 		<model name='WSP-1L'>
 			<roles>recon</roles>
 			<availability>CC:2-</availability>
 		</model>
-		<model name='WSP-3M'>
+		<model name='WSP-1D'>
 			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,WOB:8,MH:6,MERC:6,DC:6</availability>
+			<availability>FVC:2,FS:2-</availability>
 		</model>
-		<model name='WSP-1K'>
+		<model name='WSP-1'>
 			<roles>recon</roles>
-			<availability>FRR:1-,CGB.FRR:1-,DC:1-</availability>
+			<availability>CC:3-,MOC:3-,FWL:3-,RCM:3-</availability>
+		</model>
+		<model name='WSP-3L'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:3,PIR:3,WOB:3,DA:3,TC:3</availability>
+		</model>
+		<model name='WSP-3A'>
+			<roles>recon</roles>
+			<availability>OA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
@@ -17198,15 +17196,15 @@
 	</chassis>
 	<chassis name='White Flame' unitType='Mek'>
 		<availability>WOB.SD:6,WOB:4</availability>
+		<model name='WHF-3B'>
+			<availability>WOB:8</availability>
+		</model>
 		<model name='WHF-3C'>
 			<availability>WOB:4</availability>
 		</model>
 		<model name='WHF-4C'>
 			<roles>spotter</roles>
 			<availability>WOB:3</availability>
-		</model>
-		<model name='WHF-3B'>
-			<availability>WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='White Tip Submarine' unitType='Naval'>
@@ -17220,46 +17218,46 @@
 		<model name='WTH-3'>
 			<availability>FS.CMM:5</availability>
 		</model>
+		<model name='WTH-2A'>
+			<availability>DC:1</availability>
+		</model>
+		<model name='WTH-1'>
+			<roles>fire_support</roles>
+			<availability>Periphery.Deep:8,MERC:2,Periphery:2</availability>
+		</model>
+		<model name='WTH-2'>
+			<roles>fire_support</roles>
+			<availability>CS:8,OA:6,MH:6,FS:1,MERC:3,CDP:6,DC:1,TC:6</availability>
+		</model>
 		<model name='WTH-1H'>
 			<availability>Periphery.CM:4,Periphery.HR:4,PIR:5,Periphery.ME:4,MH:5</availability>
 		</model>
 		<model name='WTH-K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='WTH-1'>
-			<roles>fire_support</roles>
-			<availability>Periphery.Deep:8,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='WTH-2A'>
-			<availability>DC:1</availability>
-		</model>
-		<model name='WTH-2'>
-			<roles>fire_support</roles>
-			<availability>CS:8,OA:6,MH:6,FS:1,MERC:3,CDP:6,DC:1,TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:4,LA:4,CNC:2-,FWL:4,MERC:4,DC:7</availability>
-		<model name='WGT-3SC'>
-			<availability>CC:8,LA:4,FWL:4,MERC:4</availability>
-		</model>
-		<model name='WGT-1LAW/SC3'>
-			<availability>DC:6</availability>
+		<model name='WGT-2LAW'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='WGT-4NC &apos;Dezgra&apos;'>
 			<availability>CNC:8</availability>
 		</model>
+		<model name='WGT-1LAW/SC3'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='WGT-2LAWC3'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WGT-2LAW'>
-			<availability>DC:4</availability>
+		<model name='WGT-1LAW/SC'>
+			<availability>LA:6,FWL:6,MERC:6,DC:7</availability>
 		</model>
 		<model name='WGT-2SC'>
 			<availability>LA:6,FWL:6,MERC:6</availability>
 		</model>
-		<model name='WGT-1LAW/SC'>
-			<availability>LA:6,FWL:6,MERC:6,DC:7</availability>
+		<model name='WGT-3SC'>
+			<availability>CC:8,LA:4,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -17271,14 +17269,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>FRR:3,CGB.FRR:3,ROS:3,WOB:3,MERC:3,DC:5-</availability>
-		<model name='WFT-C'>
-			<availability>FRR:4,CGB.FRR:4,DC:4</availability>
-		</model>
 		<model name='WFT-2'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:6,DC:4</availability>
 		</model>
 		<model name='WFT-B'>
 			<availability>ROS:6,WOB:6</availability>
@@ -17286,24 +17278,15 @@
 		<model name='WFT-1'>
 			<availability>General:4</availability>
 		</model>
+		<model name='WFT-C'>
+			<availability>FRR:4,CGB.FRR:4,DC:4</availability>
+		</model>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:6,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,MERC.KH:7,DoO:3,FRR:5,DO:3,DGM:3,FS:3,MERC:4,CIR:4,CWIE:5,DTA:3,SC:3,MERC.WD:5,FVC:3,LA:7,MCM:3,CGB.FRR:5,ROS:5,FWL:2,MH:4,TP:3</availability>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:3,MERC:3,CWIE:5</availability>
-		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:5,LA:4,ROS:4,MERC:3,FS:3,CWIE:4</availability>
-		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:3,MERC.WD:2,FVC:2,LA:5,ROS:4,FRR:6,CGB.FRR:6,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-1A'>
-			<availability>MERC.KH:1</availability>
-		</model>
-		<model name='WLF-3M'>
-			<availability>DTA:8,SC:8,DoO:8,MCM:8,FWL:8,DO:8,DGM:8,TP:8</availability>
-		</model>
 		<model name='WLF-4WA'>
 			<roles>ew_support</roles>
 			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:1,CWIE:2</availability>
@@ -17311,71 +17294,86 @@
 		<model name='WLF-1'>
 			<availability>MERC.KH:3,MERC.WD:1,HL:6,LA:3,ROS:3,Periphery.Deep:6,FS:2,MERC:3,Periphery:8</availability>
 		</model>
+		<model name='WLF-3M'>
+			<availability>DTA:8,SC:8,DoO:8,MCM:8,FWL:8,DO:8,DGM:8,TP:8</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:3,MERC.WD:2,FVC:2,LA:5,ROS:4,FRR:6,CGB.FRR:6,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:3,MERC:3,CWIE:5</availability>
+		</model>
+		<model name='WLF-2H'>
+			<availability>LA:2,MERC:1,CWIE:2</availability>
+		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:5,LA:4,ROS:4,MERC:3,FS:3,CWIE:4</availability>
+		</model>
 		<model name='WLF-3S'>
 			<availability>LA:4,CWIE:1</availability>
 		</model>
 		<model name='WLF-1B'>
 			<availability>MERC.KH:1</availability>
 		</model>
-		<model name='WLF-2H'>
-			<availability>LA:2,MERC:1,CWIE:2</availability>
+		<model name='WLF-1A'>
+			<availability>MERC.KH:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,HL:4,FRR:3,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CGB.FRR:3,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
-		<model name='WVR-9K'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='WVR-6R'>
+		<model name='WVR-7M'>
 			<roles>recon</roles>
-			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>FVC:6,LA:6,ROS:4,WOB:4,FS:6</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,DC:5</availability>
-		</model>
-		<model name='WVR-9W2'>
-			<availability>IS:4,DC:5</availability>
+			<availability>CC:4,FWL:6,WOB:5,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-9D'>
 			<roles>spotter</roles>
 			<availability>FS:5,MERC:4</availability>
 		</model>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,FWL:6,WOB:5,MERC:6,DC:4</availability>
+		<model name='WVR-8K'>
+			<availability>FRR:5,CGB.FRR:5,ROS:4,CNC:6,MERC:3,DC:3</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:5</availability>
+		<model name='WVR-9W2'>
+			<availability>IS:4,DC:5</availability>
 		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>FRR:8,CGB.FRR:8,MERC:6,DC:6</availability>
 		</model>
+		<model name='WVR-8D'>
+			<availability>FS:5</availability>
+		</model>
 		<model name='WVR-9W'>
 			<availability>CS:3,WOB:5</availability>
-		</model>
-		<model name='WVR-9M'>
-			<availability>FWL:4</availability>
 		</model>
 		<model name='WVR-6M'>
 			<roles>recon</roles>
 			<availability>Periphery.MW:5,PIR:4,Periphery.ME:5,FWL:3-,MH:4</availability>
 		</model>
-		<model name='WVR-8K'>
-			<availability>FRR:5,CGB.FRR:5,ROS:4,CNC:6,MERC:3,DC:3</availability>
+		<model name='WVR-8C'>
+			<availability>ROS:4,DC:5</availability>
+		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>HL:1-,General:3-,Periphery.Deep:8,Periphery:4-</availability>
+		</model>
+		<model name='WVR-9M'>
+			<availability>FWL:4</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>FVC:6,LA:6,ROS:4,WOB:4,FS:6</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -17392,19 +17390,19 @@
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
 		<availability>CHH:4,CW:4,CLAN:2</availability>
+		<model name='2'>
+			<availability>CW:7</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>CW:2,CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CW:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>PR:3,DoO:3,FRR:5,CLAN:2,DO:3,FS:7,DC.GHO:5,SC:3,CGB.FRR:5,NIOPS:5,RFS:3,CC:3,IS:3,WOB:4-,DGM:3,MERC:5,CS:5,DTA:3,FVC:3,MCM:3,PG:3,ROS:5,TP:3,RCM:3,DA:3,DC:6</availability>
-		<model name='WVE-9N'>
+		<model name='WVE-5N'>
 			<roles>urban</roles>
-			<availability>CS:8,ROS:8,WOB:8</availability>
+			<availability>DC.GHO:3,CS:4,FRR:8,CGB.FRR:8,ROS:6,NIOPS:4,WOB:4,FS:8,MERC:8,BAN:2,DC:3</availability>
 		</model>
 		<model name='WVE-10N'>
 			<roles>urban</roles>
@@ -17414,9 +17412,9 @@
 			<roles>urban</roles>
 			<availability>CLAN:1,CGS:1</availability>
 		</model>
-		<model name='WVE-5N'>
+		<model name='WVE-9N'>
 			<roles>urban</roles>
-			<availability>DC.GHO:3,CS:4,FRR:8,CGB.FRR:8,ROS:6,NIOPS:4,WOB:4,FS:8,MERC:8,BAN:2,DC:3</availability>
+			<availability>CS:8,ROS:8,WOB:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -17451,23 +17449,20 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CSR:3,CLAN:5</availability>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CSL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CSL:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>CS:6,FVC:8,HL:3,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
 		<model name='(RAC)'>
 			<availability>CS:4,IS:3,FS:5</availability>
-		</model>
-		<model name='(PPC)'>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2,FS:4</availability>
@@ -17479,15 +17474,18 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(PPC)'>
+			<availability>IS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
 		<availability>FWL.FWL:6,FWL:4,WOB:4,MH:3,MERC:3</availability>
-		<model name='YMN-10-OR'>
-			<availability>FWL:4,MERC:4</availability>
-		</model>
 		<model name='YMN-6Y'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='YMN-10-OR'>
+			<availability>FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ymir' unitType='Mek'>
@@ -17505,12 +17503,6 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='Y-H10G'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Y-H9G'>
 			<availability>General:8</availability>
 		</model>
@@ -17518,13 +17510,19 @@
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
 		</model>
+		<model name='Y-H11G'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='Y-H10G'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Yurei' unitType='Mek'>
-        <availability>WOB:3</availability>
-        <model name='S-YR-1LAM'>
-            <availability>WOB:3</availability>
-        </model>
-    </chassis>
+		<availability>WOB:3</availability>
+		<model name='S-YR-1LAM'>
+			<availability>WOB:3</availability>
+		</model>
+	</chassis>
 	<chassis name='Zechetinu Corvette' unitType='Warship'>
 		<availability>FWL:2</availability>
 		<model name='(Standard)'>
@@ -17541,13 +17539,6 @@
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
 		<availability>CS:7,DC.GHO:2,FRR:5,CGB.FRR:5,CLAN:4,WOB:7,MERC:4,DC:2</availability>
-		<model name='(LRM)'>
-			<availability>WOB:4</availability>
-		</model>
-		<model name='(C3i)'>
-			<roles>spotter</roles>
-			<availability>WOB:8</availability>
-		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<deployedWith>Chaparral</deployedWith>
@@ -17558,50 +17549,57 @@
 			<deployedWith>Chaparral</deployedWith>
 			<availability>CS:8,FRR:8,CGB.FRR:8,NIOPS:8,MERC:8,DC:8</availability>
 		</model>
+		<model name='(C3i)'>
+			<roles>spotter</roles>
+			<availability>WOB:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>WOB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
 		<availability>CS:5,ROS:4,CLAN:1,NIOPS:5,WOB:5</availability>
-		<model name='ZRO-115'>
-			<availability>CS:8,ROS:8,WOB:8</availability>
+		<model name='ZRO-114'>
+			<availability>CS:3-,CLAN:1,NIOPS:2-,WOB:3-</availability>
 		</model>
 		<model name='ZRO-CX-3'>
 			<availability>CS:2</availability>
 		</model>
-		<model name='ZRO-114'>
-			<availability>CS:3-,CLAN:1,NIOPS:2-,WOB:3-</availability>
+		<model name='ZRO-115'>
+			<availability>CS:8,ROS:8,WOB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:3-</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='ZEU-X'>
 			<availability>LA:5</availability>
 		</model>
 		<model name='ZEU-9WD'>
 			<availability>General:4</availability>
 		</model>
-		<model name='ZEU-X2'>
-			<availability>LA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>HL:5,FRR:4,IS:1,WOB:3,FS:5-,MERC:5,CDP:4,Periphery:1,TC:4,Periphery.R:5,LA:10,CGB.FRR:4,ROS:5,PIR:4,MH:4</availability>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4,WOB:8</availability>
-		</model>
-		<model name='ZEU-6S'>
-			<availability>HL:3,General:2-,Periphery.Deep:2,Periphery:5</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>FVC:5,LA:8,FRR:6,CGB.FRR:6,PIR:6,MH:3,FS:1,MERC:6,CDP:6,TC:6</availability>
 		</model>
-		<model name='ZEU-9S2'>
-			<availability>LA:4,ROS:4,FS:5,MERC:4</availability>
+		<model name='ZEU-6T'>
+			<availability>FVC:2-,LA:2-,FS:2-</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='ZEU-6T'>
-			<availability>FVC:2-,LA:2-,FS:2-</availability>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4,WOB:8</availability>
+		</model>
+		<model name='ZEU-9S2'>
+			<availability>LA:4,ROS:4,FS:5,MERC:4</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:3,General:2-,Periphery.Deep:2,Periphery:5</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -17609,14 +17607,14 @@
 	</chassis>
 	<chassis name='Zhukov Heavy Tank' unitType='Tank'>
 		<availability>MOC:3,CC:6,HL:2,IS:3,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:5</availability>
-		<model name='(Liao)'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>WOB:6</availability>
 		</model>
 		<model name='(WoB)'>
 			<availability>WOB:8</availability>
+		</model>
+		<model name='(Liao)'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
@@ -17624,14 +17622,14 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,CBS:8,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(ATM)'>
 			<availability>CW:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3082.xml
+++ b/megamek/data/forcegenerator/3082.xml
@@ -1151,18 +1151,18 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 		<model name='[TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
@@ -1216,17 +1216,17 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CSL:6,CJF:6</availability>
-		<model name='(Jade Falcon)' mechanized='true'>
-			<availability>CJF:8</availability>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Jade Falcon)' mechanized='true'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ailette Rescue PA(L)' unitType='BattleArmor'>
@@ -1258,13 +1258,12 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4</availability>
@@ -1272,17 +1271,15 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>ROS:3,CNC:4,DC:6</availability>
-		<model name='AKU-2X'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,DC:5</availability>
+		<model name='AKU-2XK'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='AKU-1X'>
 			<availability>DC:4</availability>
@@ -1290,17 +1287,20 @@
 		<model name='AKU-2XC'>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='AKU-2XK'>
-			<availability>DC:4</availability>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,DC:5</availability>
+		</model>
+		<model name='AKU-2X'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,CW:2,LA:6,ROS:4,CNC:4,NIOPS:7,FS:5,MERC:2,CWIE:6,DC:3</availability>
-		<model name='Mk VII'>
-			<availability>LA:4,FS:4</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk VII'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
@@ -1308,20 +1308,20 @@
 		<model name='ALB-3U'>
 			<availability>FWL:8,MERC:8</availability>
 		</model>
-		<model name='ALB-3Ur'>
-			<availability>ROS:4,FWL:4,MERC:4</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,SC:6,DoO:6,MCM:6,FWL:6,DO:6,DGM:6,MSC:6,TP:6</availability>
+		</model>
+		<model name='ALB-3Ur'>
+			<availability>ROS:4,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CCO:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CGB:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='XR'>
 			<availability>CDS:2</availability>
@@ -1356,6 +1356,9 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>MERC.KH:3,CHH:3,CSR:3,MERC:3,CCO:2,CWIE:4,BAN:2,RA:3,CSA:2,MERC.WD:8,LA:4,ROS:5,CGB:2</availability>
+		<model name='C 2'>
+			<availability>MERC.WD:5,CLAN:6,IS:3,BAN:1</availability>
+		</model>
 		<model name='ANH-4A'>
 			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:3,ROS:3,MERC:3,CWIE:5</availability>
 		</model>
@@ -1367,9 +1370,6 @@
 		</model>
 		<model name='ANH-3A'>
 			<availability>MERC.WD:5,CHH:4,LA:5,ROS:5,MERC:5,CWIE:4</availability>
-		</model>
-		<model name='C 2'>
-			<availability>MERC.WD:5,CLAN:6,IS:3,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1388,34 +1388,28 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:5,MOC:6,DA:2,TC:3</availability>
+		<model name='ABS-3R'>
+			<availability>General:4</availability>
+		</model>
 		<model name='ABS-3T'>
 			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
-		<model name='ABS-3R'>
-			<availability>General:4</availability>
+		<model name='ABS-4C'>
+			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
 			<availability>FVC:0,General:8</availability>
 		</model>
-		<model name='ABS-4C'>
-			<availability>CC:2,MOC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>PR:6,DoO:6,DO:6,DGM:6,MERC:4,DTA:6,SC:6,MCM:6,ROS:4,PG:6,FWL:5,MSC:4,TP:6,DA:6,RFS:6</availability>
-		<model name='ANV-5M'>
-			<availability>DTA:5,DoO:5,FWL:5,DO:5,TP:5,DA:5</availability>
-		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>DTA:5,SC:5,PR:5,DoO:5,MCM:5,PG:5,DO:5,DGM:5,MSC:5,TP:5,DA:5,RFS:5</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>ROS:6,FWL:4,MERC:4</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,MERC:4</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:5,DoO:5,FWL:5,DO:5,TP:5,DA:5</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
@@ -1424,24 +1418,30 @@
 		<model name='ANV-5Q'>
 			<availability>DTA:4,SC:4,PR:4,MCM:4,PG:4,DGM:4,MSC:4,RFS:4</availability>
 		</model>
+		<model name='ANV-3R'>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>ROS:6,FWL:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,SC:8,MCM:8,Periphery.MW:1,ROS:4,Periphery.ME:1,FWL:8,MH:3,DGM:8,MSC:6,MERC:4,DC:6</availability>
-		<model name='APL-3T'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
 		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>CC:2,FWL:4,MERC:2,DC:3</availability>
 		</model>
-		<model name='APL-2S'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
-			<availability>CC:2,FWL:4,DC:3</availability>
+			<availability>FWL:4,DC:3</availability>
 		</model>
 		<model name='APL-4M'>
 			<roles>fire_support</roles>
 			<availability>MCM:4,MSC:4</availability>
+		</model>
+		<model name='APL-2S'>
+			<roles>fire_support</roles>
+			<availability>CC:2,FWL:4,DC:3</availability>
 		</model>
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
@@ -1461,14 +1461,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,ROS:3,CNC:5,MERC:3,FS:2,DC:2</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1501,98 +1501,89 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,HL:3,LA:6,CGB.FRR:4,IS:2-,Periphery.Deep:5,FWL:6,NIOPS:4-,FS:2-,Periphery:4,DC:5,CGB:2</availability>
-		<model name='ARC-6W'>
+		<model name='ARC-7L'>
 			<roles>fire_support</roles>
-			<availability>FVC:4,HL:1,TC:5,Periphery:4</availability>
+			<availability>CC:7,MOC:3</availability>
 		</model>
 		<model name='ARC-9W'>
 			<roles>fire_support</roles>
 			<availability>ROS:5</availability>
 		</model>
-		<model name='ARC-6S'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>LA:3,CGB.FRR:3,ROS:4,MERC:3,CGB:2</availability>
-		</model>
-		<model name='ARC-8M'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,DoO:5,DO:5,DGM:5,MERC:4,DTA:5,SC:5,MCM:5,CGB.FRR:3,ROS:4,PIR:3,MH:3,MSC:5,TP:5</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6</availability>
-		</model>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:7,MOC:3</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:1-,DC:3-</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:5</availability>
+			<availability>CLAN:4,FWL:4,MERC:3,BAN:2</availability>
 		</model>
 		<model name='ARC-9KC'>
 			<roles>fire_support</roles>
 			<availability>DC:2</availability>
 		</model>
-		<model name='ARC-5R'>
+		<model name='ARC-5W'>
 			<roles>fire_support</roles>
-			<availability>CGB.FRR:8,MERC:4,CGB:3</availability>
+			<availability>MERC.WD:8,LA:3,MERC:3</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:3,CGB.FRR:3,ROS:4,MERC:3,CGB:2</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:5</availability>
+		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:1,TC:5,Periphery:4</availability>
 		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
 		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3</availability>
-		</model>
 		<model name='ARC-9M'>
 			<roles>fire_support</roles>
 			<availability>LA:5,ROS:4,FWL:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>LA:2-,CGB.FRR:2-,IS:2-,Periphery.Deep:8,BAN:2,DC:2-,Periphery:3-</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:3,MERC:3</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,MERC:3,BAN:2</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:6,CCC:6</availability>
 		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:8,MERC:4,CGB:3</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>LA:2-,CGB.FRR:2-,IS:2-,Periphery.Deep:8,BAN:2,DC:2-,Periphery:3-</availability>
+		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FVC:4,PIR:5,FWL:5,MERC:4,DC:4,Periphery:2</availability>
 		</model>
+		<model name='ARC-2K'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:1-,DC:3-</availability>
+		</model>
+		<model name='ARC-8M'>
+			<roles>fire_support</roles>
+			<availability>MOC:3,DoO:5,DO:5,DGM:5,MERC:4,DTA:5,SC:5,MCM:5,CGB.FRR:3,ROS:4,PIR:3,MH:3,MSC:5,TP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,LA:3,ROS:2,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1E'>
-			<availability>General:6</availability>
+		<model name='AF1C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
@@ -1600,6 +1591,15 @@
 		</model>
 		<model name='AF1B'>
 			<availability>General:5</availability>
+		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
@@ -1616,11 +1616,11 @@
 		<model name='A'>
 			<availability>General:3</availability>
 		</model>
-		<model name='J'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:5</availability>
+		</model>
+		<model name='J'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -1650,12 +1650,6 @@
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
 		<availability>FS:6</availability>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
@@ -1665,40 +1659,26 @@
 		<model name='AGS-6F'>
 			<availability>General:4</availability>
 		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>RA.OA:3,PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>RA.OA:3,PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1708,17 +1688,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1738,16 +1738,16 @@
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
 		<availability>MOC:2-,CC:2-,FVC:1,LA:1,FS.CMM:1-,MERC:1-,RCM:1-,DA:1-,CDP:2-,TC:2-,Periphery:1-</availability>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
+		<model name='ASN-99'>
+			<roles>spotter</roles>
+			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:2,FVC:4,Periphery.HR:4,PIR:3,MH:4,RCM:4,DA:4</availability>
 		</model>
-		<model name='ASN-99'>
-			<roles>spotter</roles>
-			<availability>CC:2,MOC:2</availability>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -1780,20 +1780,20 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,CCC:5,CDS:5,CSR:3,CW:5,ROS:3,CSL:8,CJF:3,RA:4,CGB:6</availability>
-		<model name='(HAG)'>
-			<availability>CHH:7,ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:7,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>LA:4,ROS:3,CLAN:1</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -1801,69 +1801,57 @@
 		<model name='AS7-Dr'>
 			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>CGB.FRR:4,IS:4,DC:4</availability>
+		<model name='AS7-K4'>
+			<availability>PR:4,LA:2,PG:4,RFS:4,DC:2</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>MOC:3,RA.OA:4,FVC:3,OA:4,CGB.FRR:5,CNC:5,MERC:4,CDP:3,DC:7,Periphery:2,TC:3</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:6,ROS:4,MERC:3</availability>
+		</model>
+		<model name='AS7-K3'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
+		</model>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:4</availability>
+		</model>
+		<model name='AS7-D-DC'>
+			<availability>IS:1-,MERC:0,DC:1-</availability>
+		</model>
+		<model name='AS7-K2'>
+			<availability>LA:3,CNC:4,IS:2,CLAN.IS:3,Periphery:2,CWIE:4</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:3,FS:4,DC:4</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>CGB.FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>CGB.FRR:5,MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
-		</model>
-		<model name='AS7-C'>
-			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
-		</model>
 		<model name='AS7-S2'>
 			<availability>LA:2,ROS:3,MERC:3</availability>
 		</model>
-		<model name='AS7-D'>
-			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:6,ROS:4,MERC:3</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1-,MERC:0,DC:1-</availability>
-		</model>
-		<model name='AS7-K4'>
-			<availability>PR:4,LA:2,PG:4,RFS:4,DC:2</availability>
-		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:4</availability>
-		</model>
-		<model name='AS7-K3'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>MOC:3,RA.OA:4,FVC:3,OA:4,CGB.FRR:5,CNC:5,MERC:4,CDP:3,DC:7,Periphery:2,TC:3</availability>
-		</model>
-		<model name='AS7-K2'>
-			<availability>LA:3,CNC:4,IS:2,CLAN.IS:3,Periphery:2,CWIE:4</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,OA:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(CV)'>
@@ -1874,6 +1862,14 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Gunship)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
@@ -1881,6 +1877,10 @@
 		<model name='(Tanker)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1892,24 +1892,24 @@
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:2,CCC:2,CSR:2,CW:4,CLAN:2,CNC:4,RA:1,BAN:5,CWIE:4</availability>
+		<model name='A'>
+			<availability>CSA:7,CSR:4,General:6,RA:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,CSR:5,General:7,CCO:8,RA:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5,CCO:6</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CSA:7,CSR:4,General:6,RA:7</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
@@ -1920,34 +1920,34 @@
 		<model name='AV1-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
+		</model>
 		<model name='AV1-OI'>
 			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='AV1-OE'>
-			<availability>General:6</availability>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AV1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
@@ -1955,31 +1955,31 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:2,RA.OA:2,OA:2,LA:4,CGB.FRR:2,IS:2,FWL:3,FS:4,TC:2,Periphery:1,DC:3</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>LA:1-,General:4,FS:1-</availability>
 		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:5,Periphery.Deep:7,FS:5,Periphery:8,TC:6,RA.OA:7,OA:7,LA:5,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
-		<model name='AWS-8Q'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
 		<model name='AWS-10KM'>
 			<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,DO:4,DGM:4,MSC:4,TP:4,DC:5</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:3,PIR:4,FWL:5,IS:4,MH:3,TC:3,Periphery:3</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DoO:3,DO:3,DGM:3,FS:3,MERC:3,DTA:3,SC:3,LA:3,MCM:3,ROS:3,FWL:3,MSC:3,TP:3</availability>
-		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:5,HL:2,FWL:5,IS:5,MH:5,TC:5,Periphery:4</availability>
+		</model>
+		<model name='AWS-9Ma'>
+			<availability>DoO:3,DO:3,DGM:3,FS:3,MERC:3,DTA:3,SC:3,LA:3,MCM:3,ROS:3,FWL:3,MSC:3,TP:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
@@ -2002,8 +2002,18 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:2,LA:4,CGB.FRR:2,ROS:4,FS:2,MERC:1</availability>
+		<model name='AXM-6T'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='AXM-3S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='AXM-4D'>
 			<availability>FS:5</availability>
+		</model>
+		<model name='AXM-2N'>
+			<roles>fire_support</roles>
+			<availability>FVC:1,LA:2,FS:1</availability>
 		</model>
 		<model name='AXM-1N'>
 			<availability>FVC:5,LA:5,CGB.FRR:5,MERC:5,FS:5</availability>
@@ -2011,19 +2021,13 @@
 		<model name='AXM-3Sr'>
 			<availability>LA:5,ROS:4,FS:6,MERC:2</availability>
 		</model>
-		<model name='AXM-6T'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='AXM-3S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-2N'>
-			<roles>fire_support</roles>
-			<availability>FVC:1,LA:2,FS:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:4,CSR:3,CJF:5,RA:4</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>CSR:3,RA:6</availability>
+		</model>
 		<model name='3 &apos;Devil&apos;'>
 			<availability>CSR:3,RA:8</availability>
 		</model>
@@ -2031,14 +2035,30 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>CSR:3,RA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:3,CHH:2,CW:3,LA:1,ROS:2,CSL:2</availability>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:6,CLAN:5,General:3</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:6,General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2050,38 +2070,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>CLAN:6,General:4</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,LA:2,MERC:4</availability>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -2097,7 +2093,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -2105,15 +2101,13 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>RA.OA:6,OA:6,IS:6,CLAN.IS:6</availability>
-		<model name='(Hybrid)'>
-			<availability>CLAN:3,IS:3</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
@@ -2121,24 +2115,30 @@
 		<model name='(Standard)'>
 			<availability>CLAN:8,IS:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Hybrid)'>
+			<availability>CLAN:3,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:4+</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -2146,33 +2146,41 @@
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:4,DTA:3,HL:1,LA:2,ROS:4,FWL:4,MERC:8,FS:4,DA:3,Periphery:2</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:3</availability>
+		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
 		<model name='BNDR-01B'>
 			<availability>General:4,MERC:8</availability>
 		</model>
-		<model name='BNDR-01Ar'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:2,CLAN:1,CSL:2</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3,CCO:6</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
@@ -2182,16 +2190,8 @@
 			<roles>apc</roles>
 			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -2204,9 +2204,13 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:5</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -2216,9 +2220,9 @@
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:6</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
@@ -2228,36 +2232,38 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:6-,PR:3-,HL:7-,Periphery.Deep:8-,DGM:2-,MERC:3-,Periphery:8-,TC:6-,RA.OA:6-,SC:2-,FVC:3-,OA:6-,LA:4-,MCM:2-,CGB.FRR:2-,PG:3-,FWL:2-,MH:6-,MSC:1-,RFS:3-</availability>
+		<model name='BNC-3Mr'>
+			<availability>MOC:5,FWL:5,CDP:5,TC:5</availability>
+		</model>
 		<model name='BNC-3MC'>
 			<availability>MOC:5-</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>RA.OA:1-,OA:1-,LA:2-,MERC:1-,CDP:1,TC:1-,Periphery:2-</availability>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
-		<model name='BNC-6S'>
+		<model name='BNC-9S'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BNC-3Mr'>
-			<availability>MOC:5,FWL:5,CDP:5,TC:5</availability>
+		<model name='BNC-8S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1-,FVC:2-,OA:2-,FWL:1-,MH:2-,MERC:2-,CDP:1-,TC:1-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>SC:2-,PR:2-,MCM:2-,PG:2-,DGM:2-,MSC:2-,RFS:2-</availability>
@@ -2265,39 +2271,33 @@
 		<model name='BNC-3E'>
 			<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
 		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6</availability>
+		<model name='BNC-3S'>
+			<availability>RA.OA:1-,OA:1-,LA:2-,MERC:1-,CDP:1,TC:1-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:4,CGB.FRR:3,MH:3,FS:6,MERC:5</availability>
 		</model>
-		<model name='BNC-9S'>
+		<model name='BNC-6S'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1-,FVC:2-,OA:2-,FWL:1-,MH:2-,MERC:2-,CDP:1-,TC:1-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,CGB.FRR:4,ROS:3,MERC:4</availability>
-		<model name='BGS-2T'>
-			<availability>LA:5,ROS:5,MERC:5</availability>
-		</model>
-		<model name='BGS-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BGS-1T'>
 			<availability>General:6</availability>
+		</model>
+		<model name='BGS-3T'>
+			<availability>LA:4,ROS:4,MERC:4</availability>
+		</model>
+		<model name='BGS-2T'>
+			<availability>LA:5,ROS:5,MERC:5</availability>
 		</model>
 		<model name='BGS-4T'>
 			<availability>LA:5</availability>
 		</model>
-		<model name='BGS-3T'>
-			<availability>LA:4,ROS:4,MERC:4</availability>
+		<model name='BGS-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Barouche Military Transport' unitType='Tank'>
@@ -2309,21 +2309,21 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>CSR:4,ROS:2+,CNC:5,CLAN:4,IS:2+,RA:5,BAN:5</availability>
-		<model name='D'>
-			<availability>CSR:3,CNC:3,CLAN:2,RA:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CSR:5,CNC:8,General:7,RA:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='D'>
+			<availability>CSR:3,CNC:3,CLAN:2,RA:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
@@ -2332,38 +2332,38 @@
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CSA:4,CCC:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSR:1,CBS:4,CSL:5,CJF:6,CCO:3</availability>
+		<model name='C'>
+			<availability>General:6,CCO:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='F'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>CBS:8,General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='F'>
-			<availability>General:5</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:6,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2389,32 +2389,47 @@
 		<model name='BKX-7K'>
 			<availability>FS:3-,MERC:4-</availability>
 		</model>
-		<model name='BKX-1X'>
-			<availability>LA:8-,FS:3-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>ROS:8,FS:8,MERC:3</availability>
+		</model>
+		<model name='BKX-1X'>
+			<availability>LA:8-,FS:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:4,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
-		<model name='BLR-4L'>
-			<availability>CC:4</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:1,LA:1,FWL:1,FS:1,Periphery:1,DC:1</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1-,MERC:0</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:4,CGB.FRR:3,ROS:4,MERC:4</availability>
+		<model name='BLR-1Gb'>
+			<availability>CC:2,DoO:3,CLAN:8,DO:3,DGM:3,FS:2,MERC:3,BAN:2,SC:3,MCM:3,MSC:3,TP:3,DC:2</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>SC:2,MCM:2,DGM:2,MSC:2</availability>
 		</model>
+		<model name='BLR-1D'>
+			<availability>FVC:3-,FS:3-</availability>
+		</model>
+		<model name='BLR-6X'>
+			<availability>LA:1</availability>
+		</model>
+		<model name='BLR-4S'>
+			<availability>LA:4,CGB.FRR:3,ROS:4,MERC:4</availability>
+		</model>
+		<model name='BLR-1S'>
+			<availability>LA:1-</availability>
+		</model>
 		<model name='BLR-10S'>
 			<availability>LA:6,ROS:4,FS:4</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1-,MERC:0</availability>
+		</model>
+		<model name='BLR-3S'>
+			<availability>LA:3</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>IS:3-,Periphery.Deep:8,FS:1-,BAN:8,Periphery:3-</availability>
 		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:6,ROS:4,FS:4</availability>
@@ -2426,36 +2441,21 @@
 			<roles>spotter</roles>
 			<availability>DTA:5,DoO:5,ROS:4,DO:5,TP:5,DA:5,MERC:4</availability>
 		</model>
-		<model name='BLR-K4'>
-			<availability>CGB.FRR:5,ROS:4,DC:5</availability>
-		</model>
-		<model name='BLR-1S'>
-			<availability>LA:1-</availability>
-		</model>
-		<model name='BLR-6X'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='BLR-3S'>
-			<availability>LA:3</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>IS:3-,Periphery.Deep:8,FS:1-,BAN:8,Periphery:3-</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:2,DoO:3,CLAN:8,DO:3,DGM:3,FS:2,MERC:3,BAN:2,SC:3,MCM:3,MSC:3,TP:3,DC:2</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:3-,FS:3-</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:1,LA:1,FWL:1,FS:1,Periphery:1,DC:1</availability>
-		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:6,SC:6,DoO:6,MCM:6,DO:6,DGM:6,MSC:6,TP:6</availability>
+		</model>
+		<model name='BLR-K4'>
+			<availability>CGB.FRR:5,ROS:4,DC:5</availability>
 		</model>
 		<model name='BLR-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-3M'>
+			<availability>CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='BLR-K3'>
 			<roles>spotter</roles>
@@ -2471,16 +2471,9 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CSA:6,CHH:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CCO:3,CGB:6,CWIE:4</availability>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CNC:9,General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CJF:6</availability>
@@ -2488,55 +2481,62 @@
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
 		<availability>ROS:6,NIOPS:5</availability>
-		<model name='(Sealed)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>ROS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>ROS:3,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:6,CSR:2,RA:3</availability>
-		<model name='(Standard)'>
-			<availability>CSR:2,RA:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:7</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CSR:2,RA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:2,HL:3,IS:2,MERC:2,FS:4,Periphery:4,RA.OA:3,OA:3,CDS:5,LA:3,CGB.FRR:3,PIR:2,CNC:4,FWL:2,DC:5</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:6,IS:6,DC:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>FVC:4,CDS:4,General:8,DC:3</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Kurita)'>
-			<availability>CLAN:6,IS:6,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>FVC:4,CDS:4,General:8,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2548,11 +2548,11 @@
 	</chassis>
 	<chassis name='Bellona Hover Tank' unitType='Tank'>
 		<availability>CHH:6</availability>
-		<model name='(Laser)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Beowulf IIC' unitType='Mek'>
@@ -2564,25 +2564,25 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>CGB.FRR:6,ROS:6,CNC:4,CGB:5</availability>
-		<model name='BEO-14'>
-			<roles>recon</roles>
-			<availability>ROS:3</availability>
-		</model>
 		<model name='BEO-12'>
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='BEO-14'>
+			<roles>recon</roles>
+			<availability>ROS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>PR:5,LA:7,CGB.FRR:3,ROS:4,PG:5,FS:3,MERC:3,RFS:5</availability>
-		<model name='BRZ-B3'>
-			<availability>LA:2</availability>
+		<model name='BRZ-A3'>
+			<availability>PR:8,LA:4,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>PR:4,LA:6,ROS:6,PG:4,MERC:6,RFS:4</availability>
 		</model>
-		<model name='BRZ-A3'>
-			<availability>PR:8,LA:4,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2600,70 +2600,70 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CSA:1,CHH:3,CSR:2,CW:2,ROS:2+,IS:2+,CJF:2,RA:1,BAN:3,CWIE:3,CGB:2</availability>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:5,General:6,CJF:8,CGB:7</availability>
 		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:5,LA:6,CGB.FRR:6,IS:4,FS:5,MERC:5,DC:8</availability>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OX'>
+			<availability>FS:2,DC:2</availability>
+		</model>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='BHKU-OX'>
-			<availability>FS:2,DC:2</availability>
-		</model>
 		<model name='BHKU-OR'>
 			<availability>General:3+,DC:3+</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BHKU-OD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
@@ -2674,17 +2674,17 @@
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:4,PR:6,DoO:6,CLAN:5,DO:6,FS:5,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,SC:6,OA:3,CDS:4,CBS:6,CGB.FRR:4,FWL:4,NIOPS:7,MSC:4,RFS:6,CGB:6,CSR:4,IS:4,DGM:6,MERC:4,RA:4,Periphery:2,TC:4,DTA:6,FVC:4,CW:6,LA:4,MCM:6,ROS:6,PG:6,CNC:6,TP:6,RCM:6,DA:6,CJF:4,DC:4</availability>
-		<model name='BL-12-KNT'>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:5,Periphery:5,DC.GHO:4,RA.OA:6,OA:6,LA:6,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>DoO:6,CLAN:5,DO:6,MERC:5,FS:5,BAN:2,DTA:6,LA:5,ROS:6,FWL:6,TP:6,DA:6,DC:5</availability>
 		</model>
 		<model name='BL-9-KNT'>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='BL-6-KNT'>
+			<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:5,Periphery:5,DC.GHO:4,RA.OA:6,OA:6,LA:6,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
+		</model>
+		<model name='BL-12-KNT'>
+			<availability>ROS:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -2692,19 +2692,15 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:6</availability>
 		</model>
 		<model name='X'>
 			<availability>CJF:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6,CCO:6</availability>
@@ -2712,6 +2708,10 @@
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -2730,36 +2730,42 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:6,MERC:3</availability>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:3-,MOC:3,RA.OA:4,FVC:5,OA:4,HL:3,FS:5,MERC:3,TC:3,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:7,MERC:6</availability>
-		</model>
 		<model name='BJ-1'>
 			<availability>Periphery.Deep:8,Periphery:2</availability>
+		</model>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>FVC:4,LA:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:7,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,FVC:3,ROS:4,FWL:5,IS:2,FS:6,MERC:3,DA:4,DC:6</availability>
-		<model name='BJ2-O'>
-			<availability>General:7</availability>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
 		</model>
-		<model name='BJ2-OX'>
-			<availability>General:2</availability>
+		<model name='BJ2-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:6</availability>
@@ -2767,23 +2773,17 @@
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OC'>
+		<model name='BJ2-OD'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
+		<model name='BJ2-O'>
+			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		<model name='BJ2-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
@@ -2797,39 +2797,39 @@
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MERC:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Black Blizzard&apos;'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,CHH:5,CCC:4,CBS:4,CSL:5</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='G'>
+		<model name='E'>
 			<availability>General:5</availability>
 		</model>
 		<model name='D'>
@@ -2838,37 +2838,37 @@
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
 		<availability>CSA:5,CCC:3,CBS:10</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3,CBS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CW:7</availability>
-		<model name='2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
 		<availability>DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,MCM:6,ROS:3,FWL:6,MH:3,MSC:4,TP:6,DA:6</availability>
-		<model name='B3-HND'>
-			<roles>anti_infantry</roles>
-			<availability>:0,IS:3</availability>
+		<model name='B2-HND'>
+			<availability>General:4,RCM:0</availability>
 		</model>
 		<model name='B1-HND'>
 			<availability>:0,General:8</availability>
 		</model>
-		<model name='B2-HND'>
-			<availability>General:4,RCM:0</availability>
+		<model name='B3-HND'>
+			<roles>anti_infantry</roles>
+			<availability>:0,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
-		<availability>MOC:6,OA:5,FS:2,Periphery:4,DC:2,OA.RA:5</availability>
+		<availability>MOC:6,OA:5,OA.RA:5,FS:2,Periphery:4,DC:2</availability>
 		<model name='MSF-42'>
 			<availability>General:6</availability>
 		</model>
@@ -2882,12 +2882,12 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank (RotS)' unitType='Tank' omni='IS'>
 		<availability>ROS:1</availability>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
@@ -2904,6 +2904,10 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>RA.OA:5,FVC:4,OA:5,CDS:3,CLAN:2,NIOPS:3,DC:5,RA:4</availability>
+		<model name='BMB-12D'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:4,FVC:6,OA:4,CGB.FRR:6,ROS:3,CLAN:8,NIOPS:4,MERC.SI:8,BAN:8</availability>
+		</model>
 		<model name='BMB-10D'>
 			<roles>fire_support</roles>
 			<availability>Periphery.Deep:8</availability>
@@ -2915,10 +2919,6 @@
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='BMB-12D'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:4,FVC:6,OA:4,CGB.FRR:6,ROS:3,CLAN:8,NIOPS:4,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -2937,42 +2937,42 @@
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
 		<availability>MERC:1,TC:5</availability>
-		<model name='BRM-5A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BRM-5B'>
 			<availability>TC:2</availability>
+		</model>
+		<model name='BRM-5A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2</availability>
-		<model name='LDT-5'>
-			<availability>PIR:5</availability>
-		</model>
 		<model name='LDT-X3'>
+			<availability>PIR:4</availability>
+		</model>
+		<model name='LDT-X4'>
 			<availability>PIR:4</availability>
 		</model>
 		<model name='LDT-1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='LDT-X4'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-X1'>
-			<availability>General:4</availability>
+		<model name='LDT-5'>
+			<availability>PIR:5</availability>
 		</model>
 		<model name='LDT-X2'>
+			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X1'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -2984,16 +2984,19 @@
 	</chassis>
 	<chassis name='Bruin' unitType='Mek'>
 		<availability>CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -3005,9 +3008,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:4,MOC:4,RA.OA:2,IS:2,FS:3</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3032,13 +3032,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -3050,11 +3050,11 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:3-,General:8,FS:3-,MERC:3-,DC:3-</availability>
-		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>LA:3-,General:8,FS:3-,MERC:3-,DC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3090,14 +3090,14 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,ROS:3,FS:5,MERC:3</availability>
+		<model name='BSW-S2r'>
+			<availability>General:3</availability>
+		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4,FS:1</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BSW-S2r'>
-			<availability>General:3</availability>
 		</model>
 		<model name='BSW-X2'>
 			<availability>LA:4,MERC:4</availability>
@@ -3108,17 +3108,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>FVC:5,LA:4,FS:5,MERC:4</availability>
-		<model name='CES-3R'>
-			<availability>FVC:8,FS:4,MERC:4</availability>
-		</model>
-		<model name='CES-4S'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='CES-4R'>
 			<availability>FS:6</availability>
 		</model>
 		<model name='CES-3S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='CES-3R'>
+			<availability>FVC:8,FS:4,MERC:4</availability>
+		</model>
+		<model name='CES-4S'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -3143,11 +3143,11 @@
 	</chassis>
 	<chassis name='Carnivore Assault Tank' unitType='Tank'>
 		<availability>CC:3,CHH:3,CW:4,LA:3,FS:3,MERC:3,CJF:3,CWIE:3,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>CW:8,CJF:4</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CW:6,CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CW:8,CJF:4</availability>
 		</model>
 		<model name='(Second Line)'>
 			<availability>CW:4-,General:8,CJF:4-</availability>
@@ -3155,13 +3155,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CHH:1,CDS:3,CSR:2,CW:1,CNC:5,CCO:1,CJF:1,RA:2,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3173,14 +3173,20 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:5,MOC:4,FVC:4,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2,FS:4,MERC:4,CDP:4,TC:4</availability>
-		<model name='CTF-1X'>
-			<availability>General:3-,Periphery:4-</availability>
-		</model>
 		<model name='CTF-2X'>
 			<availability>CC:1-,MOC:1,FVC:1,MERC:1,TC:1</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:4,MH:2,FS:4,MERC:2</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='CTF-3LL'>
+			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FVC:4,FS:4,MERC:3</availability>
@@ -3188,42 +3194,44 @@
 		<model name='CTF-4L'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
-		<model name='CTF-5D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
+		<model name='CTF-1X'>
+			<availability>General:3-,Periphery:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,DoO:2,DO:2,MERC:2,Periphery:2,TC:3,CGB.FRR:5,FWL:2,NIOPS:4,MH:4,TP:2,DA:3,RCM:3,DC:6</availability>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:2,PIR:4,MH:8,Periphery:4</availability>
+		</model>
 		<model name='CPLT-K4'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:2-</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:6,DC:8</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:3,MOC:3,FWL:3,MERC:3,CDP:3,TC:3,DC:4</availability>
 		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:2-</availability>
-		</model>
 		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,PIR:4,MH:8,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:6,DC:8</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
@@ -3237,14 +3245,6 @@
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
-		</model>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
-		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
@@ -3253,12 +3253,6 @@
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CCC:5,CDS:5,CSR:3,CNC:5,RA:4,DC:3+</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
@@ -3268,10 +3262,6 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -3279,26 +3269,42 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
@@ -3308,20 +3314,14 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
 		<availability>CSR:1,CBS:5+,RA:2</availability>
-		<model name='2'>
-			<availability>CSR:3,CBS:6,RA:6</availability>
-		</model>
 		<model name='4'>
 			<availability>CBS:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSR:3,CBS:6,RA:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSR:5,CBS:8,RA:8</availability>
@@ -3329,11 +3329,11 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CSR:3,CBS:4,CNC:6,CSL:5,RA:4</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,CNC:8,CSL:4</availability>
-		</model>
 		<model name='3'>
 			<availability>CSR:3,CBS:6,RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8,CNC:8,CSL:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CSL:6</availability>
@@ -3341,13 +3341,13 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
@@ -3365,57 +3365,57 @@
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='CNT-1A'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,DoO:2,DO:2,DGM:2,Periphery.OS:4,FS:8,MERC:2,CDP:3,Periphery:2,DTA:2,SC:2,FVC:8,LA:4,MCM:2,Periphery.HR:4,ROS:3,FWL:2,NIOPS:2-,MH:5,MSC:1,TP:2</availability>
-		<model name='CN9-D3'>
-			<availability>FVC:2,ROS:3,FS:3,MERC:3,CDP:2</availability>
-		</model>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:1-,FS:1-,MERC:1-</availability>
-		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:4,Periphery:3</availability>
-		</model>
-		<model name='CN9-H'>
-			<availability>MH:6</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:4,IS:4,FS:4,Periphery:3</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:4,HL:2,FS:3,MERC:5,Periphery:4</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:3-,Periphery.Deep:8,FS:1-,MERC:1-,Periphery:3-</availability>
 		</model>
+		<model name='CN9-D'>
+			<availability>FVC:4,HL:2,FS:3,MERC:5,Periphery:4</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:3,ROS:3,FWL:3,FS:3,MERC:3,CDP:2</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:1-,FS:1-,MERC:1-</availability>
 		</model>
-		<model name='CN9-Da'>
-			<availability>DoO:3,DO:3,DGM:3,FS:2,MERC:2,Periphery:2,SC:3,FVC:2,MCM:3,ROS:2,FWL:2,MSC:3,TP:3</availability>
+		<model name='CN9-H'>
+			<availability>MH:6</availability>
 		</model>
 		<model name='CN9-D4D'>
 			<availability>DTA:3,SC:3,DoO:3,MCM:3,ROS:3,DO:3,DGM:3,MSC:3,TP:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='CN9-Ar'>
+			<availability>IS:4,Periphery:3</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FVC:2,ROS:3,FS:3,MERC:3,CDP:2</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:4,IS:4,FS:4,Periphery:3</availability>
+		</model>
+		<model name='CN9-Da'>
+			<availability>DoO:3,DO:3,DGM:3,FS:2,MERC:2,Periphery:2,SC:3,FVC:2,MCM:3,ROS:2,FWL:2,MSC:3,TP:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -3423,11 +3423,11 @@
 		<model name='MR-5M'>
 			<availability>CC:4,MOC:2,ROS:5,FWL:6</availability>
 		</model>
-		<model name='MR-V3'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='MR-V2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MR-V3'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3447,15 +3447,15 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
-		<model name='4'>
-			<roles>spotter</roles>
-			<availability>CSR:2,RA:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<roles>spotter</roles>
+			<availability>CSR:2,RA:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CSR:3,RA:5</availability>
@@ -3485,21 +3485,21 @@
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:5,CC:5,RA.OA:5,OA:5,HL:3,LA:6,IS:4,FWL:5,FS:5,TC:5,Periphery:4,DC:4</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:2-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>HL:1,LA:6,IS:4,FS:6,Periphery:2</availability>
-		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:4,IS:3,FS:4,Periphery:2</availability>
+		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>HL:1,LA:6,IS:4,FS:6,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
@@ -3507,12 +3507,12 @@
 		<model name='CHP-3N'>
 			<availability>ROS:6</availability>
 		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,LA:4,ROS:2,MERC:4,CGB:2</availability>
+		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>DC.GHO:2-,CHH:2,LA:4,NIOPS:4,MERC.SI:4,MERC:4,BAN:3,CGB:2</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,LA:4,ROS:2,MERC:4,CGB:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -3520,10 +3520,6 @@
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CGB.FRR:3+,ROS:4,IS:3,NIOPS:4,MERC:2,BAN:4,Periphery:2,CGB:1</availability>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
@@ -3532,22 +3528,36 @@
 			<roles>missile_artillery</roles>
 			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='(ERML)'>
-			<roles>missile_artillery</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(CASE)'>
+			<roles>missile_artillery</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='(ERML)'>
+			<roles>missile_artillery</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:2-,MOC:2-,RA.OA:2-,FVC:2,OA:2-,LA:2-,CGB.FRR:4-,ROS:2-,MERC:1-,TC:2-,Periphery:2,DC:4-</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,RA.OA:10,FVC:5,OA:10,HL:2,PIR:5,MH:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
 		<model name='CGR-3K'>
 			<availability>CGB.FRR:3-,MERC:2-,DC:3-</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>CC:2-,FVC:3,Periphery:3</availability>
+		<model name='CGR-3Kr'>
+			<availability>CC:1,CGB.FRR:3,ROS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='CGR-C'>
+			<availability>DC:3</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>RA.OA:3-,FVC:3-,OA:3-,Periphery:2-</availability>
@@ -3555,74 +3565,64 @@
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,RA.OA:10,FVC:5,OA:10,HL:2,PIR:5,MH:5,Periphery:4</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:2,MERC:3</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-C'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>CC:1,CGB.FRR:3,ROS:3,MERC:3,DC:3</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>CC:2-,FVC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>PR:8,HL:2,DoO:10,DO:10,FS:2,RA.OA:4,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:7,RFS:8,MOC:5,CC:2,DGM:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
-		<model name='F-11'>
-			<availability>CC:3,MOC:3,PR:8,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:1,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='F-13'>
+			<availability>CC:2,DoO:4,DO:4,DGM:4,FS:3,MERC:4,DTA:4,SC:4,MCM:4,ROS:4,FWL:4,MSC:4,TP:4</availability>
 		</model>
-		<model name='F-14-S'>
-			<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:3,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:3,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
-		<model name='OF-17A-R'>
-			<roles>recon</roles>
-			<availability>SC:5,MCM:5,ROS:4,DGM:5,MSC:5</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:3-,PR:2-,DoO:2-,Periphery.Deep:8,DO:2-,DGM:2-,MERC:3-,Periphery:3-,DTA:2-,SC:2-,MCM:2-,PG:2-,FWL:3-,MSC:2-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
+		<model name='F-12-S'>
+			<availability>FWL:1-</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,PR:2,DoO:2,DO:2,DGM:2,MERC:2,Periphery:1,DTA:2,SC:2,FVC:1,MCM:2,PG:2,FWL:2,MSC:2,TP:2,DA:2,RCM:2,RFS:2</availability>
 		</model>
-		<model name='F-13'>
-			<availability>CC:2,DoO:4,DO:4,DGM:4,FS:3,MERC:4,DTA:4,SC:4,MCM:4,ROS:4,FWL:4,MSC:4,TP:4</availability>
-		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2-,FVC:2,FWL:2-,MERC:2-,Periphery:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:1-</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:3-,PR:2-,DoO:2-,Periphery.Deep:8,DO:2-,DGM:2-,MERC:3-,Periphery:3-,DTA:2-,SC:2-,MCM:2-,PG:2-,FWL:3-,MSC:2-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:3,MOC:3,PR:8,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:1,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
+		<model name='OF-17A-R'>
+			<roles>recon</roles>
+			<availability>SC:5,MCM:5,ROS:4,DGM:5,MSC:5</availability>
+		</model>
+		<model name='F-14-S'>
+			<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:3,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:3,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>DTA:2,CDS:3,LA:2,ROS:5,CNC:3,NIOPS:5,FS:2,RCM:2,DC:3</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>ROS:2</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>ROS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:4,CDS:3,LA:4,ROS:3,FS:4,RCM:4,DC:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>ROS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3642,23 +3642,23 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,RA.OA:2,FVC:5,OA:2,LA:8,CGB.FRR:2,ROS:5,CGB:3</availability>
-		<model name='CHP-W7T'>
-			<availability>TC:8</availability>
-		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,CGB.FRR:6,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>FVC:3,CDP:3,TC:3</availability>
 		</model>
-		<model name='CHP-W8'>
-			<availability>LA:7</availability>
-		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
+		<model name='CHP-W7T'>
+			<availability>TC:8</availability>
+		</model>
+		<model name='CHP-W8'>
+			<availability>LA:7</availability>
+		</model>
+		<model name='CHP-W7'>
+			<availability>LA:8,CGB.FRR:6,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
@@ -3672,13 +3672,6 @@
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:3,SC:5,MCM:5,PG:5,FWL:5,DGM:5,MSC:5,MERC:2,CDP:3,RFS:5,Periphery:3,DC:2</availability>
-		<model name='CDA-3P'>
-			<availability>SC:6,PR:6,MCM:6,PG:6,FWL:7,DGM:6,MSC:6,RFS:6</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:3,MOC:3,FWL:3,MERC:3</availability>
-		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
 			<availability>CC:6,CGB.FRR:6,FWL:5,MERC:6,DC:6</availability>
@@ -3687,9 +3680,16 @@
 			<roles>recon</roles>
 			<availability>FWL:8,IS:6,MERC:6,Periphery:3</availability>
 		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:3,MOC:3,FWL:3,MERC:3</availability>
+		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:4,IS:4</availability>
+		</model>
+		<model name='CDA-3P'>
+			<availability>SC:6,PR:6,MCM:6,PG:6,FWL:7,DGM:6,MSC:6,RFS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Anti-Infantry' unitType='Infantry'>
@@ -3713,20 +3713,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -3746,14 +3746,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -3761,29 +3758,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -3794,8 +3794,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -3803,18 +3806,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -3823,15 +3832,6 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -3852,14 +3852,14 @@
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -3867,8 +3867,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -3880,13 +3880,13 @@
 	</chassis>
 	<chassis name='Claymore' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='Interceptor'>
-			<roles>assault</roles>
-			<availability>LA:1</availability>
-		</model>
 		<model name='V3'>
 			<roles>assault</roles>
 			<availability>LA:3,FS:3</availability>
+		</model>
+		<model name='Interceptor'>
+			<roles>assault</roles>
+			<availability>LA:1</availability>
 		</model>
 		<model name='(3054)'>
 			<roles>assault</roles>
@@ -3904,50 +3904,50 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,PR:3,HL:1,FS:3,MERC:2,CDP:2,TC:2,Periphery:3,FVC:2,LA:3,PG:3,ROS:3,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3</availability>
-		<model name='CLNT-2-3UL'>
-			<availability>CC:8,MOC:4,TC:7</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:5,Periphery.HR:5,Periphery.CM:5,MH:5,CDP:5,TC:8,Periphery:3</availability>
-		</model>
-		<model name='CLNT-5U'>
-			<roles>spotter</roles>
-			<availability>LA:8,General:5,MERC:8</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>Periphery.Deep:8,NIOPS:8</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:5,LA:2,General:6</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
 		</model>
+		<model name='CLNT-5U'>
+			<roles>spotter</roles>
+			<availability>LA:8,General:5,MERC:8</availability>
+		</model>
+		<model name='CLNT-2-3UL'>
+			<availability>CC:8,MOC:4,TC:7</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:5,Periphery.HR:5,Periphery.CM:5,MH:5,CDP:5,TC:8,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>MOC:3,IS:3</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>LA:4,ROS:4,NIOPS:4,FS:4,DC:4</availability>
+			<availability>MOC:2,IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>MOC:2,IS:2</availability>
+			<availability>LA:4,ROS:4,NIOPS:4,FS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra' unitType='Mek'>
 		<availability>LA:6,CGB.FRR:4,ROS:3,MH:3,MERC:3</availability>
-		<model name='CBR-03'>
-			<roles>fire_support</roles>
-			<availability>LA:5,General:4</availability>
-		</model>
 		<model name='CBR-02'>
 			<roles>fire_support</roles>
 			<availability>IS:5</availability>
+		</model>
+		<model name='CBR-03'>
+			<roles>fire_support</roles>
+			<availability>LA:5,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
@@ -3972,68 +3972,68 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,MERC:5,FS:2,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
-		<model name='COM-1A'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>FVC:2-,LA:2-,Periphery:2-</availability>
+			<availability>MOC:4,FVC:3,LA:8,CGB.FRR:6,MH:4,FS:2,MERC:5,CDP:4,TC:4</availability>
 		</model>
-		<model name='COM-7B'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>LA:3,ROS:8</availability>
+			<availability>MOC:5,FVC:5,PIR:8,MH:10,CDP:5,TC:3,Periphery:2</availability>
 		</model>
 		<model name='COM-2Dr'>
 			<roles>recon</roles>
 			<availability>HL:3,LA:5,MERC:5,Periphery:5</availability>
 		</model>
-		<model name='COM-7S'>
+		<model name='COM-7B'>
 			<roles>recon</roles>
-			<availability>LA:7,MERC:6</availability>
+			<availability>LA:3,ROS:8</availability>
 		</model>
-		<model name='COM-5S'>
+		<model name='COM-1A'>
 			<roles>recon</roles>
-			<availability>MOC:4,FVC:3,LA:8,CGB.FRR:6,MH:4,FS:2,MERC:5,CDP:4,TC:4</availability>
+			<availability>FVC:2-,LA:2-,Periphery:2-</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
 			<availability>LA:2-,MERC:1-,Periphery:2</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>MOC:5,FVC:5,PIR:8,MH:10,CDP:5,TC:3,Periphery:2</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>General:3-,Periphery.Deep:8,TC:3-,Periphery:3-</availability>
 		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:7,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:4,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:5-</availability>
-		</model>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:8,FWL:6,MERC:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:1,LA:1,FS:1</availability>
+		<model name='(Standard)'>
+			<availability>CC:4-,FVC:3-,General:2-,FS:4-,Periphery:3-</availability>
 		</model>
 		<model name='(Upgrade) (Laser)'>
 			<availability>LA:6,IS:7</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CC:4-,FVC:3-,General:2-,FS:4-,Periphery:3-</availability>
+		<model name='(Flamer)'>
+			<availability>CC:1,LA:1,FS:1</availability>
+		</model>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:8,FWL:6,MERC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:2,IS:2</availability>
 		</model>
+		<model name='(Liao)'>
+			<availability>CC:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Multi-Purpose Tank' unitType='Tank'>
 		<availability>ROS:3</availability>
-		<model name='(Reactive)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Reactive)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -4056,24 +4056,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CLAN:4,NIOPS:6,BAN:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CHH:1,MERC.WD:1,CSR:1,CW:1,NIOPS:2,CJF:2,RA:1</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -4095,17 +4095,17 @@
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corax' unitType='Aero'>
@@ -4122,17 +4122,17 @@
 		<model name='CRX-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='CRX-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='CRX-OR'>
-			<availability>RA.OA:3,OA:3,CLAN:8</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='CRX-OD'>
+			<availability>General:5</availability>
+		</model>
 		<model name='CRX-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='CRX-OR'>
+			<availability>RA.OA:3,OA:3,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
@@ -4146,8 +4146,17 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,RA.OA:3,OA:3,LA:4,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,TC:2,Periphery:2,DC:1</availability>
-		<model name='CSR-V18'>
-			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
+		</model>
+		<model name='CSR-X12 Rigid Night'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='CSR-12D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>ROS:4,CLAN:6,FS:4,MERC:2,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>FVC:1,FS.AH:1-,Periphery:1</availability>
@@ -4155,17 +4164,8 @@
 		<model name='CSR-V12'>
 			<availability>IS:3-,Periphery.Deep:8,BAN:4,Periphery:3-</availability>
 		</model>
-		<model name='CSR-X12 Rigid Night'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>ROS:4,CLAN:6,FS:4,MERC:2,BAN:2</availability>
-		</model>
-		<model name='CSR-12D'>
-			<availability>FS:5</availability>
+		<model name='CSR-V18'>
+			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -4189,50 +4189,50 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:1</availability>
-		<model name='XR'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='G'>
 			<availability>CHH:6,General:4</availability>
+		</model>
+		<model name='XR'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
 		<availability>CW:3,CJF:5,CWIE:3</availability>
-		<model name='H'>
-			<availability>CSA:6,General:5</availability>
-		</model>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>CW:3,CJF:3,CWIE:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<availability>CW:3,CJF:3,CWIE:3</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,General:5</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -4241,16 +4241,16 @@
 			<roles>raider</roles>
 			<availability>CGB.FRR:6,ROS:8,CLAN:4,FWL:5,MERC:5,BAN:2,DC:6</availability>
 		</model>
-		<model name='CRB-27'>
+		<model name='CRB-20'>
 			<roles>raider</roles>
-			<availability>DC.GHO:5-,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,BAN:8,DC:8</availability>
+			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='CRB-20'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>Periphery.Deep:8,NIOPS:0</availability>
+			<availability>DC.GHO:5-,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
@@ -4258,39 +4258,42 @@
 		<model name='(Standard)'>
 			<availability>SC:8,MCM:8,ROS:8,CLAN.IS:8,DGM:8,MSC:8,FS:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CC:8,CDS:4,CBS:8,CNC:4,MERC:8,DC:8</availability>
-		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CC:8,CDS:4,CBS:8,CNC:4,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CDS:4,CSR:2,CBS:6,RA:3</availability>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>CBS:8,General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:6,CSR:4,CLAN:5,RA:4,CWIE:6,DC.GHO:2,CDS:4,CW:6,CBS:6,CGB.FRR:6,ROS:4,NIOPS:9,CJF:4,CGB:6</availability>
-		<model name='CRK-5003-3'>
-			<availability>CGB.FRR:4,ROS:8</availability>
+		<model name='CRK-5004-1'>
+			<availability>CGB.FRR:4,ROS:6</availability>
+		</model>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='CRK-5005-1'>
 			<availability>ROS:8</availability>
@@ -4301,20 +4304,17 @@
 		<model name='CRK-5003-1'>
 			<availability>ROS:4,CLAN:6,NIOPS:4,BAN:8</availability>
 		</model>
-		<model name='CRK-5004-1'>
-			<availability>CGB.FRR:4,ROS:6</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='CRK-5003-3'>
+			<availability>CGB.FRR:4,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
 		<availability>HL:3,Periphery.MW:4,ROS:2,Periphery.ME:4,FWL:4,MERC:4,Periphery:4</availability>
-		<model name='CNS-5M'>
-			<availability>PIR:4,IS:8</availability>
-		</model>
 		<model name='CNS-3M'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CNS-5M'>
+			<availability>PIR:4,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
@@ -4325,28 +4325,28 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CSR:3,CDS:3,CW:3,CBS:5,CLAN:2,CNC:3,CCO:4,CJF:3,RA:4,CWIE:3,CGB:3</availability>
-		<model name='D'>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
 			<availability>General:4</availability>
 		</model>
 		<model name='U'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
-		<model name='C'>
+		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
+		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4356,97 +4356,97 @@
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>MOC:4,IS:4,DC:8</availability>
 		</model>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>HL:4,CLAN:5,IS:6,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='CRD-4D'>
-			<availability>FVC:8,FS:8</availability>
-		</model>
-		<model name='CRD-2R'>
-			<availability>FVC:3,ROS:5,CLAN:4,FWL:5,IS:3,MERC:5,BAN:2</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>ROS:5,MERC:5</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>CGB.FRR:5,MERC:6,DC:7</availability>
-		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:5,MERC:5</availability>
+		<model name='CRD-8S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='CRD-7L'>
 			<availability>CC:7</availability>
 		</model>
-		<model name='CRD-5S'>
-			<availability>LA:5,MERC:4</availability>
-		</model>
 		<model name='CRD-3R'>
 			<availability>General:2-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>DTA:5,SC:5,MCM:5,ROS:4,Periphery.MW:3,Periphery.ME:3,MH:3,DGM:5,MSC:5,MERC:3,RCM:5</availability>
-		</model>
-		<model name='CRD-8S'>
-			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='CRD-5M'>
 			<availability>CC:3,MOC:3,FWL:8,FS:3,MERC:4,CDP:3,DC:3,TC:3</availability>
 		</model>
+		<model name='CRD-7W'>
+			<availability>DTA:5,SC:5,MCM:5,ROS:4,Periphery.MW:3,Periphery.ME:3,MH:3,DGM:5,MSC:5,MERC:3,RCM:5</availability>
+		</model>
 		<model name='CRD-4K'>
 			<availability>CGB.FRR:6,DC:5</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>ROS:5,MERC:5</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:5,MERC:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:3,MOC:3</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>CGB.FRR:5,MERC:6,DC:7</availability>
 		</model>
 		<model name='CRD-8L'>
 			<availability>CC:4</availability>
 		</model>
+		<model name='CRD-2R'>
+			<availability>FVC:3,ROS:5,CLAN:4,FWL:5,IS:3,MERC:5,BAN:2</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:5,MERC:5</availability>
+		</model>
+		<model name='CRD-4D'>
+			<availability>FVC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:4,MOC:4,IS:3,FS:4,Periphery:2,TC:2,RA.OA:2,OA:2,LA:4,CGB.FRR:5,ROS:3,FWL:3,NIOPS:3,DC:5</availability>
+		<model name='CP-11-G'>
+			<availability>MOC:3,CGB.FRR:8,IS:3,MERC:4,CDP:3,TC:3</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:7,DC:7</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>MOC:4,CC:5,LA:5,FWL:6,IS:5,MH:3,FS:6,CDP:4,DC:2,TC:4,Periphery:1</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>General:3-</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
+		</model>
+		<model name='CP-11-B'>
+			<availability>CC:5,MOC:4,IS:3+,MERC:5,DC:5</availability>
+		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
 			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,DC:5</availability>
 		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-11-H'>
 			<availability>FVC:5,HL:3,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:5</availability>
-		</model>
-		<model name='CP-10-Z'>
-			<availability>General:3-</availability>
 		</model>
 		<model name='CP-11-C3'>
 			<roles>spotter</roles>
 			<availability>FS:2,DC:2</availability>
 		</model>
-		<model name='CP-11-A'>
-			<availability>MOC:4,CC:5,LA:5,FWL:6,IS:5,MH:3,FS:6,CDP:4,DC:2,TC:4,Periphery:1</availability>
-		</model>
-		<model name='CP-11-G'>
-			<availability>MOC:3,CGB.FRR:8,IS:3,MERC:4,CDP:3,TC:3</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:1</availability>
 		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:7,DC:7</availability>
-		</model>
-		<model name='CP-11-B'>
-			<availability>CC:5,MOC:4,IS:3+,MERC:5,DC:5</availability>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
@@ -4467,6 +4467,10 @@
 			<roles>recon,escort</roles>
 			<availability>CC:4,HL:2,MERC:4,TC:2,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,escort</roles>
+			<availability>CC:4,HL:1,ROS:2,General:4,NIOPS:4,MERC:2,Periphery:2</availability>
+		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -4475,22 +4479,18 @@
 			<roles>recon,escort</roles>
 			<availability>MOC:3,CDP:3,TC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon,escort</roles>
-			<availability>CC:4,HL:1,ROS:2,General:4,NIOPS:4,MERC:2,Periphery:2</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:6,IS:4</availability>
 		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dagger' unitType='Aero'>
@@ -4501,18 +4501,18 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='DARO-1'>
-			<availability>General:6,FS:8</availability>
-		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='DARO-1C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1'>
+			<availability>General:6,FS:8</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1A'>
 			<availability>General:7</availability>
@@ -4520,12 +4520,12 @@
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01r'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DAI-01'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DAI-01r'>
+			<availability>General:4</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
@@ -4538,13 +4538,13 @@
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
 		<availability>CGB.FRR:3+,DC:3+,CGB:2</availability>
-		<model name='67-K'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='67-K2'>
 			<roles>support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='67-K'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
@@ -4552,49 +4552,49 @@
 		<model name='DMO-4K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='DMO-5K'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
+		<model name='DMO-2K'>
+			<availability>CGB.FRR:4,DC:6</availability>
 		</model>
 		<model name='DMO-1K'>
 			<availability>General:8,DC:4</availability>
 		</model>
-		<model name='DMO-2K'>
-			<availability>CGB.FRR:4,DC:6</availability>
+		<model name='DMO-5K'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,CBS:4,ROS:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4,CCO:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4617,11 +4617,11 @@
 			<roles>marine</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_aircraft</roles>
@@ -4630,24 +4630,21 @@
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>LA:5,ROS:4,MH:3,FS:6,MERC:4</availability>
-		<model name='DRT-3S'>
-			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='DRT-4S'>
-			<availability>LA:3,MH:3,FS:4,MERC:4</availability>
-		</model>
 		<model name='DRT-6T'>
 			<availability>LA:5,ROS:8,FS:5,MERC:5</availability>
+		</model>
+		<model name='DRT-3S'>
+			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:3</availability>
 		</model>
+		<model name='DRT-4S'>
+			<availability>LA:3,MH:3,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:3,ROS:2,FS:7,CDP:3</availability>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:1,CDP:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5,CDP:3</availability>
@@ -4655,6 +4652,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5,CDP:3</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -4664,13 +4665,18 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:1,CDP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:1,CHH:4,CCC:2,MERC.WD:3,CDS:2,CLAN:2,IS:3+,CCO:1,CJF:3,BAN:3,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CDS:5,CBS:4,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -4678,27 +4684,21 @@
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
 		</model>
+		<model name='K'>
+			<availability>General:2,CGB:4</availability>
+		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CDS:5,CBS:4,General:4,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
-		</model>
-		<model name='K'>
-			<availability>General:2,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
@@ -4721,19 +4721,19 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:4,MOC:4,SC:3,MCM:3,DGM:3,MSC:2</availability>
-		<model name='DFC-OD'>
-			<roles>ground_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='DFC-OB'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='DFC-OD'>
+			<roles>ground_support</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OB'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -4744,11 +4744,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:5,MERC:4</availability>
-		<model name='DFN-3T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='DFN-3S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='DFN-3T'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Deimos' unitType='Mek'>
@@ -4772,24 +4772,24 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,OA:9,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,MOC:4,HL:1,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:1,Periphery:1</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:2,IS:3,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:8,MOC:7,LA:8,CGB.FRR:6,ROS:8,FWL:8,IS:7,FS:8,DC:8,TC:7,CWIE:4</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>FVC:4,HL:1,DC:7,Periphery:4</availability>
+		<model name='(Defensive)'>
+			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
 		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:2,IS:3,Periphery.Deep:6,Periphery:4</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,MOC:4,HL:1,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>FVC:4,HL:1,DC:7,Periphery:4</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -4798,15 +4798,15 @@
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
 		<availability>LA:6,ROS:3,MERC:3,CWIE:4</availability>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MML)'>
 			<availability>LA:4,ROS:4,CWIE:4</availability>
 		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:3,CWIE:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -4822,13 +4822,13 @@
 	</chassis>
 	<chassis name='Demon Medium Tank' unitType='Tank'>
 		<availability>ROS:5-</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
@@ -4842,23 +4842,23 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:1,CC:1,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,TC:3,RA.OA:1,FVC:5,OA:1,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
-		<model name='DV-1S'>
-			<availability>IS:2-</availability>
-		</model>
 		<model name='DV-8D'>
 			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
 		</model>
-		<model name='DV-6Mr'>
-			<availability>General:2</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:5,LA:5,FS:5,MERC:4,CDP:4,TC:4</availability>
+		<model name='DV-6M'>
+			<availability>CLAN:4,IS:2-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>ROS:5,FS:6,MERC:3</availability>
 		</model>
-		<model name='DV-6M'>
-			<availability>CLAN:4,IS:2-,Periphery.Deep:8,Periphery:4-</availability>
+		<model name='DV-7D'>
+			<availability>FVC:5,LA:5,FS:5,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='DV-6Mr'>
+			<availability>General:2</availability>
+		</model>
+		<model name='DV-1S'>
+			<availability>IS:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -4869,14 +4869,14 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:3,FVC:6,LA:6,ROS:4,FS:6,MERC:3,TC:4</availability>
-		<model name='DVS-1D'>
-			<availability>FVC:8,TC:8</availability>
+		<model name='DVS-3'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='DVS-3'>
-			<availability>LA:4,ROS:4,FS:4</availability>
+		<model name='DVS-1D'>
+			<availability>FVC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -4887,6 +4887,9 @@
 	</chassis>
 	<chassis name='Diomede' unitType='Mek'>
 		<availability>CC:4,MOC:4,LA:4,ROS:4,FWL:4,IS:3,MH:4,MERC:4,Periphery:3</availability>
+		<model name='D-M3D-M'>
+			<availability>General:4</availability>
+		</model>
 		<model name='D-M3D-3 ConstructionMech'>
 			<roles>support</roles>
 			<availability>CC:4,MOC:4,LA:4,ROS:4,FWL:4,MH:4,MERC:4</availability>
@@ -4894,9 +4897,6 @@
 		<model name='D-M3D-4 DemolitionMech'>
 			<roles>support</roles>
 			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,MH:8,MERC:8</availability>
-		</model>
-		<model name='D-M3D-M'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Djinn Battle Armor' unitType='BattleArmor'>
@@ -4923,9 +4923,6 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:6,CGB:4</availability>
@@ -4933,6 +4930,9 @@
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CSL:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragon Fire' unitType='Mek'>
@@ -4946,17 +4946,17 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,CGB.FRR:6,MERC:3,DC:4</availability>
-		<model name='DRG-5N'>
-			<availability>HL:2,CGB.FRR:4,MERC:4,DC:4,Periphery:4</availability>
-		</model>
 		<model name='DRG-7N'>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='DRG-5Nr'>
-			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='DRG-5N'>
+			<availability>HL:2,CGB.FRR:4,MERC:4,DC:4,Periphery:4</availability>
+		</model>
+		<model name='DRG-5Nr'>
+			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
@@ -4965,18 +4965,14 @@
 			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:7,CHH:7,CCC:7,CDS:8,CSR:4,CBS:7,General:6,CJF:8,RA:7,CWIE:7,CGB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>General:2,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
@@ -4984,16 +4980,20 @@
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:2</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
 		</model>
-		<model name='I'>
-			<availability>General:2</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>General:2,CGB:5</availability>
 		</model>
-		<model name='U'>
+		<model name='D'>
+			<availability>CSA:7,CHH:7,CCC:7,CDS:8,CSR:4,CBS:7,General:6,CJF:8,RA:7,CWIE:7,CGB:7</availability>
+		</model>
+		<model name='I'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5006,17 +5006,17 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2-,HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:3-,Periphery:2-,FVC:4-,LA:6,ROS:3,FWL:2-,CC.MAC:3-,DC:2-</availability>
-		<model name='(SRM)'>
-			<availability>CC:3-,General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:2-,General:3-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>LA:8,FS:7</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:3,ROS:3,FS:3</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CC:3-,General:1</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:8,FS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5037,54 +5037,54 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
-		<model name='EGL-R6'>
-			<availability>General:4-</availability>
-		</model>
 		<model name='EGL-R6b'>
 			<availability>SC:5,DoO:5,MCM:5,DO:5,DGM:5,MSC:5,TP:5,RCM:5</availability>
 		</model>
 		<model name='EGL-R11'>
 			<availability>PR:6,LA:5,ROS:6,PG:6,MERC:5,FS:3,RFS:6</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>General:4-</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,PR:6,DGM:7,MERC:4,DTA:6,SC:7,MCM:7,PG:6,FWL:6,MH:4,MSC:5,DA:5,RFS:6</availability>
-		<model name='EGL-3M'>
-			<availability>DTA:4,SC:4,MCM:4,FWL:4,DGM:4,MSC:4</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
-		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
+		</model>
+		<model name='EGL-3M'>
+			<availability>DTA:4,SC:4,MCM:4,FWL:4,DGM:4,MSC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Ebony' unitType='Mek'>
 		<availability>MOC:4,CC:3</availability>
-		<model name='MEB-11'>
+		<model name='MEB-10'>
 			<roles>recon</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='MEB-9'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='MEB-10'>
+		<model name='MEB-11'>
 			<roles>recon</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:5,ROS:3,MERC:4,Periphery:2-</availability>
+		<model name='EFT-7X'>
+			<availability>IS:8,MH:5</availability>
+		</model>
 		<model name='EFT-4J'>
 			<availability>LA:1-,MERC:2-,Periphery:8</availability>
 		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
-		</model>
-		<model name='EFT-7X'>
-			<availability>IS:8,MH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5095,78 +5095,78 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:4,ROS:3,MERC:3</availability>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
+		<model name='EST-OD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='EST-OD'>
-			<availability>General:4</availability>
+		<model name='EST-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Eldingar Hover Sled' unitType='Tank'>
 		<availability>CGB.FRR:4,CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>CGB.FRR:8,CGB:8</availability>
+		</model>
 		<model name='(Streak)'>
 			<roles>fire_support</roles>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CGB.FRR:8,CGB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,MERC.WD:5,CW:5,CLAN:5,CNC:5+</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:2,CLAN:2,RA:3</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [AP Gauss]' mechanized='true'>
 			<availability>CHH:1,CW:1,CJF:4</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='(Fire) [MicroPL]' mechanized='true'>
-			<availability>CHH:1,CW:1,CJF:4</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='[MicroPL]' mechanized='true'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CSR:2,CLAN:2,RA:3</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Space) [MicroPL]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CSR:2,CLAN:2,RA:4</availability>
 		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:2,CLAN:2,RA:3</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Fire) [Flamer]' mechanized='true'>
 			<availability>CHH:1,CW:1,CJF:4</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CSR:2,CLAN:2,RA:3</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [MicroPL]' mechanized='true'>
+			<availability>CHH:1,CW:1,CJF:4</availability>
+		</model>
+		<model name='[MicroPL]' mechanized='true'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5180,20 +5180,20 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:2,TC:4,LA:4,CNC:5,FWL:4,NIOPS:7,MH:2,DC:4</availability>
-		<model name='EMP-6D'>
-			<availability>ROS:8,FS:8</availability>
-		</model>
 		<model name='EMP-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='EMP-6S'>
-			<availability>LA:8</availability>
+		<model name='EMP-7L'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='EMP-7L'>
-			<availability>CC:6</availability>
+		<model name='EMP-6S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='EMP-6D'>
+			<availability>ROS:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
@@ -5202,6 +5202,10 @@
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4,FS:4</availability>
 		</model>
+		<model name='END-6Q'>
+			<roles>urban</roles>
+			<availability>LA:5,MERC:5</availability>
+		</model>
 		<model name='END-6S'>
 			<roles>urban</roles>
 			<availability>LA:2,MERC:2</availability>
@@ -5209,21 +5213,17 @@
 		<model name='END-6Sr'>
 			<availability>LA:3,ROS:8,MERC:3</availability>
 		</model>
-		<model name='END-6Q'>
-			<roles>urban</roles>
-			<availability>LA:5,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:6,ROS:3,FS:7,MERC:5</availability>
-		<model name='ENF-6Ma'>
-			<availability>FVC:3,FS:3,MERC:2</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-6Ma'>
+			<availability>FVC:3,FS:3,MERC:2</availability>
 		</model>
 		<model name='ENF-6T'>
 			<availability>FS:4</availability>
@@ -5234,17 +5234,17 @@
 		<model name='ENF-7C3BS'>
 			<availability>FS:1</availability>
 		</model>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>FVC:6,MH:2,FS:6,MERC:3,CDP:2,TC:2</availability>
-		<model name='ENF-4R'>
-			<availability>FVC:3-,General:2-,FS:3-,TC:3-</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>FVC:8,FS:8,MERC:6,CDP:5,TC:5</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>FVC:3-,General:2-,FS:3-,TC:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -5276,14 +5276,6 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CDS:4+,CW:4+,CNC:3+,CSL:6+,CGB:3+,CWIE:4+</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>CHH:8</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
@@ -5292,38 +5284,46 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>CHH:8</availability>
+		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CDS:2,CSR:1,ROS:1,CCO:1,RA:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8,DC:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,IS:5,FS:2,Periphery:2,TC:3,RA.OA:2,OA:2,LA:5,CGB.FRR:6,FWL:5,NIOPS:5,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:3,FS:6</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>FS:4,MERC:2</availability>
-		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -5350,45 +5350,42 @@
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
 		<availability>MOC:8,CC:4</availability>
-		<model name='EYL-45A'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='EYL-45B'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='EYL-45A'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6,MERC:2</availability>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CC:5</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='(Support) [King David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
 		<availability>LA:4,ROS:1,MERC:1</availability>
-		<model name='FNR-5X'>
-			<availability>ROS:2,General:2</availability>
-		</model>
 		<model name='FNR-5B'>
 			<availability>LA:4</availability>
 		</model>
@@ -5396,18 +5393,21 @@
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='FNR-5X'>
+			<availability>ROS:2,General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Falcon Hawk' unitType='Mek'>
 		<availability>MOC:3,ROS:6,FWL:7,IS:4,MERC:5,CDP:3,TC:3</availability>
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>SC:6,MCM:6,ROS:5,DGM:6,MSC:6</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5418,10 +5418,10 @@
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-8R'>
+		<model name='FLC-9R'>
 			<availability>General:5</availability>
 		</model>
-		<model name='FLC-9R'>
+		<model name='FLC-8R'>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
@@ -5434,35 +5434,29 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:2</availability>
-		<model name='(Upgrade)'>
-			<roles>cruiser</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>cruiser</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Upgrade)'>
+			<roles>cruiser</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Fennec' unitType='Mek'>
 		<availability>FS:2</availability>
-		<model name='FEC-3C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='FEC-1CM'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='FEC-3C'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SRM]' mechanized='false'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[SL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='&apos;Longshot&apos;' mechanized='false'>
 			<availability>General:4</availability>
@@ -5470,66 +5464,72 @@
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[SRM]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:5,MERC.KH:3+,CHH:2,CW:5,CJF:3,CWIE:5,CGB:2</availability>
-		<model name='B'>
-			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:3,CNC:5,General:4,CWIE:3</availability>
-		</model>
-		<model name='H'>
-			<availability>MERC.KH:3,MERC.WD:3,General:2,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
 		</model>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		<model name='A'>
+			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CBS:3,CLAN:4,General:2,CCO:5,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:3,MERC.WD:3,General:2,CWIE:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:3,CNC:5,General:4,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fensalir Combat WiGE' unitType='Tank'>
 		<availability>MERC.KH:2,LA:3,CWIE:3</availability>
+		<model name='(Infantry)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(HAG)'>
 			<availability>MERC.KH:8,General:2,CWIE:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>LA:8,General:4</availability>
 		</model>
-		<model name='(Infantry)'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:3,HL:4,LA:4,ROS:3,Periphery.HR:3,Periphery.MW:3,Periphery.CM:3,FWL:3,FS:5</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='&apos;Fermi&apos;'>
+			<roles>apc</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
@@ -5539,9 +5539,9 @@
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:4</availability>
 		</model>
-		<model name='&apos;Fermi&apos;'>
-			<roles>apc</roles>
-			<availability>FS:4</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -5568,63 +5568,15 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(LBX20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(UAC20)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
-		</model>
 		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -5632,9 +5584,57 @@
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(LBX2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LBX10)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
@@ -5643,55 +5643,55 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CNC:3,CJF:7,CLAN.HW:5</availability>
-		<model name='Prime'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CSA:7,CLAN:6,IS:3</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CSA:7,CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:3,CCO:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:6,MERC:6,FS:6</availability>
-		</model>
 		<model name='ALM-10D'>
 			<availability>LA:4,ROS:5,FS:4,MERC:4</availability>
 		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -5716,26 +5716,26 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>HL:6,LA:6,IS:5,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:2,MOC:3,LA:5,CGB.FRR:3,General:3,FS:3,TC:2</availability>
+		<model name='FS9-S2'>
+			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
 		</model>
-		<model name='FS9-S2'>
-			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='FS9-P'>
 			<availability>FVC:4,HL:1,Periphery:4</availability>
 		</model>
 		<model name='FS9-S3'>
 			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:2,MOC:3,LA:5,CGB.FRR:3,General:3,FS:3,TC:2</availability>
 		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
@@ -5744,61 +5744,61 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CC:4,FVC:4,LA:5,IS:3,FS:4,MERC:4,DC:7</availability>
-		<model name='FS9-OE'>
+		<model name='FS9-OD'>
 			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OX'>
-			<availability>General:2</availability>
 		</model>
 		<model name='FS9-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='FS9-OH'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='FS9-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OG'>
-			<availability>General:6</availability>
-		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='FS9-OA'>
+		<model name='FS9-OE'>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OR'>
 			<availability>CLAN:4,IS:2+,DC:2+</availability>
 		</model>
+		<model name='FS9-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OG'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OX'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:4</availability>
-		<model name='C'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
@@ -5806,51 +5806,51 @@
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:1,CLAN:2,DGM:5,DC.GHO:5,SC:5,CDS:1,LA:4,CBS:1,MCM:5,CGB.FRR:4,ROS:3,FWL:4,NIOPS:5,MSC:4,CJF:3,CGB:1,DC:4</availability>
-		<model name='FLS-9M'>
-			<availability>SC:8,MCM:8,FWL:6,DGM:8,MSC:8</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,SC:6,LA:8,MCM:6,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,MERC.SI:5,MSC:6,BAN:8</availability>
+		</model>
+		<model name='FLS-9M'>
+			<availability>SC:8,MCM:8,FWL:6,DGM:8,MSC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,CLAN.IS:4,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,PR:3,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:3,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:1,DA:3,RCM:3,RFS:3</availability>
+		<model name='FLE-19'>
+			<roles>urban</roles>
+			<availability>MOC:4-,CC:4-,PR:4-,HL:4-,MERC:5-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,OA:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
+		</model>
 		<model name='FLE-20'>
 			<availability>CC:4,MOC:1</availability>
 		</model>
 		<model name='FLE-17'>
 			<availability>CC:7,PR:7,ROS:8,PG:7,FWL:6,MERC:6,RCM:7,DA:7,RFS:7,Periphery:6</availability>
-		</model>
-		<model name='FLE-19'>
-			<roles>urban</roles>
-			<availability>MOC:4-,CC:4-,PR:4-,HL:4-,MERC:5-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,OA:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -5861,20 +5861,18 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
@@ -5885,33 +5883,35 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
 		<availability>LA:4,NIOPS:4,FS:4,Periphery:1</availability>
-		<model name='(2613)'>
-			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3058)'>
 			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
 			<availability>LA:8,FS:8</availability>
 		</model>
+		<model name='(2613)'>
+			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fortune Wheeled Assault Vehicle' unitType='Tank'>
 		<availability>PR:3,LA:6,ROS:3,PG:3,RFS:3</availability>
-		<model name='(Thunderbolt)'>
-			<availability>PR:4,LA:4,PG:4,RFS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Thunderbolt)'>
+			<availability>PR:4,LA:4,PG:4,RFS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Armored Car' unitType='Tank'>
@@ -5919,13 +5919,13 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Interdictor)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(VSP)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Flamer)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Interdictor)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -5968,13 +5968,13 @@
 			<roles>spotter</roles>
 			<availability>LA:5,FS:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
@@ -5983,14 +5983,14 @@
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='CX-17'>
-			<availability>ROS:4</availability>
+		<model name='(Royal)'>
+			<availability>ROS:4,CLAN:4,BAN:2</availability>
 		</model>
 		<model name='(C3S)'>
 			<availability>ROS:5,FS:5</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>ROS:4,CLAN:4,BAN:2</availability>
+		<model name='CX-17'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -6010,21 +6010,17 @@
 	</chassis>
 	<chassis name='Fwltur' unitType='Mek'>
 		<availability>IS:4,MERC:3,Periphery:3</availability>
-		<model name='FWL-3R SalvageMech'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='FWL-3V SalvageMech'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='FWL-3R SalvageMech'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
 		<availability>CGB.FRR:2,NIOPS:3,TC:4</availability>
-		<model name='(TDF)'>
-			<roles>recon</roles>
-			<availability>TC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
@@ -6032,17 +6028,21 @@
 		<model name='(ERSL)'>
 			<availability>TC:4</availability>
 		</model>
+		<model name='(TDF)'>
+			<roles>recon</roles>
+			<availability>TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CSR:2,CW:3,ROS:1,RA:2</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CSA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CW:6,ROS:8,CCO:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6053,22 +6053,15 @@
 	</chassis>
 	<chassis name='Gallant' unitType='Mek'>
 		<availability>MOC:2,LA:4,ROS:4,CNC:2,IS:2,FS:4,MERC:3,CDP:2,CWIE:2,TC:2</availability>
-		<model name='GLT-8-0'>
-			<availability>ROS:3,FS:8,MERC:3</availability>
-		</model>
 		<model name='GLT-7-0'>
 			<availability>General:8,FS:4</availability>
+		</model>
+		<model name='GLT-8-0'>
+			<availability>ROS:3,FS:8,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:1,LA:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
-		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
-		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3</availability>
 		</model>
@@ -6076,30 +6069,40 @@
 			<roles>recon</roles>
 			<availability>MOC:5,RA.OA:3,OA:3,LA:5,CGB.FRR:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,Periphery:4</availability>
 		</model>
+		<model name='GAL-200'>
+			<availability>MOC:1,LA:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
+		</model>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>MERC.WD:6,ROS:5,MH:4,MERC:5,CWIE:4</availability>
-		<model name='GAL-2GLS'>
-			<availability>HL:2-,IS:4-,Periphery:4-</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
 		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2,ROS:1,MERC:1</availability>
 		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		<model name='GAL-2GLS'>
+			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8-,CWIE:8</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:5,FS:6,MERC:4,CDP:4,TC:4</availability>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A2'>
 			<availability>FS:4</availability>
 		</model>
@@ -6108,9 +6111,6 @@
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
-		</model>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Garuda Heavy VTOL' unitType='VTOL'>
@@ -6136,41 +6136,41 @@
 		<model name='GST-50'>
 			<availability>DTA:5,SC:5,DoO:5,MCM:5,DO:5,DGM:5,MSC:5,TP:5</availability>
 		</model>
-		<model name='GST-11'>
-			<availability>General:4</availability>
-		</model>
 		<model name='GST-10'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GST-11'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CDS:5,CSR:1,ROS:2+,CNC:5,CLAN:5,CJF:4,BAN:4,CGB:9</availability>
-		<model name='Prime'>
-			<availability>CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
-		</model>
-		<model name='P'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:3,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7,CGB:4</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:3,CCO:6,CGB:5</availability>
 		</model>
-		<model name='K'>
-			<availability>CHH:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		</model>
+		<model name='P'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:3,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator Battle Armor' unitType='BattleArmor'>
@@ -6181,31 +6181,31 @@
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
 		<availability>MOC:3-,FVC:2-,LA:2,MH:2,MERC:3,DA:1-,Periphery:3-,DC:2-,TC:3-</availability>
-		<model name='GLD-5R'>
-			<availability>LA:5,General:8,MH:5,MERC:7</availability>
-		</model>
 		<model name='GLD-1R'>
 			<availability>LA:2-,FWL:2-,MH:3-,MERC:2-,DA:4-,DC:2-,Periphery:3-</availability>
+		</model>
+		<model name='GLD-5R'>
+			<availability>LA:5,General:8,MH:5,MERC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladius Medium Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:4,Periphery.CM:3,Periphery.ME:3,MH:6,CDP:4,TC:5,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk II'>
 			<availability>MH:6,TC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Glaive Medium Tank' unitType='Tank'>
 		<availability>LA:4,ROS:2</availability>
-		<model name='(MFB)'>
-			<roles>support</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MFB)'>
+			<roles>support</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
@@ -6214,31 +6214,31 @@
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>FS:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>FS:8</availability>
 		</model>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>FS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6279,45 +6279,49 @@
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CGB:7</availability>
-		<model name='(Fast Assault)' mechanized='false'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Rock Golem)' mechanized='false'>
-			<availability>CHH:8</availability>
+		<model name='(Fast Assault)' mechanized='false'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
 			<roles>urban,anti_infantry</roles>
 			<availability>CGB:4</availability>
 		</model>
+		<model name='(Rock Golem)' mechanized='false'>
+			<availability>CHH:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:4,HL:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:2,FVC:2,OA:3,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-3L'>
+		<model name='GOL-4S'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4</availability>
+			<availability>LA:6</availability>
 		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:8,MOC:2,FWL:8,MH:2,MERC:6,CDP:4,TC:2</availability>
 		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GOL-6M'>
 			<roles>fire_support</roles>
 			<availability>ROS:4,FWL:4,MERC:3</availability>
+		</model>
+		<model name='GOL-3L'>
+			<roles>fire_support</roles>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
 		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>HL:1,Periphery.HR:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,MH:5,Periphery:4</availability>
 		</model>
-		<model name='GOL-4S'>
+		<model name='GOL-1H'>
 			<roles>fire_support</roles>
-			<availability>LA:6</availability>
+			<availability>CC:2-,LA:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='GOL-2H'>
 			<roles>fire_support</roles>
@@ -6327,10 +6331,6 @@
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
 		</model>
-		<model name='GOL-1H'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,LA:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CSA:7,CSR:3,CBS:4,CNC:4,CCO:4,RA:4</availability>
@@ -6338,33 +6338,42 @@
 			<roles>anti_infantry</roles>
 			<availability>CSA:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:5,CSR:3,CBS:5,CNC:5,RA:5</availability>
+		<model name='2'>
+			<availability>CSA:8,CCO:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,CSR:3,CBS:6,RA:6</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CCO:8</availability>
+		<model name='(Standard)'>
+			<availability>CSA:5,CSR:3,CBS:5,CNC:5,RA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>DoO:7,CLAN:3,DO:7,DGM:7,MERC:3,DTA:7,SC:7,CDS:4,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:5,TP:7</availability>
-		<model name='GTHA-600'>
-			<availability>DTA:7,SC:7,DoO:7,MCM:7,ROS:7,DO:7,DGM:7,MSC:7,TP:7</availability>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CDS:4,HL:3,ROS:6,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,MERC:5,BAN:2,Periphery:5</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
+		</model>
+		<model name='GTHA-600'>
+			<availability>DTA:7,SC:7,DoO:7,MCM:7,ROS:7,DO:7,DGM:7,MSC:7,TP:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>CGB.FRR:6,ROS:6,CNC:6,MERC:2,DC:8,CGB:3</availability>
+		<model name='DRG-1G'>
+			<availability>CGB.FRR:2-,DC:3-</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:5</availability>
+		</model>
+		<model name='DRG-5K'>
+			<availability>CGB.FRR:6,ROS:6,CNC:8,MERC:5,DC:4,CGB:8</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>ROS:4,DC:5</availability>
 		</model>
@@ -6372,56 +6381,47 @@
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:5</availability>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='DRG-7K'>
 			<availability>ROS:6,MERC:4,DC:4</availability>
 		</model>
-		<model name='DRG-1G'>
-			<availability>CGB.FRR:2-,DC:3-</availability>
-		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-5K'>
-			<availability>CGB.FRR:6,ROS:6,CNC:8,MERC:5,DC:4,CGB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>CC:5,MOC:5,PR:7,DoO:7,DO:7,DGM:7,FS:5,MERC:5,SC:7,DTA:7,FVC:5,MCM:7,ROS:6,Periphery.MW:4,PG:7,Periphery.ME:3,FWL:7,MH:4,MSC:5,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
-		<model name='T-IT-N10M'>
-			<availability>HL:3,ROS:5,FWL:5,MERC:5,Periphery:5</availability>
+		<model name='T-IT-N13M'>
+			<availability>PR:2,DoO:4,DO:4,DGM:4,MERC:2,DTA:4,SC:4,MCM:4,ROS:2,PG:2,MSC:4,TP:4,DA:2,RCM:2,RFS:2</availability>
 		</model>
 		<model name='T-IT-N11M'>
 			<availability>DTA:5,CC:5,MOC:5,SC:6,MCM:6,ROS:6,DGM:6,MSC:6,MERC:4,FS:5,DC:5</availability>
 		</model>
-		<model name='T-IT-N13M'>
-			<availability>PR:2,DoO:4,DO:4,DGM:4,MERC:2,DTA:4,SC:4,MCM:4,ROS:2,PG:2,MSC:4,TP:4,DA:2,RCM:2,RFS:2</availability>
+		<model name='T-IT-N10M'>
+			<availability>HL:3,ROS:5,FWL:5,MERC:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>MOC:6,OA:6,HL:5,IS:4,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:5,TC:6</availability>
-		<model name='GHR-5J'>
-			<availability>HL:1,IS:6,Periphery:4</availability>
-		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='GHR-5H'>
-			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='GHR-C'>
-			<availability>IS:3,DC:3</availability>
-		</model>
-		<model name='GHR-5N'>
-			<availability>General:1-</availability>
+		<model name='GHR-5J'>
+			<availability>HL:1,IS:6,Periphery:4</availability>
 		</model>
 		<model name='GHR-6K'>
 			<availability>CGB.FRR:4,ROS:4,MERC:2,FS:2,DC:4</availability>
 		</model>
+		<model name='GHR-5H'>
+			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
 		<model name='GHR-7P'>
 			<availability>LA:6,MERC:4</availability>
+		</model>
+		<model name='GHR-5N'>
+			<availability>General:1-</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Heavy Suit' unitType='BattleArmor'>
@@ -6445,14 +6445,14 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Strike Armor' unitType='BattleArmor'>
@@ -6465,20 +6465,26 @@
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
 		<availability>CSA:4,CCC:4,CHH:5,CCO:4,CGB:5</availability>
-		<model name='2'>
-			<availability>CHH:8,CGB:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:8,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:4</availability>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[MagShot]' mechanized='false'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:4</availability>
@@ -6486,12 +6492,6 @@
 		<model name='[TAG]' mechanized='false'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='[MagShot]' mechanized='false'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
@@ -6502,8 +6502,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
@@ -6514,23 +6520,26 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3,CCO:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:4</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:5,CDS:6,CW:3,LA:3,CNC:7,IS:3,CCO:6,CJF:3,CWIE:4,DC:4</availability>
+		<model name='4'>
+			<availability>CSA:6,CDS:6,CNC:8,IS:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:8,CNC:5,IS:8,CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>MERC.WD:8,CNC:3</availability>
+		</model>
 		<model name='6'>
 			<availability>ROS:4,CNC:6,DC:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CSA:6,CDS:6,CNC:8,IS:6</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CNC:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CNC:5</availability>
@@ -6541,109 +6550,96 @@
 		<model name='5'>
 			<availability>CDS:4,CNC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CNC:4</availability>
-		</model>
-		<model name='2'>
-			<availability>MERC.WD:8,CNC:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:8,CNC:5,IS:8,CCO:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,HL:3,IS:6,Periphery.Deep:6,MERC:7,TC:5,Periphery:4,RA.OA:1,OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-3M'>
-			<availability>MOC:2,PR:6,DoO:5,IS:5,DO:5,DGM:5,FS:4,DTA:5,SC:5,LA:5,MCM:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:6,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='GRF-4N'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='GRF-4R'>
-			<availability>CC:2,ROS:6,CGB.FRR:5,CNC:2,FWL:3,FS:3,DC:2,CGB:5</availability>
+		<model name='GRF-1S'>
+			<availability>LA:2-,MERC:2-</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CC:3,MOC:2,DoO:4,CLAN:6,DO:4,DGM:4,FS:3,MERC:4,BAN:4,SC:4,MCM:4,MH:3,MSC:4,TP:4,RCM:4,DC:3</availability>
 		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:5,DO:6,DGM:6,MSC:6,TP:6,MERC:5</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>General:3-,Periphery.Deep:8,BAN:2,Periphery:3-</availability>
-		</model>
 		<model name='GRF-1A'>
 			<availability>LA:2-,MERC:2-,TC:3-</availability>
 		</model>
-		<model name='GRF-1S'>
-			<availability>LA:2-,MERC:2-</availability>
+		<model name='GRF-5M'>
+			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:5,DO:6,DGM:6,MSC:6,TP:6,MERC:5</availability>
 		</model>
-		<model name='GRF-5K'>
-			<availability>CNC:6,DC:6</availability>
+		<model name='GRF-3M'>
+			<availability>MOC:2,PR:6,DoO:5,IS:5,DO:5,DGM:5,FS:4,DTA:5,SC:5,LA:5,MCM:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CC:2,ROS:6,CGB.FRR:5,CNC:2,FWL:3,FS:3,DC:2,CGB:5</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>FVC:5,LA:3,CGB.FRR:3,ROS:4,FS:5,MERC:3,DC:4</availability>
 		</model>
+		<model name='GRF-5K'>
+			<availability>CNC:6,DC:6</availability>
+		</model>
+		<model name='GRF-4N'>
+			<availability>TC:4</availability>
+		</model>
 		<model name='GRF-5L'>
 			<availability>CC:5</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>General:3-,Periphery.Deep:8,BAN:2,Periphery:3-</availability>
+		</model>
+		<model name='GRF-6S'>
+			<availability>LA:6,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>ROS:6,MERC:5,DC:5</availability>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>MERC:4</availability>
+		</model>
 		<model name='GRM-R-PR30'>
 			<availability>ROS:4,MERC:3</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>ROS:5,MERC:8,DC:8</availability>
 		</model>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
 		<availability>CSA:3,CCC:3,CHH:3,CSR:2,CBS:3,CLAN:2,CCO:3,RA:1,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>General:3</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:2,FVC:1,PR:3,ROS:3,PG:3,FWL:2,MERC:2,RCM:3,RFS:3,TC:2,Periphery:1</availability>
-		<model name='D'>
-			<availability>CC:3,MOC:3,MERC:2,RCM:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CC:1,FWL:1,Periphery:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5,MERC:2,RCM:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5,MERC:2,RCM:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CC:1,FWL:1,Periphery:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CC:3,MOC:3,MERC:2,RCM:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>MERC.KH:2,MERC.WD:2,CHH:2-,CW:4,LA:2,ROS:2,CNC:2-,CCO:4,CWIE:4</availability>
-		<model name='2'>
-			<availability>CW:4,IS:8,CCO:6,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>ROS:4,CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:4,IS:8,CCO:6,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,CHH:2,CSR:2,DGM:5,FS:5,MERC:3,RA:1,Periphery:2,DC.GHO:3,SC:5,MCM:5,ROS:6,FWL:5,NIOPS:7,MSC:5</availability>
-		<model name='GLT-3N'>
-			<roles>raider</roles>
-			<availability>ROS:6,CGB.FRR:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='GLT-6WB3'>
 			<roles>raider</roles>
 			<availability>SC:6,MCM:6,ROS:3,DGM:6,MSC:6,MERC:3</availability>
@@ -6660,13 +6656,13 @@
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:4,MERC:4</availability>
 		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>ROS:6,CGB.FRR:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
 		<availability>FVC:5,LA:8,CGB.FRR:5,IS:5,MH:2,FS:5,DC:7</availability>
-		<model name='GUN-2ERDr'>
-			<roles>spotter</roles>
-			<availability>FS:4,DC:4</availability>
-		</model>
 		<model name='GUN-2ERD'>
 			<roles>spotter</roles>
 			<availability>LA:6,General:3,FS:5,DC:5</availability>
@@ -6674,15 +6670,19 @@
 		<model name='GUN-1ERD'>
 			<availability>General:8</availability>
 		</model>
+		<model name='GUN-2ERDr'>
+			<roles>spotter</roles>
+			<availability>FS:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
 		<availability>LA:5+,ROS:4,FS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HALO Paratrooper' unitType='Infantry'>
@@ -6694,30 +6694,30 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,LA:4,CBS:3,CNC:5,IS:3,DC:4,CWIE:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>LA:4+,CLAN:5,IS:4+,DC:4+</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:3,CDS:3,LA:2+,ROS:4+,CNC:3,DC:2+</availability>
-		</model>
 		<model name='HKO-1C'>
 			<roles>fire_support</roles>
 			<availability>LA:6,DC:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:3,CDS:3,LA:2+,ROS:4+,CNC:3,DC:2+</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>LA:4+,CLAN:5,IS:4+,DC:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,RA.OA:3,CHH:7,OA:4,LA:1,CBS:6,ROS:2,CLAN:5,FS:1,MERC:1</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
-		</model>
 		<model name='(AAA)'>
 			<roles>fire_support</roles>
 			<availability>RA.OA:8,OA:7,CDS:4,CSR:3,RA:8,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hamilcar' unitType='Dropship'>
@@ -6751,8 +6751,8 @@
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>ROS:2,FS:4,MERC:3</availability>
-		<model name='HMH-6E'>
-			<availability>General:5,MERC:5</availability>
+		<model name='HMH-6D'>
+			<availability>ROS:6,General:6</availability>
 		</model>
 		<model name='HMH-3D'>
 			<availability>General:3-,MERC:3-</availability>
@@ -6760,17 +6760,17 @@
 		<model name='HMH-5D'>
 			<availability>General:2,MERC:4</availability>
 		</model>
-		<model name='HMH-6D'>
-			<availability>ROS:6,General:6</availability>
+		<model name='HMH-6E'>
+			<availability>General:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>ROS:6,CLAN:2,CNC:3,NIOPS:7</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>ROS:4,NIOPS:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:4</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>CSR:3,ROS:4,CLAN:4,RA:6,BAN:2</availability>
@@ -6778,30 +6778,30 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CDS:4,ROS:2+,CNC:5,CJF:4,CCO:3,CGB:3</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='E'>
-			<roles>anti_infantry</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>CSA:8,General:7</availability>
+		</model>
+		<model name='E'>
+			<roles>anti_infantry</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -6820,10 +6820,6 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>PR:5,HL:2-,DoO:5,Periphery.Deep:4,DO:5,SC:5,FWL.pm:5,CGB.FRR:4-,Periphery.CM:4-,Periphery.MW:4-,FWL:5,MH:4,MSC:4,RFS:5,MOC:4,CC:4,IS:3-,DGM:5,MERC:4,Periphery:2-,DTA:5,LA:3,MCM:5,PG:5,Periphery.ME:4-,TP:5,DA:5,RCM:5,DC:3-</availability>
-		<model name='(Standard)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>General:3-</availability>
-		</model>
 		<model name='(MML)'>
 			<availability>MOC:2,CC:2,PR:2,DoO:4,DO:4,DGM:4,MERC:2,DTA:2,SC:4,LA:2,MCM:4,PG:2,MSC:4,TP:4,RCM:2,DA:2,RFS:2</availability>
 		</model>
@@ -6831,11 +6827,18 @@
 			<deployedWith>Galleon</deployedWith>
 			<availability>FWL:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>General:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CSA:3,CHH:6,CBS:2,CSL:6</availability>
 		<model name='(Standard)'>
 			<availability>CSA:4,CHH:4,CBS:4,CSL:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:8,CBS:8,CSL:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6</availability>
@@ -6843,20 +6846,17 @@
 		<model name='4'>
 			<availability>CHH:6,CSL:6</availability>
 		</model>
-		<model name='2'>
-			<availability>CHH:8,CBS:8,CSL:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>CGB.FRR:3,ROS:5,MERC:2,DC:6</availability>
 		<model name='HTM-28T'>
 			<availability>ROS:4,DC:3</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>CGB.FRR:6,MERC:4,DC:5</availability>
-		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:6,DC:4</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>CGB.FRR:6,MERC:4,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -6898,33 +6898,33 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,Periphery:2,DTA:4,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,MSC:3,DC:4</availability>
-		<model name='HCT-5DD'>
-			<availability>ROS:6,FS:6,MERC:6,CDP:3</availability>
+		<model name='HCT-6S'>
+			<availability>LA:7,MERC:6</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>ROS:2,FS:1,MERC:1,CDP:2</availability>
 		</model>
-		<model name='HCT-6D'>
-			<availability>ROS:5,FS:4,MERC:6</availability>
-		</model>
 		<model name='HCT-6M'>
 			<availability>DTA:8,SC:8,MCM:8,ROS:2,FWL:8,DGM:8,MSC:8,MERC:2</availability>
-		</model>
-		<model name='HCT-7S'>
-			<availability>LA:6,ROS:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='HCT-5S'>
 			<availability>FVC:4,LA:4,CGB.FRR:4,FS:4,MERC:4,DC:2,Periphery:3</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>DC:8</availability>
+		<model name='HCT-5DD'>
+			<availability>ROS:6,FS:6,MERC:6,CDP:3</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:6,ROS:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:2-,LA:2-,TC.PL:3-,MERC:2-,Periphery:2-</availability>
 		</model>
-		<model name='HCT-6S'>
-			<availability>LA:7,MERC:6</availability>
+		<model name='HCT-6D'>
+			<availability>ROS:5,FS:4,MERC:6</availability>
+		</model>
+		<model name='HCT-5K'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
@@ -6942,24 +6942,24 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:6</availability>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OB'>
-			<availability>General:7</availability>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='HA1-OC'>
+		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OD'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OC'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
@@ -6996,25 +6996,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7061,8 +7061,8 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:4,CC:3,RA.OA:5,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
@@ -7070,14 +7070,14 @@
 		<model name='Meteor-U'>
 			<availability>ROS:2,FS:3,MERC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:4,CC:3,RA.OA:5,OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,TC:1</availability>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
 		</model>
 		<model name='Meteor-G'>
 			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7088,10 +7088,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7099,6 +7095,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7107,6 +7107,18 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(WoB)'>
+			<roles>apc,support</roles>
+			<availability>ROS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7115,21 +7127,13 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(WoB)'>
-			<roles>apc,support</roles>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:3,CSR:1,LA:2+,CNC:3,CSL:4,RA:2,CWIE:5</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -7137,35 +7141,31 @@
 		<model name='Prime'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
 		<availability>CC:3,MOC:3,IS:2,MERC:3</availability>
-		<model name='HEP-4H'>
-			<roles>artillery</roles>
-			<availability>General:8,MERC:8</availability>
-		</model>
 		<model name='HEP-1H'>
 			<roles>artillery</roles>
 			<availability>CC:2-,MOC:2-,MERC:2-</availability>
 		</model>
+		<model name='HEP-4H'>
+			<roles>artillery</roles>
+			<availability>General:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
 		<availability>CC:5,MOC:5,FS:3,MERC:3,DC:3,TC:5</availability>
-		<model name='HEL-3D'>
-			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		<model name='HEL-4A'>
+			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
 		<model name='HEL-C'>
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='HEL-4A'>
-			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
+		<model name='HEL-3D'>
+			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -7176,20 +7176,20 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,CSR:2,HL:2-,Periphery.Deep:1-,MERC:2-,CDP:4,RA:3,TC:2-,Periphery:3-,RA.OA:5,FVC:4,OA:5,LA:2-</availability>
-		<model name='HCT-213'>
-			<availability>General:3</availability>
-		</model>
 		<model name='HCT-313'>
 			<availability>RA.OA:8,FVC:7,OA:8,CSR:5,CDP:7,RA:8</availability>
+		</model>
+		<model name='HCT-213'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
 		<availability>CSA:5,CCC:4,CHH:3</availability>
-		<model name='(Standard)'>
-			<availability>CSA:8,CCC:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
@@ -7197,8 +7197,8 @@
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:1,CHH:3,CDS:2,ROS:1,DC.AL:1,CNC:6,CJF:3</availability>
-		<model name='2'>
-			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
+		<model name='5'>
+			<availability>ROS:5,CNC:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
@@ -7206,15 +7206,27 @@
 		<model name='4'>
 			<availability>CNC:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CHH:6,CJF:6</availability>
-		</model>
-		<model name='5'>
-			<availability>ROS:5,CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CDS:5,CBS:2,CNC:5,CSL:5,CCO:5,CJF:2</availability>
+		<model name='B'>
+			<availability>CSA:8,General:7,CJF:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:4,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:3,General:7,CJF:3</availability>
+		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -7223,58 +7235,58 @@
 			<roles>fire_support</roles>
 			<availability>CSA:3,General:6,CJF:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:8,General:7,CJF:3</availability>
-		</model>
 		<model name='F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:3,General:7,CJF:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:4,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>LA:3,ROS:3,FS:6,MERC:4</availability>
+		<model name='HSN-9F'>
+			<roles>fire_support</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='HSN-10SR'>
 			<roles>spotter</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
+		</model>
+		<model name='HSN-8E'>
+			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
 		<model name='HSN-7D'>
 			<roles>fire_support</roles>
 			<availability>FS:8,MERC:8</availability>
 		</model>
-		<model name='HSN-8E'>
-			<roles>fire_support</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-9F'>
-			<roles>fire_support</roles>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellstar' unitType='Mek'>
 		<availability>CC:1,CHH:5,MERC.WD:3,MERC.KH:3,LA:2,ROS:2,FS:1,CWIE:5,DC:2</availability>
+		<model name='2'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:4+,CSL:4+</availability>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>recon,apc,fire_support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -7282,18 +7294,6 @@
 		<model name='Prime'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon,apc,fire_support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -7318,13 +7318,13 @@
 			<roles>recon</roles>
 			<availability>ROS:3-,FWL:2-,MERC:3-</availability>
 		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>SC:4,DoO:4,MCM:4,FWL:4,DO:4,DGM:4,MSC:4,TP:4</availability>
+		</model>
 		<model name='HER-6D'>
 			<roles>recon</roles>
 			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-5Sr'>
-			<roles>recon</roles>
-			<availability>MOC:4,IS:4,MH:2</availability>
 		</model>
 		<model name='HER-5SA'>
 			<roles>training</roles>
@@ -7338,9 +7338,9 @@
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:4,FS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>SC:4,DoO:4,MCM:4,FWL:4,DO:4,DGM:4,MSC:4,TP:4</availability>
+			<availability>MOC:4,IS:4,MH:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
@@ -7349,36 +7349,36 @@
 			<roles>recon,spotter</roles>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='HER-4K'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>SC:6,DoO:6,MCM:6,DO:6,DGM:6,MSC:6,TP:6,MERC:4,DC:8</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:4</availability>
+			<availability>DC.GHO:3-,CLAN:6,NIOPS:4,BAN:8</availability>
 		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:5</availability>
 		</model>
-		<model name='HER-1S'>
+		<model name='HER-4K'>
 			<roles>recon</roles>
-			<availability>DC.GHO:3-,CLAN:6,NIOPS:4,BAN:8</availability>
+			<availability>SC:6,DoO:6,MCM:6,DO:6,DGM:6,MSC:6,TP:6,MERC:4,DC:8</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>SC:4,DoO:4,MCM:4,CGB.FRR:3,FWL:4,DO:4,DGM:4,MSC:4,TP:4</availability>
 		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:7,CDS:3,Periphery.CM:6,CGB.FRR:2,CNC:3,IS:3-,Periphery.Deep:6,MERC:1,Periphery:1,CWIE:3</availability>
-		<model name='(SRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:5-</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
 			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(LRM)'>
@@ -7387,11 +7387,11 @@
 		<model name='(LB-X)'>
 			<availability>CC:8,MOC:6,PR:5,PG:5,DA:5,CDP:5,RFS:5,TC:6</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:1,IS:1,Periphery:1</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -7408,37 +7408,37 @@
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CHH:5,CDS:4,CW:6,LA:2,ROS:3,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CDS:4,CW:4,CLAN:3,CNC:4,IS:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:5,CW:3,ROS:4,CJF:5,CGB:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:4,CW:4,CLAN:3,CNC:4,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>MOC:2,CC:3,LA:6,CLAN:4,IS:2,FWL:2,NIOPS:9,MH:2,MERC:4,FS:5,CJF:5,DC:2</availability>
-		<model name='HGN-732b'>
-			<availability>LA:4,CLAN:4,IS:2,FWL:2,MH:4,FS:4,BAN:2</availability>
-		</model>
 		<model name='HGN-734'>
 			<availability>LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='HGN-738'>
-			<availability>LA:6,ROS:6</availability>
-		</model>
-		<model name='HGN-732'>
-			<availability>MOC:6,CC:4,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6,DC:3</availability>
+		<model name='HGN-732b'>
+			<availability>LA:4,CLAN:4,IS:2,FWL:2,MH:4,FS:4,BAN:2</availability>
 		</model>
 		<model name='HGN-733'>
 			<availability>CC:2-,MOC:2-,:0,LA:2-,DC:2-</availability>
 		</model>
+		<model name='HGN-732'>
+			<availability>MOC:6,CC:4,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6,DC:3</availability>
+		</model>
+		<model name='HGN-738'>
+			<availability>LA:6,ROS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:4</availability>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7446,7 +7446,7 @@
 			<roles>recon,apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7472,11 +7472,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F5'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BZK-F7'>
 			<availability>General:6</availability>
+		</model>
+		<model name='BZK-F5'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -7490,16 +7490,16 @@
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,FS:5,MERC:3,Periphery.OS:4,FS.CrMM:7,Periphery:2,TC:2,MERC.WD:3,FVC:8,OA:2,FS.PMM:4,Periphery.HR:4,FS.CMM:7,FS.DMM:7</availability>
+		<model name='HNT-152'>
+			<roles>recon,urban</roles>
+			<availability>FVC:1-,IS:1-</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:2-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='HNT-152'>
-			<roles>recon,urban</roles>
-			<availability>FVC:1-,IS:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hover Assault Infantry' unitType='Infantry'>
@@ -7516,13 +7516,13 @@
 	</chassis>
 	<chassis name='Huitzilopochtli Assault Tank &apos;Huey&apos;' unitType='Tank'>
 		<availability>ROS:3,CLAN:5</availability>
-		<model name='(AAA)'>
-			<roles>missile_artillery,anti_aircraft</roles>
-			<availability>CHH:4,RA:4,CGB:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>missile_artillery,anti_aircraft</roles>
+			<availability>CHH:4,RA:4,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Humming Bird VTOL' unitType='VTOL'>
@@ -7534,9 +7534,6 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:4,CDS:7,CSR:5,CW:5,CJF:5,CGB:5,CWIE:4,RA:5</availability>
-		<model name='3'>
-			<availability>CSR:5,CCO:8,RA:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:8,CBS:8</availability>
 		</model>
@@ -7546,14 +7543,20 @@
 		<model name='(Standard)'>
 			<availability>CSR:2,General:8,RA:4</availability>
 		</model>
+		<model name='3'>
+			<availability>CSR:5,CCO:8,RA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:2,CC:2,HL:3,IS:2-,Periphery.Deep:5,FS:3,Periphery:4,TC:2,RA.OA:2,OA:2,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:2</availability>
+		<model name='HBK-5SS'>
+			<availability>LA:5</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
 		<model name='HBK-6S'>
 			<availability>LA:5,ROS:5,MERC:5</availability>
-		</model>
-		<model name='HBK-4N'>
-			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:1-,FWL:1-,MERC:1-,Periphery:1-</availability>
@@ -7561,14 +7564,17 @@
 		<model name='HBK-5P'>
 			<availability>ROS:6,FWL:6,MERC:4</availability>
 		</model>
+		<model name='HBK-4H'>
+			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-5H'>
+			<availability>FVC:3,HL:1,MH:6,Periphery:4</availability>
+		</model>
 		<model name='HBK-4SP'>
 			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
 		</model>
-		<model name='HBK-5SS'>
-			<availability>LA:5</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='HBK-5N'>
+			<availability>MOC:4,CC:4,CGB.FRR:4,FWL:5,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:1-,Periphery:2-</availability>
@@ -7576,17 +7582,11 @@
 		<model name='HBK-5S'>
 			<availability>LA:4,CGB.FRR:3,ROS:3,MH:3,MERC:2,FS:3</availability>
 		</model>
-		<model name='HBK-6N'>
-			<availability>ROS:3,FWL:3,MH:4,MERC:4,DC:2</availability>
-		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
-		<model name='HBK-5H'>
-			<availability>FVC:3,HL:1,MH:6,Periphery:4</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:4,CC:4,CGB.FRR:4,FWL:5,MERC:4,CDP:4,TC:4</availability>
+		<model name='HBK-6N'>
+			<availability>ROS:3,FWL:3,MH:4,MERC:4,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -7600,41 +7600,47 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:4,CC:6,HL:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,RA.OA:5,OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
-		<model name='&apos;Assault Hunter&apos;'>
-			<availability>LA:2,FS:2</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:1-</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:2-</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:4</availability>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>PR:6,LA:8,ROS:6,PG:6,FS:6,RCM:5,MERC:5,DA:6,RFS:6</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
 			<availability>General:2-</availability>
 		</model>
+		<model name='(LRM15)'>
+			<roles>fire_support</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:1-</availability>
+		</model>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
 		<model name='(Amphibious)'>
 			<availability>LA:1,MERC:1</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>PR:6,LA:8,ROS:6,PG:6,FS:6,RCM:5,MERC:5,DA:6,RFS:6</availability>
+		<model name='&apos;Assault Hunter&apos;'>
+			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4O'>
+			<availability>CC:8,MOC:8,FWL:4,MERC:6,TC:4</availability>
+		</model>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:4,MOC:4,FWL:5</availability>
 		</model>
@@ -7642,42 +7648,36 @@
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4O'>
-			<availability>CC:8,MOC:8,FWL:4,MERC:6,TC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>LA:3,CGB.FRR:5,ROS:4,CNC:4,MERC:3,FS:3,CGB:5,DC:3</availability>
-		<model name='HSCL-1-OD'>
-			<availability>General:4</availability>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:2+</availability>
 		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HSCL-1-OA'>
+		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OB'>
+		<model name='HSCL-1-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:2+</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>DC.GHO:3,LA:2,CGB.FRR:1,ROS:3,CLAN:3,NIOPS:4,MERC:2,DC:1</availability>
-		<model name='HSR-400-D'>
-			<availability>LA:8,ROS:8,MERC:8</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6,NIOPS:4,MERC.SI:4,BAN:8</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -7689,11 +7689,11 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CCC:6,CSR:3,CLAN:4,RA:4</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Algar)'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:6</availability>
@@ -7701,19 +7701,19 @@
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
 		<availability>CHH:5,CBS:2,CSL:5</availability>
+		<model name='2'>
+			<availability>CHH:6,CSL:6</availability>
+		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CBS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CHH:6,CBS:6,CSL:6</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:6,CSL:6</availability>
-		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
 			<availability>CBS:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:6,CBS:6,CSL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hyena' unitType='Mek'>
@@ -7725,11 +7725,8 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:3,MOC:8,LA:2,ROS:4,FWL:3,IS:8,MH:8,FS:1,DC:1,TC:8</availability>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -7737,8 +7734,11 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -7772,11 +7772,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='IMP-4E'>
 			<availability>MERC.WD:6,MERC.KH:8</availability>
+		</model>
+		<model name='IMP-3E'>
+			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -7795,11 +7795,11 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5</availability>
-		<model name='(BA)'>
-			<availability>CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(BA)'>
+			<availability>CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
@@ -7815,14 +7815,14 @@
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4,TC:3</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
+		<model name='&apos;Puma&apos;' mechanized='true'>
+			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
 		</model>
-		<model name='&apos;Puma&apos;' mechanized='true'>
-			<availability>FS:8,TC:8</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Marine)' mechanized='true'>
 			<roles>marine</roles>
@@ -7831,6 +7831,10 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>CC:2,LA:2,ROS:3,FWL:2,FS:2,DC:2</availability>
+		<model name='(Standard)'>
+			<roles>assault</roles>
+			<availability>CC:8,ROS:6,FWL:8</availability>
+		</model>
 		<model name='(SCC)'>
 			<roles>assault</roles>
 			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
@@ -7838,10 +7842,6 @@
 		<model name='(Sub-Capital)'>
 			<roles>assault</roles>
 			<availability>ROS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>assault</roles>
-			<availability>CC:8,ROS:6,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -7857,29 +7857,29 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,CLAN:9,IS:7,Periphery.Deep:7,FS:9,BAN:6,Periphery:8,TC:8,RA.OA:8,OA:8,LA:9,CGB.FRR:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ironhold Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CJF:4</availability>
-		<model name='(Fire)' mechanized='false'>
-			<availability>General:4</availability>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Tank)' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='(Fire)' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Isegrim Assault DropShip' unitType='Dropship'>
@@ -7920,15 +7920,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -7949,38 +7949,38 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>MOC:3-,DC.LV:4-,DC.GR:3-,FS.AH:3-,IS:3-,Periphery.Deep:5,FS:2-,Periphery:3-,TC:4-,RA.OA:3-,OA:2-,LA:3-,CGB.FRR:2-,FWL:1-,NIOPS:2-,DC:3-</availability>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>FVC:3,IS:4,TC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Kurita)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>DC:8,TC:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Kurita)'>
-			<roles>recon,raider</roles>
-			<availability>DC:8,TC:4</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 		</model>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
 		<availability>HL:1,IS:2,TC:3,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>TC:5</availability>
-		</model>
 		<model name='(3082 Upgrade)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
@@ -8036,27 +8036,27 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:2,CW:5,General:2,RA:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CSR:3,CW:4,CLAN:2,RA:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CSR:3,CW:4,CLAN:2,RA:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8070,35 +8070,16 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:3,CC:3-,MERC:3,Periphery.OS:2,FS:6,TC:3,Periphery:3,RA.OA:2,FVC:7,OA:2,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,MH:3,DC:2</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>MOC:3,RA.OA:5,FVC:5,OA:5,LA:5,CGB.FRR:5,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='JM7-C3BS'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>CC:2-,CGB.FRR:1-,IS:2-,FS:2-,Periphery:5</availability>
 		</model>
-		<model name='JM6-DGr'>
-			<roles>anti_aircraft</roles>
-			<availability>FVC:2,LA:2,ROS:2,CGB.FRR:2,FS:2,MERC:2,CDP:3,DC:2</availability>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:5,FS:4,MERC:6</availability>
-		</model>
-		<model name='JM7-F'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
 		</model>
 		<model name='JM6-DDa'>
 			<roles>anti_aircraft</roles>
@@ -8108,32 +8089,51 @@
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,PIR:2,MH:6,Periphery:2</availability>
 		</model>
+		<model name='JM7-F'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:4,FS:4</availability>
+		</model>
+		<model name='JM6-DGr'>
+			<roles>anti_aircraft</roles>
+			<availability>FVC:2,LA:2,ROS:2,CGB.FRR:2,FS:2,MERC:2,CDP:3,DC:2</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM7-G'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>MOC:3,RA.OA:5,FVC:5,OA:5,LA:5,CGB.FRR:5,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:3,HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,TC:3,RA.OA:1,FVC:7,OA:1,LA:1,Periphery.HR:4,ROS:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+		<model name='JVN-10P'>
 			<roles>recon</roles>
-			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3,CDP:3</availability>
+			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:4,MERC:6,CDP:6,TC:6</availability>
 		</model>
 		<model name='JVN-11F'>
 			<roles>recon</roles>
 			<availability>FS:5</availability>
 		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
+		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
-			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:4,MERC:6,CDP:6,TC:6</availability>
+			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3,CDP:3</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>ROS:6,FS:6</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -8142,14 +8142,14 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -8160,67 +8160,59 @@
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
+		<model name='B'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CDS:6,CW:6,ROS:4,CNC:8,CCO:5,DC:3</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>CCC:6,CNC:6</availability>
 		</model>
-		<model name='3'>
+		<model name='(Standard)'>
+			<availability>CW:4,CNC:4,CLAN:1</availability>
+		</model>
+		<model name='2'>
 			<availability>CCC:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:7,CNC:8,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CW:4,CNC:4,CLAN:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,IS:3,MERC:4,Periphery.OS:5,FS:4,RA:3,Periphery:3,OA:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
-		<model name='JR7-K'>
+		<model name='JR7-C4'>
 			<roles>raider</roles>
-			<availability>MOC:3,RA.OA:3,OA:3,CGB.FRR:8,MERC:3,RA:2,DC:3,TC:3</availability>
-		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>ROS:4,DC:5</availability>
-		</model>
-		<model name='JR7-C3'>
-			<roles>raider</roles>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+			<availability>DC:3</availability>
 		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='JR7-C3'>
+			<roles>raider</roles>
+			<availability>ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='JR7-K'>
+			<roles>raider</roles>
+			<availability>MOC:3,RA.OA:3,OA:3,CGB.FRR:8,MERC:3,RA:2,DC:3,TC:3</availability>
+		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
 			<availability>MERC:6,FS:6,DC:5</availability>
 		</model>
-		<model name='JR7-C4'>
+		<model name='JR7-C2'>
 			<roles>raider</roles>
-			<availability>DC:3</availability>
+			<availability>ROS:4,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:6,TC:4</availability>
-		<model name='JI-50 (Q-Vehicle)'>
-			<roles>support</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='JI-50'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='JI-50 (ML)'>
+		<model name='JI-50 (Hoist)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8228,21 +8220,29 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='JI-50 (Hoist)'>
+		<model name='JI-50'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Q-Vehicle)'>
+			<roles>support</roles>
+			<availability>TC:2</availability>
+		</model>
+		<model name='JI-50 (ML)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:6,MOC:5,TC:4</availability>
-		<model name='JN-G8A'>
-			<availability>General:8</availability>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
+		<model name='JN-G8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Joust Medium Tank' unitType='Tank'>
@@ -8258,11 +8258,11 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
@@ -8274,8 +8274,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -8295,29 +8295,28 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>ROS:2,DC:6</availability>
-		<model name='KBO-7B'>
+		<model name='KBO-7A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='KBO-7A'>
+		<model name='KBO-7B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+		<model name='C' mechanized='true'>
+			<availability>DC:3</availability>
 		</model>
-		<model name='(DEST)' mechanized='true'>
+		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
@@ -8325,28 +8324,29 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C' mechanized='true'>
-			<availability>DC:3</availability>
+		<model name='[MG]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
+		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='(Space)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='(Vibro-Claw)' mechanized='true'>
+		<model name='[ECM]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
+			<availability>MERC:2,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -8358,6 +8358,13 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Salvage Arm]' mechanized='false'>
+			<roles>support</roles>
+			<availability>DC.NSR:6,DC.SL:6,General:6</availability>
+		</model>
 		<model name='[Industrial Drill]' mechanized='false'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -8365,23 +8372,16 @@
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Salvage Arm]' mechanized='false'>
-			<roles>support</roles>
-			<availability>DC.NSR:6,DC.SL:6,General:6</availability>
-		</model>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>CGB:5</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
@@ -8403,38 +8403,38 @@
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(AC)'>
+			<availability>MH:5,MERC:5</availability>
+		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:4,RA.OA:5,FVC:4,OA:5,HL:3,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
+		</model>
+		<model name='(Heavy Stealth)'>
+			<availability>PIR:3</availability>
+		</model>
 		<model name='(3055 Upgrade)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:2,Periphery:6</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:5,MERC:5</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>FWL:5,IS:6</availability>
 		</model>
-		<model name='(Heavy Stealth)'>
-			<availability>PIR:3</availability>
-		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:4,RA.OA:5,FVC:4,OA:5,HL:3,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,CGB.FRR:2,DC:6</availability>
+		<model name='CRK-5003-2'>
+			<availability>CGB.FRR:8,DC:3-</availability>
+		</model>
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:6,DC:5</availability>
 		</model>
-		<model name='CRK-5003-2'>
-			<availability>CGB.FRR:8,DC:3-</availability>
+		<model name='CRK-5003-C'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CRK-5003-CM'>
 			<roles>spotter</roles>
 			<availability>DC:7</availability>
-		</model>
-		<model name='CRK-5003-C'>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
@@ -8443,21 +8443,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
@@ -8465,23 +8465,23 @@
 		<model name='KGC-001'>
 			<availability>FVC:8,LA:5,IS:5,MH:6</availability>
 		</model>
-		<model name='KGC-008B'>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='KGC-005r'>
-			<availability>ROS:3,MERC:2</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CGB.FRR:5,ROS:3,CLAN:4,BAN:2,DC:5</availability>
+		</model>
+		<model name='KGC-007'>
+			<availability>LA:7,ROS:8,FS:7,MERC:7</availability>
 		</model>
 		<model name='KGC-0000'>
 			<availability>IS:3-</availability>
 		</model>
+		<model name='KGC-008B'>
+			<availability>ROS:4</availability>
+		</model>
 		<model name='KGC-000'>
 			<availability>CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,BAN:8,DC:8</availability>
 		</model>
-		<model name='KGC-007'>
-			<availability>LA:7,ROS:8,FS:7,MERC:7</availability>
+		<model name='KGC-005r'>
+			<availability>ROS:3,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
@@ -8489,26 +8489,26 @@
 		<model name='C'>
 			<availability>General:5,CGB:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6,CGB:5</availability>
-		</model>
 		<model name='E'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
+		<model name='D'>
+			<availability>General:6,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kinnol MBT' unitType='Tank'>
@@ -8519,11 +8519,11 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>DC.GHO:5,CGB.FRR:4,ROS:6,NIOPS:7,FS:2,MERC:4,DC:4</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:6</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:3,DC.SL:4,ROS:4,CLAN:6,NIOPS:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:3-,MERC:3-</availability>
@@ -8534,29 +8534,29 @@
 		<model name='KTO-20'>
 			<availability>CGB.FRR:3,MERC:5,DC:4</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:6</availability>
+		<model name='KTO-19b'>
+			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,BAN:7,CWIE:5,CGB:7</availability>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -8579,18 +8579,18 @@
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
 		<availability>CGB.FRR:6</availability>
-		<model name='[GL/Flamer]' mechanized='true'>
-			<availability>CGB.FRR:6</availability>
-		</model>
-		<model name='[SL/Flamer]' mechanized='true'>
-			<availability>CGB.FRR:6</availability>
+		<model name='[GL]' mechanized='true'>
+			<availability>CGB.FRR:4</availability>
 		</model>
 		<model name='[SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>CGB.FRR:8</availability>
 		</model>
-		<model name='[GL]' mechanized='true'>
-			<availability>CGB.FRR:4</availability>
+		<model name='[SL/Flamer]' mechanized='true'>
+			<availability>CGB.FRR:6</availability>
+		</model>
+		<model name='[GL/Flamer]' mechanized='true'>
+			<availability>CGB.FRR:6</availability>
 		</model>
 		<model name='[GL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
@@ -8599,6 +8599,9 @@
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CCC:3,CSR:3,ROS:3,CCO:3,RA:4,CGB:8</availability>
+		<model name='5'>
+			<availability>CGB:4</availability>
+		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
 			<availability>CSR:3,RA:5</availability>
@@ -8608,9 +8611,6 @@
 		</model>
 		<model name='4'>
 			<availability>ROS:4,CGB:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
@@ -8622,9 +8622,6 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='KIM-2'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>General:8,DC:4</availability>
@@ -8633,30 +8630,26 @@
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
 		</model>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DoO:5,ROS:4,FWL:4,DO:5,TP:5,MERC:3</availability>
-		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='(AI Mk II)' mechanized='false'>
+			<availability>DoO:4,DO:4,TP:4</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(AI Mk II)' mechanized='false'>
-			<availability>DoO:4,DO:4,TP:4</availability>
+		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,DTA:2,ROS:2,MERC:4</availability>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
-			<availability>MERC:4</availability>
-		</model>
 		<model name='KSC-4I'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='KSC-4L'>
 			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='KSC-5I'>
@@ -8665,28 +8658,39 @@
 		<model name='KSC-5MC'>
 			<availability>MOC:8,CC:8,MERC:2</availability>
 		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:4</availability>
+		</model>
+		<model name='KSC-4L'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,MERC.WD:5,CDS:5,CSR:5,CW:5,CBS:6,IS:4+,CCO:1,CJF:4,BAN:6</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>CDS:3,CW:7,General:4,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<roles>recon</roles>
-			<availability>CSA:3,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CLAN:5,IS:3</availability>
 		</model>
-		<model name='E'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CLAN:5,IS:3,CCO:6</availability>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CLAN:5,IS:3</availability>
 		</model>
 		<model name='G'>
 			<roles>recon,anti_infantry</roles>
@@ -8696,17 +8700,13 @@
 			<roles>recon</roles>
 			<availability>CSA:6,CDS:6,CW:6,General:5,CCO:4,CWIE:5,CGB:5</availability>
 		</model>
-		<model name='P'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CLAN:2,IS:2</availability>
+			<availability>CSA:3,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
-		<model name='Prime'>
+		<model name='E'>
 			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
+			<availability>CLAN:5,IS:3,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Koto' unitType='Mek'>
@@ -8733,12 +8733,12 @@
 	</chassis>
 	<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CSR:3,CDS:2,CW:4,CNC:2,CJF:4,RA:4,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(IFV) &apos;Turhan II&apos;'>
 			<roles>apc</roles>
 			<availability>CHH:8,CJF:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kuan Ti' unitType='Dropship'>
@@ -8750,11 +8750,11 @@
 	</chassis>
 	<chassis name='Kuma' unitType='Mek'>
 		<availability>CGB.FRR:2,CGB:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
@@ -8803,33 +8803,33 @@
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>PR:6,DoO:6,DO:6,FS:2,SC:6,Periphery.MW:2,Periphery.CM:2,FWL:6,MH:2,MSC:4,RFS:6,CC:2,MOC:2,DGM:6,MERC:2,DTA:6,FVC:2,LA:2,MCM:6,ROS:2,PG:6,Periphery.ME:2,TP:6,DA:6,RCM:6</availability>
-		<model name='LX-2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LX-2A'>
 			<availability>PR:5,DoO:5,DO:5,DGM:5,MERC:5,DTA:5,SC:5,LA:5,MCM:5,ROS:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
 		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
+		<model name='LX-2'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:8,MOC:6,FS:4,TC:4</availability>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3B'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:6</availability>
-		</model>
 		<model name='LHU-4E'>
 			<availability>CC:4</availability>
 		</model>
 		<model name='LHU-3L'>
 			<availability>CC:6,MOC:7,FS:8</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-3B'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -8841,32 +8841,32 @@
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>ROS:3,FS:7,MERC:3</availability>
-		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGN-2F'>
 			<availability>FS:7</availability>
 		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
+		</model>
+		<model name='LGN-2XU'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-2XA'>
 			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>RA.OA:8,OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>CC:8,PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:5-</availability>
+		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>CC:8,PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
@@ -8916,27 +8916,27 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
-		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:3,FWL:7,IS:3</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:3</availability>
+		<model name='Owl'>
+			<availability>LA:1,ROS:1,MERC:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,General:1,Periphery.ME:3,FWL:2,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1,ROS:1,MERC:1</availability>
+		<model name='Comet'>
+			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:3,HL:5,LA:3</availability>
 		</model>
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
+		</model>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:3,FWL:7,IS:3</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -8947,9 +8947,6 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CLAN:3,NIOPS:2,CJF:4</availability>
-		<model name='(ERSL)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
@@ -8957,29 +8954,32 @@
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='LTN-G15b'>
-			<availability>CC:5,MOC:5,CLAN:3,IS:2,MERC:4</availability>
-		</model>
-		<model name='LTN-G16L'>
-			<availability>CC:6,MOC:6,SC:4,PR:4,MCM:4,PG:4,DGM:4,MSC:4,MERC:4,DA:6,RFS:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:4-</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='LTN-G16S'>
-			<availability>LA:6</availability>
+		<model name='LTN-G15b'>
+			<availability>CC:5,MOC:5,CLAN:3,IS:2,MERC:4</availability>
 		</model>
 		<model name='LTN-G16D'>
 			<availability>ROS:6,FS:6,MERC:4</availability>
 		</model>
+		<model name='LTN-G16L'>
+			<availability>CC:6,MOC:6,SC:4,PR:4,MCM:4,PG:4,DGM:4,MSC:4,MERC:4,DA:6,RFS:4</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='LTN-G16O'>
 			<availability>RA.OA:6,FVC:4,OA:6,CDP:4</availability>
+		</model>
+		<model name='LTN-G16S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
@@ -8987,11 +8987,14 @@
 		<model name='B'>
 			<availability>CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:4,CW:4,CBS:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
@@ -8999,26 +9002,23 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CW:4,CBS:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:3</availability>
+		<model name='D'>
+			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lineholder' unitType='Mek'>
 		<availability>CC:4,HL:1,ROS:4,FWL:4,IS:3,FS:5,TC:6,Periphery:3</availability>
-		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
-			<availability>ROS:3,FS:7,MERC:6,CDP:4</availability>
-		</model>
 		<model name='KW1-LH3'>
 			<availability>General:2,FS:3</availability>
 		</model>
 		<model name='KW1-LH2'>
 			<availability>General:5,FS:2</availability>
+		</model>
+		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
+			<availability>ROS:3,FS:7,MERC:6,CDP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -9052,75 +9052,74 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:7,ROS:3,CJF:6,DC:3,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CW:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:4,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
-		</model>
 		<model name='6'>
 			<availability>CW:5,CGB:5</availability>
-		</model>
-		<model name='5'>
-			<availability>CHH:4,CW:4,ROS:4,CCO:4,CGB:4</availability>
 		</model>
 		<model name='9'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='7'>
-			<availability>CHH:4,ROS:1</availability>
+		<model name='(Standard)'>
+			<availability>CW:3</availability>
 		</model>
 		<model name='8'>
 			<availability>ROS:3,CGB:6,DC:3</availability>
 		</model>
+		<model name='7'>
+			<availability>CHH:4,ROS:1</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:4,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
 		<model name='2'>
 			<availability>CCC:2,CJF:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CHH:4,CW:4,ROS:4,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>HL:5,CLAN:2-,IS:7,NIOPS:2-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='LCT-3M'>
+		<model name='LCT-6M'>
 			<roles>recon</roles>
-			<availability>MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+			<availability>SC:5,MCM:5,ROS:2,FWL:4,DGM:5,MSC:5,MERC:3</availability>
+		</model>
+		<model name='LCT-5M2'>
+			<availability>SC:3,MCM:3,ROS:3,DGM:3,MSC:3</availability>
 		</model>
 		<model name='LCT-5T'>
 			<roles>recon,anti_infantry</roles>
 			<availability>MOC:4,CC:4,FVC:3,TC:6</availability>
 		</model>
-		<model name='LCT-5M2'>
-			<availability>SC:3,MCM:3,ROS:3,DGM:3,MSC:3</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:4,ROS:4,PIR:4,FWL:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='LCT-6M'>
-			<roles>recon</roles>
-			<availability>SC:5,MCM:5,ROS:2,FWL:4,DGM:5,MSC:5,MERC:3</availability>
-		</model>
-		<model name='LCT-5W2'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4,ROS:4,CLAN:2,IS:2,FS:4,DC:4</availability>
+		<model name='LCT-5M3'>
+			<availability>SC:4,MCM:4,ROS:4,DGM:4,MSC:4</availability>
 		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CC:5,MOC:3,CLAN:6,FWL:3,MERC:3,BAN:2</availability>
 		</model>
-		<model name='LCT-5V'>
+		<model name='LCT-3V'>
 			<roles>recon</roles>
-			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:3,TC:4,Periphery:3</availability>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:4,ROS:4,PIR:4,FWL:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='LCT-1V2'>
+			<roles>recon</roles>
+			<availability>PIR:4,MH:4,MERC:2</availability>
+		</model>
+		<model name='LCT-5W2'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4,ROS:4,CLAN:2,IS:2,FS:4,DC:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:2-,General:3-,FS:3-</availability>
 		</model>
-		<model name='LCT-3V'>
+		<model name='LCT-5V'>
 			<roles>recon</roles>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:3,TC:4,Periphery:3</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -9130,25 +9129,26 @@
 			<roles>recon</roles>
 			<availability>LA:8,CGB.FRR:6,MERC:6</availability>
 		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:3-,MERC:3-</availability>
 		</model>
-		<model name='LCT-5M3'>
-			<availability>SC:4,MCM:4,ROS:4,DGM:4,MSC:4</availability>
-		</model>
-		<model name='LCT-1V2'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>PIR:4,MH:4,MERC:2</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CW:4,CBS:4,IS:2+,CJF:1,BAN:5,CWIE:4</availability>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
@@ -9159,15 +9159,15 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -9183,9 +9183,9 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6,CGB:2</availability>
-		<model name='LGB-14C2'>
+		<model name='LGB-7V'>
 			<roles>fire_support</roles>
-			<availability>IS:2</availability>
+			<availability>MOC:3,FVC:4,FWL:4,IS:3,Periphery:2</availability>
 		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
@@ -9195,47 +9195,47 @@
 			<roles>missile_artillery,fire_support</roles>
 			<availability>LA:4,CGB.FRR:4,FWL:4,IS:3,FS:5,MERC:4,CGB:3</availability>
 		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:5,LA:5,IS:3,FS:5,MERC:5,DC:5,Periphery:3</availability>
-		</model>
-		<model name='LGB-13NAIS'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGB-12R'>
 			<roles>fire_support</roles>
 			<availability>DTA:4,LA:4,ROS:8,FS:4,DC:3</availability>
-		</model>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,FVC:4,FWL:4,IS:3,Periphery:2</availability>
-		</model>
-		<model name='LGB-12C'>
-			<roles>fire_support</roles>
-			<availability>CC:5,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CDP:3,TC:3</availability>
-		</model>
-		<model name='LGB-13C'>
-			<roles>fire_support</roles>
-			<availability>CC:5,MOC:3,DoO:6,DO:6,DGM:6,FS:5,MERC:5,SC:6,MCM:6,ROS:6,MSC:6,TP:6,DA:6,RCM:5,DC:5</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:2-,OA:2-,General:2-,TC:2-,Periphery:2-</availability>
 		</model>
+		<model name='LGB-12C'>
+			<roles>fire_support</roles>
+			<availability>CC:5,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CDP:3,TC:3</availability>
+		</model>
+		<model name='LGB-13NAIS'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGB-13C'>
+			<roles>fire_support</roles>
+			<availability>CC:5,MOC:3,DoO:6,DO:6,DGM:6,FS:5,MERC:5,SC:6,MCM:6,ROS:6,MSC:6,TP:6,DA:6,RCM:5,DC:5</availability>
+		</model>
+		<model name='LGB-14C2'>
+			<roles>fire_support</roles>
+			<availability>IS:2</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:5,LA:5,IS:3,FS:5,MERC:5,DC:5,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>PR:8,DoO:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:6,MSC:6,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>FWL:6</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -9243,41 +9243,41 @@
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
-		<model name='LCF-R16K'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:1,RA.OA:1,Periphery.R:4,FVC:2,OA:1,HL:4,LA:7,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:3,MERC:6</availability>
+		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:2-,FS:2-</availability>
 		</model>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:3,MERC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,HL:1,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM5/M'>
-			<availability>LA:2-</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='LM5/M'>
+			<availability>LA:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -9318,13 +9318,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3</availability>
-		<model name='(Standard)'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='M1'>
 			<roles>escort</roles>
 			<availability>FWL:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -9349,20 +9349,23 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>PR:1-,LA:1-,PG:1-,FWL:1-,RFS:1-</availability>
-		<model name='MSK-5S'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>PR:8,PG:8,FWL:8,RFS:8</availability>
 		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
 		</model>
+		<model name='MSK-5S'>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:2+,CLAN:3,MERC:1+,CCO:4,BAN:2,CWIE:7,CSA:4,MERC.WD:7,CDS:4,CW:6,CBS:3,ROS:1+,CJF:4</availability>
-		<model name='Prime'>
-			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CCO:6,CJF:8,CGB:7</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -9372,26 +9375,23 @@
 			<roles>spotter</roles>
 			<availability>CHH:4,CW:5,CBS:4,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:3,General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:3,General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5,CGB:5</availability>
+		<model name='Prime'>
+			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CCO:6,CJF:8,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
@@ -9399,48 +9399,48 @@
 		<model name='Enhanced'>
 			<availability>CGB.FRR:5,CLAN:5,CNC:3,CWIE:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CDS:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
 		<availability>LA:6,IS:3,FS:4,MERC:4,DC:6</availability>
-		<model name='MTR-6E'>
-			<roles>recon,spotter</roles>
-			<availability>DC:1</availability>
+		<model name='MTR-5K'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:2,DC:4</availability>
 		</model>
-		<model name='MTR-5K'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='MTR-6E'>
+			<roles>recon,spotter</roles>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>CC:2,MOC:2,Periphery.MM:2,PR:8,DoO:8,DO:8,DGM:8,MERC:2,DTA:8,SC:8,LA:2,MCM:8,ROS:2,Periphery.CM:2,PG:8,Periphery.ME:2,FWL:8,MH:2,MSC:6,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>MOC:4,IS:4</availability>
+		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(XL)'>
-			<availability>MOC:4,IS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Malaika' unitType='Aero'>
@@ -9458,9 +9458,6 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,MERC.WD:7,CDS:7,CW:7,CBS:5,CNC:3,CJF:7,BAN:5,CWIE:7</availability>
-		<model name='E'>
-			<availability>CLAN:6,General:3,CCO:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
 		</model>
@@ -9471,17 +9468,20 @@
 		<model name='G'>
 			<availability>General:2</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:3,CCO:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
@@ -9489,14 +9489,14 @@
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
 		<availability>MERC.KH:3,PR:2,LA:2,ROS:2,PG:2,MERC:2,RFS:2,CWIE:5</availability>
+		<model name='MNL-4S'>
+			<availability>General:4</availability>
+		</model>
 		<model name='MNL-3L'>
 			<availability>MERC.KH:6,ROS:5,CWIE:6</availability>
 		</model>
 		<model name='MNL-3W'>
 			<availability>ROS:2,CWIE:2</availability>
-		</model>
-		<model name='MNL-4S'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -9513,28 +9513,40 @@
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>General:3</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
+		<model name='E'>
+			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,FS:6,Periphery:6,TC:6,CWIE:4,RA.OA:6,OA:6,LA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
+		<model name='(LB-X)'>
+			<availability>LA:7,ROS:8,FS:7</availability>
+		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,PR:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:2,LA:1-,General:3-,Periphery.Deep:6,FS:1-,DC:1-,Periphery:4</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -9542,18 +9554,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:2,MOC:2,DTA:3,LA:2,ROS:5,FS:4,MERC:2,DC:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>LA:7,ROS:8,FS:7</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,PR:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:2,LA:1-,General:3-,Periphery.Deep:6,FS:1-,DC:1-,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
@@ -9567,26 +9567,26 @@
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:6,CW:5,CNC:5,CJF:6,RA:4,CWIE:5,CGB:6</availability>
-		<model name='3'>
-			<availability>CSA:3,CJF:5,CGB:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CW:5,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:8,CJF:4,CGB:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:4,CCC:2,CJF:3,CGB:3</availability>
 		</model>
 		<model name='5'>
 			<availability>CJF:4,CWIE:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CNC:6,RA:3,CGB:4</availability>
+		<model name='6'>
+			<availability>CW:5,CJF:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:3,CJF:5,CGB:5</availability>
 		</model>
 		<model name='7'>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:4,CCC:2,CJF:3,CGB:3</availability>
+		</model>
+		<model name='4'>
+			<availability>CNC:6,RA:3,CGB:4</availability>
 		</model>
 		<model name='8'>
 			<availability>CJF:4,CGB:4</availability>
@@ -9594,8 +9594,8 @@
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,MOC:2,FS:6,MERC:6,TC:4,MERC.WD:6,LA:3,CGB.FRR:5,ROS:6,PIR:4,FWL:6,MH:4,DC:6</availability>
-		<model name='MAD-4H'>
-			<availability>PIR:7,MH:7,TC:7</availability>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
@@ -9603,102 +9603,102 @@
 		<model name='MAD-6M'>
 			<availability>ROS:4,FWL:5,MERC:5</availability>
 		</model>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:4</availability>
-		</model>
 		<model name='MAD-4L'>
 			<availability>CC:5,MOC:5</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:5</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>LA:8,CGB.FRR:5,ROS:6,CNC:8,FWL:3,FS:7,MERC:7,DC:3</availability>
 		</model>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:2</availability>
+		</model>
 		<model name='MAD-4K'>
 			<availability>DC:7</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:2</availability>
+		<model name='MAD-4H'>
+			<availability>PIR:7,MH:7,TC:7</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2,IS:2-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:6,SC:6,DoO:6,MCM:6,DO:6,DGM:6,MSC:6,TP:6,MERC:3,DA:6</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:4,CGB.FRR:6,FS:3,MERC:3,DC:7</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>LA:6,CGB.FRR:4,ROS:4,MH:3,MERC:4,CGB:3</availability>
+		<model name='MAD-3D'>
+			<availability>FVC:2-,MH:2-,FS:2-</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>PR:5,DoO:5,ROS:4,PG:5,DO:5,TP:5,MERC:4,DA:5,RFS:5,DC:2</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:5,ROS:4,FS:5,MERC:4,DC:5</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:5,MOC:4</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>FVC:3,LA:5,CGB.FRR:3,FS:3,MERC:4</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>DTA:6,SC:6,DoO:6,MCM:6,DO:6,DGM:6,MSC:6,TP:6,MERC:3,DA:6</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:2-,Periphery.MW:2-,PIR:2-,Periphery.ME:2-,FWL:1-,MH:2-,MERC:2-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:4,CGB.FRR:6,FS:3,MERC:3,DC:7</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>MOC:3,ROS:4,FWL:7,MERC:4</availability>
 		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:2-,MH:2-,FS:2-</availability>
+		<model name='MAD-6L'>
+			<availability>CC:5,MOC:4</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:3-,TC:3-</availability>
 		</model>
-		<model name='MAD-5L'>
-			<availability>CC:6,MOC:5</availability>
+		<model name='MAD-9S'>
+			<availability>LA:6,CGB.FRR:4,ROS:4,MH:3,MERC:4,CGB:3</availability>
 		</model>
 		<model name='MAD-2R'>
 			<availability>MOC:3,RA.OA:3,MH:3,MERC:3,BAN:1,TC:4</availability>
 		</model>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:2-,Periphery.MW:2-,PIR:2-,Periphery.ME:2-,FWL:1-,MH:2-,MERC:2-</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:6,MOC:5</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>FVC:3,LA:5,CGB.FRR:3,FS:3,MERC:4</availability>
+		</model>
+		<model name='MAD-9W2'>
+			<availability>LA:5,ROS:4,FS:5,MERC:4,DC:5</availability>
+		</model>
+		<model name='MAD-7D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
 		<availability>CHH:3,LA:6,IS:3</availability>
-		<model name='(Light PPC)'>
-			<roles>artillery</roles>
-			<availability>LA:8,IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CHH:8,BAN:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>artillery</roles>
+			<availability>LA:8,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,ROS:4,CLAN:7</availability>
-		<model name='(HAG)'>
-			<availability>CHH:4,CDS:4,ROS:4,CGB:4</availability>
-		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CCO:6,CJF:2</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CSA:4,CHH:4,CCC:3,ROS:4,CSL:4,CCO:3,CGB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ATM)'>
+			<availability>General:5,CCO:6,CJF:2</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:4,CDS:4,ROS:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -9709,11 +9709,11 @@
 	</chassis>
 	<chassis name='Marshal' unitType='Mek'>
 		<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:3,Periphery:2,TC:7</availability>
-		<model name='MHL-6MC'>
-			<availability>MOC:4,CC:2</availability>
-		</model>
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:4,CC:2</availability>
 		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,HL:2,PIR:4,MERC:4,TC:4,Periphery:2</availability>
@@ -9721,36 +9721,36 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3,IS:2,FS:3,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,MERC.WD:3,CSR:2,CDS:5,CW:3,CBS:4,CNC:2,MERC:2+,CJF:4,RA:2,BAN:3,CGB:4</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:8,General:5</availability>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:5,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:8,General:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,General:4,CCO:6,CGB:5</availability>
@@ -9758,11 +9758,11 @@
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CSR:1,CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
@@ -9770,41 +9770,41 @@
 		<model name='MAL-1R'>
 			<availability>CGB.FRR:8,MERC:6,DC:1</availability>
 		</model>
-		<model name='MAL-1K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='MAL-C'>
 			<availability>DC:4</availability>
 		</model>
 		<model name='MAL-3R'>
 			<availability>DC:5</availability>
 		</model>
+		<model name='MAL-1K'>
+			<availability>DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:3,CLAN:1,MH:4,TC:6</availability>
-		<model name='(Intermediate)'>
+		<model name='(Fusion)'>
 			<roles>apc</roles>
-			<availability>TC:1</availability>
-		</model>
-		<model name='(Basic)'>
-			<roles>apc</roles>
-			<availability>TC:1-</availability>
-		</model>
-		<model name='(BA)'>
-			<roles>apc</roles>
-			<availability>TC:6</availability>
+			<availability>TC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
+		<model name='(Intermediate)'>
+			<roles>apc</roles>
+			<availability>TC:1</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Fusion)'>
+		<model name='(BA)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:6</availability>
+		</model>
+		<model name='(Basic)'>
+			<roles>apc</roles>
+			<availability>TC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -9824,70 +9824,70 @@
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Company Command)'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:1,CC:1,CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,TC:1,RA.OA:1,OA:1,LA:3,CGB.FRR:2,ROS:1,FWL:1,NIOPS:2-,DC:1</availability>
-		<model name='(C3M)'>
-			<roles>apc,spotter</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
-		</model>
-		<model name='(BA Factory Upgrade)'>
-			<roles>apc</roles>
-			<availability>CC:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
-		</model>
 		<model name='(SRM2)'>
 			<roles>apc</roles>
 			<availability>IS:1-,Periphery:2-</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:1-,Periphery:2-</availability>
-		</model>
-		<model name='(Anti-Infantry)'>
-			<roles>apc,spotter,anti_infantry</roles>
-			<availability>IS:2,DC:3</availability>
-		</model>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
-		<model name='(C3S)'>
+		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
-			<availability>IS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
+		<model name='(BA Field Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
+		</model>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
+			<roles>apc</roles>
+			<availability>CC:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
+		</model>
+		<model name='(C3S)'>
+			<roles>apc,spotter</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Anti-Infantry)'>
+			<roles>apc,spotter,anti_infantry</roles>
+			<availability>IS:2,DC:3</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:1-,Periphery:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Mk II Transport' unitType='Tank'>
 		<availability>LA:2,ROS:3,MERC:1</availability>
-		<model name='(Standard)'>
+		<model name='(ECM)'>
 			<roles>apc</roles>
-			<availability>LA:8,ROS:8</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Infantry Support) &apos;Shiloh&apos;'>
 			<roles>apc</roles>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>General:4</availability>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -9911,12 +9911,12 @@
 			<roles>interceptor</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<roles>interceptor</roles>
 			<availability>FVC:1,CGB.FRR:1,MERC:1,Periphery:1,DC:1</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -9931,8 +9931,11 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -9941,11 +9944,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -9953,35 +9953,35 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -9994,11 +9994,11 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -10033,11 +10033,11 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5+</availability>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -10045,21 +10045,21 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='MS1-OU'>
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='MS1-OA'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
@@ -10115,14 +10115,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>RA.OA:8,OA:8,CSR:2,HL:3,MERC:6,RA:4,Periphery:4</availability>
-		<model name='MLN-1C'>
-			<availability>RA.OA:6,FVC:4,OA:6,CSR:3,MERC:4,CDP:4,RA:6,TC:4</availability>
-		</model>
 		<model name='MLN-1A'>
 			<availability>General:3-</availability>
 		</model>
 		<model name='MLN-1B'>
 			<availability>RA.OA:8,OA:8,HL:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='MLN-1C'>
+			<availability>RA.OA:6,FVC:4,OA:6,CSR:3,MERC:4,CDP:4,RA:6,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -10131,6 +10131,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,ROS:6</availability>
+		</model>
+		<model name='(Gauss) &apos;Sandblaster&apos;'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
@@ -10142,28 +10147,23 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Gauss) &apos;Sandblaster&apos;'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CSA:6,CHH:8,CCC:8,CSR:2,CBS:4,CSL:8,RA:2</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='P2'>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='4'>
 			<availability>CBS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='XP'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CHH:8,CCC:6,CSL:8</availability>
+		</model>
+		<model name='P2'>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -10198,34 +10198,34 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:5,ROS:3,FS:3,MERC:3</availability>
-		<model name='MLR-BX'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='MLR-B2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MLR-BX'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -10248,15 +10248,15 @@
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
 		<availability>DTA:3,CC:3,MOC:3,PR:3,DoO:4,PG:3,DO:4,TP:4,DA:4,RCM:3,MERC:3,RFS:3</availability>
-		<model name='M2'>
-			<availability>General:6</availability>
-		</model>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
 			<availability>FWL:2,DA:4</availability>
+		</model>
+		<model name='M2'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>
@@ -10302,9 +10302,6 @@
 		<model name='(2776)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
 		<availability>ROS:3</availability>
@@ -10325,6 +10322,10 @@
 	</chassis>
 	<chassis name='Morrigan' unitType='Mek'>
 		<availability>CDS:1,ROS:1,CNC:2,DC:1</availability>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<roles>specops</roles>
 			<availability>IS:4</availability>
@@ -10332,10 +10333,6 @@
 		<model name='2'>
 			<roles>recon</roles>
 			<availability>CLAN:4,IS:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
@@ -10370,33 +10367,33 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mountaineer' unitType='Infantry'>
@@ -10422,29 +10419,29 @@
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>ROS:3,FS:6</availability>
-		<model name='(Armor)'>
+		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
-			<availability>FS:4</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='(3080 Upgrade)'>
+		<model name='(Armor)'>
 			<roles>spotter</roles>
-			<availability>General:6</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:5,RA.OA:2,OA:2,LA:5,ROS:4,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
-		<model name='Type 2'>
-			<availability>CC:7</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>ROS:5,FS:4,MERC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Naga' unitType='Mek' omni='Clan'>
@@ -10453,36 +10450,36 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>ROS:3,MERC:3,DC:6</availability>
-		<model name='NG-C3A'>
-			<roles>fire_support,spotter</roles>
-			<availability>DC:8</availability>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+		<model name='NG-C3A'>
+			<roles>fire_support,spotter</roles>
+			<availability>DC:8</availability>
 		</model>
 		<model name='NG-C3B'>
 			<roles>spotter</roles>
@@ -10511,11 +10508,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -10527,11 +10524,17 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CJF:5</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:7,CLAN:5,IS:3</availability>
@@ -10539,28 +10542,22 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='F'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>RA.OA:3,FVC:3,OA:3,CW:4,LA:5,ROS:3,CLAN:2,MERC:3,CGB:4</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Wolf' unitType='Mek'>
@@ -10594,6 +10591,9 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>ROS:5</availability>
@@ -10602,29 +10602,26 @@
 			<roles>apc</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>Periphery.R:2,PR:5,LA:8,DoO:5,ROS:6,PG:5,DO:5,TP:5,FS:7,MERC:6,RFS:5</availability>
-		<model name='NGS-4T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-4S'>
 			<availability>:0,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 		</model>
-		<model name='NGS-5T'>
-			<availability>PR:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
+		<model name='NGS-4T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6T'>
 			<availability>PR:6,LA:6,ROS:6,PG:6,MERC:6,FS:6,RFS:6</availability>
 		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
+		<model name='NGS-5T'>
+			<availability>PR:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
 		</model>
 		<model name='NGS-6S'>
 			<availability>LA:7,ROS:6,MERC:3</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -10632,11 +10629,11 @@
 		<model name='NSR-9FC'>
 			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
-		<model name='NSR-9SS'>
-			<availability>LA:4,MERC:2,FS:4</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9SS'>
+			<availability>LA:4,MERC:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nike Air Defense Platform' unitType='Tank'>
@@ -10650,11 +10647,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-4'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='NJT-3'>
 			<availability>General:2</availability>
+		</model>
+		<model name='NJT-4'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -10666,31 +10663,40 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:8,DC.SL:2,LA:3,CGB.FRR:4,ROS:4,MERC:3,DC:7,CGB:4</availability>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
-		</model>
-		<model name='NDA-2KC'>
-			<availability>ROS:6,MERC:6,DC:7</availability>
+		<model name='NDA-2KO'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
+		<model name='NDA-2KC'>
+			<availability>ROS:6,MERC:6,DC:7</availability>
+		</model>
 		<model name='NDA-1K'>
 			<availability>CGB.FRR:5,ROS:6,MERC:5,DC:5,CGB:4</availability>
 		</model>
-		<model name='NDA-2KO'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,ROS:1+,CNC:8</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
+		</model>
+		<model name='N'>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10699,18 +10705,9 @@
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -10722,6 +10719,15 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CDS:6,ROS:4+,CNC:9,CLAN:3,CWIE:4</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -10730,36 +10736,24 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-	</chassis>
-	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
-		<availability>RA.OA:2,RA:3-</availability>
-		<model name='2 &apos;Numantia&apos;'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
 		<availability>RA.OA:5,RA:6-</availability>
+		<model name='2 &apos;Numantia&apos;'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
@@ -10767,10 +10761,6 @@
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>DTA:2,LA:2,ROS:4,MERC:3,FS:2,DC:4,CGB:2</availability>
-		<model name='NX-80C'>
-			<roles>recon</roles>
-			<availability>DTA:3,ROS:3,MERC:2,DC:3</availability>
-		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -10783,46 +10773,50 @@
 			<roles>recon</roles>
 			<availability>ROS:4,DC:2</availability>
 		</model>
+		<model name='NX-80C'>
+			<roles>recon</roles>
+			<availability>DTA:3,ROS:3,MERC:2,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='OBK-M12'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>DC:2</availability>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
+		<model name='OBK-M12'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ocelot' unitType='Mek'>
 		<availability>CDS:3,ROS:2,CNC:6,DC:2,CGB:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CNC:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CNC:3,DC:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CNC:4</availability>
 		</model>
+		<model name='4'>
+			<availability>CNC:3,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
 		<availability>ROS:3,CLAN:5,CJF:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8,ROS:8,CLAN:8</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>recon,spotter</roles>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8,ROS:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Odyssey Jumpship' unitType='Jumpship'>
@@ -10846,53 +10840,53 @@
 	</chassis>
 	<chassis name='Oni' unitType='Aero'>
 		<availability>CGB.FRR:4,CNC:4,DC:5</availability>
-		<model name='ON-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ON-2'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='ON-1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:7,CC:5,HL:1,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4,DC:3</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:7,CNC:8,IS:7</availability>
+		<model name='HEAT'>
+			<availability>PR:2,LA:1,ROS:2,PG:2,FS:1,RFS:2</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
+		<model name='(Fusion)'>
+			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:5,IS:5</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1</availability>
+		<model name='(MML)'>
+			<availability>MOC:5,IS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,General:3,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='HEAT'>
-			<availability>PR:2,LA:1,ROS:2,PG:2,FS:1,RFS:2</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:7,CNC:8,IS:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:6,CSL:5,CCO:4</availability>
+		<model name='3'>
+			<availability>CHH:4,CSL:4</availability>
+		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:4,CSL:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<availability>CHH:4,CSL:4</availability>
 		</model>
 	</chassis>
@@ -10904,42 +10898,42 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,OA:2,CW:2,LA:1,CGB.FRR:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:4-,DC:4</availability>
-		<model name='ON1-MD'>
-			<availability>MOC:4,CC:4,PR:4,DGM:4,MERC:2,FS:2,SC:4,MCM:4,ROS:4,PG:4,FWL:4,MSC:4,RFS:4</availability>
-		</model>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2,MOC:2,DoO:4,DO:4,DGM:4,MERC:2,SC:4,MCM:4,ROS:4,FWL:4,MSC:4,TP:4,DA:4,RCM:4,DC:2</availability>
-		</model>
-		<model name='ON2-M'>
-			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3</availability>
-		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1-</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
-		</model>
-		<model name='ON1-V'>
-			<availability>IS:1-,MH:1-,CDP:1-,TC:1-</availability>
-		</model>
-		<model name='ON1-VA'>
-			<availability>IS:1-</availability>
-		</model>
-		<model name='ON1-M-DC'>
-			<availability>IS:5,DC:8</availability>
-		</model>
 		<model name='ON3-M'>
 			<roles>spotter</roles>
 			<availability>CC:2,FWL:2,MERC:2</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		</model>
+		<model name='ON1-MC'>
+			<availability>CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
+		</model>
+		<model name='ON1-V'>
+			<availability>IS:1-,MH:1-,CDP:1-,TC:1-</availability>
+		</model>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1-</availability>
+		</model>
+		<model name='ON1-MB'>
+			<availability>CC:2,MOC:2,DoO:4,DO:4,DGM:4,MERC:2,SC:4,MCM:4,ROS:4,FWL:4,MSC:4,TP:4,DA:4,RCM:4,DC:2</availability>
+		</model>
 		<model name='ON1-K'>
 			<availability>General:2-,CLAN:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='ON1-M'>
+			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:4,CC:4,PR:4,DGM:4,MERC:2,FS:2,SC:4,MCM:4,ROS:4,PG:4,FWL:4,MSC:4,RFS:4</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:1-</availability>
+		</model>
+		<model name='ON2-M'>
+			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3</availability>
+		</model>
+		<model name='ON1-M-DC'>
+			<availability>IS:5,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -10960,14 +10954,14 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,ROS:3,FS:6,MERC:4,CDP:3</availability>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='OSR-5D'>
 			<availability>FS:5</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -10975,16 +10969,25 @@
 		<model name='OSP-26'>
 			<availability>CC:2,ROS:8</availability>
 		</model>
-		<model name='OSP-25'>
-			<availability>General:6</availability>
-		</model>
 		<model name='OSP-15'>
 			<roles>fire_support,urban</roles>
 			<availability>CC:2</availability>
 		</model>
+		<model name='OSP-25'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,LA:4,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,TC:4,Periphery:2,DC:5</availability>
+		<model name='OSR-3C'>
+			<availability>FVC:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='OSR-4K'>
+			<availability>ROS:4,MERC:3,DC:4</availability>
+		</model>
+		<model name='OSR-5C'>
+			<availability>TC:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
@@ -10992,15 +10995,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2,Periphery:1</availability>
-		</model>
-		<model name='OSR-5C'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='OSR-4K'>
-			<availability>ROS:4,MERC:3,DC:4</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>FVC:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='OSR-2D'>
 			<availability>HL:2,ROS:6,IS:4,Periphery:4</availability>
@@ -11014,11 +11008,11 @@
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>RA:1,CGB:3</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
@@ -11029,9 +11023,9 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,PR:4,DoO:4,DO:4,FS:2,MERC:3,FVC:2,LA:2,CGB.FRR:3,ROS:4,PG:4,NIOPS:3,FWL:2,TP:4,RFS:4,DC:3</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='OTT-7K'>
+			<roles>recon,spotter</roles>
+			<availability>FVC:8,IS:8,DC:8</availability>
 		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
@@ -11045,9 +11039,9 @@
 			<roles>recon,spotter</roles>
 			<availability>CC:2,PR:2,LA:7,DoO:4,ROS:5,PG:2,DO:4,TP:4,MERC:5,FS:2,RFS:2,DC:2</availability>
 		</model>
-		<model name='OTT-7K'>
-			<roles>recon,spotter</roles>
-			<availability>FVC:8,IS:8,DC:8</availability>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -11055,23 +11049,8 @@
 		<model name='OTL-7M'>
 			<availability>DTA:7,SC:8,DoO:8,MCM:8,ROS:6,FWL:6,DO:8,DGM:8,MSC:8,TP:8,MERC:4</availability>
 		</model>
-		<model name='OTL-5D'>
-			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:3,Periphery:3</availability>
-		</model>
 		<model name='OTL-9M'>
 			<availability>ROS:2,FWL:4</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:6,ROS:6,MERC:5</availability>
-		</model>
-		<model name='OTL-5M'>
-			<availability>FWL:4,MERC:4</availability>
-		</model>
-		<model name='OTL-8M'>
-			<availability>DTA:6,SC:6,PR:6,MCM:6,PG:6,DGM:6,MSC:6,MERC:3,RFS:6</availability>
 		</model>
 		<model name='OTL-8D'>
 			<availability>FS:6</availability>
@@ -11079,25 +11058,40 @@
 		<model name='OTL-4D'>
 			<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 		</model>
+		<model name='OTL-6D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-5M'>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
+		<model name='OTL-8M'>
+			<availability>DTA:6,SC:6,PR:6,MCM:6,PG:6,DGM:6,MSC:6,MERC:3,RFS:6</availability>
+		</model>
+		<model name='OTL-9R'>
+			<availability>DTA:6,ROS:6,MERC:5</availability>
+		</model>
+		<model name='OTL-5D'>
+			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:3,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>MOC:2-,PR:4,LA:2-,PG:4,FWL:2,MERC:2-,RFS:4,DC:2-</availability>
-		<model name='OWR-2M'>
-			<availability>General:8,FWL:2-</availability>
-		</model>
 		<model name='OWR-3M'>
 			<availability>PR:8,PG:8,RFS:8</availability>
+		</model>
+		<model name='OWR-2M'>
+			<availability>General:8,FWL:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:7,CW:4,CSL:6</availability>
-		<model name='(3063)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(3070)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(3063)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
@@ -11113,41 +11107,37 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,CLAN:8,IS:5,Periphery.Deep:4,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,OA:5,LA:6,CBS:7,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='A3A'>
-			<availability>LA:2,ROS:2,FS:2</availability>
-		</model>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:3,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:7,IS:3,FS:7</availability>
+		</model>
+		<model name='A3A'>
+			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 		<model name='A3'>
 			<roles>assault</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:3,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:4,ROS:3,CNC:4,FWL:4,FS:4,MERC:4,DC:6</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='OW-1C'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -11155,13 +11145,17 @@
 			<roles>recon,spotter</roles>
 			<availability>General:2,CLAN:6</availability>
 		</model>
-		<model name='OW-1A'>
+		<model name='OW-1E'>
 			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='OW-1F'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter II' unitType='Mek'>
@@ -11172,17 +11166,17 @@
 		<model name='4'>
 			<availability>CWIE:2</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CWIE:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:2,CHH:2,CCC:2,CDS:4,CSR:1,CNC:2,CCO:2,CWIE:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CDS:3,CWIE:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CWIE:4</availability>
@@ -11190,16 +11184,12 @@
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CDS:3,CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:2-,CC:3-,HL:2-,IS:3-,Periphery.Deep:4,FS:5-,FS.CrMM:6-,Periphery:3-,TC:3-,RA.OA:3-,FVC:6-,OA:3-,LA:5-,FS.PMM:4-,CGB.FRR:3-,FS.CMM:6-,FS.DMM:6-,FWL:3-,NIOPS:6,DC:3-</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -11208,13 +11198,17 @@
 			<roles>recon,raider</roles>
 			<availability>CC:2,CGB.FRR:2,PIR:2,General:2,FWL:2,Periphery.Deep:6,MERC:2,FS:2,Periphery:3,DC:2</availability>
 		</model>
-		<model name='&apos;Gespenst&apos;'>
-			<roles>recon,specops</roles>
-			<availability>LA:2</availability>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
 			<availability>FWL.pm:4,SC:3-,MCM:3-,MSC.pm:4,DGM:3-,DA:3-,RCM.pm:4</availability>
+		</model>
+		<model name='&apos;Gespenst&apos;'>
+			<roles>recon,specops</roles>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -11226,17 +11220,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:2</availability>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>LA:3,DoO:3,ROS:3,DO:3,TP:3,FS:3,DC:3</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>LA:3,DoO:3,ROS:3,DO:3,TP:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pandarus' unitType='Mek'>
@@ -11262,68 +11256,64 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:4,HL:2,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CGB.FRR:6,ROS:4,FS.DMM:4,CNC:2,NIOPS:2,DC:8</availability>
-		<model name='PNT-16K'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
 		<model name='PNT-10KA'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:2,CGB.FRR:2,PIR:2,CNC:8,FS.DMM:2,MERC:2,DC:2,TC:2</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,FVC:3,CGB.FRR:5,PIR:3,CNC:4,FS.DMM:3,MERC:3,DC:4,TC:3</availability>
-		</model>
-		<model name='PNT-10K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:2,CGB.FRR:2,ROS:2,FS.DMM:2,MERC:2,RA:2,DC:3,TC:2</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:1,FS.DMM:1,MERC:1,DC:1</availability>
-		</model>
-		<model name='PNT-13K'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:4,DC:4</availability>
 		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>ROS:3,DC:4</availability>
 		</model>
-		<model name='PNT-C'>
+		<model name='PNT-12K2'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:3,CGB.FRR:2,FS.DMM:3,MERC:3,DC:3</availability>
+			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='PNT-9R'>
+		<model name='PNT-CA'>
 			<roles>fire_support</roles>
-			<availability>IS:3-,Periphery.Deep:8,MERC:3-,Periphery:3-,DC:3-</availability>
+			<availability>FS.RR:1,FS.DMM:1,MERC:1,DC:1</availability>
+		</model>
+		<model name='PNT-10K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:2,CGB.FRR:2,ROS:2,FS.DMM:2,MERC:2,RA:2,DC:3,TC:2</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,FVC:3,CGB.FRR:5,PIR:3,CNC:4,FS.DMM:3,MERC:3,DC:4,TC:3</availability>
 		</model>
 		<model name='PNT-12K'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:4,CGB.FRR:4,FS.DMM:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='PNT-12K2'>
+		<model name='PNT-16K'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4</availability>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PNT-9R'>
+			<roles>fire_support</roles>
+			<availability>IS:3-,Periphery.Deep:8,MERC:3-,Periphery:3-,DC:3-</availability>
+		</model>
+		<model name='PNT-13K'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:4,DC:4</availability>
+		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,CGB.FRR:2,FS.DMM:3,MERC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
 		<availability>FWL:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MFB)'>
 			<roles>support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Parash' unitType='Mek'>
 		<availability>CHH:4</availability>
-		<model name='3'>
-			<roles>recon,spotter</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
@@ -11332,23 +11322,27 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='3'>
+			<roles>recon,spotter</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,HL:4,LA:7,CGB.FRR:4,CNC:5,IS:5,FS:8,DC:6,Periphery:5,CWIE:5</availability>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:5,FS:5</availability>
-		</model>
 		<model name='(Quad RAC)'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:5,FS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>HL:1,IS:4,Periphery:4</availability>
 		</model>
-		<model name='(Company Command)'>
+		<model name='(Lance Command)'>
 			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:2,FS:2</availability>
+			<availability>ROS:5,FS:5</availability>
 		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
@@ -11357,31 +11351,31 @@
 		<model name='(Cell)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>ROS:2,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:4-,CC:1-,HL:3-,IS:3-,Periphery.Deep:9,FS:4-,Periphery:4-,TC:4-,RA.OA:2-,OA:2-,CDS:1,LA:3-,FWL:3-,DC:1-</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
-		<model name='(C3)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:1-,Periphery:3-</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -11423,11 +11417,11 @@
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
 		<availability>FVC:4,PR:5,LA:6,CGB.FRR:4,ROS:5,PG:5,FS:5,MERC:4,RFS:5,CWIE:5</availability>
-		<model name='(Standard)'>
-			<availability>HL:2,IS:2-,Periphery:4</availability>
-		</model>
 		<model name='(Ultra)'>
 			<availability>LA:8,General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:2,IS:2-,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Peacekeeper' unitType='Mek'>
@@ -11441,13 +11435,21 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:1,RA.OA:1,OA:1,LA:6,ROS:6,FWL:1,Periphery.Deep:8,FS:6,Periphery:1,TC:1,DC:6</availability>
+		<model name='(C3)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4,FS:4,DC:7</availability>
+		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>FVC:1</availability>
 		</model>
-		<model name='(C3)'>
+		<model name='(MRM)'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='(Sealed)'>
 			<roles>recon,spotter</roles>
-			<availability>LA:4,FS:4,DC:7</availability>
+			<availability>LA:5,ROS:6,FS:5,DC:5</availability>
 		</model>
 		<model name='X-Pulse'>
 			<roles>recon</roles>
@@ -11461,14 +11463,6 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:6,FS:8,DC:7</availability>
 		</model>
-		<model name='(MRM)'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Sealed)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:5,ROS:6,FS:5,DC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Pendragon' unitType='Mek'>
 		<availability>FS:2</availability>
@@ -11479,20 +11473,20 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='PTR-6T'>
-			<availability>FS.DBG:8,FS:4</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-6T'>
+			<availability>FS.DBG:8,FS:4</availability>
+		</model>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Penthesilea' unitType='Mek'>
@@ -11522,31 +11516,31 @@
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:3,FWL:5,DO:6,DGM:6,MSC:4,TP:6</availability>
-		<model name='P1E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='P1D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1'>
-			<availability>General:8</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='P1B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1W'>
 			<availability>General:2</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -11563,101 +11557,100 @@
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
 		<availability>CC:3,LA:3,FWL:4,IS:2,FS:3,MERC:3,DC:3</availability>
+		<model name='(Prototype)'>
+			<availability>LA:2</availability>
+		</model>
 		<model name='(Production)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Prototype)'>
-			<availability>LA:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CSR:3,CW:8,CSL:7,CCO:4,CJF:7,RA:4,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,General:8,CCO:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:7,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,General:8,CCO:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
-		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CC:2,CCC:5,CSR:3,CLAN:3,MERC:2,FS:2,CCO:5,RA:4,CSA:3,DTA:2,CDS:5,CBS:3,LA:2,ROS:3,MSC:2,DC:2</availability>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>DTA:3,CDS:7,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:3,CSR:2,CNC:3,IS:2,CCO:3,DC:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:6,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
-		</model>
-		<model name='6'>
-			<availability>CDS:6,CGB:6</availability>
 		</model>
 		<model name='7'>
 			<availability>CDS:5,General:4,CGB:6,DC:4</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:2</availability>
+		<model name='4'>
+			<availability>CDS:6,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='3'>
+			<availability>DTA:3,CDS:7,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='6'>
+			<availability>CDS:6,CGB:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CCC:2,CDS:2,CSR:3,CNC:2,CCO:2,RA:4</availability>
 		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK1R'>
-            <availability>IS:2</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK1R'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>HL:5,IS:8,FWL:9,NIOPS:5,Periphery.Deep:4,Periphery:6,CGB:2</availability>
-		<model name='PXH-6D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CC:3,DoO:4,CLAN:3,DO:4,DGM:5,MERC:3,SC:5,MCM:5,FWL:4,MSC:5,TP:4,DA:4,RCM:4</availability>
+		<model name='PXH-7K'>
+			<availability>DoO:4,DO:4,TP:4,DC:4</availability>
 		</model>
 		<model name='PXH-7S'>
 			<availability>PR:3,LA:6,ROS:4,PG:3,MERC:5,RFS:3</availability>
+		</model>
+		<model name='PXH-4W'>
+			<availability>MOC:4,TC:4</availability>
 		</model>
 		<model name='PXH-4L'>
 			<availability>CC:7,MOC:4,MH:4,DA:4,TC:4</availability>
@@ -11666,48 +11659,49 @@
 			<roles>recon</roles>
 			<availability>FVC:2-,PIR:2-,FS:2-,MERC:2-</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,FS:6,MERC:4</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:2-,BAN:6,Periphery:2-</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>ROS:2,CGB.FRR:4,DC:2</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
 		<model name='PXH-5L'>
 			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>CGB.FRR:8,DC:8</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>SC:6,MCM:6,CLAN:5,FWL:4,DGM:6,MSC:6,BAN:1</availability>
 		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:1-</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>CGB.FRR:8,DC:8</availability>
+		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:5,MERC:4</availability>
 		</model>
-		<model name='PXH-7K'>
-			<availability>DoO:4,DO:4,TP:4,DC:4</availability>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:4,TC:4</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,FS:6,MERC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>ROS:2,CGB.FRR:4,DC:2</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:2-,BAN:6,Periphery:2-</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CC:3,DoO:4,CLAN:3,DO:4,DGM:5,MERC:3,SC:5,MCM:5,FWL:4,MSC:5,TP:4,DA:4,RCM:4</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -11715,17 +11709,17 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:3,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,FS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:3-,OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-,DC:2-</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>CC:8,MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:3,IS:3,Periphery:5</availability>
 		</model>
 		<model name='(RAC) &apos;Assault Pike&apos;'>
 			<availability>CC:7,MOC:6,FS:6,MERC:7,DA:8,TC:6</availability>
 		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
+		<model name='(Standard)'>
+			<availability>HL:3,IS:3,Periphery:5</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -11733,6 +11727,9 @@
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,MOC:3,MERC.WD:4,MERC.KH:4,ROS:3,CNC:6,NIOPS:4,MERC:4</availability>
+		<model name='PLG-5Z'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
@@ -11743,19 +11740,16 @@
 		<model name='PLG-3Z'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PLG-5Z'>
-			<availability>CC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,ROS:4,FS:7,MERC:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -11778,9 +11772,6 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:5,CDS:4,CSR:2,CBS:3,RA:2,CWIE:3</availability>
-		<model name='2'>
-			<availability>CHH:3,CDS:3</availability>
-		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4</availability>
@@ -11790,6 +11781,9 @@
 		</model>
 		<model name='3'>
 			<availability>CDS:5,CSR:2,RA:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:3,CDS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -11801,9 +11795,6 @@
 	</chassis>
 	<chassis name='Plainsman Medium Hovertank' unitType='Tank'>
 		<availability>MERC.WD:3,HL:2,LA:5,CGB.FRR:6,FWL:4,IS:3,TC:8,Periphery:3,CGB:2</availability>
-		<model name='(Sealed)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>HL:2,IS:6,TC:6,Periphery:4</availability>
 		</model>
@@ -11813,6 +11804,9 @@
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,IS:5,Periphery:5</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
@@ -11860,61 +11854,61 @@
 		<model name='(Gauss)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CC:7,MOC:7</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,CC:2</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CC:7,MOC:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Poignard' unitType='Aero'>
 		<availability>DTA:3,SC:5,MCM:5,ROS:3,FWL:3,DGM:5,MSC:4,RCM:3,MERC:2</availability>
-		<model name='PGD-R3'>
-			<roles>ground_support</roles>
+		<model name='PGD-L3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='PGD-Y3'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PGD-L3'>
+		<model name='PGD-R3'>
+			<roles>ground_support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CSA:1,CHH:1,CCC:2,CDS:5,CSR:3,NIOPS:1,CCO:2,RA:4,CWIE:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CSL:4,CCO:6,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>CDS:6,CBS:6,General:8,CJF:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:6,CBS:6,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:3,General:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
@@ -11932,10 +11926,16 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:6,CBS:4,CSL:6,CCO:6</availability>
-		<model name='3'>
-			<availability>CCO:4</availability>
+		<model name='(Quad)'>
+			<availability>CHH:5+</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:1,CCO:1</availability>
 		</model>
 		<model name='4'>
+			<availability>CCO:4</availability>
+		</model>
+		<model name='3'>
 			<availability>CCO:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -11943,12 +11943,6 @@
 		</model>
 		<model name='5'>
 			<availability>CCO:4</availability>
-		</model>
-		<model name='(Quad)'>
-			<availability>CHH:5+</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:1,CCO:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -11959,7 +11953,7 @@
 		</model>
 	</chassis>
 	<chassis name='Protector Combat Support Fighter' unitType='Conventional Fighter'>
-		<availability>MOC:5,OA:6,FS:2,Periphery:4,DC:2,OA.RA:6</availability>
+		<availability>MOC:5,OA:6,OA.RA:6,FS:2,Periphery:4,DC:2</availability>
 		<model name='ASF-23'>
 			<availability>General:6</availability>
 		</model>
@@ -11970,17 +11964,9 @@
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(RAF)'>
-			<roles>apc</roles>
-			<availability>ROS:6</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:3,Periphery:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
@@ -11990,9 +11976,24 @@
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4,CGB:4,RA:4</availability>
 		</model>
+		<model name='(RAF)'>
+			<roles>apc</roles>
+			<availability>ROS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CSR:4,CLAN:7,MERC:2+,CCO:6,RA:5,BAN:6,CWIE:8,CSA:8,MERC.WD:5,CDS:8,CW:8,CBS:6,ROS:2+,CNC:8,CJF:5,CGB:6</availability>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:3,CJF:6</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,General:4,CGB:3</availability>
 		</model>
@@ -12000,25 +12001,18 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:3,CCO:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CBS:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CBS:6,CLAN:4,General:3,CJF:6</availability>
+		<model name='E'>
+			<availability>CSA:5,CDS:5,CW:5,CBS:3,CLAN:4,General:3,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -12035,15 +12029,15 @@
 	</chassis>
 	<chassis name='Purifier Adaptive Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:4</availability>
-		<model name='[Laser] (RAF)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[PPC] (RAF)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[TAG] (RAF)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='[PPC] (RAF)' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (RAF)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
@@ -12063,73 +12057,73 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>PR:6,HL:3,DoO:6,Periphery.Deep:4,DO:6,FS:4,CDP:3,RA.OA:3,SC:6,OA:3,CGB.FRR:7,FWL:6,NIOPS:3-,MSC:4,RFS:6,MOC:3,CC:4,IS:3,DGM:6,Periphery:4,TC:3,DTA:6,FVC:3,LA:3,MCM:6,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
-		<model name='QKD-4H'>
-			<availability>General:2-</availability>
+		<model name='QKD-5K2'>
+			<availability>MERC:1,DC:1</availability>
+		</model>
+		<model name='QKD-5K'>
+			<availability>CGB.FRR:4,MERC:5,DC:5</availability>
 		</model>
 		<model name='QKD-5A'>
 			<availability>MERC:2-,DC:2-,Periphery:2-</availability>
-		</model>
-		<model name='QKD-8K'>
-			<availability>CGB.FRR:5,ROS:5,MERC:4,DC:8</availability>
 		</model>
 		<model name='QKD-8P'>
 			<roles>spotter</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>CGB.FRR:4,MERC:5,DC:5</availability>
-		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:5,FWL:7</availability>
-		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:7,FVC:7,Periphery.CM:7,Periphery.ME:7,FWL:8,IS:7,MH:7,TC:7,Periphery:3</availability>
-		</model>
-		<model name='QKD-5K2'>
-			<availability>MERC:1,DC:1</availability>
-		</model>
-		<model name='QKD-4G'>
-			<availability>MOC:3-,OA:3-,Periphery.Deep:8,FWL:2-,IS:2-,Periphery:3-,DC:2-,TC:3-</availability>
+		<model name='QKD-8K'>
+			<availability>CGB.FRR:5,ROS:5,MERC:4,DC:8</availability>
 		</model>
 		<model name='QKD-C'>
 			<availability>CGB.FRR:8,MERC:6,DC:8</availability>
 		</model>
+		<model name='QKD-4G'>
+			<availability>MOC:3-,OA:3-,Periphery.Deep:8,FWL:2-,IS:2-,Periphery:3-,DC:2-,TC:3-</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:7,FVC:7,Periphery.CM:7,Periphery.ME:7,FWL:8,IS:7,MH:7,TC:7,Periphery:3</availability>
+		</model>
+		<model name='QKD-5Mr'>
+			<availability>General:5,FWL:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Rabid Coyote' unitType='Mek'>
 		<availability>CCC:3,CW:4,CCO:5-</availability>
-		<model name='2'>
-			<availability>CW:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCC:8,CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:7</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:3,ROS:3,MERC:3,FS:4</availability>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='MDG-1Ar'>
 			<availability>ROS:8,FS:4,MERC:4</availability>
@@ -12137,23 +12131,19 @@
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>FVC:4,LA:4,ROS:5,ROS.pm:6,FWL:4,MH:5,MERC:5,FS:4,CDP:4,DC:4</availability>
-		<model name='VV1'>
+		<model name='VV1 (MG)'>
 			<roles>urban</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VV1 (Interdictor)'>
 			<roles>urban</roles>
 			<availability>FS:2</availability>
-		</model>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='VV2'>
 			<roles>urban</roles>
@@ -12163,27 +12153,35 @@
 			<roles>urban</roles>
 			<availability>LA:1,ROS:1,FS:1</availability>
 		</model>
+		<model name='VV1'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:5,ROS:5,CLAN:2,NIOPS:6</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='RPR-100'>
+			<availability>General:3,NIOPS:8</availability>
 		</model>
 		<model name='RPR-300S'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>General:3,NIOPS:8</availability>
+		<model name='RPR-200'>
+			<availability>CSR:1,CBS:1</availability>
+		</model>
+		<model name='RPR-100b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='RPR-300'>
 			<availability>LA:6,ROS:3,MERC:3</availability>
 		</model>
-		<model name='RPR-200'>
-			<availability>CSR:1,CBS:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
 		<availability>ROS:4</availability>
+		<model name='RPT-2X'>
+			<roles>specops</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='RPT-5X'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
@@ -12196,24 +12194,32 @@
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='RPT-2X'>
-			<roles>specops</roles>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>FS:4,DC:6</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='RTX1-OU'>
-			<availability>General:2</availability>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
@@ -12221,18 +12227,6 @@
 		<model name='RTX1-OD'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
@@ -12246,40 +12240,40 @@
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:7,MOC:3,FWL:3,MERC:6,DA:4,TC:3</availability>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:4,MOC:2</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:3,MOC:2,FWL:1,MERC:2,DC:2,TC:2</availability>
-		</model>
 		<model name='RVN-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:2,MOC:3,FWL:3,MERC:3,TC:3</availability>
 		</model>
-		<model name='RVN-4L'>
+		<model name='RVN-4Lr'>
 			<roles>spotter</roles>
-			<availability>CC:6,MOC:6,DA:6,TC:6</availability>
+			<availability>CC:4,MOC:2</availability>
 		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
 		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:3,MOC:2,FWL:1,MERC:2,DC:2,TC:2</availability>
+		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6,DA:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>PR:3,DoO:4,DO:4,MERC:4,FS:4,LA:6,ROS:3,CGB.FRR:5,PG:3,MH:3,TP:4,DA:3,RFS:3</availability>
-		<model name='RZK-9S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RZK-10T'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='RZK-10S'>
-			<availability>LA:4</availability>
+		<model name='RZK-9S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Recon Infantry' unitType='Infantry'>
@@ -12307,99 +12301,113 @@
 		<model name='(Stealth)'>
 			<availability>CC:6</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>ROS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,CLAN:4,Periphery.Deep:9,IS:5,FS:6,MERC:7,Periphery:10,TC:7,RA.OA:7,OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:1,CW:1,General:8,CNC:1</availability>
 		</model>
-		<model name='(ML)'>
+		<model name='(MG)'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(ML)'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>PR:7,DoO:8,DO:8,FS:2,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:6,RFS:7,MOC:2,CC:3,DGM:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
+		<model name='F-700a'>
+			<availability>CC:7,MOC:2,PR:6,DoO:6,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
+		</model>
+		<model name='F-100b'>
+			<availability>CGB.FRR:1-,DC:2-</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>FVC:2-,FWL:3-,MERC:3-,Periphery:2-</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:8,MOC:2,PR:8,DoO:8,DO:8,DGM:8,MERC:8,DTA:8,SC:8,MCM:8,ROS:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
-		<model name='F-100b'>
-			<availability>CGB.FRR:1-,DC:2-</availability>
+		<model name='F-700b'>
+			<availability>MOC:2,CC:2,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,ROS:6,FWL:6,MSC:8,TP:8,DC:6</availability>
 		</model>
 		<model name='F-100'>
 			<availability>FVC:3-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 		</model>
-		<model name='F-700a'>
-			<availability>CC:7,MOC:2,PR:6,DoO:6,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
-		</model>
-		<model name='F-700b'>
-			<availability>MOC:2,CC:2,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,ROS:6,FWL:6,MSC:8,TP:8,DC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CSR:3,CNC:5,IS:3,RA:4,CGB:5</availability>
-		<model name='2'>
-			<availability>CNC:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CSA:6,CHH:4,CDS:4</availability>
-		</model>
 		<model name='8'>
 			<availability>CC:3,DoO:3,IS:2,DO:3,DGM:3,FS:3,MERC:3,SC:3,CDS:4,LA:3,MCM:3,MSC:3,TP:3,DC:3,CGB:6</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:5,CCC:6,CDS:4,CBS:2,ROS:4,MERC:4,FS:4</availability>
-		</model>
-		<model name='7'>
-			<availability>ROS:4,CNC:6,DC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:2,CNC:2,CLAN:1,RA:2</availability>
 		</model>
 		<model name='5'>
 			<availability>CSA:6,CDS:4,IS:4,CLAN.HW:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:2,CNC:2,CLAN:1,RA:2</availability>
+		</model>
+		<model name='7'>
+			<availability>ROS:4,CNC:6,DC:5</availability>
+		</model>
 		<model name='4'>
 			<availability>CSA:6,CCC:5,CBS:5,ROS:4,FS:4</availability>
+		</model>
+		<model name='6'>
+			<availability>CSA:6,CHH:4,CDS:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:5,CCC:6,CDS:4,CBS:2,ROS:4,MERC:4,FS:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:5,CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
+		<model name='RFL-7M'>
+			<availability>MOC:3,PR:7,DoO:7,IS:2,DO:7,DGM:7,CDP:3,TC:3,DTA:7,SC:7,MCM:7,CGB.FRR:5,PG:7,FWL:7,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
+		</model>
+		<model name='RFL-4D'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FVC:1-,FS:1-</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='RFL-5D'>
+			<availability>FVC:4,LA:3,FS:3,MERC:4</availability>
+		</model>
+		<model name='RFL-3Cr'>
+			<availability>FS:2</availability>
+		</model>
 		<model name='RFL-1N'>
 			<roles>fire_support</roles>
 			<availability>CC:2-,MOC:2-,DoO:2-,PIR:2-,MH:2-,DO:2-,TP:2-,FS:2-,DA:2-,RCM:2-</availability>
 		</model>
-		<model name='RFL-7M'>
-			<availability>MOC:3,PR:7,DoO:7,IS:2,DO:7,DGM:7,CDP:3,TC:3,DTA:7,SC:7,MCM:7,CGB.FRR:5,PG:7,FWL:7,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:4,LA:3,FS:3,MERC:4</availability>
+		<model name='C 2'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='RFL-8D'>
 			<availability>FS:4</availability>
@@ -12410,79 +12418,69 @@
 		<model name='RFL-8X'>
 			<availability>ROS:4,MERC:4</availability>
 		</model>
+		<model name='RFL-6X'>
+			<availability>FVC:2,FS:2,MERC:2</availability>
+		</model>
 		<model name='RFL-7X'>
 			<roles>fire_support</roles>
 			<availability>ROS:4,MERC:4</availability>
 		</model>
-		<model name='C 2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='RFL-5M'>
 			<availability>CC:3,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:3,MH:3,MERC:3,DC:3</availability>
-		</model>
-		<model name='RFL-3Cr'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RFL-4D'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FVC:1-,FS:1-</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:2,FS:2,MERC:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,FVC:4,CSR:1,LA:5,CGB.FRR:5,ROS:6,CLAN:2,NIOPS:6,FS:5,DC:5</availability>
-		<model name='(SPL)'>
-			<roles>apc</roles>
-			<availability>FVC:4,IS:4</availability>
-		</model>
-		<model name='(ERML)'>
-			<roles>apc</roles>
-			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>CNC:3,FS:2,DC:5</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8,BAN:2</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>CNC:3,FS:2,DC:5</availability>
+		</model>
+		<model name='(ERML)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(Infantry)'>
+			<roles>apc</roles>
+			<availability>LA:5,ROS:4,FS:3</availability>
+		</model>
+		<model name='(SPL)'>
+			<roles>apc</roles>
+			<availability>FVC:4,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:4,CHH:4,CSR:4,CBS:7,CNC:7,CSL:4,CCO:8,RA:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CCC:6,CSR:5,CBS:8,CNC:6,CSL:6,CCO:8,RA:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CSR:3,CBS:6,CNC:4,CCO:4,RA:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CSR:3,CCO:4,RA:6</availability>
 		</model>
-		<model name='2'>
-			<availability>CCC:6,CSR:5,CBS:8,CNC:6,CSL:6,CCO:8,RA:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CGB:6-</availability>
+		<model name='HR' mechanized='true'>
+			<roles>recon</roles>
+			<availability>CGB:2</availability>
+		</model>
 		<model name='(Hybrid)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
@@ -12490,18 +12488,14 @@
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HR' mechanized='true'>
-			<roles>recon</roles>
-			<availability>CGB:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>PR:4,FS:4,MERC:2,CWIE:6,TC:6,RA.OA:5,FVC:4,OA:5,LA:6,CGB.FRR:4,ROS:4,PG:4,RFS:4</availability>
-		<model name='(Sealed)'>
-			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
-		</model>
 		<model name='(Gauss)'>
 			<availability>OA:0,FRR:0,General:8</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>ROS:0,General:3,TC:0,CWIE:0</availability>
@@ -12512,14 +12506,14 @@
 		<model name='NH-3X'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='NH-2'>
+			<availability>General:8</availability>
+		</model>
 		<model name='NH-1X &apos;Rook-X&apos;'>
 			<availability>FS:2-</availability>
 		</model>
 		<model name='NH-1A'>
 			<availability>General:2-</availability>
-		</model>
-		<model name='NH-2'>
-			<availability>General:8</availability>
 		</model>
 		<model name='NH-1B'>
 			<availability>ROS:4-,MERC:5-,FS:5-</availability>
@@ -12538,16 +12532,16 @@
 			<roles>urban</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='(Firedrake)' mechanized='false'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>LA:5</availability>
 		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>LA:7</availability>
+		</model>
+		<model name='(Firedrake)' mechanized='false'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -12560,47 +12554,47 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,MERC.WD:6,CDS:6,CSR:4,CBS:7,CLAN:5,MERC:3+,CJF:6,RA:4,BAN:6,CWIE:6,DC:4+</availability>
-		<model name='G'>
-			<availability>CHH:5,General:3</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
 		</model>
+		<model name='A'>
+			<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:5,CCC:5,CBS:4,CLAN:3,General:2</availability>
-		</model>
-		<model name='I'>
-			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
+		<model name='F'>
+			<availability>General:3,CJF:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
+		<model name='I'>
+			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CDS:6,CSR:3,CNC:4,General:5,CCO:7,CJF:4,RA:6,CWIE:6</availability>
 		</model>
-		<model name='F'>
-			<availability>General:3,CJF:5</availability>
-		</model>
 		<model name='C'>
 			<availability>CSR:3,CBS:6,General:5,RA:6,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ryoken II' unitType='Mek'>
 		<availability>CHH:2,CDS:2,ROS:1,IS:1,CGB:4</availability>
-		<model name='2'>
-			<availability>ROS:6,CGB:6</availability>
+		<model name='3'>
+			<availability>CHH:8,ROS:4,CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CDS:8,IS:8,CGB:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CHH:8,ROS:4,CGB:4</availability>
+		<model name='2'>
+			<availability>ROS:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
@@ -12630,13 +12624,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:8,LA:8,FWL:8,IS:7,FS:8,DC:6,Periphery:6</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,DC:7,Periphery:4</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:8,LA:8,FWL:8,IS:7,FS:8,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -12653,33 +12647,27 @@
 		<model name='SB-29'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='SB-31D'>
-			<roles>escort</roles>
-			<availability>DC:5</availability>
+		<model name='SB-28'>
+			<availability>LA:8,ROS:5,NIOPS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:6</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>LA:8,ROS:5,NIOPS:6,FS:6,MERC:6</availability>
+		<model name='SB-31D'>
+			<roles>escort</roles>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
+		<model name='E'>
 			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='X'>
-			<availability>CSR:2,General:1,CJF:3,RA:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -12688,14 +12676,20 @@
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='X'>
+			<availability>CSR:2,General:1,CJF:3,RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
 		<availability>FVC:5,ROS:3,FS:6,MERC:3</availability>
-		<model name='SGT-10X'>
-			<availability>ROS:3,FS:3,MERC:3</availability>
-		</model>
 		<model name='SGT-8R'>
 			<availability>FVC:8,FS:6</availability>
+		</model>
+		<model name='SGT-10X'>
+			<availability>ROS:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='SGT-9D'>
 			<roles>spotter</roles>
@@ -12713,8 +12707,8 @@
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CDS:4,CW:4,CGB.FRR:6,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
-		<model name='S-7'>
-			<availability>ROS:6,CNC:6,DC:6</availability>
+		<model name='S-4C'>
+			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
 		<model name='S-3'>
 			<availability>DC:1-</availability>
@@ -12725,43 +12719,51 @@
 		<model name='S-4'>
 			<availability>CGB.FRR:6,ROS:6,FS:5,DC:6</availability>
 		</model>
-		<model name='S-4C'>
-			<availability>ROS:4,CLAN:8,DC:4</availability>
+		<model name='S-7'>
+			<availability>ROS:6,CNC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:5,Periphery.DD:5,DC.AL:9,IS:5,MERC:5,Periphery.OS:5,FS:4,Periphery:4,RA.OA:4,LA:5,CGB.FRR:6,FWL:5,CJF:4,DC:8</availability>
-		<model name='(Armor)'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>IS:7,DC:8</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
+		<model name='(LB-X)'>
+			<availability>IS:6,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:5-,Periphery:5-</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>IS:6,DC:8</availability>
+		<model name='(Armor)'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:7,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>anti_infantry</roles>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='(Laser)' mechanized='true'>
 			<availability>CSR:3,CW:6,RA:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>anti_infantry</roles>
+			<availability>CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:7,ROS:4,FS:5,MERC:5</availability>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
+		</model>
+		<model name='PPR-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
@@ -12770,17 +12772,9 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,FS:2,MERC:2</availability>
-		</model>
-		<model name='PPR-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -12823,42 +12817,42 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:3,CSR:2,CBS:5,CNC:2,CCO:7,RA:3</availability>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CSR:2,CNC:4,RA:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CSR:2,CNC:4,RA:4</availability>
+		</model>
 		<model name='XP'>
 			<availability>CNC:6</availability>
-		</model>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CHH:2,CW:5,CCO:9</availability>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:8,CLAN:6</availability>
-		</model>
-		<model name='W'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>CHH:3,CW:3</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:3,General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
+		<model name='C'>
+			<availability>CSA:8,CLAN:6</availability>
 		</model>
 		<model name='J'>
 			<availability>CHH:4,CW:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
+		</model>
+		<model name='W'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>CHH:3,CW:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
@@ -12880,32 +12874,36 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MASH)'>
-			<roles>apc,support</roles>
-			<availability>General:4</availability>
+		<model name='(HQ)'>
+			<roles>apc,support,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(HQ)'>
-			<roles>apc,support,spotter</roles>
-			<availability>General:2</availability>
+		<model name='(MASH)'>
+			<roles>apc,support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>PR:5,LA:4,ROS:5,PG:5,FS:6,MERC:4,DA:5,RFS:5</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>PR:5,LA:6,ROS:4,PG:5,FS:3,MERC:5,DA:5,RFS:5</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>PR:5,LA:6,ROS:4,PG:5,FS:3,MERC:5,DA:5,RFS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,DoO:4,CGB.FRR:4,ROS:4,FWL:4,DO:4,TP:4,FS:4,MERC:4,DC:4,CGB:3</availability>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -12914,6 +12912,10 @@
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
@@ -12921,14 +12923,6 @@
 		<model name='E'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
@@ -12943,6 +12937,10 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>MOC:3,CC:1,HL:3,IS:3,Periphery.Deep:5,MERC:3,FS:3,Periphery:4,TC:3,RA:3,RA.OA:4,OA:3,LA:3,CGB.FRR:2,CNC:3,FWL:2,DC:1</availability>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -12950,10 +12948,6 @@
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>CNC:7,IS:5,RA:7</availability>
@@ -12977,11 +12971,8 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,HL:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(MRM)'>
-			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:5,MOC:4,LA:5,ROS:5,FWL:5,IS:4,MH:4,FS:5,MERC:5,CDP:3,DC:5,TC:4</availability>
+		<model name='(LRM)'>
+			<availability>General:2-</availability>
 		</model>
 		<model name='(Minesweeper)'>
 			<roles>minesweeper</roles>
@@ -12990,14 +12981,17 @@
 		<model name='(Standard)'>
 			<availability>General:4-</availability>
 		</model>
-		<model name='(ML)'>
-			<availability>General:2-</availability>
+		<model name='(LAC)'>
+			<availability>CC:5,MOC:4,LA:5,ROS:5,FWL:5,IS:4,MH:4,FS:5,MERC:5,CDP:3,DC:5,TC:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:4-</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:2-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -13005,18 +12999,18 @@
 		<model name='SCP-1N'>
 			<availability>FRR:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 		</model>
-		<model name='SCP-10M'>
-			<availability>CC:4,MOC:3,CGB.FRR:4,ROS:4,FWL:6,MERC:4,DC:4</availability>
-		</model>
-		<model name='SCP-12S'>
-			<availability>LA:3,ROS:2,MERC:2</availability>
-		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
 		<model name='SCP-1O'>
 			<availability>HL:1,IS:5,Periphery:3</availability>
+		</model>
+		<model name='SCP-12S'>
+			<availability>LA:3,ROS:2,MERC:2</availability>
+		</model>
+		<model name='SCP-10M'>
+			<availability>CC:4,MOC:3,CGB.FRR:4,ROS:4,FWL:6,MERC:4,DC:4</availability>
 		</model>
 		<model name='SCP-1TB'>
 			<availability>ROS:4,MERC:4</availability>
@@ -13037,14 +13031,14 @@
 	</chassis>
 	<chassis name='Scylla' unitType='Mek'>
 		<availability>CHH:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:2</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Scytha' unitType='Aero'>
@@ -13058,27 +13052,30 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
+		</model>
 		<model name='(SRM6)'>
 			<availability>General:3</availability>
 		</model>
@@ -13087,9 +13084,6 @@
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:3</availability>
-		</model>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SeaBuster Strike Fighter' unitType='Conventional Fighter'>
@@ -13132,37 +13126,37 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,CC:3,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,OA:7,LA:7,CGB.FRR:2,ROS:6,FWL:2-,MH:2,DC:2-</availability>
-		<model name='SYD-21'>
+		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
-			<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>RA.OA:2-,OA:2-,HL:3-,FRR:2-,ROS:2-,FWL:2-,Periphery:5-,TC:3-,DC:2-</availability>
-		</model>
-		<model name='SYD-Z4'>
-			<availability>CC:8,FVC:2,OA:5,HL:1,LA:6,CGB.FRR:2,ROS:4,MERC:5,FS:2,Periphery:2</availability>
-		</model>
-		<model name='SYD-45X &apos;Starling&apos;'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:1-</availability>
+			<availability>LA:2-,Periphery.Deep:8,Periphery:2-</availability>
 		</model>
 		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
 			<availability>LA:8,CGB.FRR:6,ROS:4,FS:8,MERC:6</availability>
 		</model>
-		<model name='SYD-Z2'>
+		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
-			<availability>LA:2-,Periphery.Deep:8,Periphery:2-</availability>
+			<availability>RA.OA:2-,OA:2-,HL:3-,FRR:2-,ROS:2-,FWL:2-,Periphery:5-,TC:3-,DC:2-</availability>
+		</model>
+		<model name='SYD-Z3A'>
+			<availability>LA:6,CGB.FRR:3,ROS:3,MERC:3,FS:3</availability>
+		</model>
+		<model name='SYD-45X &apos;Starling&apos;'>
+			<availability>LA:1</availability>
+		</model>
+		<model name='SYD-Z4'>
+			<availability>CC:8,FVC:2,OA:5,HL:1,LA:6,CGB.FRR:2,ROS:4,MERC:5,FS:2,Periphery:2</availability>
+		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='SYD-Z2B'>
 			<availability>RA.OA:4,OA:4,LA:4,ROS:4,PIR:3,FS:3,MERC:3,RA:4</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>LA:6,CGB.FRR:3,ROS:3,MERC:3,FS:3</availability>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
@@ -13171,27 +13165,27 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='SYU-4B'>
+		<model name='SYU-6B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SYU-6B'>
+		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat II' unitType='Mek'>
 		<availability>CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='3'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
+		</model>
+		<model name='3'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
@@ -13203,103 +13197,103 @@
 			<roles>recon</roles>
 			<availability>CSR:5,CW:3,General:6,RA:8</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>CSR:2,General:8,RA:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='J'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSR:2,CW:3,General:6,RA:3</availability>
 		</model>
+		<model name='J'>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>CSR:2,General:8,RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>PR:3,CHH:5,DoO:3,DO:3,FS:3,CWIE:5,RA.OA:3,SC:3,OA:3,CDS:5,CGB.FRR:4,FWL:3,MSC:2,RFS:3,CGB:5,IS:2,DGM:3,MERC:4,RA:5,DTA:3,LA:3,MCM:3,ROS:4,PG:3,CNC:5,TP:3,RCM:3,DA:3,DC:3</availability>
+		<model name='8'>
+			<availability>CDS:4,LA:4,CNC:5,IS:2,CWIE:5</availability>
+		</model>
 		<model name='2'>
 			<availability>CSA:2,CCC:2,CGB:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:4,CDS:5,CNC:5,IS:2</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:6</availability>
 		</model>
 		<model name='7'>
 			<availability>RA.OA:6,OA:2,CSR:2,RA:6</availability>
 		</model>
-		<model name='5'>
-			<availability>CDS:7,LA:7,CGB.FRR:6,FWL:7,IS:5,FS:7,MERC:7,DC:7,CGB:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:5,IS:2,RA:4</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:4,LA:4,CNC:5,IS:2,CWIE:5</availability>
+		<model name='3'>
+			<availability>CSA:4,CDS:5,CNC:5,IS:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:7,LA:7,CGB.FRR:6,FWL:7,IS:5,FS:7,MERC:7,DC:7,CGB:4</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>HL:5,IS:4,NIOPS:4-,Periphery.Deep:5,BAN:4,Periphery:6,CGB:4</availability>
-		<model name='SHD-2D2'>
-			<availability>FVC:6,FS:5</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,SC:4,MCM:4,ROS:4,CLAN:4,DGM:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:3-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
-		</model>
 		<model name='SHD-2K'>
 			<availability>MERC:1-,DC:3-</availability>
 		</model>
-		<model name='SHD-9D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='SHD-5M'>
-			<availability>CC:6,CGB.FRR:6,Periphery.MW:4,Periphery.ME:4,FWL:5,MERC:6,Periphery:2,DC:6</availability>
-		</model>
-		<model name='SHD-3K'>
-			<availability>CGB.FRR:4,DC:5,CGB:2</availability>
-		</model>
-		<model name='SHD-5D'>
-			<availability>LA:4,ROS:4,FS:6,MERC:5</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,DoO:6,DO:6,DGM:6,MERC:4,CDP:3,TC:3,DTA:6,SC:6,FVC:3,MCM:6,ROS:4,MSC:6,TP:6,RCM:6</availability>
-		</model>
-		<model name='SHD-12C'>
-			<availability>CGB.FRR:6,ROS:3,CGB:4,DC:3</availability>
+		<model name='SHD-2D2'>
+			<availability>FVC:6,FS:5</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:2-,MOC:2-,FWL:2-,MH:3-,MERC:2-</availability>
 		</model>
+		<model name='SHD-2H'>
+			<availability>General:3-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,SC:4,MCM:4,ROS:4,CLAN:4,DGM:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
+		</model>
+		<model name='SHD-12C'>
+			<availability>CGB.FRR:6,ROS:3,CGB:4,DC:3</availability>
+		</model>
+		<model name='SHD-5M'>
+			<availability>CC:6,CGB.FRR:6,Periphery.MW:4,Periphery.ME:4,FWL:5,MERC:6,Periphery:2,DC:6</availability>
+		</model>
 		<model name='SHD-8L'>
 			<availability>CC:6</availability>
+		</model>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,DoO:6,DO:6,DGM:6,MERC:4,CDP:3,TC:3,DTA:6,SC:6,FVC:3,MCM:6,ROS:4,MSC:6,TP:6,RCM:6</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:4,ROS:4,FS:6,MERC:5</availability>
+		</model>
+		<model name='SHD-3K'>
+			<availability>CGB.FRR:4,DC:5,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CSA:5,CDS:5,CW:5,CBS:7,ROS:3,CLAN:3,CGB:5</availability>
+		<model name='(Flamer)'>
+			<availability>CDS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Interdictor)'>
 			<availability>CHH:4,CDS:4,CSR:2,CW:4,ROS:8,CNC:4,CJF:4,RA:4,CGB:5,CWIE:4</availability>
 		</model>
-		<model name='(Flamer)'>
-			<availability>CDS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,OA:4,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:3,DC:7,Periphery:2</availability>
-		<model name='SL-17'>
-			<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
 		<model name='SL-18'>
 			<availability>ROS:6,MERC:3,DC:7</availability>
+		</model>
+		<model name='SL-17'>
+			<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>RA.OA:2,OA:2,CGB.FRR:2,ROS:3,MERC:2,RA:2,DC:3</availability>
@@ -13313,11 +13307,14 @@
 	</chassis>
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>PR:4,DoO:6,DO:6,DGM:6,DTA:4,SC:6,MCM:6,ROS:3,PG:4,FWL:5,MSC:4,TP:6,RCM:4,DA:4,RFS:4</availability>
-		<model name='SHV-OB'>
+		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
+		</model>
+		<model name='SHV-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -13325,30 +13322,27 @@
 		<model name='SHV-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SHV-OA'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shockwave' unitType='Mek'>
 		<availability>CC:2,DoO:4,DO:4,DGM:4,FS:1,DTA:3,SC:4,MCM:4,ROS:2,FWL:3,MSC:3,TP:4,RCM:2,DC:1</availability>
-		<model name='SKW-4G'>
-			<availability>General:2</availability>
-		</model>
 		<model name='SKW-2F'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SKW-4G'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,CDS:4,CW:3,ROS:2,CNC:5,CGB:3,CWIE:2,DC:3</availability>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:6,DC:6</availability>
+		</model>
 		<model name='(Streak)'>
 			<availability>CDS:2,CW:6,ROS:4,CNC:6,CJF:6,DC:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -13377,28 +13371,40 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverback Coastal Cutter' unitType='Naval'>
+		<availability>LA:7</availability>
+		<model name='(Standard)'>
+			<availability>LA:7</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:5,CCC:7,CCO:4</availability>
+		<model name='2'>
+			<availability>CSA:8,CCC:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSA:4,CCC:4,CCO:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CCC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,SC:5,DoO:5,MCM:5,ROS:2,DO:5,DGM:5,MSC:4,TP:5,MERC:3</availability>
-		<model name='SRC-6C'>
-			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:5,DO:5,DGM:5,MSC:5,TP:5</availability>
-		</model>
 		<model name='SRC-5C'>
 			<availability>DTA:5,SC:5,DoO:5,MCM:5,ROS:5,FWL:5,DO:5,DGM:5,MSC:5,TP:5</availability>
 		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-6C'>
+			<availability>DTA:5,SC:5,DoO:5,MCM:5,FWL:5,DO:5,DGM:5,MSC:5,TP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank Mk II' unitType='Tank'>
@@ -13410,9 +13416,9 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:2,Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,FS:2,RA.OA:1,OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:4,IS.pm:4</availability>
+			<availability>General:4-</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -13422,24 +13428,24 @@
 			<roles>recon</roles>
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:4-</availability>
+			<availability>FVC:4,IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,OA:5,CGB.FRR:7,ROS:4,DC:7,CGB:4</availability>
+		<model name='SL-15A'>
+			<availability>OA:1</availability>
+		</model>
 		<model name='SL-15R'>
 			<availability>RA.OA:6,OA:6,CSR:3,CGB.FRR:8,ROS:6,FS:6,MERC:6,CDP:4,RA:6,DC:8,TC:4,CGB:6</availability>
-		</model>
-		<model name='SL-15'>
-			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
 		</model>
 		<model name='SL-15K'>
 			<availability>CGB.FRR:4,ROS:4,MERC:2,DC:4,CGB:4</availability>
 		</model>
-		<model name='SL-15A'>
-			<availability>OA:1</availability>
+		<model name='SL-15'>
+			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
@@ -13472,11 +13478,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CNC:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sokar Urban Combat Unit' unitType='Tank'>
@@ -13503,11 +13509,11 @@
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
 		<availability>CCC:3,CDS:6+,CGB:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
@@ -13520,18 +13526,14 @@
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Spad' unitType='Aero'>
 		<availability>RA.OA:2,OA:2,ROS:4,NIOPS:6,RA:1</availability>
-		<model name='SPD-504'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='SPD-503'>
 			<availability>ROS:6,BAN:2</availability>
@@ -13539,19 +13541,19 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,OA:2,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+		<model name='SPR-6D'>
+			<availability>FVC:7,LA:3,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
+		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:3-,Periphery.Deep:8,FS:3-,MERC:3-,CDP:3-,TC:3-</availability>
 		</model>
-		<model name='SPR-H5K'>
-			<roles>interceptor</roles>
-			<availability>OA:1</availability>
-		</model>
 		<model name='SPR-7D'>
 			<availability>ROS:5,FS:5,MERC:5</availability>
 		</model>
-		<model name='SPR-6D'>
-			<availability>FVC:7,LA:3,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
+		<model name='SPR-H5K'>
+			<roles>interceptor</roles>
+			<availability>OA:1</availability>
 		</model>
 		<model name='SPR-DH'>
 			<availability>RA.OA:4-,FVC:4-,OA:4-,MERC:4-,Periphery:1-</availability>
@@ -13597,39 +13599,39 @@
 		<model name='SDR-5V'>
 			<availability>IS:1-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
+		<model name='SDR-5K'>
+			<roles>anti_infantry</roles>
+			<availability>CGB.FRR:2-,DC:2-</availability>
+		</model>
+		<model name='SDR-7Kr'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='SDR-7K'>
+			<availability>ROS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='SDR-7M'>
 			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,DC:6</availability>
 		</model>
-		<model name='SDR-7K2'>
-			<availability>ROS:3,MERC:3,DC:4</availability>
+		<model name='SDR-7KC'>
+			<availability>ROS:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='SDR-8K'>
 			<availability>ROS:2,MERC:2,DC:3</availability>
 		</model>
+		<model name='SDR-7K2'>
+			<availability>ROS:3,MERC:3,DC:4</availability>
+		</model>
 		<model name='SDR-8R'>
 			<availability>ROS:3,MERC:3</availability>
-		</model>
-		<model name='SDR-7Kr'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='SDR-8M'>
 			<availability>MOC:3,CC:3,FWL:8,MH:3,MERC:2</availability>
 		</model>
 		<model name='SDR-8X'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='SDR-7K'>
-			<availability>ROS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='SDR-5K'>
-			<roles>anti_infantry</roles>
-			<availability>CGB.FRR:2-,DC:2-</availability>
-		</model>
-		<model name='SDR-7KC'>
-			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Spindrift Aquatic SecurityMech' unitType='Mek'>
@@ -13640,34 +13642,34 @@
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
 		<availability>CJF:5-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>MOC:2,FVC:2,LA:7,CGB.FRR:7,ROS:7,IS:6,MH:1,FS:7,DC:7</availability>
-		<model name='(Interdictor)'>
-			<roles>spotter</roles>
-			<availability>FVC:2,LA:4,ROS:4,FWL:4,IS:2,MERC:4,FS:4,DC:4</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>CGB.FRR:5,IS:4,DC:6</availability>
+		</model>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Interdictor)'>
+			<roles>spotter</roles>
+			<availability>FVC:2,LA:4,ROS:4,FWL:4,IS:2,MERC:4,FS:4,DC:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -13678,17 +13680,20 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:5,CC:4,HL:9,CLAN:2,IS:5,Periphery.Deep:9,FS:5,Periphery:10,TC:7,RA.OA:7,OA:7,LA:6,CGB.FRR:5,ROS:4,FWL:7,NIOPS:5,DC:4</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		<model name='STK-8S'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-7D'>
-			<availability>ROS:4,FS:4,MERC:3</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:2,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
+		<model name='STK-4P'>
+			<availability>MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='STK-7D'>
+			<availability>ROS:4,FS:4,MERC:3</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
@@ -13696,30 +13701,27 @@
 		<model name='STK-3Fb'>
 			<availability>CC:3,MOC:3,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:2,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:1-,OA:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-6M'>
 			<availability>CC:4,MOC:4,PR:6,DoO:6,DO:6,MERC:6,ROS:6,PG:6,FWL:6,TP:6,DA:5,RCM:6,RFS:6</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>MERC:1,Periphery:1</availability>
-		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CJF:3,TC:4</availability>
-		</model>
-		<model name='STK-8S'>
-			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:6+,CBS:3+</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
@@ -13743,12 +13745,12 @@
 			<roles>raider</roles>
 			<availability>MOC:5,CC:2,LA:5,DoO:3,ROS:3,DO:3,TP:3,FS:2,MERC:5</availability>
 		</model>
+		<model name='STY-3Dr'>
+			<availability>CC:3,MOC:3,PR:6,LA:5,ROS:6,PG:6,MERC:4,RFS:6</availability>
+		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>CC:3,MOC:3,PR:6,LA:5,ROS:6,PG:6,MERC:4,RFS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
@@ -13757,21 +13759,21 @@
 			<roles>recon,spotter</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='STH-3S'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='STH-1D'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>FS:4,MERC:4</availability>
-		</model>
 		<model name='STH-2D'>
 			<roles>recon</roles>
 			<availability>FS:6,MERC:4</availability>
+		</model>
+		<model name='STH-3S'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='STH-2D1'>
+			<roles>recon</roles>
+			<availability>FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stiletto' unitType='Mek'>
@@ -13779,14 +13781,14 @@
 		<model name='STO-4C'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='STO-6S'>
-			<availability>LA:2</availability>
+		<model name='STO-4B'>
+			<availability>General:4</availability>
 		</model>
 		<model name='STO-4A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='STO-4B'>
-			<availability>General:4</availability>
+		<model name='STO-6S'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -13797,62 +13799,65 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,CGB.FRR:4,IS:8,NIOPS:2-,Periphery.Deep:5,MERC:8,Periphery:6,DC:5,CGB:2-</availability>
-		<model name='STG-5R'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FVC:4,HL:1,PIR:4,MERC:2,CDP:4,TC:4,Periphery:2</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FVC:2,FWL:8,FS:6,MERC:6,CDP:2,DC:6</availability>
-		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:5,CC:4,FVC:4,HL:1,MERC:2,DA:4,TC:4,Periphery:2</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>IS:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
-		</model>
-		<model name='STG-6L'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:4,DA:4</availability>
-		</model>
-		<model name='STG-7S'>
-			<roles>recon</roles>
-			<availability>LA:5,ROS:5,MERC:3,FS:3</availability>
 		</model>
 		<model name='STG-5G'>
 			<roles>recon</roles>
 			<availability>CC:4,DoO:4,DO:4,MERC:1,FS:4,CDP:4,TC:4,FVC:4,ROS:4,FWL:1,MH:4,TP:4,RCM:4,DA:4</availability>
 		</model>
+		<model name='STG-6S'>
+			<roles>recon</roles>
+			<availability>LA:6,ROS:5,MERC:6,FS:4</availability>
+		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CC:3,DoO:6,CLAN:8,DGM:6,DO:6,MERC:2,BAN:2,SC:6,MCM:6,FWL:5,MSC:6,TP:6,RCM:6,DA:6</availability>
 		</model>
-		<model name='STG-3P'>
+		<model name='STG-5M'>
 			<roles>recon</roles>
-			<availability>HL:1,LA:2,ROS:5,IS:4,MERC:5,DC:2,Periphery:4,CGB:3</availability>
-		</model>
-		<model name='STG-6S'>
-			<roles>recon</roles>
-			<availability>LA:6,ROS:5,MERC:6,FS:4</availability>
+			<availability>CC:6,MOC:6,FVC:2,FWL:8,FS:6,MERC:6,CDP:2,DC:6</availability>
 		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 		</model>
+		<model name='STG-6L'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:4,DA:4</availability>
+		</model>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:5,CC:4,FVC:4,HL:1,MERC:2,DA:4,TC:4,Periphery:2</availability>
+		</model>
+		<model name='STG-3P'>
+			<roles>recon</roles>
+			<availability>HL:1,LA:2,ROS:5,IS:4,MERC:5,DC:2,Periphery:4,CGB:3</availability>
+		</model>
+		<model name='STG-5R'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,FVC:4,HL:1,PIR:4,MERC:2,CDP:4,TC:4,Periphery:2</availability>
+		</model>
+		<model name='STG-7S'>
+			<roles>recon</roles>
+			<availability>LA:5,ROS:5,MERC:3,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,RA.OA:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:4,RFS:5,MOC:3,CC:5,IS:3,DGM:6,MERC:5,TC:2,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
+		<model name='F-95'>
+			<availability>CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
+		</model>
 		<model name='F-94'>
 			<availability>MOC:2,Periphery.MW:2,Periphery.ME:2,IS:4,MH:2</availability>
 		</model>
@@ -13862,35 +13867,32 @@
 		<model name='F-90'>
 			<availability>IS:3-,Periphery:3-</availability>
 		</model>
-		<model name='F-95'>
-			<availability>CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CBS:5,CGB:3</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>:0,CLAN:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='F'>
+		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>:0,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -13902,47 +13904,51 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>CC:3,MOC:3,LA:5,ROS:4,FWL:5,FS:5,MERC:5,DA:3,DC:7</availability>
-		<model name='SR1-OA'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SR1-OD'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
+		<model name='SR1-OG'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SR1-OR'>
 			<availability>CLAN:6,General:3</availability>
 		</model>
-		<model name='SR1-OG'>
-			<availability>General:4</availability>
-		</model>
 		<model name='SR1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OF'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,LA:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2</availability>
+		<model name='(Narc)'>
+			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:4-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>FVC:3-,IS:2-</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,CDS:4,LA:6,ROS:6,CNC:4,FS:7,DC:5,CWIE:4</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2</availability>
@@ -13953,30 +13959,26 @@
 		<model name='(SRM)'>
 			<availability>FVC:3-,IS:2-</availability>
 		</model>
-		<model name='(Narc)'>
-			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(3061 Upgrade)'>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:4-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,CDS:4,LA:6,ROS:6,CNC:4,FS:7,DC:5,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:4,MOC:4,LA:2-,NIOPS:4</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>CC:3-,General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -13984,17 +13986,17 @@
 		<model name='STU-K5'>
 			<availability>FVC:3-,IS:3-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
 		</model>
-		<model name='STU-K10'>
-			<availability>OA:1</availability>
-		</model>
-		<model name='STU-K15'>
-			<availability>OA:1</availability>
-		</model>
 		<model name='STU-D7'>
 			<availability>ROS:6,FS:7,MERC:2</availability>
 		</model>
 		<model name='STU-K5b'>
 			<availability>ROS:6,CLAN:8,FS:4,MERC:2,BAN:2</availability>
+		</model>
+		<model name='STU-K10'>
+			<availability>OA:1</availability>
+		</model>
+		<model name='STU-K15'>
+			<availability>OA:1</availability>
 		</model>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
@@ -14002,12 +14004,12 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:3,PR:4,CDS:2,HL:2,LA:5,ROS:4,PG:4,CNC:3,MERC:1,FS:3,RFS:4,CWIE:3</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Heavy Gauss)'>
 			<availability>PR:4,LA:6,PG:4,CNC:6,RFS:4,CWIE:6</availability>
@@ -14015,13 +14017,13 @@
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,IS:1,Periphery:1</availability>
-		<model name='(Standard)'>
-			<roles>recon,fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
@@ -14029,14 +14031,14 @@
 		<model name='E'>
 			<availability>CW:5,CLAN:2,CGB:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:6,CBS:6,General:2,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,CBS:6,General:2,CJF:6,CGB:6</availability>
@@ -14047,21 +14049,24 @@
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
 		<availability>CDS:2,CW:5,ROS:2</availability>
-		<model name='(Standard)'>
-			<availability>CDS:4,CW:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CDS:8,ROS:8,MERC:8,FS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:4,CW:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,ROS:4,FS:5,MERC:4,DC:7</availability>
-		<model name='SD1-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='SD1-OX'>
+			<availability>General:1</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='SD1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
@@ -14072,9 +14077,6 @@
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
-		</model>
-		<model name='SD1-OX'>
-			<availability>General:1</availability>
 		</model>
 		<model name='SD1-OC'>
 			<availability>General:6,DC:7</availability>
@@ -14091,11 +14093,11 @@
 		<model name='3'>
 			<availability>ROS:6,CNC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='4'>
 			<availability>ROS:5,CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Suzaku' unitType='Aero'>
@@ -14121,19 +14123,19 @@
 	</chassis>
 	<chassis name='Svartalfa Ultra ProtoMech' unitType='ProtoMek'>
 		<availability>CHH:3+</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM Variant)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:1,MOC:1,DA:1,CDP:1,TC:1</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -14145,33 +14147,33 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:2</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>ROS:5,CLAN:4,NIOPS:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CSR:5,CLAN:8,RA:9</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>ROS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CCC:9,CSR:5,CLAN:8,RA:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:2,CCC:6,CDS:2,CSR:2,RA:3</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='XR' mechanized='true'>
 			<roles>recon</roles>
@@ -14209,11 +14211,11 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:5,MERC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(RL)'>
 			<availability>MOC:4</availability>
@@ -14224,53 +14226,53 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,DoO:6,DO:6,DGM:6,MERC:4,DTA:6,SC:6,MCM:6,ROS:4,FWL:6,MSC:4,TP:6,DC:6</availability>
-		<model name='ZPH-3A'>
-			<roles>recon</roles>
-			<availability>DTA:7,SC:8,DoO:8,MCM:8,ROS:5,FWL:7,DGM:8,DO:8,MSC:8,TP:8,MERC:4,DC:4</availability>
-		</model>
 		<model name='ZPH-2A'>
 			<roles>recon</roles>
 			<availability>MOC:2,CC:5,ROS:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:7,SC:8,DoO:8,MCM:8,ROS:6,DO:8,DGM:8,MSC:8,TP:8,MERC:6,DC:7</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='ZPH-3A'>
+			<roles>recon</roles>
+			<availability>DTA:7,SC:8,DoO:8,MCM:8,ROS:5,FWL:7,DGM:8,DO:8,MSC:8,TP:8,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Targe' unitType='Mek'>
 		<availability>ROS:2</availability>
-		<model name='TRG-1N'>
-			<roles>recon</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='TRG-2N'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
 		</model>
+		<model name='TRG-1N'>
+			<roles>recon</roles>
+			<availability>ROS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>CGB.FRR:5,ROS:3,CNC:4,DC:6</availability>
+		<model name='MIK-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-O'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsumaki Destroyer' unitType='Warship'>
@@ -14282,8 +14284,8 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:4,DTA:8,SC:8,MCM:8,ROS:5,Periphery.MW:2,PG:8,Periphery.ME:2,FWL:8,MH:2,MSC:6,TP:8,RFS:8</availability>
-		<model name='TMP-3G'>
-			<availability>ROS:2,FWL:2,MERC:2</availability>
+		<model name='TMP-3M'>
+			<availability>HL:6,ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>SC:4,PR:4,MCM:4,ROS:4,PG:4,DGM:4,MSC:4,MERC:4,RFS:4</availability>
@@ -14291,8 +14293,8 @@
 		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
 			<availability>DTA:6,SC:6,DoO:6,MCM:6,ROS:6,DO:6,DGM:6,MSC:6,TP:6,MERC:2</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>HL:6,ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		<model name='TMP-3G'>
+			<availability>ROS:2,FWL:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
@@ -14300,38 +14302,38 @@
 		<model name='TLR1-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OH'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OB'>
 			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OG'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OI'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OE'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
+		<model name='TLR1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OF'>
 			<roles>spotter</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OI'>
-			<availability>General:5</availability>
+		<model name='TLR1-OG'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OU'>
-			<availability>General:2</availability>
+		<model name='TLR1-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Tessen' unitType='Mek'>
@@ -14340,36 +14342,36 @@
 			<roles>recon,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
 		</model>
-		<model name='TSN-C3M'>
+		<model name='TSN-1Cr'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='TSN-1Cr'>
+		<model name='TSN-C3M'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CSR:1,CW:1,CCO:1,CJF:1,RA:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
 		<availability>LA:6,ROS:3,MH:3,FS:6,MERC:4,CDP:3</availability>
-		<model name='TNS-4T'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='TNS-6S'>
 			<availability>LA:5,IS:4</availability>
+		</model>
+		<model name='TNS-4T'>
+			<availability>IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Tharkad Battlecruiser' unitType='Warship'>
@@ -14381,43 +14383,43 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CSR:2,CLAN:3,CCO:3,RA:1,BAN:4,CWIE:4,CSA:2,MERC.WD:3,CDS:3,CW:3,ROS:1+,CNC:3,CJF:5,CGB:3</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CHH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
 		</model>
-		<model name='HH'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CBS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:3,CCO:6,CWIE:5</availability>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CWIE:6,CGB:8</availability>
+		<model name='HH'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:3,CCO:6,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -14433,49 +14435,49 @@
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>ROS:6</availability>
-		<model name='THE-N1'>
+		<model name='THE-N2'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='THE-N2'>
+		<model name='THE-N1'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CSR:1,RA:1</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:3-,FVC:3-,HL:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
+		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:3,MERC:2</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:4,FVC:1,FWL:1,FS:1,MERC:1,Periphery:1</availability>
 		</model>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:3-,FVC:3-,HL:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
-		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:3,PR:5,CLAN:4,FS:2,CWIE:5,DC.GHO:4,SC:5,RA.OA:4,OA:4,CDS:3,CBS:3,Periphery.MW:1,FWL:5,NIOPS:8,MH:3,MSC:4,RFS:5,CGB:5,MOC:3,IS:4,DGM:5,CW:5,MCM:5,ROS:5,PG:5,PIR:1,CNC:3,Periphery.ME:1,DA:5,CJF:5</availability>
-		<model name='THG-11Eb'>
-			<availability>SC:6,MCM:6,ROS:6,CLAN:4,FWL:6,DGM:6,MSC:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>MOC:8,CLAN:6,IS:8,FS:8,BAN:8,DC.GHO:8,OA:8,CGB.FRR:6,ROS:8,PG:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,NIOPS:4,DC:8</availability>
 		</model>
-		<model name='THG-12K'>
-			<availability>ROS:5,DC:7</availability>
+		<model name='THG-11Eb'>
+			<availability>SC:6,MCM:6,ROS:6,CLAN:4,FWL:6,DGM:6,MSC:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>MOC:3-,PIR:3-,FWL:3-,MH:3-,MSC:3-,MERC:3-,DA:3-,Periphery:4</availability>
+		</model>
+		<model name='THG-12K'>
+			<availability>ROS:5,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -14495,9 +14497,6 @@
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
 		<availability>LA:4,ROS:5,DC:4</availability>
-		<model name='TFT-L8'>
-			<availability>LA:5</availability>
-		</model>
 		<model name='TFT-A9'>
 			<availability>ROS:5,General:4</availability>
 		</model>
@@ -14505,12 +14504,12 @@
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
+		<model name='TFT-L8'>
+			<availability>LA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,ROS:4,MERC:4</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:6,ROS:6,MERC:2</availability>
@@ -14520,6 +14519,9 @@
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -14536,69 +14538,57 @@
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,PR:5,PG:5,MERC:4,DA:5,RFS:5,TC:4</availability>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-C4'>
-			<availability>CC:3,MOC:3,CC.LCC:4</availability>
-		</model>
 		<model name='THR-1L'>
 			<availability>General:7</availability>
+		</model>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='THR-C4'>
+			<availability>CC:3,MOC:3,CC.LCC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CC:2,MOC:4,LA:8,ROS:8,CGB.FRR:6,MH:4,MERC:6</availability>
-		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:3-</availability>
-		</model>
-		<model name='TRB-D36b'>
-			<roles>ground_support</roles>
-			<availability>CLAN:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='TRB-D56'>
 			<availability>LA:6,ROS:4,MERC:4</availability>
 		</model>
 		<model name='TRB-D50'>
 			<availability>TC:6</availability>
 		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CC:2,MOC:4,LA:8,ROS:8,CGB.FRR:6,MH:4,MERC:6</availability>
+		</model>
+		<model name='TRB-D36b'>
+			<roles>ground_support</roles>
+			<availability>CLAN:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:5,HL:2,IS:4,Periphery.Deep:6,FS:5,MERC:6,Periphery:3,TC:4,LA:6,ROS:5,NIOPS:3-,MH:4,DC:5</availability>
-		<model name='TDR-9NAIS'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='TDR-9M'>
-			<availability>MOC:3,CC:3,DoO:5,DO:5,DGM:5,MERC:2,DTA:5,SC:5,MCM:5,PIR:3,FWL:3,MH:3,MSC:5,TP:5,DA:5</availability>
-		</model>
-		<model name='TDR-9S'>
-			<availability>FVC:4,LA:5,FS:3,MERC:3</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>CC:2-,MOC:2-,LA:2-,MERC:2-,TC:2-</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,ROS:2,PIR:2,MH:2,MERC:3,FS:3</availability>
 		</model>
 		<model name='TDR-60-RLA'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:3-,MERC:1-</availability>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
 		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MH:1,MERC:6,FS:2</availability>
+		<model name='TDR-9S'>
+			<availability>FVC:4,LA:5,FS:3,MERC:3</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,MH:1,MERC:4,FS:2</availability>
 		</model>
 		<model name='TDR-9T'>
 			<availability>TC:4</availability>
@@ -14606,26 +14596,38 @@
 		<model name='TDR-5S'>
 			<availability>CC:3-,LA:1-,General:3-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		<model name='TDR-7M'>
+			<availability>CC:5,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:7,MH:2,MERC:5</availability>
 		</model>
-		<model name='TDR-10M'>
-			<availability>CC:2,ROS:6,FWL:4,MERC:2</availability>
+		<model name='TDR-9M'>
+			<availability>MOC:3,CC:3,DoO:5,DO:5,DGM:5,MERC:2,DTA:5,SC:5,MCM:5,PIR:3,FWL:3,MH:3,MSC:5,TP:5,DA:5</availability>
+		</model>
+		<model name='TDR-5SS'>
+			<availability>LA:3-,MERC:1-</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CCC:6</availability>
 		</model>
-		<model name='TDR-7M'>
-			<availability>CC:5,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:7,MH:2,MERC:5</availability>
+		<model name='TDR-5Sb'>
+			<availability>TC:5</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,MH:1,MERC:4,FS:2</availability>
+		<model name='TDR-7SE'>
+			<availability>CC:3,ROS:2,PIR:2,MH:2,MERC:3,FS:3</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>FS:3,MERC:3</availability>
 		</model>
+		<model name='TDR-10M'>
+			<availability>CC:2,ROS:6,FWL:4,MERC:2</availability>
+		</model>
 		<model name='TDR-17S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MH:1,MERC:6,FS:2</availability>
+		</model>
+		<model name='TDR-9NAIS'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
@@ -14633,15 +14635,15 @@
 		<model name='TSG-9J'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TSG-9H'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='TSG-9DDC'>
+			<availability>CC:2,CC.WHO:6</availability>
 		</model>
 		<model name='TSG-9C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
-		<model name='TSG-9DDC'>
-			<availability>CC:2,CC.WHO:6</availability>
+		<model name='TSG-9H'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat Pocket Warship' unitType='Dropship'>
@@ -14667,35 +14669,35 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CSR:3,CLAN:4,NIOPS:3,RA:4</availability>
-		<model name='(2953)'>
-			<roles>asf_carrier</roles>
-			<availability>CLAN:8,RA:8</availability>
-		</model>
 		<model name='(2647)'>
 			<roles>asf_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2953)'>
+			<roles>asf_carrier</roles>
+			<availability>CLAN:8,RA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,ROS:4,CNC:6,DC:8</availability>
-		<model name='(C3)'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='TKG-150'>
-			<availability>CGB.FRR:2-,DC:2-</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>CGB.FRR:4-,DC:4-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>CDS:8,ROS:6,CNC:8,DC:6</availability>
+		<model name='(C3)'>
+			<availability>ROS:5,DC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>ROS:8,DC:8</availability>
 		</model>
+		<model name='(Streak)'>
+			<availability>CDS:8,ROS:6,CNC:8,DC:6</availability>
+		</model>
 		<model name='(MRM)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
+		</model>
+		<model name='TKG-150'>
+			<availability>CGB.FRR:2-,DC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Aero'>
@@ -14703,15 +14705,15 @@
 		<model name='CH'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>ROS:8</availability>
+		<model name='THK-63'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
 		</model>
-		<model name='THK-63'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
+		<model name='THK-63CS'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
@@ -14722,10 +14724,10 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -14738,23 +14740,23 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>FWL:2,MH:1</availability>
-		<model name='G13 [Grenade Launcher]' mechanized='true'>
-			<availability>MH:4</availability>
-		</model>
-		<model name='G13 [Machine Gun]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 		<model name='G12' mechanized='true'>
 			<roles>specops</roles>
 			<availability>FWL:8</availability>
 		</model>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>MH:4</availability>
+		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Machine Gun]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 	</chassis>
@@ -14767,13 +14769,13 @@
 	</chassis>
 	<chassis name='Trajan Assault Infantry Fighting Vehicle' unitType='Tank'>
 		<availability>ROS:4</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>apc</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -14784,43 +14786,40 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,PR:3,Periphery.CM:2,PG:3,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:2-</availability>
-		</model>
-		<model name='TR-16'>
-			<availability>CC:7,MOC:5,PR:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
-		</model>
-		<model name='TR-13'>
-			<availability>CC:2-,MERC:2-,Periphery:3-</availability>
-		</model>
 		<model name='TR-13A'>
 			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:2-</availability>
 		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13'>
+			<availability>CC:2-,MERC:2-,Periphery:3-</availability>
+		</model>
+		<model name='TR-16'>
+			<availability>CC:7,MOC:5,PR:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:1,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:4,MOC:4,General:6,TC:4</availability>
-		</model>
-		<model name='TR-12'>
-			<availability>CC:6,MOC:3</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='TR-12'>
+			<availability>CC:6,MOC:3</availability>
+		</model>
 		<model name='TR-13G'>
 			<roles>ground_support,assault</roles>
 			<availability>CC:4</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>CC:4,MOC:4,General:6,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Transportable Field Repair Unit' unitType='Tank'>
@@ -14832,11 +14831,11 @@
 	</chassis>
 	<chassis name='Trebaruna' unitType='Mek'>
 		<availability>CC:4,DTA:2,SC:3,DoO:3,MCM:3,ROS:4,DO:3,DGM:3,MSC:2,TP:3,MERC:2</availability>
-		<model name='TR-XJ'>
-			<availability>DTA:8,SC:8,DoO:8,MCM:8,DGM:8,DO:8,MSC:8,TP:8,MERC:4</availability>
-		</model>
 		<model name='TR-XB'>
 			<availability>CC:4,DTA:4,SC:4,MCM:4,ROS:8,DGM:4,MSC:4,MERC:4</availability>
+		</model>
+		<model name='TR-XJ'>
+			<availability>DTA:8,SC:8,DoO:8,MCM:8,DGM:8,DO:8,MSC:8,TP:8,MERC:4</availability>
 		</model>
 		<model name='TR-XL'>
 			<availability>CC:8</availability>
@@ -14844,35 +14843,35 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:2,MOC:2,PR:6,IS:2,FS:1,MERC:2,Periphery:4,TC:4,RA.OA:2,OA:2,LA:2,CGB.FRR:4,ROS:4,Periphery.MW:4,PG:6,Periphery.ME:4,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:1-</availability>
-		</model>
-		<model name='TBT-5S'>
-			<availability>Periphery.Deep:4,CDP:2-,TC:2-</availability>
-		</model>
-		<model name='TBT-7M'>
+		<model name='TBT-5N'>
 			<roles>fire_support</roles>
-			<availability>CC:4,CGB.FRR:4,FWL:5,MH:4,FS:4,MERC:4,TC:3,DC:4</availability>
-		</model>
-		<model name='TBT-9K'>
-			<roles>fire_support</roles>
-			<availability>DC:7</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>SC:5,MCM:5,ROS:5,DGM:5,MSC:5,MERC:4</availability>
+			<availability>CC:1-,MOC:5-,LA:1-,FWL:1-,IS:3-,NIOPS:2-,FS:1-,MERC:3-,DC:1-,Periphery:5-</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>SC:4,PR:4,MCM:4,ROS:5,PG:4,NIOPS:5,DGM:4,MSC:4,MERC:4,RFS:4</availability>
 		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CGB.FRR:4,FWL:5,MH:4,FS:4,MERC:4,TC:3,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>SC:5,MCM:5,ROS:5,DGM:5,MSC:5,MERC:4</availability>
+		</model>
+		<model name='TBT-9K'>
+			<roles>fire_support</roles>
+			<availability>DC:7</availability>
+		</model>
 		<model name='TBT-XK7'>
 			<roles>fire_support</roles>
 			<availability>TC:4</availability>
 		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:1-,MOC:5-,LA:1-,FWL:1-,IS:3-,NIOPS:2-,FS:1-,MERC:3-,DC:1-,Periphery:5-</availability>
+		<model name='TBT-5J'>
+			<availability>FWL:1-</availability>
+		</model>
+		<model name='TBT-5S'>
+			<availability>Periphery.Deep:4,CDP:2-,TC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -14886,17 +14885,8 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:7,MOC:7,MH:4,TC:7</availability>
-		<model name='(Theseus RL)[LRR]' mechanized='true'>
-			<availability>MOC:6</availability>
-		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='(Asterion)[PPC]' mechanized='true'>
-			<availability>MH:4,TC:4</availability>
-		</model>
-		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
-			<availability>MOC:6</availability>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Asterion)[MRR]' mechanized='true'>
 			<availability>MH:4,TC:4</availability>
@@ -14904,11 +14894,20 @@
 		<model name='(Ying Long)(Plasma)' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
+		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
+			<availability>MOC:6</availability>
+		</model>
 		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:5</availability>
 		</model>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
+		<model name='(Theseus RL)[LRR]' mechanized='true'>
+			<availability>MOC:6</availability>
+		</model>
+		<model name='(Asterion)[PPC]' mechanized='true'>
+			<availability>MH:4,TC:4</availability>
+		</model>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+			<availability>TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Triumph' unitType='Dropship'>
@@ -14924,14 +14923,14 @@
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
 		<availability>CC:5,MOC:6,FVC:3,HL:1,Periphery.CM:4,Periphery.ME:4,MERC:3,DA:3,TC:6,Periphery:3</availability>
+		<model name='CMT-3T'>
+			<availability>CC:8,MOC:8,MERC:5,DA:5,TC:8</availability>
+		</model>
 		<model name='CMT-4U'>
 			<availability>General:5</availability>
 		</model>
 		<model name='CMT-6T'>
 			<availability>MOC:5,CC:5,MERC:4,DA:4</availability>
-		</model>
-		<model name='CMT-3T'>
-			<availability>CC:8,MOC:8,MERC:5,DA:5,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Trojan' unitType='Dropship'>
@@ -14943,10 +14942,10 @@
 	</chassis>
 	<chassis name='Tsunami' unitType='Mek'>
 		<availability>MERC:3</availability>
-		<model name='TS-P1D'>
+		<model name='TS-P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TS-P1'>
+		<model name='TS-P1D'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -14963,17 +14962,17 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CW:5+,ROS:2,CWIE:3</availability>
-		<model name='4'>
-			<availability>General:8</availability>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
 		</model>
 		<model name='3'>
 			<availability>CW:3,ROS:2</availability>
 		</model>
+		<model name='4'>
+			<availability>General:8</availability>
+		</model>
 		<model name='5'>
 			<availability>CW:1</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
@@ -14981,35 +14980,35 @@
 	</chassis>
 	<chassis name='Turhan Urban Combat Vehicle' unitType='Tank'>
 		<availability>ROS:3,DC:4</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>:0,General:5</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>apc,urban,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>:0,General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2,CGB:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:2,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>CLAN:2,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CGB:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
@@ -15017,11 +15016,21 @@
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
+		<model name='Prime'>
+			<availability>CHH:8,CW:8,CNC:8,CJF:8,CCO:8</availability>
+		</model>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:9,General:7,CGB:9</availability>
@@ -15029,19 +15038,13 @@
 		<model name='H'>
 			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CW:8,CNC:8,CJF:8,CCO:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,ROS:2,FS:6,MERC:3</availability>
+		<model name='(RAC)'>
+			<roles>urban</roles>
+			<availability>General:4,FS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
@@ -15049,10 +15052,6 @@
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>urban</roles>
-			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -15064,53 +15063,26 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,CGB.FRR:2,ROS:2,CGB:5,DC:2</availability>
-		<model name='(Kurita)'>
-			<roles>apc</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CGB.FRR:8,CLAN:8</availability>
 		</model>
+		<model name='(Kurita)'>
+			<roles>apc</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CHH:3,MERC.WD:2,CSR:3,CW:3,CBS:5,MERC:1+,CCO:1,CJF:5,RA:4,CWIE:3</availability>
-		<model name='B'>
-			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:6,CSR:3,CBS:6,General:5,CCO:4,RA:6</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
-		</model>
 		<model name='F'>
 			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
 		</model>
@@ -15118,8 +15090,35 @@
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
+		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:6,CSR:3,CBS:6,General:5,CCO:4,RA:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
@@ -15151,24 +15150,24 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:3</availability>
-		<model name='(3065)'>
-			<roles>troop_carrier</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(3071)'>
 			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(3065)'>
+			<roles>troop_carrier</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:3,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:8,IS:6,FS:8</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:3,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech IIC' unitType='Mek'>
@@ -15184,6 +15183,10 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,HL:3-,IS:4-,FS:4-,Periphery:4-,TC:3-,RA.OA:3-,OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+		<model name='UM-R80'>
+			<roles>urban,spotter</roles>
+			<availability>CC:4,MOC:4,IS:2,FWL:3,MERC:3,Periphery:2</availability>
+		</model>
 		<model name='UM-R69'>
 			<roles>urban</roles>
 			<availability>FWL:6,IS:6,Periphery:6</availability>
@@ -15196,26 +15199,22 @@
 			<roles>urban</roles>
 			<availability>CC:2-,FVC:1,Periphery:2</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:6,IS:3,Periphery:3</availability>
-		</model>
-		<model name='UM-R80'>
-			<roles>urban,spotter</roles>
-			<availability>CC:4,MOC:4,IS:2,FWL:3,MERC:3,Periphery:2</availability>
-		</model>
-		<model name='UM-R63'>
+		<model name='UM-R60'>
 			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+			<availability>CC:3-,HL:2-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>CC:3,MOC:3,SC:3,MCM:3,FS.CMM:6,DGM:3,MSC:3,FS:4</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R63'>
 			<roles>urban</roles>
-			<availability>CC:3-,HL:2-,Periphery.Deep:8,Periphery:4-</availability>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:6,IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus II' unitType='Mek'>
@@ -15226,23 +15225,23 @@
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
 		<availability>CHH:2,ROS:3,CGB:7</availability>
-		<model name='(Standard)'>
+		<model name='3'>
+			<roles>anti_infantry,specops</roles>
 			<deployedWith>IS</deployedWith>
-			<availability>General:8</availability>
+			<availability>CGB:2</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:2</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:2</availability>
-		</model>
-		<model name='3'>
-			<roles>anti_infantry,specops</roles>
+		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
-			<availability>CGB:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -15260,41 +15259,37 @@
 	</chassis>
 	<chassis name='Valiant' unitType='Mek'>
 		<availability>LA:5,IS:4,FS:5,MERC:4,CDP:4,DC:6</availability>
-		<model name='V4-LNT-J3'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
+		<model name='V4-LNT-K7'>
+			<availability>General:8</availability>
 		</model>
 		<model name='VLN-3T'>
 			<availability>LA:2,General:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='V4-LNT-K7'>
-			<availability>General:8</availability>
+		<model name='V4-LNT-J3'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:3,ROS:4,FS:9,MERC:4,CDP:4,TC:4</availability>
-		<model name='VLK-QD4'>
+		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
-			<availability>ROS:3,FS:2</availability>
-		</model>
-		<model name='VLK-QD2'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4,FS:4</availability>
+			<availability>FS:1-,MERC:1-</availability>
 		</model>
 		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:5,ROS:4,MERC:2</availability>
 		</model>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:3-,FS:3-,MERC:3-,CDP:3-,TC:3-</availability>
-		</model>
-		<model name='VLK-QF'>
-			<roles>recon,fire_support</roles>
-			<availability>FS:1-,MERC:1-</availability>
-		</model>
 		<model name='VLK-QD'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:5,LA:5,ROS:6,FS:7,MERC:6</availability>
+		</model>
+		<model name='VLK-QD2'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,FS:4</availability>
+		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:3-,FS:3-,MERC:3-,CDP:3-,TC:3-</availability>
 		</model>
 		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
@@ -15308,6 +15303,10 @@
 			<roles>recon,fire_support</roles>
 			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='VLK-QD4'>
+			<roles>recon,fire_support</roles>
+			<availability>ROS:3,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
 		<availability>FS:2</availability>
@@ -15318,27 +15317,27 @@
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>CSR:3,General:5,RA:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>CSR:3,General:5,RA:6</availability>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -15350,35 +15349,35 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>HL:9,IS:10,Periphery.Deep:8,Periphery:10</availability>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(Liao)'>
 			<availability>CC:3-</availability>
-		</model>
-		<model name='V-G7X'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='V7'>
-			<availability>LA:3,ROS:3,FS:3,MERC:4</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>CC:8,MOC:8,FVC:5,Periphery.CM:5,Periphery.HR:5,PIR:5,MH:5,CDP:5,TC:8,Periphery:3</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>IS:4,FS:6</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>CC:5,MOC:5,DTA:5,PR:5,PG:5,DA:5,RCM:5,CDP:5,RFS:5,TC:5</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
+		<model name='(RAC)'>
+			<availability>IS:4,FS:6</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>CC:1-,General:1-</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='V-G7X'>
+			<availability>LA:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
+		<model name='V7'>
+			<availability>LA:3,ROS:3,FS:3,MERC:4</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>CC:4,LA:4,FWL:4,IS:2,FS:4,MERC:5,DC:4,Periphery:2</availability>
@@ -15386,6 +15385,10 @@
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:4,IS:1,FS:4,Periphery:1,TC:1,RA.OA:1,OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:3,CC:3</availability>
 		</model>
@@ -15393,73 +15396,41 @@
 			<roles>asf_carrier</roles>
 			<availability>IS:3,FS:8</availability>
 		</model>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
 		<availability>CGB.FRR:5,ROS:4,CNC:3,MERC:3,RCM:4,DC:8</availability>
+		<model name='SDR-9KC'>
+			<availability>ROS:6,FWL:6,MERC:6,RCM:6,DC:6</availability>
+		</model>
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
-		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,RCM:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,RCM:5,DC:5</availability>
 		</model>
-		<model name='SDR-9KC'>
-			<availability>ROS:6,FWL:6,MERC:6,RCM:6,DC:6</availability>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,RCM:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:3,LA:3,ROS:3,CWIE:2</availability>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:3,CC:6,HL:3,IS:3-,Periphery.Deep:4,FS:8,Periphery.OS:3,Periphery:4,TC:3,RA.OA:3,OA:3,LA:4,CGB.FRR:6,Periphery.HR:3,FWL:3,NIOPS:3-,DC:5</availability>
-		<model name='VTR-C'>
-			<availability>CC:4,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
-		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='VTR-9B'>
 			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-9D'>
-			<availability>CC:1,FVC:2,LA:1,FS:1,CDP:2</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-10D'>
-			<availability>ROS:5,FS:6,MERC:2</availability>
-		</model>
-		<model name='VTR-11D'>
-			<roles>urban</roles>
-			<availability>ROS:2,FS:2,MERC:1</availability>
-		</model>
-		<model name='VTR-Cr'>
-			<availability>FS:1,DC:2</availability>
-		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='VTR-9K'>
 			<availability>MOC:4,FVC:4,HL:2,CGB.FRR:8,ROS:4,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
@@ -15467,18 +15438,46 @@
 		<model name='VTR-9Ka'>
 			<availability>CC:1,FVC:3,ROS:3,FS:3,MERC:3,DC:2,Periphery:1</availability>
 		</model>
+		<model name='VTR-Cr'>
+			<availability>FS:1,DC:2</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-C'>
+			<availability>CC:4,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
+		</model>
+		<model name='VTR-11D'>
+			<roles>urban</roles>
+			<availability>ROS:2,FS:2,MERC:1</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>FVC:1,Periphery:1</availability>
+		</model>
 		<model name='VTR-9S'>
 			<availability>LA:1-</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='VTR-10D'>
+			<availability>ROS:5,FS:6,MERC:2</availability>
+		</model>
+		<model name='VTR-9D'>
+			<availability>CC:1,FVC:2,LA:1,FS:1,CDP:2</availability>
+		</model>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CGB.FRR:7,ROS:4,MERC:4,CGB:5</availability>
+		<model name='VKG-2G'>
+			<availability>CGB.FRR:6,ROS:6,MERC:6,CGB:6</availability>
+		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-2G'>
-			<availability>CGB.FRR:6,ROS:6,MERC:6,CGB:6</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
@@ -15498,26 +15497,26 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,PIR:2,MERC:4,TC:6</availability>
-		<model name='VND-1SIC'>
-			<availability>CC:1</availability>
+		<model name='VND-5L'>
+			<availability>CC:3,MOC:2,MERC:2,TC:2</availability>
 		</model>
 		<model name='VND-4L'>
 			<availability>CC:7,MOC:6</availability>
 		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:4,MOC:4,PIR:2,MERC:4,TC:4</availability>
+		<model name='VND-1R'>
+			<availability>General:3</availability>
 		</model>
 		<model name='VND-3L'>
 			<availability>CC:6,MOC:3,General:3,TC:3</availability>
 		</model>
-		<model name='VND-5L'>
-			<availability>CC:3,MOC:2,MERC:2,TC:2</availability>
+		<model name='VND-1SIC'>
+			<availability>CC:1</availability>
 		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
 		</model>
-		<model name='VND-1R'>
-			<availability>General:3</availability>
+		<model name='VND-3Lr'>
+			<availability>CC:4,MOC:4,PIR:2,MERC:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Viper (Black Python)' unitType='Mek'>
@@ -15531,23 +15530,23 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CJF:8,BAN:6</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CSR:3,General:2,CJF:6,RA:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CSR:3,General:2,CJF:6,RA:6</availability>
+		</model>
 		<model name='E'>
 			<availability>CSR:3,General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
@@ -15555,28 +15554,28 @@
 		<model name='(Standard)'>
 			<availability>CLAN:2,CJF:4</availability>
 		</model>
-		<model name='5'>
+		<model name='4'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:5,DC:6+</availability>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:5</availability>
-		</model>
-		<model name='(Nova Cat)' mechanized='true'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Nova Cat)' mechanized='true'>
+			<availability>CNC:8</availability>
+		</model>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Volga Transport' unitType='Warship'>
@@ -15589,18 +15588,14 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CGB.FRR:4,PIR:2,FS:2,DC:3</availability>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
-		</model>
 		<model name='VNL-K75N'>
 			<availability>LA:8,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
+		</model>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -15614,9 +15609,17 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:2,MOC:4,LA:5,CGB.FRR:4,FWL:5,IS:3,NIOPS:3,Periphery:4,TC:4</availability>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>DoO:6,DO:6,TP:6,DA:6,RCM:5</availability>
+		</model>
 		<model name='VL-2T'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:2-,General:3-,FS:2-</availability>
+		</model>
+		<model name='VL-5T'>
+			<roles>anti_infantry</roles>
+			<availability>MOC:2,FVC:3,PIR:2,IS:2,FS:3-,Periphery:2,TC:2</availability>
 		</model>
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
@@ -15626,26 +15629,27 @@
 			<roles>anti_infantry</roles>
 			<availability>FVC:5,LA:5,CGB.FRR:5,ROS:6,MH:4,FS:5,MERC:5</availability>
 		</model>
-		<model name='VL-5T'>
-			<roles>anti_infantry</roles>
-			<availability>MOC:2,FVC:3,PIR:2,IS:2,FS:3-,Periphery:2,TC:2</availability>
-		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:4,LA:8,CGB.FRR:5,MH:4,FS:4,MERC:5</availability>
 		</model>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>DoO:6,DO:6,TP:6,DA:6,RCM:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,MERC.WD:5,ROS:2+,CLAN:5,MERC:1+,CCO:5,CJF:5,BAN:6,CWIE:5,CGB:6,DC:3+</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CNC:7,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,CSR:3,General:4,CCO:6,RA:5,CGB:5</availability>
@@ -15655,15 +15659,6 @@
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CBS:5,CNC:5,CLAN:4,General:2</availability>
@@ -15680,18 +15675,8 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>MOC:1,CLAN:7,IS:3,TC:1</availability>
-		<model name='6'>
-			<availability>CSR:3,RA:6,CGB:6</availability>
-		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>IS:3</availability>
-		</model>
 		<model name='9'>
 			<availability>CDS:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CC:3,CDS:5,LA:3,ROS:3,FWL:3,DC:3</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:5,IS:4</availability>
@@ -15699,81 +15684,91 @@
 		<model name='8'>
 			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
 		</model>
+		<model name='6'>
+			<availability>CSR:3,RA:6,CGB:6</availability>
+		</model>
 		<model name='7'>
 			<availability>CSR:2,RA:5</availability>
 		</model>
 		<model name='4'>
 			<availability>CC:3,CHH:3,CSR:1,FS:3,CCO:5,RA:4,CWIE:5,CSA:5,CDS:6,LA:3,ROS:3,CNC:5,CGB:5,DC:3</availability>
 		</model>
+		<model name='3'>
+			<availability>CC:3,CDS:5,LA:3,ROS:3,FWL:3,DC:3</availability>
+		</model>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>HL:5,LA:8,IS:7,FWL:8,NIOPS:4-,Periphery.Deep:5,TC:8,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>General:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
-		</model>
-		<model name='WHM-10T'>
-			<availability>FS:3,TC:7</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:1-</availability>
+		</model>
+		<model name='WHM-9S'>
+			<availability>LA:6,ROS:4,MH:3,MERC:4</availability>
+		</model>
+		<model name='WHM-8M'>
+			<availability>PR:6,PG:6,FWL:4,RFS:6</availability>
 		</model>
 		<model name='WHM-7K'>
 			<roles>spotter</roles>
 			<availability>DC:7</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:6,MERC:3</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='WHM-8M'>
-			<availability>PR:6,PG:6,FWL:4,RFS:6</availability>
-		</model>
-		<model name='WHM-11T'>
-			<availability>MOC:3,TC:2</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:5</availability>
-		</model>
-		<model name='WHD-10CT'>
-			<availability>CC:3,LA:2,DoO:3,ROS:3,DO:3,TP:3</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>FVC:3,CLAN:4,MERC:3,BAN:2,TC:5,Periphery:2</availability>
-		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:3,PIR:4,IS:2,MH:3,FS:3,MERC:3,CDP:3,TC:4</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:5,LA:5,FS:4,MERC:4</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CC:3,FVC:3,CGB.FRR:1,ROS:4,FWL:7,MERC:3,DC:1,Periphery:3</availability>
-		</model>
-		<model name='WHM-9S'>
-			<availability>LA:6,ROS:4,MH:3,MERC:4</availability>
+		<model name='WHM-6R'>
+			<availability>General:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-</availability>
 		</model>
+		<model name='WHM-4L'>
+			<availability>CC:6,MOC:3</availability>
+		</model>
+		<model name='WHM-11T'>
+			<availability>MOC:3,TC:2</availability>
+		</model>
+		<model name='WHM-8K'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='WHD-10CT'>
+			<availability>CC:3,LA:2,DoO:3,ROS:3,DO:3,TP:3</availability>
+		</model>
 		<model name='WHM-8D2'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='WHM-4L'>
-			<availability>CC:6,MOC:3</availability>
+		<model name='WHM-5L'>
+			<availability>CC:5</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FVC:2-,FS:1-</availability>
 		</model>
+		<model name='WHM-7M'>
+			<availability>CC:3,FVC:3,CGB.FRR:1,ROS:4,FWL:7,MERC:3,DC:1,Periphery:3</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:5,LA:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:6,MERC:3</availability>
+		</model>
+		<model name='WHM-10T'>
+			<availability>FS:3,TC:7</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>FVC:3,CLAN:4,MERC:3,BAN:2,TC:5,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:6,ROS:3,FS:5</availability>
-		<model name='BLR-2G'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BLR-2D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BLR-2G'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:5</availability>
@@ -15788,17 +15783,17 @@
 			<roles>apc</roles>
 			<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
 		</model>
-		<model name='H-7C'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
 		<model name='H-8'>
 			<availability>HL:4,LA:4,FS.CH:8,CGB.FRR:6,ROS:6,IS:2,Periphery.Deep:4,FWL:2,FS:6,MERC:6,Periphery:6,RA:8</availability>
 		</model>
-		<model name='H-9'>
-			<availability>LA:5</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='H-7C'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='H-9'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Stealth Helicopter' unitType='VTOL'>
@@ -15810,30 +15805,58 @@
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>HL:5,IS:8,Periphery.Deep:5,Periphery:6,RA:4</availability>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:5,CC:4,DA:4,TC:4</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='WSP-8T'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,ROS:2,IS:2,TC:5</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:2-</availability>
+		</model>
+		<model name='WSP-1S'>
+			<roles>recon</roles>
+			<availability>FVC:4,LA:5,FS:4,MERC:2</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='WSP-1L'>
+			<roles>recon</roles>
+			<availability>CC:1-</availability>
 		</model>
 		<model name='WSP-1D'>
 			<roles>recon</roles>
@@ -15843,41 +15866,13 @@
 			<roles>recon</roles>
 			<availability>CC:2-,MOC:2-,FVC:3-,FWL:2-,RCM:2-,Periphery:2-</availability>
 		</model>
-		<model name='WSP-8T'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,ROS:2,IS:2,TC:5</availability>
-		</model>
 		<model name='WSP-3L'>
 			<roles>recon</roles>
 			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
 		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
-		</model>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:5,CC:4,DA:4,TC:4</availability>
-		</model>
 		<model name='WSP-3A'>
 			<roles>recon</roles>
 			<availability>RA.OA:4,OA:2,RA:8</availability>
-		</model>
-		<model name='WSP-1S'>
-			<roles>recon</roles>
-			<availability>FVC:4,LA:5,FS:4,MERC:2</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:1-</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
@@ -15905,46 +15900,46 @@
 		<model name='WTH-3'>
 			<availability>FS.CMM:5</availability>
 		</model>
+		<model name='WTH-2A'>
+			<availability>DC:1</availability>
+		</model>
+		<model name='WTH-1'>
+			<roles>fire_support</roles>
+			<availability>Periphery.Deep:8,MERC:1,Periphery:1</availability>
+		</model>
+		<model name='WTH-2'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:6,OA:6,MH:6,MERC:4,CDP:6,TC:6</availability>
+		</model>
 		<model name='WTH-1H'>
 			<availability>Periphery.CM:4,Periphery.HR:4,PIR:5,Periphery.ME:4,MH:5,Periphery:3</availability>
 		</model>
 		<model name='WTH-K'>
 			<availability>DC:5</availability>
 		</model>
-		<model name='WTH-1'>
-			<roles>fire_support</roles>
-			<availability>Periphery.Deep:8,MERC:1,Periphery:1</availability>
-		</model>
-		<model name='WTH-2A'>
-			<availability>DC:1</availability>
-		</model>
-		<model name='WTH-2'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:6,OA:6,MH:6,MERC:4,CDP:6,TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:4,LA:4,CNC:2-,FWL:4,IS:3,MERC:4,DC:7</availability>
-		<model name='WGT-3SC'>
-			<availability>CC:8,LA:5,FWL:5,IS:5,MERC:5</availability>
-		</model>
-		<model name='WGT-1LAW/SC3'>
-			<availability>ROS:5,DC:6</availability>
+		<model name='WGT-2LAW'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='WGT-4NC &apos;Dezgra&apos;'>
 			<availability>CNC:8</availability>
 		</model>
+		<model name='WGT-1LAW/SC3'>
+			<availability>ROS:5,DC:6</availability>
+		</model>
 		<model name='WGT-2LAWC3'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WGT-2LAW'>
-			<availability>DC:5</availability>
+		<model name='WGT-1LAW/SC'>
+			<availability>LA:5,FWL:5,IS:4,MERC:5,DC:6</availability>
 		</model>
 		<model name='WGT-2SC'>
 			<availability>LA:6,FWL:6,IS:4,MERC:6</availability>
 		</model>
-		<model name='WGT-1LAW/SC'>
-			<availability>LA:5,FWL:5,IS:4,MERC:5,DC:6</availability>
+		<model name='WGT-3SC'>
+			<availability>CC:8,LA:5,FWL:5,IS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -15956,14 +15951,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>CGB.FRR:3,ROS:3,MERC:3,DC:5-</availability>
-		<model name='WFT-C'>
-			<availability>CGB.FRR:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='WFT-2'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:8,DC:4</availability>
 		</model>
 		<model name='WFT-B'>
 			<availability>ROS:6</availability>
@@ -15971,21 +15960,15 @@
 		<model name='WFT-1'>
 			<availability>General:4</availability>
 		</model>
+		<model name='WFT-C'>
+			<availability>CGB.FRR:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:8,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,MERC.KH:7,DoO:3,DO:3,DGM:3,FS:2,MERC:4,CWIE:5,DTA:3,SC:3,MERC.WD:5,FVC:2,LA:7,MCM:3,CGB.FRR:5,ROS:5,MH:4,MSC:2,TP:3</availability>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
-		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:6,LA:5,ROS:5,MERC:4,FS:4,CWIE:5</availability>
-		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:2,MERC.WD:1,FVC:2,LA:4,ROS:4,CGB.FRR:6,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-3M'>
-			<availability>DTA:8,SC:8,DoO:8,MCM:8,FWL:8,DO:8,DGM:8,MSC:8,TP:8</availability>
-		</model>
 		<model name='WLF-4WA'>
 			<roles>ew_support</roles>
 			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
@@ -15993,65 +15976,77 @@
 		<model name='WLF-1'>
 			<availability>MERC.KH:2,HL:6,LA:2,ROS:2,Periphery.Deep:6,FS:1,MERC:2,Periphery:8</availability>
 		</model>
-		<model name='WLF-3S'>
-			<availability>LA:4</availability>
+		<model name='WLF-3M'>
+			<availability>DTA:8,SC:8,DoO:8,MCM:8,FWL:8,DO:8,DGM:8,MSC:8,TP:8</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:2,MERC.WD:1,FVC:2,LA:4,ROS:4,CGB.FRR:6,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
 		</model>
 		<model name='WLF-2H'>
 			<availability>LA:3,MERC:2,CWIE:3</availability>
 		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:6,LA:5,ROS:5,MERC:4,FS:4,CWIE:5</availability>
+		</model>
+		<model name='WLF-3S'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,TC:4,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5,CGB:1</availability>
-		<model name='WVR-9K'>
-			<availability>ROS:3,DC:3</availability>
-		</model>
-		<model name='WVR-6R'>
+		<model name='WVR-7M'>
 			<roles>recon</roles>
-			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>FVC:6,LA:5,ROS:4,FS:5,MERC:3</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,MERC:3,DC:6</availability>
-		</model>
-		<model name='WVR-9W2'>
-			<availability>IS:4,DC:6</availability>
+			<availability>CC:4,MOC:4,FWL:5,MH:2,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-9D'>
 			<roles>spotter</roles>
 			<availability>FS:6,MERC:4</availability>
 		</model>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FWL:5,MH:2,MERC:6,DC:4</availability>
+		<model name='WVR-8K'>
+			<availability>CGB.FRR:5,ROS:4,CNC:5,MERC:3,DC:3,CGB:5</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:6</availability>
+		<model name='WVR-9W2'>
+			<availability>IS:4,DC:6</availability>
 		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>CGB.FRR:8,MERC:6,CGB:8,DC:6</availability>
 		</model>
-		<model name='WVR-9M'>
-			<availability>LA:2,ROS:4,FWL:5,MH:2,MERC:3</availability>
+		<model name='WVR-8D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='WVR-6M'>
 			<roles>recon</roles>
 			<availability>Periphery.MW:4-,PIR:4-,Periphery.ME:4-,FWL:2-,MH:4-</availability>
 		</model>
-		<model name='WVR-8K'>
-			<availability>CGB.FRR:5,ROS:4,CNC:5,MERC:3,DC:3,CGB:5</availability>
+		<model name='WVR-8C'>
+			<availability>ROS:4,MERC:3,DC:6</availability>
+		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='WVR-9M'>
+			<availability>LA:2,ROS:4,FWL:5,MH:2,MERC:3</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>FVC:6,LA:5,ROS:4,FS:5,MERC:3</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>ROS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -16065,7 +16060,7 @@
 	</chassis>
 	<chassis name='Wusun' unitType='Aero' omni='Clan'>
 		<availability>RA.OA:1+,RA:2</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -16074,29 +16069,29 @@
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
 		<availability>CHH:4,CW:4,CLAN:2</availability>
+		<model name='2'>
+			<availability>CW:7</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CW:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:2,PR:2,DoO:2,IS:2,DO:2,DGM:2,FS:7,MERC:5,DC.GHO:4,SC:2,DTA:2,FVC:2,MCM:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
-		<model name='WVE-9N'>
-			<roles>urban</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>DC.GHO:3,CGB.FRR:8,ROS:6,NIOPS:4,FS:8,MERC:8,BAN:2,DC:3</availability>
+		</model>
+		<model name='WVE-9N'>
+			<roles>urban</roles>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -16131,23 +16126,20 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CSR:3,CLAN:5,RA:4</availability>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CSL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CSL:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>FVC:8,HL:3,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
 		<model name='(RAC)'>
 			<availability>IS:3,FS:5</availability>
-		</model>
-		<model name='(PPC)'>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2,FS:4</availability>
@@ -16159,15 +16151,18 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(PPC)'>
+			<availability>IS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
 		<availability>ROS:3,FWL:4,MH:3,MERC:3</availability>
-		<model name='YMN-10-OR'>
-			<availability>ROS:4,FWL:4,MERC:4</availability>
-		</model>
 		<model name='YMN-6Y'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='YMN-10-OR'>
+			<availability>ROS:4,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ymir' unitType='Mek'>
@@ -16185,18 +16180,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:5</availability>
-		</model>
-		<model name='Y-H10G'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Y-H9G'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='Y-H10G'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
@@ -16214,13 +16209,13 @@
 	</chassis>
 	<chassis name='Zephyros Infantry Support Vehicle' unitType='Tank'>
 		<availability>CHH:4,CW:1,CGB:1,CWIE:1</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Dual Turret)'>
 			<roles>apc</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
@@ -16231,35 +16226,35 @@
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:3-,ROS:4</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='ZEU-X'>
 			<availability>LA:4</availability>
 		</model>
 		<model name='ZEU-9WD'>
 			<availability>General:4</availability>
 		</model>
-		<model name='ZEU-X2'>
-			<availability>LA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:5,LA:10,CGB.FRR:4,ROS:5,PIR:4,MH:4,FS:4-,MERC:5,CDP:4,TC:4</availability>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
-		<model name='ZEU-6S'>
-			<availability>HL:3,General:1-,Periphery:5</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>FVC:6,LA:8,CGB.FRR:6,PIR:6,MH:3,MERC:6,CDP:6,TC:6</availability>
 		</model>
-		<model name='ZEU-9S2'>
-			<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
+		<model name='ZEU-6T'>
+			<availability>LA:2-</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='ZEU-6T'>
-			<availability>LA:2-</availability>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4</availability>
+		</model>
+		<model name='ZEU-9S2'>
+			<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:3,General:1-,Periphery:5</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -16276,14 +16271,14 @@
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,CBS:8,ROS:4,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(ATM)'>
 			<availability>CW:6,ROS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CBS:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3085.xml
+++ b/megamek/data/forcegenerator/3085.xml
@@ -1139,28 +1139,28 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
 		<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:5</availability>
+		<model name='(3088)'>
+			<availability>DC:3</availability>
+		</model>
 		<model name='(2582)'>
 			<roles>assault</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='(3088)'>
-			<availability>DC:3</availability>
 		</model>
 		<model name='(3055)'>
 			<roles>assault</roles>
@@ -1214,17 +1214,17 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CSL:6,CJF:6</availability>
-		<model name='(Jade Falcon)' mechanized='true'>
-			<availability>CJF:8</availability>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Jade Falcon)' mechanized='true'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ailette Rescue PA(L)' unitType='BattleArmor'>
@@ -1256,13 +1256,12 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4</availability>
@@ -1270,17 +1269,15 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>ROS:4,CNC:4,DC:6</availability>
-		<model name='AKU-2X'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,DC:5</availability>
+		<model name='AKU-2XK'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='AKU-1X'>
 			<availability>DC:4</availability>
@@ -1288,17 +1285,20 @@
 		<model name='AKU-2XC'>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='AKU-2XK'>
-			<availability>DC:4</availability>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,DC:5</availability>
+		</model>
+		<model name='AKU-2X'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,CW:3,LA:6,ROS:5,CNC:4,NIOPS:7,FS:5,MERC:2,CWIE:6,DC:3</availability>
-		<model name='Mk VII'>
-			<availability>LA:4,FS:4</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk VII'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
@@ -1306,20 +1306,20 @@
 		<model name='ALB-3U'>
 			<availability>FWL:8,MERC:8</availability>
 		</model>
-		<model name='ALB-3Ur'>
-			<availability>ROS:4,FWL:4,MERC:4</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,OP:6,DoO:6,FWL:6,DO:6,MSC:6,TP:6</availability>
+		</model>
+		<model name='ALB-3Ur'>
+			<availability>ROS:4,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CCO:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CGB:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='XR'>
 			<availability>CDS:1</availability>
@@ -1361,6 +1361,9 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>CSA:2,MERC.KH:3,CHH:3,MERC.WD:8,LA:4,ROS:5,MERC:3,CCO:2,CWIE:4,BAN:2,RA:3,CGB:2</availability>
+		<model name='C 2'>
+			<availability>MERC.WD:5,CLAN:6,IS:3,BAN:1</availability>
+		</model>
 		<model name='ANH-4A'>
 			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:3,ROS:3,MERC:3,CWIE:5</availability>
 		</model>
@@ -1372,9 +1375,6 @@
 		</model>
 		<model name='ANH-3A'>
 			<availability>MERC.WD:5,CHH:4,LA:5,ROS:5,MERC:5,CWIE:4</availability>
-		</model>
-		<model name='C 2'>
-			<availability>MERC.WD:5,CLAN:6,IS:3,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1393,34 +1393,28 @@
 	</chassis>
 	<chassis name='Anubis' unitType='Mek'>
 		<availability>CC:5,MOC:6,DA:3,TC:3</availability>
+		<model name='ABS-3R'>
+			<availability>General:4</availability>
+		</model>
 		<model name='ABS-3T'>
 			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
-		<model name='ABS-3R'>
-			<availability>General:4</availability>
+		<model name='ABS-4C'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
 			<availability>FVC:0,General:8</availability>
 		</model>
-		<model name='ABS-4C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>OP:6,PR:6,DoO:6,DO:6,MERC:4,DTA:6,RF:6,ROS:4,PG:6,FWL:5,MSC:6,TP:6,DA:6,RFS:6</availability>
-		<model name='ANV-5M'>
-			<availability>DTA:5,OP:5,DoO:5,FWL:5,DO:5,TP:5,DA:5</availability>
-		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>DTA:5,OP:5,PR:5,RF:5,DoO:5,PG:5,DO:5,MSC:5,TP:5,DA:5,RFS:5</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>ROS:6,FWL:4,MERC:4</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,MERC:4</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:5,OP:5,DoO:5,FWL:5,DO:5,TP:5,DA:5</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
@@ -1428,6 +1422,12 @@
 		</model>
 		<model name='ANV-5Q'>
 			<availability>DTA:4,PR:4,RF:4,PG:4,MSC:4,RFS:4</availability>
+		</model>
+		<model name='ANV-3R'>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>ROS:6,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Anzu' unitType='Mek'>
@@ -1439,21 +1439,21 @@
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,Periphery.MW:2,ROS:4,Periphery.ME:2,FWL:8,MH:3,MSC:8,MERC:4,DC:6</availability>
-		<model name='APL-3T'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
 		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>CC:3,FWL:4,MERC:3,DC:3</availability>
 		</model>
-		<model name='APL-2S'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
-			<availability>CC:3,FWL:4,DC:3</availability>
+			<availability>FWL:4,DC:3</availability>
 		</model>
 		<model name='APL-4M'>
 			<roles>fire_support</roles>
 			<availability>MSC:5</availability>
+		</model>
+		<model name='APL-2S'>
+			<roles>fire_support</roles>
+			<availability>CC:3,FWL:4,DC:3</availability>
 		</model>
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
@@ -1473,14 +1473,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,ROS:4,CNC:5,MERC:3,FS:3,DC:3</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1509,98 +1509,89 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,HL:3,LA:6,CGB.FRR:4,IS:2-,Periphery.Deep:5,FWL:6,NIOPS:4-,FS:1-,Periphery:4,DC:5,CGB:2</availability>
-		<model name='ARC-6W'>
+		<model name='ARC-7L'>
 			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,TC:5,Periphery:4</availability>
+			<availability>CC:7,MOC:3</availability>
 		</model>
 		<model name='ARC-9W'>
 			<roles>fire_support</roles>
 			<availability>ROS:5</availability>
 		</model>
-		<model name='ARC-6S'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>LA:3,CGB.FRR:3,ROS:4,MERC:3,CGB:3</availability>
-		</model>
-		<model name='ARC-8M'>
-			<roles>fire_support</roles>
-			<availability>DTA:5,MOC:3,OP:5,DoO:5,CGB.FRR:3,ROS:4,PIR:3,MH:3,DO:5,MSC:5,TP:5,MERC:4</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6</availability>
-		</model>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:7,MOC:3</availability>
-		</model>
-		<model name='ARC-2K'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:1-,DC:2-</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:5</availability>
+			<availability>CLAN:4,FWL:4,MERC:3,BAN:2</availability>
 		</model>
 		<model name='ARC-9KC'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='ARC-5R'>
+		<model name='ARC-5W'>
 			<roles>fire_support</roles>
-			<availability>CGB.FRR:8,MERC:4,CGB:5</availability>
+			<availability>MERC.WD:8,LA:3,MERC:3</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:3,CGB.FRR:3,ROS:4,MERC:3,CGB:3</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:5</availability>
+		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:2,TC:5,Periphery:4</availability>
 		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
 		</model>
-		<model name='ARC-5S'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3</availability>
-		</model>
 		<model name='ARC-9M'>
 			<roles>fire_support</roles>
 			<availability>LA:5,ROS:4,FWL:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='ARC-2R'>
-			<roles>fire_support</roles>
-			<availability>LA:2-,CGB.FRR:2-,IS:2-,Periphery.Deep:8,BAN:2,DC:2-,Periphery:3-</availability>
-		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:3,MERC:3</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,MERC:3,BAN:2</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:6,CCC:6</availability>
 		</model>
+		<model name='ARC-5S'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3</availability>
+		</model>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5R'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:8,MERC:4,CGB:5</availability>
+		</model>
+		<model name='ARC-2R'>
+			<roles>fire_support</roles>
+			<availability>LA:2-,CGB.FRR:2-,IS:2-,Periphery.Deep:8,BAN:2,DC:2-,Periphery:3-</availability>
+		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CC:4,FVC:4,PIR:5,FWL:5,MERC:4,DC:4,Periphery:3</availability>
 		</model>
+		<model name='ARC-2K'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:1-,DC:2-</availability>
+		</model>
+		<model name='ARC-8M'>
+			<roles>fire_support</roles>
+			<availability>DTA:5,MOC:3,OP:5,DoO:5,CGB.FRR:3,ROS:4,PIR:3,MH:3,DO:5,MSC:5,TP:5,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,LA:4,ROS:3,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1E'>
-			<availability>General:6</availability>
+		<model name='AF1C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
@@ -1609,21 +1600,30 @@
 		<model name='AF1B'>
 			<availability>General:5</availability>
 		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Wolf II' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:2,CWIE:3</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
@@ -1640,11 +1640,11 @@
 		<model name='A'>
 			<availability>General:2</availability>
 		</model>
-		<model name='J'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:4</availability>
+		</model>
+		<model name='J'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -1674,12 +1674,6 @@
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
 		<availability>FS:6</availability>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
@@ -1689,40 +1683,26 @@
 		<model name='AGS-6F'>
 			<availability>General:4</availability>
 		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>RA.OA:3,PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>RA.OA:3,PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1732,17 +1712,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1769,16 +1769,16 @@
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
 		<availability>MOC:2-,CC:2-,FVC:1,LA:1,FS.CMM:1-,MERC:1-,RCM:2-,DA:2-,CDP:2-,TC:2-,Periphery:1-</availability>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
+		<model name='ASN-99'>
+			<roles>spotter</roles>
+			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:3,FVC:4,Periphery.HR:4,PIR:3,MH:4,RCM:4,DA:4</availability>
 		</model>
-		<model name='ASN-99'>
-			<roles>spotter</roles>
-			<availability>CC:2,MOC:2</availability>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -1811,20 +1811,20 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,CCC:5,CDS:5,CW:5,ROS:4,CSL:8,CJF:3,RA:5,CGB:6</availability>
-		<model name='(HAG)'>
-			<availability>CHH:7,ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:7,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas II' unitType='Mek'>
 		<availability>LA:4,ROS:4,CLAN:1</availability>
-		<model name='AS7-D-H'>
-			<availability>General:8</availability>
-		</model>
 		<model name='AS7-D-H2'>
 			<availability>CLAN:1</availability>
+		</model>
+		<model name='AS7-D-H'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas' unitType='Mek'>
@@ -1832,69 +1832,57 @@
 		<model name='AS7-Dr'>
 			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>CGB.FRR:4,IS:4,DC:4</availability>
+		<model name='AS7-K4'>
+			<availability>PR:4,RF:4,LA:4,PG:4,RFS:4,DC:4</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>MOC:3,RA.OA:4,FVC:3,CGB.FRR:5,CNC:5,MERC:4,CDP:3,DC:6,Periphery:3,TC:3</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:6,ROS:4,MERC:3</availability>
+		</model>
+		<model name='AS7-K3'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
+		</model>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:4</availability>
+		</model>
+		<model name='AS7-D-DC'>
+			<availability>IS:1-,MERC:0,DC:1-</availability>
+		</model>
+		<model name='AS7-K2'>
+			<availability>LA:6,CNC:4,IS:4,CLAN.IS:3,Periphery:4,CWIE:4</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:4,FS:4,DC:4</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>CGB.FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>CGB.FRR:5,MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
-		</model>
-		<model name='AS7-C'>
-			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
-		</model>
 		<model name='AS7-S2'>
 			<availability>LA:2,ROS:3,MERC:3</availability>
 		</model>
-		<model name='AS7-D'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:6,ROS:4,MERC:3</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>IS:1-,MERC:0,DC:1-</availability>
-		</model>
-		<model name='AS7-K4'>
-			<availability>PR:4,RF:4,LA:4,PG:4,RFS:4,DC:4</availability>
-		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:4</availability>
-		</model>
-		<model name='AS7-K3'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>MOC:3,RA.OA:4,FVC:3,CGB.FRR:5,CNC:5,MERC:4,CDP:3,DC:6,Periphery:3,TC:3</availability>
-		</model>
-		<model name='AS7-K2'>
-			<availability>LA:6,CNC:4,IS:4,CLAN.IS:3,Periphery:4,CWIE:4</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(CV)'>
@@ -1905,6 +1893,14 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Gunship)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
@@ -1912,6 +1908,10 @@
 		<model name='(Tanker)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1923,24 +1923,24 @@
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CSA:2,CCC:2,CW:4,CLAN:2,CNC:4,RA:2,BAN:5,CWIE:4</availability>
+		<model name='A'>
+			<availability>CSA:7,General:6,RA:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:7,CCO:8,RA:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5,CCO:6</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CSA:7,General:6,RA:7</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
@@ -1951,34 +1951,34 @@
 		<model name='AV1-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
+		</model>
 		<model name='AV1-OI'>
 			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='AV1-OE'>
-			<availability>General:6</availability>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AV1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
@@ -1986,31 +1986,31 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:2,RA.OA:2,LA:4,CGB.FRR:2,IS:2,FWL:3,FS:4,TC:2,Periphery:1,DC:3</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>LA:1-,General:4,FS:1-</availability>
 		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:7,CC:6,HL:7,CLAN:1-,IS:5,Periphery.Deep:7,FS:5,Periphery:8,TC:6,RA.OA:7,LA:5,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
-		<model name='AWS-8Q'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
 		<model name='AWS-10KM'>
 			<availability>DTA:4,OP:4,DoO:4,ROS:4,FWL:4,DO:4,MSC:4,TP:4,DC:5</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:3,PIR:4,FWL:5,IS:4,MH:3,TC:3,Periphery:3</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:3,OP:3,LA:3,ROS:3,FWL:3,MSC:3,FS:3,MERC:3</availability>
-		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:5,HL:2,FWL:5,IS:5,MH:5,TC:5,Periphery:4</availability>
+		</model>
+		<model name='AWS-9Ma'>
+			<availability>DTA:3,OP:3,LA:3,ROS:3,FWL:3,MSC:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
@@ -2033,8 +2033,18 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:2,LA:5,CGB.FRR:2,ROS:4,FS:2,MERC:1</availability>
+		<model name='AXM-6T'>
+			<availability>LA:4</availability>
+		</model>
+		<model name='AXM-3S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='AXM-4D'>
 			<availability>FS:5</availability>
+		</model>
+		<model name='AXM-2N'>
+			<roles>fire_support</roles>
+			<availability>FVC:1,LA:2,FS:1</availability>
 		</model>
 		<model name='AXM-1N'>
 			<availability>FVC:4,LA:4,CGB.FRR:4,MERC:4,FS:4</availability>
@@ -2042,19 +2052,13 @@
 		<model name='AXM-3Sr'>
 			<availability>LA:5,ROS:4,FS:6,MERC:4</availability>
 		</model>
-		<model name='AXM-6T'>
-			<availability>LA:4</availability>
-		</model>
-		<model name='AXM-3S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-2N'>
-			<roles>fire_support</roles>
-			<availability>FVC:1,LA:2,FS:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CSA:4,CJF:5,RA:5</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>RA:6</availability>
+		</model>
 		<model name='3 &apos;Devil&apos;'>
 			<availability>RA:8</availability>
 		</model>
@@ -2062,14 +2066,30 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>RA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:4,CHH:2,CW:4,LA:2,ROS:3,CSL:2</availability>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CSA:6,CLAN:5,General:3</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:6,General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2081,38 +2101,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>CLAN:6,General:4</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CSA:6,CLAN:5,General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,LA:3,MERC:4</availability>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -2128,7 +2124,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -2136,15 +2132,13 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>RA.OA:7,IS:7,CLAN.IS:7</availability>
-		<model name='(Hybrid)'>
-			<availability>CLAN:3,IS:3</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
@@ -2152,24 +2146,30 @@
 		<model name='(Standard)'>
 			<availability>CLAN:8,IS:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Hybrid)'>
+			<availability>CLAN:3,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:4+</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -2177,33 +2177,41 @@
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:4,DTA:4,HL:2,LA:3,ROS:4,FWL:4,MERC:8,FS:4,DA:4,Periphery:3</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:3</availability>
+		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
 		<model name='BNDR-01B'>
 			<availability>General:4,MERC:8</availability>
 		</model>
-		<model name='BNDR-01Ar'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:2,CLAN:1,CSL:2</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3,CCO:6</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
@@ -2213,16 +2221,8 @@
 			<roles>apc</roles>
 			<availability>CSA:6,CLAN:5,General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -2235,9 +2235,13 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:5</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -2247,9 +2251,9 @@
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:6</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
@@ -2259,36 +2263,38 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:6-,PR:3-,HL:7-,Periphery.Deep:8-,MERC:3-,Periphery:8-,TC:6-,RA.OA:6-,FVC:3-,RF:3-,LA:4-,CGB.FRR:2-,PG:3-,FWL:2-,MH:6-,MSC:2-,RFS:3-</availability>
+		<model name='BNC-3Mr'>
+			<availability>MOC:5,FWL:5,CDP:5,TC:5</availability>
+		</model>
 		<model name='BNC-3MC'>
 			<availability>MOC:4-</availability>
 		</model>
-		<model name='BNC-3S'>
-			<availability>RA.OA:1-,LA:2-,MERC:1-,CDP:1,TC:1-,Periphery:2-</availability>
+		<model name='BNC-7S'>
+			<availability>LA:2</availability>
 		</model>
-		<model name='BNC-6S'>
+		<model name='BNC-9S'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='BNC-3Mr'>
-			<availability>MOC:5,FWL:5,CDP:5,TC:5</availability>
+		<model name='BNC-8S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1-,FVC:2-,FWL:1-,MH:2-,MERC:2-,CDP:1-,TC:1-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>PR:2-,RF:2-,PG:2-,MSC:2-,RFS:2-</availability>
@@ -2296,39 +2302,33 @@
 		<model name='BNC-3E'>
 			<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
 		</model>
-		<model name='BNC-7S'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6</availability>
+		<model name='BNC-3S'>
+			<availability>RA.OA:1-,LA:2-,MERC:1-,CDP:1,TC:1-,Periphery:2-</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:4,CGB.FRR:3,MH:3,FS:6,MERC:5</availability>
 		</model>
-		<model name='BNC-9S'>
+		<model name='BNC-6S'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1-,FVC:2-,FWL:1-,MH:2-,MERC:2-,CDP:1-,TC:1-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,CGB.FRR:4,ROS:4,MERC:4</availability>
-		<model name='BGS-2T'>
-			<availability>LA:5,ROS:5,MERC:5</availability>
-		</model>
-		<model name='BGS-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BGS-1T'>
 			<availability>General:5</availability>
+		</model>
+		<model name='BGS-3T'>
+			<availability>LA:4,ROS:4,MERC:4</availability>
+		</model>
+		<model name='BGS-2T'>
+			<availability>LA:5,ROS:5,MERC:5</availability>
 		</model>
 		<model name='BGS-4T'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='BGS-3T'>
-			<availability>LA:4,ROS:4,MERC:4</availability>
+		<model name='BGS-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Barouche Military Transport' unitType='Tank'>
@@ -2340,21 +2340,21 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>ROS:3+,CNC:5,CLAN:4,IS:2+,RA:7,BAN:5</availability>
-		<model name='D'>
-			<availability>CNC:3,CLAN:2,RA:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CNC:8,General:7,RA:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='D'>
+			<availability>CNC:3,CLAN:2,RA:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
@@ -2363,38 +2363,38 @@
 	</chassis>
 	<chassis name='Basilisk' unitType='ProtoMek'>
 		<availability>CSA:4,CCC:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CCC:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CSL:5,CJF:6,CCO:3</availability>
+		<model name='C'>
+			<availability>General:6,CCO:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='F'>
+			<availability>General:5</availability>
+		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='F'>
-			<availability>General:5</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,General:6</availability>
-		</model>
-		<model name='C'>
-			<availability>General:6,CCO:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Battle Hawk' unitType='Mek'>
@@ -2420,32 +2420,47 @@
 		<model name='BKX-7K'>
 			<availability>FS:2-,MERC:4-</availability>
 		</model>
-		<model name='BKX-1X'>
-			<availability>LA:8-,FS:2-</availability>
-		</model>
 		<model name='BKX-8D'>
 			<availability>ROS:8,FS:8,MERC:6</availability>
+		</model>
+		<model name='BKX-1X'>
+			<availability>LA:8-,FS:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,HL:4,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
-		<model name='BLR-4L'>
-			<availability>CC:4</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:2,LA:2,FWL:2,FS:2,Periphery:2,DC:2</availability>
 		</model>
-		<model name='BLR-1G-DC'>
-			<availability>IS:1-,MERC:0</availability>
-		</model>
-		<model name='BLR-3M'>
-			<availability>CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:4,CGB.FRR:3,ROS:4,MERC:4</availability>
+		<model name='BLR-1Gb'>
+			<availability>CC:3,OP:3,DoO:3,CLAN:8,DO:3,MSC:3,TP:3,FS:3,MERC:3,BAN:2,DC:3</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>MSC:2</availability>
 		</model>
+		<model name='BLR-1D'>
+			<availability>FVC:3-,FS:2-</availability>
+		</model>
+		<model name='BLR-6X'>
+			<availability>LA:1</availability>
+		</model>
+		<model name='BLR-4S'>
+			<availability>LA:4,CGB.FRR:3,ROS:4,MERC:4</availability>
+		</model>
+		<model name='BLR-1S'>
+			<availability>LA:1-</availability>
+		</model>
 		<model name='BLR-10S'>
 			<availability>LA:6,ROS:4,FS:4</availability>
+		</model>
+		<model name='BLR-1G-DC'>
+			<availability>IS:1-,MERC:0</availability>
+		</model>
+		<model name='BLR-3S'>
+			<availability>LA:3</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>IS:2-,Periphery.Deep:8,FS:1-,BAN:8,Periphery:3-</availability>
 		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:6,ROS:4,FS:4</availability>
@@ -2457,36 +2472,21 @@
 			<roles>spotter</roles>
 			<availability>DTA:5,OP:5,DoO:5,ROS:4,DO:5,TP:5,DA:5,MERC:4</availability>
 		</model>
-		<model name='BLR-K4'>
-			<availability>CGB.FRR:5,ROS:4,DC:5</availability>
-		</model>
-		<model name='BLR-1S'>
-			<availability>LA:1-</availability>
-		</model>
-		<model name='BLR-6X'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='BLR-3S'>
-			<availability>LA:3</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>IS:2-,Periphery.Deep:8,FS:1-,BAN:8,Periphery:3-</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:3,OP:3,DoO:3,CLAN:8,DO:3,MSC:3,TP:3,FS:3,MERC:3,BAN:2,DC:3</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:3-,FS:2-</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:2,LA:2,FWL:2,FS:2,Periphery:2,DC:2</availability>
-		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:6,OP:6,DoO:6,DO:6,MSC:6,TP:6</availability>
+		</model>
+		<model name='BLR-K4'>
+			<availability>CGB.FRR:5,ROS:4,DC:5</availability>
 		</model>
 		<model name='BLR-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-3M'>
+			<availability>CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:4</availability>
 		</model>
 		<model name='BLR-K3'>
 			<roles>spotter</roles>
@@ -2502,16 +2502,9 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CSA:6,CHH:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CCO:3,CGB:6,CWIE:4</availability>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CNC:9,General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>CSA:7,CCC:7,General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CHH:6,General:5,CJF:6</availability>
@@ -2519,55 +2512,62 @@
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>CSA:7,CCC:7,General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
 		<availability>ROS:6,NIOPS:5</availability>
-		<model name='(Sealed)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>ROS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>ROS:4,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:6,RA:4</availability>
-		<model name='(Standard)'>
-			<availability>RA:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:7</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>RA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:2,HL:3,IS:2,MERC:2,FS:3,Periphery:4,RA.OA:3,CDS:5,LA:2,CGB.FRR:3,PIR:2,CNC:5,FWL:2,DC:5</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:6,IS:6,DC:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>FVC:4,CDS:4,General:8,DC:2</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Kurita)'>
-			<availability>CLAN:6,IS:6,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>FVC:4,CDS:4,General:8,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2579,44 +2579,44 @@
 	</chassis>
 	<chassis name='Bellona Hover Tank' unitType='Tank'>
 		<availability>CHH:6</availability>
-		<model name='(Laser)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Beowulf IIC' unitType='Mek'>
 		<availability>CGB.FRR:5,CGB:5</availability>
-		<model name='PR'>
-			<availability>General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='PR'>
+			<availability>General:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>CGB.FRR:6,ROS:6,CNC:4,CGB:5</availability>
-		<model name='BEO-14'>
-			<roles>recon</roles>
-			<availability>ROS:5</availability>
-		</model>
 		<model name='BEO-12'>
 			<roles>recon,spotter</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='BEO-14'>
+			<roles>recon</roles>
+			<availability>ROS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>PR:5,RF:5,LA:7,CGB.FRR:3,ROS:4,PG:5,FS:3,MERC:3,RFS:5</availability>
-		<model name='BRZ-B3'>
-			<availability>LA:2</availability>
+		<model name='BRZ-A3'>
+			<availability>PR:8,RF:8,LA:4,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>PR:4,RF:4,LA:6,ROS:6,PG:4,MERC:6,RFS:4</availability>
 		</model>
-		<model name='BRZ-A3'>
-			<availability>PR:8,RF:8,LA:4,CGB.FRR:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2641,103 +2641,103 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CSA:1,CHH:2,CW:2,ROS:3+,IS:2+,CJF:2,RA:2,BAN:3,CWIE:2,CGB:2</availability>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
 		<model name='B'>
 			<availability>CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		<model name='C'>
+			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CDS:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CLAN:4,General:2</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CW:5,General:6,CJF:8,CGB:7</availability>
 		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2,CCO:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:5,LA:6,CGB.FRR:6,IS:5,FS:5,MERC:5,DC:8</availability>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OX'>
+			<availability>FS:2,DC:2</availability>
+		</model>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='BHKU-OX'>
-			<availability>FS:2,DC:2</availability>
-		</model>
 		<model name='BHKU-OR'>
 			<availability>General:3+,DC:3+</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OA'>
-			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OF'>
 			<availability>General:4</availability>
 		</model>
+		<model name='BHKU-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
 		<availability>CHH:7,CDS:5,CNC:5,IS:4,MERC:5,CWIE:5</availability>
-		<model name='3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:4,PR:6,DoO:6,CLAN:5,DO:6,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CDS:4,CGB.FRR:4,FWL:5,NIOPS:7,MSC:6,RFS:6,CGB:6,MOC:2,CC:2,OP:6,IS:4,MERC:4,RA:4,Periphery:2,TC:4,DTA:6,FVC:4,CW:6,RF:6,LA:5,ROS:6,PG:6,CNC:6,TP:6,RCM:6,DA:6,CJF:4,DC:4</availability>
-		<model name='BL-12-KNT'>
+		<model name='BL-6b-KNT'>
+			<availability>OP:6,DoO:6,CLAN:5,DO:6,MERC:5,FS:5,BAN:2,DTA:6,LA:5,ROS:6,FWL:6,TP:6,DA:6,DC:5</availability>
+		</model>
+		<model name='BL-9-KNT'>
+			<availability>ROS:8</availability>
+		</model>
+		<model name='BLK-NT-2Y'>
 			<availability>ROS:6,FS:6</availability>
 		</model>
 		<model name='BL-6-KNT'>
 			<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
 		</model>
-		<model name='BL-6b-KNT'>
-			<availability>OP:6,DoO:6,CLAN:5,DO:6,MERC:5,FS:5,BAN:2,DTA:6,LA:5,ROS:6,FWL:6,TP:6,DA:6,DC:5</availability>
-		</model>
-		<model name='BLK-NT-2Y'>
-			<availability>ROS:6,FS:6</availability>
-		</model>
 		<model name='BLK-NT-3A'>
 			<availability>FS:6</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>ROS:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -2745,19 +2745,15 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='H'>
+			<availability>CSA:6,CLAN:6</availability>
 		</model>
 		<model name='X'>
 			<availability>CJF:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CLAN:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6,CCO:6</availability>
@@ -2765,6 +2761,10 @@
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -2783,36 +2783,42 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:6,MERC:3</availability>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>CC:3-,MOC:3,RA.OA:4,FVC:5,HL:3,FS:5,MERC:3,TC:3,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:8,MERC:6</availability>
-		</model>
 		<model name='BJ-1'>
 			<availability>Periphery.Deep:8,Periphery:2</availability>
+		</model>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
 		<model name='BJ-2'>
 			<availability>FVC:4,LA:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:8,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,FVC:3,ROS:4,FWL:5,IS:2,FS:6,MERC:3,DA:4,DC:6</availability>
-		<model name='BJ2-O'>
-			<availability>General:7</availability>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
 		</model>
-		<model name='BJ2-OX'>
-			<availability>General:2</availability>
+		<model name='BJ2-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:6</availability>
@@ -2820,23 +2826,17 @@
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OC'>
+		<model name='BJ2-OD'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
+		<model name='BJ2-O'>
+			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		<model name='BJ2-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blade' unitType='Mek'>
@@ -2844,15 +2844,15 @@
 		<model name='BLD-7R'>
 			<availability>DTA:8,OP:8,DoO:8,DO:8,MSC:8,TP:8</availability>
 		</model>
-		<model name='BLD-XS'>
-			<availability>ROS:4,FS:4</availability>
+		<model name='BLD-XX'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:2</availability>
 		</model>
 		<model name='BLD-XL'>
 			<availability>ROS:8,FS:8</availability>
 		</model>
-		<model name='BLD-XX'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:2</availability>
+		<model name='BLD-XS'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
@@ -2866,39 +2866,39 @@
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MERC:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Black Blizzard&apos;'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CSA:7,CHH:5,CCC:4,CSL:5</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='G'>
+		<model name='E'>
 			<availability>General:5</availability>
 		</model>
 		<model name='D'>
@@ -2907,37 +2907,37 @@
 	</chassis>
 	<chassis name='Blood Kite' unitType='Mek'>
 		<availability>CSA:5,CCC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CW:8</availability>
-		<model name='2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
 		<availability>OP:6,PR:1,DoO:6,DO:6,MERC:4,DTA:6,RF:1,ROS:4,PG:1,FWL:6,MH:4,MSC:6,TP:6,DA:6,RCM:1,RFS:1</availability>
-		<model name='B3-HND'>
-			<roles>anti_infantry</roles>
-			<availability>:0,IS:3</availability>
+		<model name='B2-HND'>
+			<availability>RF:0,General:4,RCM:0</availability>
 		</model>
 		<model name='B1-HND'>
 			<availability>:0,General:8</availability>
 		</model>
-		<model name='B2-HND'>
-			<availability>RF:0,General:4,RCM:0</availability>
+		<model name='B3-HND'>
+			<roles>anti_infantry</roles>
+			<availability>:0,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
-		<availability>MOC:6,FS:2,Periphery:4,DC:2,OA.RA:5</availability>
+		<availability>MOC:6,OA.RA:5,FS:2,Periphery:4,DC:2</availability>
 		<model name='MSF-42'>
 			<availability>General:6</availability>
 		</model>
@@ -2951,12 +2951,12 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank (RotS)' unitType='Tank' omni='IS'>
 		<availability>ROS:2</availability>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
@@ -2973,6 +2973,10 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>RA.OA:5,FVC:4,CDS:3,CLAN:2,NIOPS:3,DC:5,RA:4</availability>
+		<model name='BMB-12D'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:4,FVC:6,CGB.FRR:6,ROS:3,CLAN:8,NIOPS:4,MERC.SI:8,BAN:8</availability>
+		</model>
 		<model name='BMB-10D'>
 			<roles>fire_support</roles>
 			<availability>Periphery.Deep:8</availability>
@@ -2984,10 +2988,6 @@
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='BMB-12D'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:4,FVC:6,CGB.FRR:6,ROS:3,CLAN:8,NIOPS:4,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -3006,42 +3006,42 @@
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
 		<availability>MERC:2,TC:5</availability>
-		<model name='BRM-5A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BRM-5B'>
 			<availability>TC:2</availability>
+		</model>
+		<model name='BRM-5A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2</availability>
-		<model name='LDT-5'>
-			<availability>PIR:5</availability>
-		</model>
 		<model name='LDT-X3'>
+			<availability>PIR:4</availability>
+		</model>
+		<model name='LDT-X4'>
 			<availability>PIR:4</availability>
 		</model>
 		<model name='LDT-1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='LDT-X4'>
-			<availability>PIR:4</availability>
-		</model>
-		<model name='LDT-X1'>
-			<availability>General:4</availability>
+		<model name='LDT-5'>
+			<availability>PIR:5</availability>
 		</model>
 		<model name='LDT-X2'>
+			<availability>General:4</availability>
+		</model>
+		<model name='LDT-X1'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -3053,16 +3053,19 @@
 	</chassis>
 	<chassis name='Bruin' unitType='Mek'>
 		<availability>CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -3074,9 +3077,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:5,MOC:5,RA.OA:4,IS:4,FS:4</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3101,13 +3101,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -3119,14 +3119,14 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>LA:2-,General:8,FS:2-,MERC:2-,DC:2-</availability>
+		<model name='(Cell)'>
+			<availability>LA:6,ROS:6,FS:6,MERC:6,DC:6</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Cell)'>
-			<availability>LA:6,ROS:6,FS:6,MERC:6,DC:6</availability>
+		<model name='(Standard)'>
+			<availability>LA:2-,General:8,FS:2-,MERC:2-,DC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3162,14 +3162,14 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:5,MERC:3</availability>
+		<model name='BSW-S2r'>
+			<availability>General:3</availability>
+		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4,FS:1</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BSW-S2r'>
-			<availability>General:3</availability>
 		</model>
 		<model name='BSW-X2'>
 			<availability>LA:4,MERC:4</availability>
@@ -3180,11 +3180,11 @@
 	</chassis>
 	<chassis name='Cadaver' unitType='Mek'>
 		<availability>RA.OA:4,TC:4,RA:3</availability>
-		<model name='CVR-A1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CVR-T1'>
 			<availability>RA.OA:6,TC:4,RA:6</availability>
+		</model>
+		<model name='CVR-A1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Caerleon' unitType='Small Craft'>
@@ -3196,17 +3196,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>FVC:5,LA:4,FS:5,MERC:4</availability>
-		<model name='CES-3R'>
-			<availability>FVC:8,FS:3,MERC:3</availability>
-		</model>
-		<model name='CES-4S'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='CES-4R'>
 			<availability>FS:6</availability>
 		</model>
 		<model name='CES-3S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='CES-3R'>
+			<availability>FVC:8,FS:3,MERC:3</availability>
+		</model>
+		<model name='CES-4S'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cameron Battlecruiser' unitType='Warship'>
@@ -3231,11 +3231,11 @@
 	</chassis>
 	<chassis name='Carnivore Assault Tank' unitType='Tank'>
 		<availability>CC:4,CHH:4,CW:5,LA:4,FS:4,MERC:4,CJF:4,CWIE:4,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>CW:8,CJF:4</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CW:6,CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CW:8,CJF:4</availability>
 		</model>
 		<model name='(Second Line)'>
 			<availability>CW:4-,General:8,CJF:4-</availability>
@@ -3243,13 +3243,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CSA:1,CCC:1,CHH:1,CDS:3,CW:1,CNC:5,CCO:1,CJF:1,RA:3,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>CSA:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3268,14 +3268,20 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:5,MOC:4,FVC:4,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2,FS:4,MERC:4,CDP:4,TC:4</availability>
-		<model name='CTF-1X'>
-			<availability>General:2-,Periphery:3-</availability>
-		</model>
 		<model name='CTF-2X'>
 			<availability>CC:1-,MOC:1,FVC:1,MERC:1,TC:1</availability>
 		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:4,MH:3,FS:4,MERC:3</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='CTF-3LL'>
+			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FVC:4,FS:4,MERC:3</availability>
@@ -3283,42 +3289,44 @@
 		<model name='CTF-4L'>
 			<availability>CC:6,MOC:4</availability>
 		</model>
-		<model name='CTF-5D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
+		<model name='CTF-1X'>
+			<availability>General:2-,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:3,CC:4,OP:3,DoO:3,DO:3,MERC:2,Periphery:2,TC:3,CGB.FRR:5,FWL:2,NIOPS:4,MH:4,TP:3,DA:4,RCM:3,DC:6</availability>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,HL:2,PIR:4,MH:8,Periphery:4</availability>
+		</model>
 		<model name='CPLT-K4'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>CC:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:2-</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:6,DC:8</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:3,MOC:3,FWL:3,MERC:3,CDP:3,TC:3,DC:4</availability>
 		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:2-</availability>
-		</model>
 		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:3,MERC:3,TC:3</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,HL:2,PIR:4,MH:8,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:6,DC:8</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
@@ -3332,14 +3340,6 @@
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:3,TC:4</availability>
-		</model>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
-		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
@@ -3348,12 +3348,6 @@
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CCC:5,CDS:5,CNC:5,RA:5,DC:3+</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
@@ -3363,10 +3357,6 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -3374,26 +3364,46 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
+		<model name='(Infiltrator)'>
+			<roles>apc</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
@@ -3402,16 +3412,6 @@
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Infiltrator)'>
-			<roles>apc</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cecerops' unitType='ProtoMek'>
@@ -3425,11 +3425,11 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CNC:6,CSL:5,RA:5</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,CNC:8,CSL:4</availability>
-		</model>
 		<model name='3'>
 			<availability>RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8,CNC:8,CSL:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CSL:6</availability>
@@ -3437,13 +3437,13 @@
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
@@ -3461,57 +3461,57 @@
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:3</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='CNT-1A'>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,OP:2,DoO:2,DO:2,Periphery.OS:4,FS:8,MERC:2,CDP:4,Periphery:2,DTA:2,FVC:8,LA:4,Periphery.HR:4,ROS:3,FWL:2,NIOPS:2-,MH:5,MSC:2,TP:2</availability>
-		<model name='CN9-D3'>
-			<availability>FVC:2,ROS:3,FS:3,MERC:3,CDP:3</availability>
-		</model>
-		<model name='CN9-AH'>
+		<model name='CN9-AL'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:1-,FS:1-,MERC:1-</availability>
-		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:4,Periphery:3</availability>
-		</model>
-		<model name='CN9-H'>
-			<availability>MH:5</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:4,IS:4,FS:4,Periphery:3</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:4,HL:2,FS:2,MERC:5,Periphery:4</availability>
 		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:3-,Periphery.Deep:8,FS:1-,MERC:1-,Periphery:3-</availability>
 		</model>
+		<model name='CN9-D'>
+			<availability>FVC:4,HL:2,FS:2,MERC:5,Periphery:4</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:3,ROS:3,FWL:3,FS:3,MERC:3,CDP:3</availability>
 		</model>
-		<model name='CN9-AL'>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='CN9-AH'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:1-,FS:1-,MERC:1-</availability>
 		</model>
-		<model name='CN9-Da'>
-			<availability>OP:3,FVC:3,DoO:3,ROS:2,FWL:2,DO:3,MSC:3,TP:3,FS:2,MERC:2,Periphery:3</availability>
+		<model name='CN9-H'>
+			<availability>MH:5</availability>
 		</model>
 		<model name='CN9-D4D'>
 			<availability>DTA:3,OP:3,DoO:3,ROS:3,DO:3,MSC:3,TP:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='CN9-Ar'>
+			<availability>IS:4,Periphery:3</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FVC:2,ROS:3,FS:3,MERC:3,CDP:3</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:4,IS:4,FS:4,Periphery:3</availability>
+		</model>
+		<model name='CN9-Da'>
+			<availability>OP:3,FVC:3,DoO:3,ROS:2,FWL:2,DO:3,MSC:3,TP:3,FS:2,MERC:2,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cerberus' unitType='Mek'>
@@ -3519,11 +3519,11 @@
 		<model name='MR-5M'>
 			<availability>CC:4,MOC:4,ROS:5,FWL:6</availability>
 		</model>
-		<model name='MR-V3'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='MR-V2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MR-V3'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3543,15 +3543,15 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CSA:7,CCC:7,CW:5,CLAN:6,CJF:5,CGB:5</availability>
-		<model name='4'>
-			<roles>spotter</roles>
-			<availability>RA:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<roles>spotter</roles>
+			<availability>RA:4</availability>
 		</model>
 		<model name='3'>
 			<availability>RA:5</availability>
@@ -3572,33 +3572,33 @@
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
+		<model name='Mk. XV'>
+			<availability>FS.PMM:4,ROS:3,FS.CMM:4,FS.DMM:4,FS:3,FS.CrMM:4</availability>
+		</model>
 		<model name='XIVs'>
 			<availability>LA:3,ROS:4,FS:3,DC:3</availability>
 		</model>
 		<model name='XII'>
 			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
-		<model name='Mk. XV'>
-			<availability>FS.PMM:4,ROS:3,FS.CMM:4,FS.DMM:4,FS:3,FS.CrMM:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:5,CC:5,RA.OA:5,HL:3,LA:6,IS:4,FWL:5,FS:5,TC:5,Periphery:4,DC:4</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:2-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>HL:2,LA:6,IS:4,FS:6,Periphery:4</availability>
-		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:4,IS:3,FS:4,Periphery:3</availability>
+		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>HL:2,LA:6,IS:4,FS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
@@ -3606,12 +3606,12 @@
 		<model name='CHP-3N'>
 			<availability>ROS:6</availability>
 		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,LA:4,ROS:4,MERC:4,CGB:4</availability>
+		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>DC.GHO:2-,CHH:2,LA:4,NIOPS:4,MERC.SI:4,MERC:4,BAN:3,CGB:2</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,LA:4,ROS:4,MERC:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,CLAN:8,CGB:6</availability>
@@ -3619,10 +3619,6 @@
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>CGB.FRR:3+,ROS:4,IS:3,NIOPS:4,MERC:2,BAN:4,Periphery:2,CGB:2</availability>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
@@ -3631,22 +3627,36 @@
 			<roles>missile_artillery</roles>
 			<availability>HL:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='(ERML)'>
-			<roles>missile_artillery</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(CASE)'>
+			<roles>missile_artillery</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='(ERML)'>
+			<roles>missile_artillery</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>CC:2-,MOC:2-,RA.OA:2-,FVC:2,LA:2-,CGB.FRR:4-,ROS:2-,MERC:1-,TC:2-,Periphery:2,DC:4-,CGB:1-</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,RA.OA:10,FVC:5,HL:2,PIR:5,MH:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
 		<model name='CGR-3K'>
 			<availability>CGB.FRR:3-,MERC:2-,DC:3-</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>CC:2-,FVC:3,Periphery:3</availability>
+		<model name='CGR-3Kr'>
+			<availability>CC:2,CGB.FRR:3,ROS:3,MERC:3,DC:3,CGB:1</availability>
+		</model>
+		<model name='CGR-C'>
+			<availability>DC:3</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>RA.OA:3-,FVC:3-,Periphery:3-</availability>
@@ -3654,74 +3664,64 @@
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,RA.OA:10,FVC:5,HL:2,PIR:5,MH:5,Periphery:4</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:2,MERC:3</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-C'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>CC:2,CGB.FRR:3,ROS:3,MERC:3,DC:3,CGB:1</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>CC:2-,FVC:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>PR:8,HL:2,DoO:10,DO:10,FS:3,RA.OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:10,RFS:8,MOC:5,CC:2,OP:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,RF:8,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
-		<model name='F-11'>
-			<availability>CC:3,MOC:3,OP:8,PR:8,DoO:8,DO:8,MERC:6,DTA:8,RF:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:2,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='F-13'>
+			<availability>DTA:4,CC:3,OP:4,DoO:4,ROS:4,FWL:4,DO:4,MSC:4,TP:4,FS:3,MERC:4</availability>
 		</model>
-		<model name='F-14-S'>
-			<availability>OP:8,PR:8,DoO:8,DO:8,MERC:4,DTA:8,RF:8,PG:8,FWL:8,MH:4,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
-		<model name='OF-17A-R'>
-			<roles>recon</roles>
-			<availability>ROS:4,MSC:5</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:2-,OP:2-,PR:2-,DoO:2-,Periphery.Deep:8,DO:2-,MERC:2-,Periphery:2-,DTA:2-,RF:2-,PG:2-,FWL:2-,MSC:2-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
+		<model name='F-12-S'>
+			<availability>FWL:1-</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,OP:2,PR:2,DoO:2,DO:2,MERC:2,Periphery:2,DTA:2,FVC:2,RF:2,PG:2,FWL:2,MSC:2,TP:2,DA:2,RCM:2,RFS:2</availability>
 		</model>
-		<model name='F-13'>
-			<availability>DTA:4,CC:3,OP:4,DoO:4,ROS:4,FWL:4,DO:4,MSC:4,TP:4,FS:3,MERC:4</availability>
-		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>CC:2-,FVC:2,FWL:2-,MERC:2-,Periphery:2</availability>
 		</model>
-		<model name='F-12-S'>
-			<availability>FWL:1-</availability>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:2-,OP:2-,PR:2-,DoO:2-,Periphery.Deep:8,DO:2-,MERC:2-,Periphery:2-,DTA:2-,RF:2-,PG:2-,FWL:2-,MSC:2-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:3,MOC:3,OP:8,PR:8,DoO:8,DO:8,MERC:6,DTA:8,RF:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:2,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		</model>
+		<model name='OF-17A-R'>
+			<roles>recon</roles>
+			<availability>ROS:4,MSC:5</availability>
+		</model>
+		<model name='F-14-S'>
+			<availability>OP:8,PR:8,DoO:8,DO:8,MERC:4,DTA:8,RF:8,PG:8,FWL:8,MH:4,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>DTA:2,CDS:3,LA:2,ROS:5,CNC:4,NIOPS:5,FS:2,RCM:2,DC:3</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:5,CDS:6,LA:5,ROS:6,FS:5,RCM:5,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3741,23 +3741,23 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:2,RA.OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,CGB:3</availability>
-		<model name='CHP-W7T'>
-			<availability>TC:8</availability>
-		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,CGB.FRR:6,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>FVC:3,CDP:3,TC:3</availability>
 		</model>
-		<model name='CHP-W8'>
-			<availability>LA:7</availability>
-		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2,BAN:0</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
+		<model name='CHP-W7T'>
+			<availability>TC:8</availability>
+		</model>
+		<model name='CHP-W8'>
+			<availability>LA:7</availability>
+		</model>
+		<model name='CHP-W7'>
+			<availability>LA:8,CGB.FRR:6,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
@@ -3771,13 +3771,6 @@
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:3,PR:5,RF:5,PG:5,FWL:5,MSC:5,MERC:2,CDP:3,RFS:5,Periphery:3,DC:2</availability>
-		<model name='CDA-3P'>
-			<availability>PR:6,RF:6,PG:6,FWL:8,MSC:6,RFS:6</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:3,MOC:3,FWL:3,MERC:3</availability>
-		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
 			<availability>CC:6,CGB.FRR:6,FWL:5,MERC:6,DC:6</availability>
@@ -3786,9 +3779,16 @@
 			<roles>recon</roles>
 			<availability>FWL:8,IS:6,MERC:6,Periphery:3</availability>
 		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:3,MOC:3,FWL:3,MERC:3</availability>
+		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:4,IS:4</availability>
+		</model>
+		<model name='CDA-3P'>
+			<availability>PR:6,RF:6,PG:6,FWL:8,MSC:6,RFS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cizin Hover Tank' unitType='Tank'>
@@ -3822,20 +3822,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -3855,14 +3855,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -3870,29 +3867,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -3903,8 +3903,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -3912,18 +3915,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -3932,15 +3941,6 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -3961,14 +3961,14 @@
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -3976,8 +3976,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -3989,13 +3989,13 @@
 	</chassis>
 	<chassis name='Claymore' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='Interceptor'>
-			<roles>assault</roles>
-			<availability>LA:1</availability>
-		</model>
 		<model name='V3'>
 			<roles>assault</roles>
 			<availability>LA:4,ROS:6,FS:4</availability>
+		</model>
+		<model name='Interceptor'>
+			<roles>assault</roles>
+			<availability>LA:1</availability>
 		</model>
 		<model name='(3054)'>
 			<roles>assault</roles>
@@ -4013,50 +4013,50 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:3,MOC:2,PR:3,HL:2,FS:3,MERC:2,CDP:2,TC:2,Periphery:3,FVC:2,RF:3,LA:3,PG:3,ROS:3,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3</availability>
-		<model name='CLNT-2-3UL'>
-			<availability>CC:8,MOC:4,TC:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:5,Periphery.HR:5,Periphery.CM:5,MH:5,CDP:5,TC:8,Periphery:4</availability>
-		</model>
-		<model name='CLNT-5U'>
-			<roles>spotter</roles>
-			<availability>LA:8,General:5,MERC:8</availability>
-		</model>
-		<model name='CLNT-2-3T'>
-			<availability>Periphery.Deep:8,NIOPS:8</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:4,LA:2,General:6</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
 		</model>
+		<model name='CLNT-5U'>
+			<roles>spotter</roles>
+			<availability>LA:8,General:5,MERC:8</availability>
+		</model>
+		<model name='CLNT-2-3UL'>
+			<availability>CC:8,MOC:4,TC:8</availability>
+		</model>
+		<model name='CLNT-2-3T'>
+			<availability>Periphery.Deep:8,NIOPS:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:5,Periphery.HR:5,Periphery.CM:5,MH:5,CDP:5,TC:8,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>MOC:4,IS:4</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>LA:4,ROS:4,NIOPS:4,FS:4,DC:4</availability>
+			<availability>MOC:2,IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>MOC:2,IS:2</availability>
+			<availability>LA:4,ROS:4,NIOPS:4,FS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra' unitType='Mek'>
 		<availability>LA:6,CGB.FRR:4,ROS:4,MH:4,MERC:3</availability>
-		<model name='CBR-03'>
-			<roles>fire_support</roles>
-			<availability>LA:6,General:4</availability>
-		</model>
 		<model name='CBR-02'>
 			<roles>fire_support</roles>
 			<availability>IS:5</availability>
+		</model>
+		<model name='CBR-03'>
+			<roles>fire_support</roles>
+			<availability>LA:6,General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
@@ -4081,68 +4081,68 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,HL:4,MERC:5,FS:2,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
-		<model name='COM-1A'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>FVC:2-,LA:2-,Periphery:2-</availability>
+			<availability>MOC:5,FVC:3,LA:8,CGB.FRR:6,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
 		</model>
-		<model name='COM-7B'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>LA:5,ROS:8</availability>
+			<availability>MOC:5,FVC:5,PIR:8,MH:10,CDP:5,TC:5,Periphery:3</availability>
 		</model>
 		<model name='COM-2Dr'>
 			<roles>recon</roles>
 			<availability>HL:3,LA:5,MERC:5,Periphery:5</availability>
 		</model>
-		<model name='COM-7S'>
+		<model name='COM-7B'>
 			<roles>recon</roles>
-			<availability>LA:7,MERC:7</availability>
+			<availability>LA:5,ROS:8</availability>
 		</model>
-		<model name='COM-5S'>
+		<model name='COM-1A'>
 			<roles>recon</roles>
-			<availability>MOC:5,FVC:3,LA:8,CGB.FRR:6,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
+			<availability>FVC:2-,LA:2-,Periphery:2-</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
 			<availability>LA:1-,MERC:1-,Periphery:2</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>MOC:5,FVC:5,PIR:8,MH:10,CDP:5,TC:5,Periphery:3</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>General:2-,Periphery.Deep:8,TC:2-,Periphery:3-</availability>
 		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:7,MERC:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:3,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
-		<model name='(Liao)'>
-			<availability>CC:4-</availability>
-		</model>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:8,FWL:6,MERC:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CC:1,LA:1,FS:1</availability>
+		<model name='(Standard)'>
+			<availability>CC:3-,FVC:3-,General:2-,FS:3-,Periphery:3-</availability>
 		</model>
 		<model name='(Upgrade) (Laser)'>
 			<availability>LA:6,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CC:3-,FVC:3-,General:2-,FS:3-,Periphery:3-</availability>
+		<model name='(Flamer)'>
+			<availability>CC:1,LA:1,FS:1</availability>
+		</model>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:8,FWL:6,MERC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:2,IS:2</availability>
 		</model>
+		<model name='(Liao)'>
+			<availability>CC:4-</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Multi-Purpose Tank' unitType='Tank'>
 		<availability>ROS:4</availability>
-		<model name='(Reactive)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Reactive)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -4172,24 +4172,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CLAN:4,NIOPS:6,BAN:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CHH:1,MERC.WD:1,CW:1,NIOPS:2,CJF:2,RA:1</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -4211,36 +4211,36 @@
 	</chassis>
 	<chassis name='Constable Pacification Suit' unitType='BattleArmor'>
 		<availability>CGB:2</availability>
-		<model name='(LMG)' mechanized='true'>
+		<model name='(SRM)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(ECM)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)' mechanized='true'>
+		<model name='(LMG)' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Sensors)' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Sensors)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corax' unitType='Aero'>
@@ -4257,17 +4257,17 @@
 		<model name='CRX-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='CRX-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='CRX-OR'>
-			<availability>RA.OA:3,CLAN:8</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='CRX-OD'>
+			<availability>General:5</availability>
+		</model>
 		<model name='CRX-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='CRX-OR'>
+			<availability>RA.OA:3,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
@@ -4281,8 +4281,17 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:2,RA.OA:3,LA:3,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,TC:2,Periphery:2,DC:1</availability>
-		<model name='CSR-V18'>
-			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
+		</model>
+		<model name='CSR-X12 Rigid Night'>
+			<availability>FS:1</availability>
+		</model>
+		<model name='CSR-12D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>ROS:4,CLAN:6,FS:4,MERC:3,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>FVC:1,FS.AH:1-,Periphery:1</availability>
@@ -4290,17 +4299,8 @@
 		<model name='CSR-V12'>
 			<availability>IS:2-,Periphery.Deep:8,BAN:4,Periphery:3-</availability>
 		</model>
-		<model name='CSR-X12 Rigid Night'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>ROS:4,CLAN:6,FS:4,MERC:3,BAN:2</availability>
-		</model>
-		<model name='CSR-12D'>
-			<availability>FS:6</availability>
+		<model name='CSR-V18'>
+			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -4324,50 +4324,50 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:1</availability>
-		<model name='XR'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='G'>
 			<availability>CHH:6,General:4</availability>
+		</model>
+		<model name='XR'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
 		<availability>CW:4,CJF:5,CWIE:4</availability>
-		<model name='H'>
-			<availability>CSA:6,General:5</availability>
-		</model>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>CW:3,CJF:3,CWIE:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<availability>CW:3,CJF:3,CWIE:3</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
 		</model>
+		<model name='H'>
+			<availability>CSA:6,General:5</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -4376,16 +4376,16 @@
 			<roles>raider</roles>
 			<availability>CGB.FRR:6,ROS:8,CLAN:4,FWL:8,MERC:8,BAN:2,DC:6</availability>
 		</model>
-		<model name='CRB-27'>
+		<model name='CRB-20'>
 			<roles>raider</roles>
-			<availability>DC.GHO:5-,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,BAN:8,DC:8</availability>
+			<availability>Periphery.Deep:8,NIOPS:0</availability>
 		</model>
 		<model name='CRB-C'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='CRB-20'>
+		<model name='CRB-27'>
 			<roles>raider</roles>
-			<availability>Periphery.Deep:8,NIOPS:0</availability>
+			<availability>DC.GHO:5-,CGB.FRR:3,ROS:2,CLAN:6,NIOPS:3,BAN:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
@@ -4393,42 +4393,45 @@
 		<model name='(Standard)'>
 			<availability>ROS:8,CLAN.IS:8,MSC:8,FS:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CC:8,CDS:4,CNC:4,MERC:8,DC:8</availability>
+		<model name='4'>
+			<availability>CDS:4,CJF:4</availability>
 		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:4,CJF:4</availability>
+		<model name='2'>
+			<availability>CC:8,CDS:4,CNC:4,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CDS:4,RA:4</availability>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>DC.GHO:1,CHH:5,CDS:3,CW:5,CGB.FRR:6,ROS:4,CLAN:4,NIOPS:9,CJF:3,RA:3,CWIE:5,CGB:5</availability>
-		<model name='CRK-5003-3'>
-			<availability>CGB.FRR:4,ROS:8</availability>
+		<model name='CRK-5004-1'>
+			<availability>CGB.FRR:4,ROS:6</availability>
+		</model>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='CRK-5005-1'>
 			<availability>ROS:8</availability>
@@ -4439,20 +4442,17 @@
 		<model name='CRK-5003-1'>
 			<availability>ROS:4,CLAN:6,NIOPS:4,BAN:8</availability>
 		</model>
-		<model name='CRK-5004-1'>
-			<availability>CGB.FRR:4,ROS:6</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='CRK-5003-3'>
+			<availability>CGB.FRR:4,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
 		<availability>OP:1,PR:1,HL:3,DoO:1,DO:1,MERC:4,Periphery:4,DTA:1,RF:1,Periphery.MW:4,ROS:3,PG:1,Periphery.ME:4,FWL:4,MSC:1,TP:1,DA:1,RCM:1,RFS:1</availability>
-		<model name='CNS-5M'>
-			<availability>PIR:4,IS:8</availability>
-		</model>
 		<model name='CNS-3M'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CNS-5M'>
+			<availability>PIR:4,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
@@ -4463,28 +4463,28 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CDS:3,CW:2,CLAN:2,CNC:3,CCO:4,CJF:2,RA:5,CWIE:3,CGB:2</availability>
-		<model name='D'>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
 			<availability>General:4</availability>
 		</model>
 		<model name='U'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
-		<model name='C'>
+		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
+		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4494,58 +4494,58 @@
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>MOC:4,IS:4,DC:8</availability>
 		</model>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>HL:4,CLAN:5,IS:6,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
-		<model name='CRD-4D'>
-			<availability>FVC:8,FS:8</availability>
-		</model>
-		<model name='CRD-2R'>
-			<availability>FVC:3,ROS:5,CLAN:4,FWL:5,IS:3,MERC:5,BAN:2</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>ROS:5,MERC:5</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>CGB.FRR:5,MERC:6,DC:7</availability>
-		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:5,MERC:5</availability>
+		<model name='CRD-8S'>
+			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='CRD-7L'>
 			<availability>CC:7</availability>
 		</model>
-		<model name='CRD-5S'>
-			<availability>LA:5,MERC:4</availability>
-		</model>
 		<model name='CRD-3R'>
 			<availability>General:2-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>DTA:5,ROS:4,Periphery.MW:3,Periphery.ME:3,MH:3,MSC:5,MERC:3,RCM:5</availability>
-		</model>
-		<model name='CRD-8S'>
-			<availability>LA:6,FS:4</availability>
 		</model>
 		<model name='CRD-5M'>
 			<availability>CC:3,MOC:3,FWL:8,FS:3,MERC:4,CDP:3,DC:3,TC:3</availability>
 		</model>
+		<model name='CRD-7W'>
+			<availability>DTA:5,ROS:4,Periphery.MW:3,Periphery.ME:3,MH:3,MSC:5,MERC:3,RCM:5</availability>
+		</model>
 		<model name='CRD-4K'>
 			<availability>CGB.FRR:6,DC:5</availability>
 		</model>
+		<model name='CRD-4BR'>
+			<availability>ROS:5,MERC:5</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:5,MERC:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:3,MOC:3</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>CGB.FRR:5,MERC:6,DC:7</availability>
+		</model>
 		<model name='CRD-8L'>
 			<availability>CC:4</availability>
+		</model>
+		<model name='CRD-2R'>
+			<availability>FVC:3,ROS:5,CLAN:4,FWL:5,IS:3,MERC:5,BAN:2</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:5,MERC:5</availability>
+		</model>
+		<model name='CRD-4D'>
+			<availability>FVC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cuirass' unitType='Mek'>
@@ -4556,50 +4556,50 @@
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:4,MOC:4,IS:3,FS:4,Periphery:2,TC:2,RA.OA:2,LA:4,CGB.FRR:5,ROS:3,FWL:3,NIOPS:3,DC:5</availability>
+		<model name='CP-11-G'>
+			<availability>MOC:4,CGB.FRR:8,IS:4,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>MOC:4,CC:5,LA:5,FWL:5,IS:5,MH:4,FS:6,CDP:4,DC:2,TC:4,Periphery:2</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>General:3-</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
+		</model>
+		<model name='CP-11-B'>
+			<availability>CC:6,MOC:5,IS:3+,MERC:6,DC:6</availability>
+		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
 			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,DC:5</availability>
 		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>IS:3</availability>
-		</model>
 		<model name='CP-11-H'>
 			<availability>FVC:6,HL:4,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:6</availability>
-		</model>
-		<model name='CP-10-Z'>
-			<availability>General:3-</availability>
 		</model>
 		<model name='CP-11-C3'>
 			<roles>spotter</roles>
 			<availability>FS:2,DC:2</availability>
 		</model>
-		<model name='CP-11-A'>
-			<availability>MOC:4,CC:5,LA:5,FWL:5,IS:5,MH:4,FS:6,CDP:4,DC:2,TC:4,Periphery:2</availability>
-		</model>
-		<model name='CP-11-G'>
-			<availability>MOC:4,CGB.FRR:8,IS:4,MERC:4,CDP:4,TC:4</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:1</availability>
 		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
-		<model name='CP-11-B'>
-			<availability>CC:6,MOC:5,IS:3+,MERC:6,DC:6</availability>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:4,MERC.WD:2,ROS:2,CWIE:3</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
@@ -4614,6 +4614,10 @@
 			<roles>recon,escort</roles>
 			<availability>CC:4,HL:2,MERC:4,TC:2,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,escort</roles>
+			<availability>CC:4,HL:2,ROS:4,General:4,NIOPS:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -4622,32 +4626,28 @@
 			<roles>recon,escort</roles>
 			<availability>MOC:3,CDP:3,TC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon,escort</roles>
-			<availability>CC:4,HL:2,ROS:4,General:4,NIOPS:4,MERC:4,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:6,IS:5</availability>
 		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Multipurpose VTOL' unitType='VTOL'>
 		<availability>LA:4,CLAN:3,IS:3,Periphery:3</availability>
-		<model name='(Gunship)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Gunship)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dagger' unitType='Aero'>
@@ -4658,18 +4658,18 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='DARO-1'>
-			<availability>General:6,FS:8</availability>
-		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='DARO-1C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1'>
+			<availability>General:6,FS:8</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1A'>
 			<availability>General:7</availability>
@@ -4677,12 +4677,12 @@
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01r'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DAI-01'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DAI-01r'>
+			<availability>General:4</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
@@ -4695,13 +4695,13 @@
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
 		<availability>CGB.FRR:3+,DC:3+,CGB:2</availability>
-		<model name='67-K'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='67-K2'>
 			<roles>support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='67-K'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
@@ -4709,49 +4709,49 @@
 		<model name='DMO-4K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='DMO-5K'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
+		<model name='DMO-2K'>
+			<availability>CGB.FRR:4,DC:6</availability>
 		</model>
 		<model name='DMO-1K'>
 			<availability>General:8,DC:4</availability>
 		</model>
-		<model name='DMO-2K'>
-			<availability>CGB.FRR:4,DC:6</availability>
+		<model name='DMO-5K'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,ROS:4+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4,CCO:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4774,11 +4774,11 @@
 			<roles>marine</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_aircraft</roles>
@@ -4787,24 +4787,21 @@
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>LA:5,ROS:4,MH:3,FS:6,MERC:4</availability>
-		<model name='DRT-3S'>
-			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='DRT-4S'>
-			<availability>LA:3,MH:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='DRT-6T'>
 			<availability>LA:5,ROS:8,FS:5,MERC:5</availability>
+		</model>
+		<model name='DRT-3S'>
+			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:3</availability>
 		</model>
+		<model name='DRT-4S'>
+			<availability>LA:3,MH:4,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:3,ROS:3,FS:7,CDP:4</availability>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:1,CDP:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5,CDP:3</availability>
@@ -4812,6 +4809,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>FVC:5,General:5,CDP:3</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -4821,13 +4822,18 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:1,CDP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CSA:1,CHH:4,CCC:2,MERC.WD:3,CDS:2,CLAN:2,IS:3+,CCO:1,CJF:3,BAN:3,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CDS:5,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -4835,27 +4841,21 @@
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2,CCO:5</availability>
 		</model>
+		<model name='K'>
+			<availability>General:2,CGB:4</availability>
+		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CSA:5,CHH:8,CDS:6,CW:4,CNC:4,General:5,CCO:4,CGB:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CDS:5,General:4,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:5,CHH:8,CDS:4,CW:8,CNC:8,General:6,CCO:5,CWIE:8,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<availability>CSA:4,CHH:7,General:2,CWIE:5,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CSA:7,CHH:8,CCC:7,CDS:7,CNC:7,General:6,CCO:5,CWIE:7,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
-		</model>
-		<model name='K'>
-			<availability>General:2,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
@@ -4884,19 +4884,19 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:4,MOC:4,MSC:3</availability>
-		<model name='DFC-OD'>
-			<roles>ground_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='DFC-OB'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='DFC-OD'>
+			<roles>ground_support</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OB'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -4907,11 +4907,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:5,MERC:4</availability>
-		<model name='DFN-3T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='DFN-3S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='DFN-3T'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Deimos' unitType='Mek'>
@@ -4922,21 +4922,21 @@
 	</chassis>
 	<chassis name='Deimos' unitType='Mek' omni='Clan'>
 		<availability>RA:5</availability>
-		<model name='Prime'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
+		<model name='C'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='S'>
-			<availability>General:5</availability>
-		</model>
-		<model name='C'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='S'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -4951,24 +4951,24 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,MOC:4,HL:2,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
-		</model>
-		<model name='(Defensive)'>
-			<availability>IS:1,Periphery:1</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>HL:2,IS:2,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:8,MOC:8,LA:8,CGB.FRR:6,ROS:8,FWL:8,IS:8,FS:8,DC:8,TC:8,CWIE:4</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>FVC:4,HL:2,DC:8,Periphery:4</availability>
+		<model name='(Defensive)'>
+			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
 		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>HL:2,IS:2,Periphery.Deep:6,Periphery:4</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,MOC:4,HL:2,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>FVC:4,HL:2,DC:8,Periphery:4</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -4977,15 +4977,15 @@
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
 		<availability>LA:6,ROS:4,MERC:4,CWIE:4</availability>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MML)'>
 			<availability>LA:4,ROS:4,CWIE:4</availability>
 		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:3,CWIE:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -5001,13 +5001,13 @@
 	</chassis>
 	<chassis name='Demon Medium Tank' unitType='Tank'>
 		<availability>ROS:5-</availability>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
@@ -5021,23 +5021,23 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>MOC:1,CC:1,OP:3,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,TC:3,RA.OA:1,FVC:5,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
-		<model name='DV-1S'>
-			<availability>IS:2-</availability>
-		</model>
 		<model name='DV-8D'>
 			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
 		</model>
-		<model name='DV-6Mr'>
-			<availability>General:2</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:5,LA:5,FS:5,MERC:4,CDP:4,TC:4</availability>
+		<model name='DV-6M'>
+			<availability>CLAN:4,IS:1-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>ROS:5,FS:6,MERC:4</availability>
 		</model>
-		<model name='DV-6M'>
-			<availability>CLAN:4,IS:1-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='DV-7D'>
+			<availability>FVC:5,LA:5,FS:5,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='DV-6Mr'>
+			<availability>General:2</availability>
+		</model>
+		<model name='DV-1S'>
+			<availability>IS:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Devastator Heavy Tank' unitType='Tank'>
@@ -5048,14 +5048,14 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:3,FVC:6,LA:6,ROS:5,FS:6,MERC:3,TC:4</availability>
-		<model name='DVS-1D'>
-			<availability>FVC:8,TC:8</availability>
+		<model name='DVS-3'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='DVS-3'>
-			<availability>LA:4,ROS:4,FS:4</availability>
+		<model name='DVS-1D'>
+			<availability>FVC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -5066,6 +5066,9 @@
 	</chassis>
 	<chassis name='Diomede' unitType='Mek'>
 		<availability>CC:6,MOC:6,LA:6,ROS:6,FWL:6,IS:4,MH:6,MERC:6,Periphery:4</availability>
+		<model name='D-M3D-M'>
+			<availability>General:4</availability>
+		</model>
 		<model name='D-M3D-3 ConstructionMech'>
 			<roles>support</roles>
 			<availability>CC:4,MOC:4,LA:4,ROS:4,FWL:4,MH:4,MERC:4</availability>
@@ -5073,9 +5076,6 @@
 		<model name='D-M3D-4 DemolitionMech'>
 			<roles>support</roles>
 			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,MH:8,MERC:8</availability>
-		</model>
-		<model name='D-M3D-M'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Djinn Battle Armor' unitType='BattleArmor'>
@@ -5102,9 +5102,6 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:6,CGB:4</availability>
@@ -5112,6 +5109,9 @@
 		<model name='(Recon)'>
 			<roles>recon,spotter</roles>
 			<availability>CSA:4,CCC:4,CSL:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau II Assault Interceptor' unitType='Dropship'>
@@ -5146,17 +5146,17 @@
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,CGB.FRR:6,MERC:3,DC:4</availability>
-		<model name='DRG-5N'>
-			<availability>HL:2,CGB.FRR:4,MERC:4,DC:4,Periphery:4</availability>
-		</model>
 		<model name='DRG-7N'>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='DRG-5Nr'>
-			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>Periphery:2</availability>
+		</model>
+		<model name='DRG-5N'>
+			<availability>HL:2,CGB.FRR:4,MERC:4,DC:4,Periphery:4</availability>
+		</model>
+		<model name='DRG-5Nr'>
+			<availability>CGB.FRR:2,MERC:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
@@ -5165,18 +5165,14 @@
 			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:7,CHH:7,CCC:7,CDS:8,General:6,CJF:8,RA:7,CWIE:7,CGB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,General:4,CCO:6,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>General:2,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:8,CJF:9,CGB:6</availability>
@@ -5184,16 +5180,20 @@
 		<model name='H'>
 			<availability>CSA:4,CNC:5,CLAN:3,General:2</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CW:5,General:4,CCO:6,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
 		</model>
-		<model name='I'>
-			<availability>General:2</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>General:2,CGB:5</availability>
 		</model>
-		<model name='U'>
+		<model name='D'>
+			<availability>CSA:7,CHH:7,CCC:7,CDS:8,General:6,CJF:8,RA:7,CWIE:7,CGB:7</availability>
+		</model>
+		<model name='I'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5212,17 +5212,17 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2-,HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:2-,Periphery:2-,FVC:2-,LA:6,ROS:3,FWL:2-,CC.MAC:2-,DC:2-</availability>
-		<model name='(SRM)'>
-			<availability>CC:2-,General:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CC:2-,General:2-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:3,ROS:3,FS:3</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CC:2-,General:1</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5243,54 +5243,54 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
-		<model name='EGL-R6'>
-			<availability>General:4-</availability>
-		</model>
 		<model name='EGL-R6b'>
 			<availability>OP:5,DoO:5,DO:5,MSC:5,TP:5,RCM:5</availability>
 		</model>
 		<model name='EGL-R11'>
 			<availability>PR:6,RF:6,LA:5,ROS:6,PG:6,MERC:5,FS:6,RFS:6</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>General:4-</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,DTA:6,PR:6,RF:6,PG:6,FWL:6,MH:4,MSC:7,MERC:4,DA:5,RFS:6</availability>
-		<model name='EGL-3M'>
-			<availability>DTA:4,FWL:4,MSC:4</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
-		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
+		</model>
+		<model name='EGL-3M'>
+			<availability>DTA:4,FWL:4,MSC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Ebony' unitType='Mek'>
 		<availability>MOC:4,CC:3</availability>
-		<model name='MEB-11'>
+		<model name='MEB-10'>
 			<roles>recon</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='MEB-9'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='MEB-10'>
+		<model name='MEB-11'>
 			<roles>recon</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:5,ROS:4,MERC:4,Periphery:3-</availability>
+		<model name='EFT-7X'>
+			<availability>IS:8,MH:6</availability>
+		</model>
 		<model name='EFT-4J'>
 			<availability>MERC:2-,Periphery:8</availability>
 		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
-		</model>
-		<model name='EFT-7X'>
-			<availability>IS:8,MH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5301,78 +5301,78 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:5,ROS:4,MERC:3</availability>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
+		<model name='EST-OD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='EST-OD'>
-			<availability>General:4</availability>
+		<model name='EST-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Eldingar Hover Sled' unitType='Tank'>
 		<availability>CGB.FRR:4,CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>CGB.FRR:8,CGB:8</availability>
+		</model>
 		<model name='(Streak)'>
 			<roles>fire_support</roles>
 			<availability>CGB:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CGB.FRR:8,CGB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,MERC.WD:5,CW:5,CLAN:5,CNC:5+</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [AP Gauss]' mechanized='true'>
 			<availability>CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='(Fire) [MicroPL]' mechanized='true'>
-			<availability>CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='[MicroPL]' mechanized='true'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Space) [MicroPL]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CLAN:2,RA:4</availability>
 		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Fire) [Flamer]' mechanized='true'>
 			<availability>CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [MicroPL]' mechanized='true'>
+			<availability>CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[MicroPL]' mechanized='true'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CW:2,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5386,20 +5386,20 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:3,TC:4,LA:4,CNC:5,FWL:4,NIOPS:7,MH:3,DC:4</availability>
-		<model name='EMP-6D'>
-			<availability>ROS:8,FS:8</availability>
-		</model>
 		<model name='EMP-6L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='EMP-6S'>
-			<availability>LA:8</availability>
+		<model name='EMP-7L'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='EMP-7L'>
-			<availability>CC:6</availability>
+		<model name='EMP-6S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='EMP-6D'>
+			<availability>ROS:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
@@ -5408,6 +5408,10 @@
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4,FS:4</availability>
 		</model>
+		<model name='END-6Q'>
+			<roles>urban</roles>
+			<availability>LA:5,MERC:5</availability>
+		</model>
 		<model name='END-6S'>
 			<roles>urban</roles>
 			<availability>LA:2,MERC:2</availability>
@@ -5415,21 +5419,17 @@
 		<model name='END-6Sr'>
 			<availability>LA:3,ROS:8,MERC:3</availability>
 		</model>
-		<model name='END-6Q'>
-			<roles>urban</roles>
-			<availability>LA:5,MERC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:6,ROS:4,FS:7,MERC:5</availability>
-		<model name='ENF-6Ma'>
-			<availability>FVC:3,FS:3,MERC:3</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-6Ma'>
+			<availability>FVC:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='ENF-6T'>
 			<availability>FS:4</availability>
@@ -5440,17 +5440,17 @@
 		<model name='ENF-7C3BS'>
 			<availability>FS:1</availability>
 		</model>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>FVC:6,FS:6,MERC:3,CDP:2,TC:2</availability>
-		<model name='ENF-4R'>
-			<availability>FVC:3-,General:1-,FS:2-,TC:2-</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>FVC:8,FS:8,MERC:6,CDP:5,TC:5</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>FVC:3-,General:1-,FS:2-,TC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -5482,14 +5482,6 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:6+,CCC:3+,CDS:4+,CW:4+,CNC:3+,CSL:6+,CGB:3+,CWIE:4+</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>CHH:8</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
@@ -5498,38 +5490,46 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>CHH:8</availability>
+		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CSA:2,CDS:2,ROS:1,CCO:1,RA:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8,DC:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,RA.OA:2,LA:5,CGB.FRR:6,IS:5,FWL:5,NIOPS:5,FS:2,Periphery:2,TC:3,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:3,FS:6</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>FS:4,MERC:2</availability>
-		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -5556,13 +5556,13 @@
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
 		<availability>MOC:8,CC:4</availability>
-		<model name='EYL-45A'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='EYL-45B'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='EYL-45A'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eyrie' unitType='Mek'>
@@ -5573,34 +5573,31 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6,MERC:3</availability>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CC:5</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='(Support) [King David]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>CC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
 		<availability>LA:4,ROS:1,MERC:1</availability>
-		<model name='FNR-5X'>
-			<availability>ROS:2,General:2</availability>
-		</model>
 		<model name='FNR-5B'>
 			<availability>LA:4</availability>
 		</model>
@@ -5608,18 +5605,21 @@
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='FNR-5X'>
+			<availability>ROS:2,General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Falcon Hawk' unitType='Mek'>
 		<availability>MOC:4,ROS:6,FWL:7,IS:4,MERC:5,CDP:4,TC:4</availability>
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>ROS:8,MSC:6</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5630,11 +5630,11 @@
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-8R'>
-			<availability>General:5</availability>
-		</model>
 		<model name='FLC-9R'>
 			<availability>General:6</availability>
+		</model>
+		<model name='FLC-8R'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -5646,35 +5646,29 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:2</availability>
-		<model name='(Upgrade)'>
-			<roles>cruiser</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>cruiser</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Upgrade)'>
+			<roles>cruiser</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Fennec' unitType='Mek'>
 		<availability>FS:3</availability>
-		<model name='FEC-3C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='FEC-1CM'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='FEC-3C'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SRM]' mechanized='false'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[SL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='&apos;Longshot&apos;' mechanized='false'>
 			<availability>General:4</availability>
@@ -5682,66 +5676,72 @@
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[SRM]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:5,MERC.KH:3+,CHH:2,CW:5,CJF:3,CWIE:5,CGB:2</availability>
-		<model name='B'>
-			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CCO:5,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:3,CNC:5,General:4,CWIE:3</availability>
-		</model>
-		<model name='H'>
-			<availability>MERC.KH:3,MERC.WD:3,General:2,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
 		</model>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		<model name='A'>
+			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CCO:5,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:3,MERC.WD:3,General:2,CWIE:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:3,CNC:5,General:4,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fensalir Combat WiGE' unitType='Tank'>
 		<availability>MERC.KH:3,LA:4,CWIE:4</availability>
+		<model name='(Infantry)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(HAG)'>
 			<availability>MERC.KH:8,General:2,CWIE:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>LA:8,General:4</availability>
 		</model>
-		<model name='(Infantry)'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:3,HL:4,LA:4,ROS:3,Periphery.HR:3,Periphery.MW:3,Periphery.CM:3,FWL:3,FS:5</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='&apos;Fermi&apos;'>
+			<roles>apc</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
@@ -5751,9 +5751,9 @@
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:4</availability>
 		</model>
-		<model name='&apos;Fermi&apos;'>
-			<roles>apc</roles>
-			<availability>FS:4</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -5780,63 +5780,15 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(LBX20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(UAC20)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
-		</model>
 		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -5844,9 +5796,57 @@
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(LBX2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LBX10)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
@@ -5855,55 +5855,55 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CNC:3,CJF:7,CLAN.HW:5</availability>
-		<model name='Prime'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3,CCO:6</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CSA:7,CLAN:6,IS:3</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CW:6,General:8,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CSA:7,CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:3,CCO:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:6,MERC:6,FS:6</availability>
-		</model>
 		<model name='ALM-10D'>
 			<availability>LA:5,ROS:5,FS:5,MERC:5</availability>
 		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -5928,26 +5928,26 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>HL:6,LA:6,IS:5,NIOPS:3,Periphery.Deep:6,Periphery:7</availability>
-		<model name='FS9-H'>
-			<roles>recon</roles>
-			<deployedWith>Vulcan</deployedWith>
-			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:2,MOC:3,LA:4,CGB.FRR:3,General:3,FS:3,TC:2</availability>
+		<model name='FS9-S2'>
+			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='FS9-C'>
 			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
 		</model>
-		<model name='FS9-S2'>
-			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
+		<model name='FS9-H'>
+			<roles>recon</roles>
+			<deployedWith>Vulcan</deployedWith>
+			<availability>General:3-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='FS9-P'>
 			<availability>FVC:4,HL:2,Periphery:4</availability>
 		</model>
 		<model name='FS9-S3'>
 			<availability>LA:5,ROS:4,FWL:3,FS:3,MERC:3</availability>
+		</model>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:2,MOC:3,LA:4,CGB.FRR:3,General:3,FS:3,TC:2</availability>
 		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
@@ -5956,45 +5956,45 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CC:4,FVC:4,LA:5,IS:3,FS:4,MERC:4,DC:7</availability>
-		<model name='FS9-OE'>
+		<model name='FS9-OD'>
 			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OX'>
-			<availability>General:2</availability>
 		</model>
 		<model name='FS9-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='FS9-OH'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='FS9-OD'>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:2+,DC:2+</availability>
+		</model>
+		<model name='FS9-OB'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OG'>
 			<availability>General:6</availability>
 		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='FS9-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:2+,DC:2+</availability>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek'>
@@ -6008,18 +6008,18 @@
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:4</availability>
-		<model name='C'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
@@ -6027,51 +6027,51 @@
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>CHH:1,CLAN:1,DC.GHO:5,CDS:1,LA:4,CGB.FRR:4,ROS:3,FWL:4,NIOPS:5,MSC:5,CJF:2,CGB:1,DC:4</availability>
-		<model name='FLS-9M'>
-			<availability>FWL:6,MSC:8</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,LA:8,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,MERC.SI:5,MSC:6,BAN:8</availability>
+		</model>
+		<model name='FLS-9M'>
+			<availability>FWL:6,MSC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>HL:9,CLAN:4,IS:10,Periphery.Deep:9,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,CLAN.IS:5,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>HL:3,IS:5,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>HL:2,IS:4,Periphery.Deep:4,BAN:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,PR:3,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:1,DA:3,RCM:3,RFS:3</availability>
+		<model name='FLE-19'>
+			<roles>urban</roles>
+			<availability>MOC:4-,CC:4-,PR:4-,HL:4-,MERC:5-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
+		</model>
 		<model name='FLE-20'>
 			<availability>CC:4,MOC:2</availability>
 		</model>
 		<model name='FLE-17'>
 			<availability>CC:6,PR:7,RF:7,ROS:8,PG:7,FWL:6,MERC:6,RCM:7,DA:7,RFS:7,Periphery:6</availability>
-		</model>
-		<model name='FLE-19'>
-			<roles>urban</roles>
-			<availability>MOC:4-,CC:4-,PR:4-,HL:4-,MERC:5-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6082,20 +6082,18 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>HL:9,IS:10,Periphery.Deep:9,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
@@ -6106,33 +6104,35 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
 		<availability>LA:4,NIOPS:4,FS:4,Periphery:1</availability>
-		<model name='(2613)'>
-			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3058)'>
 			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
 			<availability>LA:8,FS:8</availability>
 		</model>
+		<model name='(2613)'>
+			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fortune Wheeled Assault Vehicle' unitType='Tank'>
 		<availability>PR:4,RF:4,LA:6,ROS:4,PG:4,RFS:4</availability>
-		<model name='(Thunderbolt)'>
-			<availability>PR:4,RF:4,LA:4,PG:4,RFS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Thunderbolt)'>
+			<availability>PR:4,RF:4,LA:4,PG:4,RFS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Armored Car' unitType='Tank'>
@@ -6140,13 +6140,13 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Interdictor)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(VSP)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Flamer)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Interdictor)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -6189,13 +6189,13 @@
 			<roles>spotter</roles>
 			<availability>LA:5,FS:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
@@ -6204,14 +6204,14 @@
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='CX-17'>
-			<availability>ROS:4</availability>
+		<model name='(Royal)'>
+			<availability>ROS:4,CLAN:4,BAN:2</availability>
 		</model>
 		<model name='(C3S)'>
 			<availability>ROS:5,FS:5</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>ROS:4,CLAN:4,BAN:2</availability>
+		<model name='CX-17'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -6231,21 +6231,17 @@
 	</chassis>
 	<chassis name='Fwltur' unitType='Mek'>
 		<availability>IS:5,MERC:4,Periphery:4</availability>
-		<model name='FWL-3R SalvageMech'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='FWL-3V SalvageMech'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='FWL-3R SalvageMech'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
 		<availability>CGB.FRR:2,NIOPS:3,TC:4</availability>
-		<model name='(TDF)'>
-			<roles>recon</roles>
-			<availability>TC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
@@ -6253,17 +6249,21 @@
 		<model name='(ERSL)'>
 			<availability>TC:4</availability>
 		</model>
+		<model name='(TDF)'>
+			<roles>recon</roles>
+			<availability>TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CW:3,ROS:2,RA:3</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='3'>
 			<availability>CSA:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CW:6,ROS:8,CCO:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6274,22 +6274,15 @@
 	</chassis>
 	<chassis name='Gallant' unitType='Mek'>
 		<availability>MOC:3,LA:4,ROS:4,CNC:3,IS:3,FS:4,MERC:3,CDP:3,CWIE:3,TC:3</availability>
-		<model name='GLT-8-0'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
-		</model>
 		<model name='GLT-7-0'>
 			<availability>General:8,FS:4</availability>
+		</model>
+		<model name='GLT-8-0'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:1,LA:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
-		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
-		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3</availability>
 		</model>
@@ -6297,30 +6290,40 @@
 			<roles>recon</roles>
 			<availability>MOC:5,RA.OA:3,LA:5,CGB.FRR:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,CGB:1,Periphery:4</availability>
 		</model>
+		<model name='GAL-200'>
+			<availability>MOC:1,LA:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
+		</model>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>MERC.WD:6,ROS:5,MH:4,MERC:5,CWIE:5</availability>
-		<model name='GAL-2GLS'>
-			<availability>HL:2-,IS:4-,Periphery:4-</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
 		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2,ROS:2,MERC:2</availability>
 		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		<model name='GAL-2GLS'>
+			<availability>HL:2-,IS:4-,Periphery:4-</availability>
 		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8-,CWIE:8</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>HL:6,ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:5,FS:6,MERC:4,CDP:4,TC:4</availability>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A2'>
 			<availability>FS:4</availability>
 		</model>
@@ -6329,9 +6332,6 @@
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
-		</model>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Garuda Heavy VTOL' unitType='VTOL'>
@@ -6357,52 +6357,52 @@
 		<model name='GST-50'>
 			<availability>DTA:5,OP:5,DoO:5,DO:5,MSC:5,TP:5</availability>
 		</model>
-		<model name='GST-11'>
-			<availability>General:4</availability>
-		</model>
 		<model name='GST-10'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GST-11'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Giggins APC' unitType='Tank'>
 		<availability>ROS:5</availability>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CDS:5,ROS:3+,CNC:5,CLAN:5,CJF:4,BAN:4,CGB:9</availability>
-		<model name='Prime'>
-			<availability>CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
-		</model>
-		<model name='P'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:3,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7,CGB:4</availability>
 		</model>
 		<model name='E'>
 			<availability>CDS:5,CW:5,CLAN:4,General:3,CCO:6,CGB:5</availability>
 		</model>
-		<model name='K'>
-			<availability>CHH:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='D'>
+			<availability>CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		</model>
+		<model name='P'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:3,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator Battle Armor' unitType='BattleArmor'>
@@ -6413,31 +6413,31 @@
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
 		<availability>MOC:2-,FVC:3-,LA:2,MH:2,MERC:3,DA:2-,Periphery:3-,DC:2-,TC:2-</availability>
-		<model name='GLD-5R'>
-			<availability>LA:8,General:8,MH:8,MERC:8</availability>
-		</model>
 		<model name='GLD-1R'>
 			<availability>LA:1-,FWL:1-,MH:3-,MERC:1-,DA:3-,DC:1-,Periphery:3-</availability>
+		</model>
+		<model name='GLD-5R'>
+			<availability>LA:8,General:8,MH:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladius Medium Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:4,Periphery.CM:3,Periphery.ME:3,MH:6,CDP:4,TC:5,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk II'>
 			<availability>MH:6,TC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Glaive Medium Tank' unitType='Tank'>
 		<availability>LA:4,ROS:3</availability>
-		<model name='(MFB)'>
-			<roles>support</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MFB)'>
+			<roles>support</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
@@ -6445,6 +6445,10 @@
 		<model name='(Light Gauss)'>
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
 		</model>
 		<model name='(3090 Upgrade)'>
 			<roles>fire_support</roles>
@@ -6454,27 +6458,23 @@
 			<roles>missile_artillery</roles>
 			<availability>FS:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6515,45 +6515,49 @@
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CGB:7</availability>
-		<model name='(Fast Assault)' mechanized='false'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Rock Golem)' mechanized='false'>
-			<availability>CHH:8</availability>
+		<model name='(Fast Assault)' mechanized='false'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
 			<roles>urban,anti_infantry</roles>
 			<availability>CGB:4</availability>
 		</model>
+		<model name='(Rock Golem)' mechanized='false'>
+			<availability>CHH:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:4,HL:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:3,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-3L'>
+		<model name='GOL-4S'>
 			<roles>fire_support</roles>
-			<availability>CC:4,MOC:4</availability>
+			<availability>LA:6</availability>
 		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:8,MOC:4,FWL:8,MH:4,MERC:6,CDP:4,TC:4</availability>
 		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GOL-6M'>
 			<roles>fire_support</roles>
 			<availability>ROS:4,FWL:4,MERC:3</availability>
+		</model>
+		<model name='GOL-3L'>
+			<roles>fire_support</roles>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
 		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>HL:2,Periphery.HR:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,MH:6,Periphery:4</availability>
 		</model>
-		<model name='GOL-4S'>
+		<model name='GOL-1H'>
 			<roles>fire_support</roles>
-			<availability>LA:6</availability>
+			<availability>CC:2-,LA:2-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='GOL-2H'>
 			<roles>fire_support</roles>
@@ -6562,10 +6566,6 @@
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
-		</model>
-		<model name='GOL-1H'>
-			<roles>fire_support</roles>
-			<availability>CC:2-,LA:2-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon Carrier' unitType='Dropship'>
@@ -6581,47 +6581,56 @@
 			<roles>anti_infantry</roles>
 			<availability>CSA:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CSA:5,CNC:5,RA:5</availability>
+		<model name='2'>
+			<availability>CSA:8,CCO:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6,RA:6</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CCO:8</availability>
+		<model name='(Standard)'>
+			<availability>CSA:5,CNC:5,RA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk II' unitType='Mek'>
 		<availability>RA:5</availability>
-		<model name='(Standard)'>
-			<availability>RA:8</availability>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>RA:4</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>RA:4</availability>
 		</model>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>RA:4</availability>
+		<model name='(Standard)'>
+			<availability>RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>OP:7,DoO:7,CLAN:3,DO:7,MERC:4,DTA:7,CDS:4,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:7,TP:7</availability>
-		<model name='GTHA-600'>
-			<availability>DTA:7,OP:7,DoO:7,ROS:7,DO:7,MSC:7,TP:7</availability>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CDS:4,HL:3,ROS:6,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,MERC:5,BAN:2,Periphery:5</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
+		</model>
+		<model name='GTHA-600'>
+			<availability>DTA:7,OP:7,DoO:7,ROS:7,DO:7,MSC:7,TP:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>CGB.FRR:6,ROS:6,CNC:6,MERC:3,DC:7,CGB:4</availability>
+		<model name='DRG-1G'>
+			<availability>CGB.FRR:2-,DC:2-</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:5</availability>
+		</model>
+		<model name='DRG-5K'>
+			<availability>CGB.FRR:6,ROS:6,CNC:8,MERC:6,DC:4,CGB:8</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>ROS:4,DC:5</availability>
 		</model>
@@ -6629,56 +6638,47 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:5</availability>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='DRG-7K'>
 			<availability>ROS:6,MERC:4,DC:4</availability>
 		</model>
-		<model name='DRG-1G'>
-			<availability>CGB.FRR:2-,DC:2-</availability>
-		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-5K'>
-			<availability>CGB.FRR:6,ROS:6,CNC:8,MERC:6,DC:4,CGB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>CC:5,MOC:5,OP:7,PR:7,DoO:7,DO:7,FS:5,MERC:5,DTA:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,PG:7,Periphery.ME:3,FWL:7,MH:4,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
-		<model name='T-IT-N10M'>
-			<availability>HL:3,ROS:5,FWL:5,MERC:5,Periphery:5</availability>
+		<model name='T-IT-N13M'>
+			<availability>OP:4,PR:4,DoO:4,DO:4,MERC:4,DTA:4,RF:4,ROS:4,PG:4,MSC:4,TP:4,DA:4,RCM:4,RFS:4</availability>
 		</model>
 		<model name='T-IT-N11M'>
 			<availability>DTA:6,CC:6,MOC:6,ROS:6,MSC:6,MERC:4,FS:6,DC:6</availability>
 		</model>
-		<model name='T-IT-N13M'>
-			<availability>OP:4,PR:4,DoO:4,DO:4,MERC:4,DTA:4,RF:4,ROS:4,PG:4,MSC:4,TP:4,DA:4,RCM:4,RFS:4</availability>
+		<model name='T-IT-N10M'>
+			<availability>HL:3,ROS:5,FWL:5,MERC:5,Periphery:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>MOC:6,HL:5,IS:4,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:5,TC:6</availability>
-		<model name='GHR-5J'>
-			<availability>HL:2,IS:6,Periphery.Deep:1,Periphery:4</availability>
-		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='GHR-5H'>
-			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='GHR-C'>
-			<availability>IS:3,DC:3</availability>
-		</model>
-		<model name='GHR-5N'>
-			<availability>General:1-</availability>
+		<model name='GHR-5J'>
+			<availability>HL:2,IS:6,Periphery.Deep:1,Periphery:4</availability>
 		</model>
 		<model name='GHR-6K'>
 			<availability>CGB.FRR:4,ROS:4,MERC:2,FS:2,DC:4</availability>
 		</model>
+		<model name='GHR-5H'>
+			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
 		<model name='GHR-7P'>
 			<availability>LA:8,MERC:4</availability>
+		</model>
+		<model name='GHR-5N'>
+			<availability>General:1-</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Heavy Suit' unitType='BattleArmor'>
@@ -6702,14 +6702,14 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Strike Armor' unitType='BattleArmor'>
@@ -6722,20 +6722,29 @@
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
 		<availability>CSA:4,CCC:4,CHH:5,CCO:4,CGB:5</availability>
-		<model name='2'>
-			<availability>CHH:8,CGB:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:8,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+		<model name='[Heavy Flamer]' mechanized='false'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[MagShot]' mechanized='false'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:4</availability>
@@ -6744,17 +6753,8 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MagShot]' mechanized='false'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Heavy Flamer]' mechanized='false'>
-			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
@@ -6762,8 +6762,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:7,CHH:8,CLAN:5,IS:3</availability>
@@ -6774,23 +6780,26 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3,CCO:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:4</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:5,CDS:6,CW:3,LA:3,CNC:7,IS:3,CCO:6,CJF:3,CWIE:4,DC:4</availability>
+		<model name='4'>
+			<availability>CSA:6,CDS:6,CNC:8,IS:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:8,CNC:5,IS:8,CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>MERC.WD:8,CNC:3</availability>
+		</model>
 		<model name='6'>
 			<availability>ROS:4,CNC:6,DC:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CSA:6,CDS:6,CNC:8,IS:6</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CNC:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CNC:5</availability>
@@ -6801,109 +6810,96 @@
 		<model name='5'>
 			<availability>CDS:4,CNC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CNC:4</availability>
-		</model>
-		<model name='2'>
-			<availability>MERC.WD:8,CNC:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:8,CNC:5,IS:8,CCO:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,HL:3,IS:6,Periphery.Deep:6,MERC:7,TC:5,Periphery:4,RA.OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
-		<model name='GRF-3M'>
-			<availability>MOC:3,OP:5,PR:6,DoO:5,IS:5,DO:5,FS:4,DTA:5,RF:6,LA:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:6,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='GRF-4N'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='GRF-4R'>
-			<availability>CC:3,ROS:6,CGB.FRR:5,CNC:3,FWL:3,FS:3,DC:3,CGB:5</availability>
+		<model name='GRF-1S'>
+			<availability>LA:2-,MERC:2-</availability>
 		</model>
 		<model name='GRF-2N'>
 			<availability>CC:4,MOC:3,OP:4,DoO:4,CLAN:6,DO:4,FS:4,MERC:4,BAN:4,MH:3,MSC:4,TP:4,RCM:4,DC:4</availability>
 		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,OP:6,DoO:6,ROS:5,DO:6,MSC:6,TP:6,MERC:5</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>General:2-,Periphery.Deep:8,BAN:2,Periphery:3-</availability>
-		</model>
 		<model name='GRF-1A'>
 			<availability>LA:2-,MERC:2-,TC:3-</availability>
 		</model>
-		<model name='GRF-1S'>
-			<availability>LA:2-,MERC:2-</availability>
+		<model name='GRF-5M'>
+			<availability>DTA:6,OP:6,DoO:6,ROS:5,DO:6,MSC:6,TP:6,MERC:5</availability>
 		</model>
-		<model name='GRF-5K'>
-			<availability>CNC:6,DC:6</availability>
+		<model name='GRF-3M'>
+			<availability>MOC:3,OP:5,PR:6,DoO:5,IS:5,DO:5,FS:4,DTA:5,RF:6,LA:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
+		</model>
+		<model name='GRF-4R'>
+			<availability>CC:3,ROS:6,CGB.FRR:5,CNC:3,FWL:3,FS:3,DC:3,CGB:5</availability>
 		</model>
 		<model name='GRF-1DS'>
 			<availability>FVC:5,LA:3,CGB.FRR:3,ROS:4,FS:5,MERC:3,DC:4</availability>
 		</model>
+		<model name='GRF-5K'>
+			<availability>CNC:6,DC:6</availability>
+		</model>
+		<model name='GRF-4N'>
+			<availability>TC:4</availability>
+		</model>
 		<model name='GRF-5L'>
 			<availability>CC:5</availability>
+		</model>
+		<model name='GRF-1N'>
+			<availability>General:2-,Periphery.Deep:8,BAN:2,Periphery:3-</availability>
+		</model>
+		<model name='GRF-6S'>
+			<availability>LA:6,CGB.FRR:3,FS:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>ROS:6,MERC:5,DC:5</availability>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>MERC:4</availability>
+		</model>
 		<model name='GRM-R-PR30'>
 			<availability>ROS:4,MERC:3</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>ROS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
 		<availability>CSA:3,CCC:3,CHH:3,CLAN:2,CCO:3,RA:2,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>General:3</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>CGB:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:2,PR:3,MERC:2,TC:2,Periphery:1,FVC:1,RF:3,ROS:3,PG:3,FWL:2,RCM:3,RFS:3</availability>
-		<model name='D'>
-			<availability>CC:3,MOC:3,RF:2,MERC:2,RCM:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CC:1,FWL:1,Periphery:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
+		</model>
+		<model name='B'>
+			<availability>CC:1,FWL:1,Periphery:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CC:3,MOC:3,RF:2,MERC:2,RCM:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>MERC.KH:3,MERC.WD:3,CHH:2-,CW:4,LA:3,ROS:3,CNC:2-,CCO:4,CWIE:4</availability>
-		<model name='2'>
-			<availability>CW:4,IS:8,CCO:6,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>ROS:4,CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:4,IS:8,CCO:6,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:5,DC.GHO:2,CHH:2,ROS:6,FWL:5,NIOPS:7,MSC:5,FS:5,MERC:3,RA:2,Periphery:2</availability>
-		<model name='GLT-3N'>
-			<roles>raider</roles>
-			<availability>ROS:6,CGB.FRR:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8,DC:8</availability>
-		</model>
 		<model name='GLT-6WB3'>
 			<roles>raider</roles>
 			<availability>ROS:3,MSC:6,MERC:3</availability>
@@ -6920,13 +6916,13 @@
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:4,MERC:4</availability>
 		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>ROS:6,CGB.FRR:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
 		<availability>FVC:5,LA:8,CGB.FRR:5,IS:5,MH:3,FS:5,DC:7</availability>
-		<model name='GUN-2ERDr'>
-			<roles>spotter</roles>
-			<availability>FS:4,DC:4</availability>
-		</model>
 		<model name='GUN-2ERD'>
 			<roles>spotter</roles>
 			<availability>LA:6,General:3,FS:5,DC:5</availability>
@@ -6934,15 +6930,19 @@
 		<model name='GUN-1ERD'>
 			<availability>General:8</availability>
 		</model>
+		<model name='GUN-2ERDr'>
+			<roles>spotter</roles>
+			<availability>FS:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
 		<availability>LA:6+,ROS:4,FS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='HALO Paratrooper' unitType='Infantry'>
@@ -6954,30 +6954,30 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,LA:4,CNC:5,IS:4,DC:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>LA:4+,CLAN:5,IS:4+,DC:4+</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CNC:6,DC:4+</availability>
-		</model>
 		<model name='HKO-1C'>
 			<roles>fire_support</roles>
 			<availability>LA:6,DC:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CNC:6,DC:4+</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>LA:4+,CLAN:5,IS:4+,DC:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>CSA:6,RA.OA:4,CHH:7,LA:2,ROS:3,CLAN:5,FS:2,MERC:2</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
-		</model>
 		<model name='(AAA)'>
 			<roles>fire_support</roles>
 			<availability>RA.OA:8,CDS:4,RA:8,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hamilcar' unitType='Dropship'>
@@ -7011,8 +7011,8 @@
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>ROS:3,FS:4,MERC:3</availability>
-		<model name='HMH-6E'>
-			<availability>General:5,MERC:5</availability>
+		<model name='HMH-6D'>
+			<availability>ROS:6,General:6</availability>
 		</model>
 		<model name='HMH-3D'>
 			<availability>General:2-,MERC:2-</availability>
@@ -7020,17 +7020,17 @@
 		<model name='HMH-5D'>
 			<availability>General:2,MERC:4</availability>
 		</model>
-		<model name='HMH-6D'>
-			<availability>ROS:6,General:6</availability>
+		<model name='HMH-6E'>
+			<availability>General:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>ROS:6,CLAN:2,CNC:3,NIOPS:7</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>ROS:4,NIOPS:8</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:4</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
@@ -7038,30 +7038,30 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CDS:4,ROS:3+,CNC:5,CJF:4,CCO:3,CGB:3</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='E'>
-			<roles>anti_infantry</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:8,CLAN:6,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>CSA:8,General:7</availability>
+		</model>
+		<model name='E'>
+			<roles>anti_infantry</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>CSA:8,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -7080,13 +7080,6 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>PR:5,HL:2-,DoO:5,Periphery.Deep:4,DO:5,FWL.pm:5,CGB.FRR:4-,Periphery.CM:2-,Periphery.MW:2-,FWL:5,MH:3,MSC:5,RFS:5,MOC:3,CC:3,OP:5,IS:2-,MERC:3,Periphery:1-,DTA:5,RF:5,LA:3,PG:5,Periphery.ME:2-,TP:5,DA:5,RCM:5,DC:2-</availability>
-		<model name='(Thunderbolt)'>
-			<availability>CC:2,MOC:2,OP:3,PR:3,DoO:3,DO:3,MERC:2,DTA:3,RF:3,PG:3,MH:2,MSC:3,TP:3,DA:3,RCM:3,RFS:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<deployedWith>Galleon</deployedWith>
-			<availability>General:2-</availability>
-		</model>
 		<model name='(MML)'>
 			<availability>MOC:3,CC:3,OP:4,PR:4,DoO:4,DO:4,MERC:3,DTA:4,RF:4,LA:3,PG:4,MSC:4,TP:4,RCM:4,DA:4,RFS:4</availability>
 		</model>
@@ -7094,11 +7087,21 @@
 			<deployedWith>Galleon</deployedWith>
 			<availability>FWL:3</availability>
 		</model>
+		<model name='(Standard)'>
+			<deployedWith>Galleon</deployedWith>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>CC:2,MOC:2,OP:3,PR:3,DoO:3,DO:3,MERC:2,DTA:3,RF:3,PG:3,MH:2,MSC:3,TP:3,DA:3,RCM:3,RFS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CSA:3,CHH:6,CSL:6</availability>
 		<model name='(Standard)'>
 			<availability>CSA:4,CHH:4,CSL:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:8,CSL:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CSA:6</availability>
@@ -7106,20 +7109,17 @@
 		<model name='4'>
 			<availability>CHH:6,CSL:6</availability>
 		</model>
-		<model name='2'>
-			<availability>CHH:8,CSL:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Hatamoto-Chi' unitType='Mek'>
 		<availability>CGB.FRR:3,ROS:5,MERC:2,DC:6</availability>
 		<model name='HTM-28T'>
 			<availability>ROS:4,DC:3</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>CGB.FRR:6,MERC:4,DC:5</availability>
-		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:6,DC:4</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>CGB.FRR:6,MERC:4,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Hi' unitType='Mek'>
@@ -7161,43 +7161,43 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,Periphery:2,DTA:4,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,MSC:4,DC:4</availability>
-		<model name='HCT-5DD'>
-			<availability>ROS:6,FS:6,MERC:6,CDP:3</availability>
+		<model name='HCT-6S'>
+			<availability>LA:7,MERC:6</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>ROS:2,FS:1,MERC:1,CDP:2</availability>
 		</model>
-		<model name='HCT-6D'>
-			<availability>ROS:5,FS:4,MERC:6</availability>
-		</model>
 		<model name='HCT-6M'>
 			<availability>DTA:8,ROS:4,FWL:8,MSC:8,MERC:3</availability>
-		</model>
-		<model name='HCT-7S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='HCT-5S'>
 			<availability>FVC:4,LA:4,CGB.FRR:4,FS:4,MERC:4,DC:2,Periphery:3</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>DC:8</availability>
+		<model name='HCT-5DD'>
+			<availability>ROS:6,FS:6,MERC:6,CDP:3</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:2-,LA:2-,TC.PL:2-,MERC:2-,Periphery:2-</availability>
 		</model>
-		<model name='HCT-6S'>
-			<availability>LA:7,MERC:6</availability>
+		<model name='HCT-6D'>
+			<availability>ROS:5,FS:4,MERC:6</availability>
+		</model>
+		<model name='HCT-5K'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Commando' mechanized='false'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk II Battle Armor' unitType='BattleArmor'>
@@ -7209,24 +7209,24 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:6</availability>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OB'>
-			<availability>General:7</availability>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='HA1-OC'>
+		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OD'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OC'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hawk Moth Gunship' unitType='VTOL'>
@@ -7263,25 +7263,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,HL:4,CLAN:4,IS:6,Periphery.Deep:5,TC:6,Periphery:5</availability>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7328,8 +7328,8 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
@@ -7337,14 +7337,14 @@
 		<model name='Meteor-U'>
 			<availability>ROS:2,FS:3,MERC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,TC:1</availability>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
 		</model>
 		<model name='Meteor-G'>
 			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7355,10 +7355,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,HL:5,CLAN:5,IS:7,Periphery.Deep:5,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7366,6 +7362,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7374,6 +7374,18 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,HL:5,CLAN:5,IS:7,Periphery.Deep:5,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(WoB)'>
+			<roles>apc,support</roles>
+			<availability>ROS:3</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,Periphery.Deep:5-,IS.pm:4,Periphery:5-</availability>
@@ -7382,21 +7394,16 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(WoB)'>
-			<roles>apc,support</roles>
-			<availability>ROS:3</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:3,LA:3+,CNC:3,CSL:4,RA:3,CWIE:5</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -7404,38 +7411,31 @@
 		<model name='Prime'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
-			<availability>General:4</availability>
-		</model>
-		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
 		<availability>CC:3,MOC:3,IS:3,MERC:3</availability>
-		<model name='HEP-4H'>
-			<roles>artillery</roles>
-			<availability>General:8,MERC:8</availability>
-		</model>
 		<model name='HEP-1H'>
 			<roles>artillery</roles>
 			<availability>CC:2-,MOC:2-,MERC:2-</availability>
 		</model>
+		<model name='HEP-4H'>
+			<roles>artillery</roles>
+			<availability>General:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
 		<availability>CC:5,MOC:5,FS:3,MERC:3,DC:3,TC:5</availability>
-		<model name='HEL-3D'>
-			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		<model name='HEL-4A'>
+			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
 		<model name='HEL-C'>
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='HEL-4A'>
-			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
+		<model name='HEL-3D'>
+			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -7446,20 +7446,20 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,HL:2-,LA:2-,Periphery.Deep:1-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
-		<model name='HCT-213'>
-			<availability>General:3</availability>
-		</model>
 		<model name='HCT-313'>
 			<availability>RA.OA:8,FVC:8,CDP:8,RA:8</availability>
+		</model>
+		<model name='HCT-213'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
 		<availability>CSA:5,CCC:4,CHH:3</availability>
-		<model name='(Standard)'>
-			<availability>CSA:8,CCC:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:3,CCC:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CSA:8,CCC:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
@@ -7467,8 +7467,8 @@
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>DC.RYU:1,CHH:3,CDS:2,ROS:2,DC.AL:1,CNC:6,CJF:3</availability>
-		<model name='2'>
-			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
+		<model name='5'>
+			<availability>ROS:5,CNC:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
@@ -7476,15 +7476,27 @@
 		<model name='4'>
 			<availability>CNC:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:6,CNC:8,CCO:8,CWIE:8,DC:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CHH:6,CJF:6</availability>
-		</model>
-		<model name='5'>
-			<availability>ROS:5,CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,CDS:5,CNC:5,CSL:5,CCO:5,CJF:2</availability>
+		<model name='B'>
+			<availability>CSA:8,General:7,CJF:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:4,General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:3,General:7,CJF:3</availability>
+		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -7493,54 +7505,42 @@
 			<roles>fire_support</roles>
 			<availability>CSA:3,General:6,CJF:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CSA:8,General:7,CJF:3</availability>
-		</model>
 		<model name='F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:3,General:7,CJF:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CSA:4,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
+		<model name='HSN-9F'>
+			<roles>fire_support</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='HSN-10SR'>
 			<roles>spotter</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
+		</model>
+		<model name='HSN-8E'>
+			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
 		<model name='HSN-7D'>
 			<roles>fire_support</roles>
 			<availability>FS:8,MERC:8</availability>
 		</model>
-		<model name='HSN-8E'>
-			<roles>fire_support</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-9F'>
-			<roles>fire_support</roles>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellstar' unitType='Mek'>
 		<availability>CC:2,CHH:5,MERC.WD:4,MERC.KH:4,LA:3,ROS:3,FS:2,CWIE:5,DC:3</availability>
+		<model name='2'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hephaestus Jump Tank' unitType='Tank'>
@@ -7556,6 +7556,18 @@
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CSA:4+,CHH:4+,CSL:4+</availability>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>recon,apc,fire_support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -7563,18 +7575,6 @@
 		<model name='Prime'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon,apc,fire_support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -7599,13 +7599,13 @@
 			<roles>recon</roles>
 			<availability>ROS:3-,FWL:2-,MERC:3-</availability>
 		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>OP:4,DoO:4,FWL:4,DO:4,MSC:4,TP:4</availability>
+		</model>
 		<model name='HER-6D'>
 			<roles>recon</roles>
 			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-5Sr'>
-			<roles>recon</roles>
-			<availability>MOC:4,IS:4,MH:3</availability>
 		</model>
 		<model name='HER-5SA'>
 			<roles>training</roles>
@@ -7619,9 +7619,9 @@
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:5,FS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>OP:4,DoO:4,FWL:4,DO:4,MSC:4,TP:4</availability>
+			<availability>MOC:4,IS:4,MH:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
@@ -7630,36 +7630,36 @@
 			<roles>recon,spotter</roles>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='HER-4K'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>OP:6,DoO:6,DO:6,MSC:6,TP:6,MERC:4,DC:8</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:4</availability>
+			<availability>DC.GHO:2-,CLAN:6,NIOPS:4,BAN:8</availability>
 		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:4</availability>
 		</model>
-		<model name='HER-1S'>
+		<model name='HER-4K'>
 			<roles>recon</roles>
-			<availability>DC.GHO:2-,CLAN:6,NIOPS:4,BAN:8</availability>
+			<availability>OP:6,DoO:6,DO:6,MSC:6,TP:6,MERC:4,DC:8</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>OP:4,DoO:4,CGB.FRR:3,FWL:4,DO:4,MSC:4,TP:4</availability>
 		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:7,CDS:3,Periphery.CM:6,CGB.FRR:2,CNC:3,IS:3-,Periphery.Deep:6,MERC:6,Periphery:6,CWIE:3</availability>
-		<model name='(SRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:5-</availability>
 		</model>
-		<model name='(AC10)'>
+		<model name='(Scout)'>
+			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
+		</model>
+		<model name='(SRM)'>
 			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(LRM)'>
@@ -7668,11 +7668,11 @@
 		<model name='(LB-X)'>
 			<availability>CC:8,MOC:6,PR:5,RF:5,PG:5,DA:5,CDP:5,RFS:5,TC:6</availability>
 		</model>
+		<model name='(AC10)'>
+			<availability>IS:1,Periphery:1</availability>
+		</model>
 		<model name='(Laser)'>
 			<availability>CC:1,IS:1,Periphery:1</availability>
-		</model>
-		<model name='(Scout)'>
-			<availability>MOC:1,Periphery.CM:1,Periphery.HR:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Hi-Scout Drone Carrier' unitType='Tank'>
@@ -7689,37 +7689,37 @@
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CHH:5,CDS:4,CW:6,LA:3,ROS:4,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CDS:4,CW:4,CLAN:2,CNC:4,IS:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:6,CW:3,ROS:4,CJF:6,CGB:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:4,CW:4,CLAN:2,CNC:4,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>MOC:3,CC:4,LA:6,CLAN:4,IS:3,FWL:3,NIOPS:9,MH:3,MERC:4,FS:5,CJF:5,DC:3</availability>
-		<model name='HGN-732b'>
-			<availability>LA:4,CLAN:4,IS:3,FWL:3,MH:4,FS:4,BAN:2</availability>
-		</model>
 		<model name='HGN-734'>
 			<availability>LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='HGN-738'>
-			<availability>LA:6,ROS:6</availability>
-		</model>
-		<model name='HGN-732'>
-			<availability>MOC:6,CC:5,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:5,NIOPS:3,MERC.SI:8,MH:6,DC:5</availability>
+		<model name='HGN-732b'>
+			<availability>LA:4,CLAN:4,IS:3,FWL:3,MH:4,FS:4,BAN:2</availability>
 		</model>
 		<model name='HGN-733'>
 			<availability>CC:2-,MOC:3-,:0,LA:2-,DC:2-</availability>
 		</model>
+		<model name='HGN-732'>
+			<availability>MOC:6,CC:5,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:5,NIOPS:3,MERC.SI:8,MH:6,DC:5</availability>
+		</model>
+		<model name='HGN-738'>
+			<availability>LA:6,ROS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:4</availability>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7727,7 +7727,7 @@
 			<roles>recon,apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7753,11 +7753,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F5'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BZK-F7'>
 			<availability>General:6</availability>
+		</model>
+		<model name='BZK-F5'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -7771,16 +7771,16 @@
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,FS:5,MERC:3,Periphery.OS:4,FS.CrMM:7,Periphery:2,TC:2,MERC.WD:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:7,FS.DMM:7</availability>
+		<model name='HNT-152'>
+			<roles>recon,urban</roles>
+			<availability>FVC:1-,IS:1-</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:2-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='HNT-152'>
-			<roles>recon,urban</roles>
-			<availability>FVC:1-,IS:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Hound' unitType='Mek'>
@@ -7804,13 +7804,13 @@
 	</chassis>
 	<chassis name='Huitzilopochtli Assault Tank &apos;Huey&apos;' unitType='Tank'>
 		<availability>ROS:4,CLAN:5</availability>
-		<model name='(AAA)'>
-			<roles>missile_artillery,anti_aircraft</roles>
-			<availability>CHH:4,RA:4,CGB:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>missile_artillery,anti_aircraft</roles>
+			<availability>CHH:4,RA:4,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Humming Bird VTOL' unitType='VTOL'>
@@ -7822,9 +7822,6 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:4,CDS:7,CW:5,CJF:5,CGB:5,CWIE:4,RA:5</availability>
-		<model name='3'>
-			<availability>CCO:8,RA:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CSA:8</availability>
 		</model>
@@ -7834,14 +7831,24 @@
 		<model name='(Standard)'>
 			<availability>General:8,RA:4</availability>
 		</model>
+		<model name='3'>
+			<availability>CCO:8,RA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:2,CC:2,HL:3,IS:2-,Periphery.Deep:5,FS:3,Periphery:4,TC:2,RA.OA:2,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:2</availability>
+		<model name='HBK-5SS'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='HBK-4G'>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
 		<model name='HBK-6S'>
 			<availability>LA:6,ROS:5,MERC:6</availability>
 		</model>
-		<model name='HBK-4N'>
-			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
+		<model name='HBK-7R'>
+			<roles>spotter</roles>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='HBK-4J'>
 			<availability>CC:1-,FWL:1-,MERC:1-,Periphery:1-</availability>
@@ -7849,18 +7856,17 @@
 		<model name='HBK-5P'>
 			<availability>ROS:6,FWL:6,MERC:4</availability>
 		</model>
+		<model name='HBK-4H'>
+			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='HBK-5H'>
+			<availability>FVC:3,HL:2,MH:6,Periphery:4</availability>
+		</model>
 		<model name='HBK-4SP'>
 			<availability>FVC:1-,FWL:1-,MERC:1-,DC:1-,Periphery:1-</availability>
 		</model>
-		<model name='HBK-7R'>
-			<roles>spotter</roles>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='HBK-5SS'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='HBK-4G'>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		<model name='HBK-5N'>
+			<availability>MOC:4,CC:4,CGB.FRR:4,FWL:5,MERC:4,CDP:4,TC:4</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>IS:1-,Periphery:2-</availability>
@@ -7868,17 +7874,11 @@
 		<model name='HBK-5S'>
 			<availability>LA:4,CGB.FRR:3,ROS:3,MH:3,MERC:2,FS:3</availability>
 		</model>
-		<model name='HBK-6N'>
-			<availability>ROS:3,FWL:3,MH:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='HBK-4H'>
+		<model name='HBK-4N'>
 			<availability>FVC:2-,FWL:2-,FS:2-,MERC:2-,Periphery:2-</availability>
 		</model>
-		<model name='HBK-5H'>
-			<availability>FVC:3,HL:2,MH:6,Periphery:4</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:4,CC:4,CGB.FRR:4,FWL:5,MERC:4,CDP:4,TC:4</availability>
+		<model name='HBK-6N'>
+			<availability>ROS:3,FWL:3,MH:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -7892,41 +7892,47 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:4,CC:6,HL:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,RA.OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
-		<model name='&apos;Assault Hunter&apos;'>
-			<availability>LA:2,FS:2</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
-		</model>
-		<model name='(Ammo)'>
-			<roles>fire_support</roles>
-			<availability>General:1-</availability>
-		</model>
-		<model name='(LRM15)'>
-			<roles>fire_support</roles>
-			<availability>General:2-</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:3-</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:4</availability>
+		<model name='(3054 Upgrade)'>
+			<roles>fire_support</roles>
+			<availability>PR:6,RF:6,LA:8,ROS:6,PG:6,FS:6,RCM:6,MERC:6,DA:6,RFS:6</availability>
 		</model>
 		<model name='(LRM10)'>
 			<roles>fire_support</roles>
 			<availability>General:2-</availability>
 		</model>
+		<model name='(LRM15)'>
+			<roles>fire_support</roles>
+			<availability>General:2-</availability>
+		</model>
+		<model name='(Ammo)'>
+			<roles>fire_support</roles>
+			<availability>General:1-</availability>
+		</model>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
 		<model name='(Amphibious)'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>fire_support</roles>
-			<availability>PR:6,RF:6,LA:8,ROS:6,PG:6,FS:6,RCM:6,MERC:6,DA:6,RFS:6</availability>
+		<model name='&apos;Assault Hunter&apos;'>
+			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4O'>
+			<availability>CC:8,MOC:8,FWL:5,MERC:6,TC:5</availability>
+		</model>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:4,MOC:4,FWL:5</availability>
 		</model>
@@ -7934,42 +7940,36 @@
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4O'>
-			<availability>CC:8,MOC:8,FWL:5,MERC:6,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>LA:4,CGB.FRR:5,ROS:6,CNC:4,MERC:4,FS:4,CGB:5,DC:4</availability>
-		<model name='HSCL-1-OD'>
-			<availability>General:4</availability>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:2+</availability>
 		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HSCL-1-OA'>
+		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OB'>
+		<model name='HSCL-1-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:2+</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>DC.GHO:2,LA:2,CGB.FRR:1,ROS:3,CLAN:3,NIOPS:4,MERC:2,DC:1</availability>
-		<model name='HSR-400-D'>
-			<availability>LA:8,ROS:8,MERC:8</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6,NIOPS:4,MERC.SI:4,BAN:8</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -7981,25 +7981,25 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CCC:6,CLAN:6,RA:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Algar)'>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:6,CLAN:4,CJF:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
 		<availability>CHH:5,CSL:5</availability>
-		<model name='(Standard)'>
+		<model name='2'>
 			<availability>CHH:6,CSL:6</availability>
 		</model>
-		<model name='2'>
+		<model name='(Standard)'>
 			<availability>CHH:6,CSL:6</availability>
 		</model>
 	</chassis>
@@ -8012,11 +8012,8 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:3,MOC:8,LA:2,ROS:4,FWL:3,IS:8,MH:8,FS:1,DC:1,TC:8</availability>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -8024,8 +8021,11 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -8059,11 +8059,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='IMP-4E'>
 			<availability>MERC.WD:6,MERC.KH:8</availability>
+		</model>
+		<model name='IMP-3E'>
+			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -8088,11 +8088,11 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5</availability>
-		<model name='(BA)'>
-			<availability>CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(BA)'>
+			<availability>CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. I Battle Armor' unitType='BattleArmor'>
@@ -8108,14 +8108,14 @@
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4,TC:3</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
+		<model name='&apos;Puma&apos;' mechanized='true'>
+			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
 		</model>
-		<model name='&apos;Puma&apos;' mechanized='true'>
-			<availability>FS:8,TC:8</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Marine)' mechanized='true'>
 			<roles>marine</roles>
@@ -8124,6 +8124,10 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>CC:3,LA:3,ROS:4,FWL:3,FS:3,DC:3</availability>
+		<model name='(Standard)'>
+			<roles>assault</roles>
+			<availability>CC:8,ROS:6,FWL:8</availability>
+		</model>
 		<model name='(SCC)'>
 			<roles>assault</roles>
 			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
@@ -8131,10 +8135,6 @@
 		<model name='(Sub-Capital)'>
 			<roles>assault</roles>
 			<availability>ROS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>assault</roles>
-			<availability>CC:8,ROS:6,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -8150,29 +8150,29 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,HL:7,CLAN:9,IS:7,Periphery.Deep:7,FS:9,BAN:6,Periphery:8,TC:8,RA.OA:8,LA:9,CGB.FRR:9,PIR:5,FWL:9,NIOPS:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ironhold Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CJF:4</availability>
-		<model name='(Fire)' mechanized='false'>
-			<availability>General:4</availability>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Tank)' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='(Fire)' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Isegrim Assault DropShip' unitType='Dropship'>
@@ -8213,15 +8213,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -8242,38 +8242,38 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>MOC:2-,DC.LV:3-,DC.GR:2-,FS.AH:2-,IS:2-,Periphery.Deep:5,FS:2-,Periphery:2-,TC:3-,RA.OA:2-,LA:2-,CGB.FRR:2-,FWL:1-,NIOPS:2-,DC:2-</availability>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>FVC:3,IS:4,TC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Kurita)'>
 			<roles>recon,raider</roles>
-			<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
+			<availability>DC:8,TC:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Kurita)'>
-			<roles>recon,raider</roles>
-			<availability>DC:8,TC:4</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 		</model>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
 		<availability>HL:2,IS:3,TC:3,Periphery:3</availability>
-		<model name='(Standard)'>
-			<availability>TC:5</availability>
-		</model>
 		<model name='(3082 Upgrade)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
@@ -8293,13 +8293,13 @@
 	</chassis>
 	<chassis name='JI2A1 Attack APC' unitType='Tank'>
 		<availability>FVC:4,ROS:3,FS:4,MERC:3</availability>
-		<model name='(MML)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MML)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jabberwocky ConstructionMech' unitType='Mek'>
@@ -8340,27 +8340,27 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:5,General:2,RA:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CW:4,CLAN:2,RA:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CW:4,CLAN:2,RA:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8374,35 +8374,16 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:3,CC:2-,MERC:3,Periphery.OS:2,FS:6,TC:3,Periphery:3,RA.OA:2,FVC:7,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,MH:3,DC:2</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>MOC:3,RA.OA:5,FVC:5,LA:5,CGB.FRR:5,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='JM7-C3BS'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>CC:2-,CGB.FRR:1-,IS:2-,FS:2-,Periphery:5</availability>
 		</model>
-		<model name='JM6-DGr'>
-			<roles>anti_aircraft</roles>
-			<availability>FVC:2,LA:2,ROS:2,CGB.FRR:2,FS:2,MERC:2,CDP:3,DC:2</availability>
+		<model name='JM6-DG'>
+			<availability>General:2</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:5,FS:4,MERC:6</availability>
-		</model>
-		<model name='JM7-F'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:2</availability>
 		</model>
 		<model name='JM6-DDa'>
 			<roles>anti_aircraft</roles>
@@ -8412,32 +8393,51 @@
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,PIR:2,MH:6,Periphery:2</availability>
 		</model>
+		<model name='JM7-F'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:4,FS:4</availability>
+		</model>
+		<model name='JM6-DGr'>
+			<roles>anti_aircraft</roles>
+			<availability>FVC:2,LA:2,ROS:2,CGB.FRR:2,FS:2,MERC:2,CDP:3,DC:2</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM7-G'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>MOC:3,RA.OA:5,FVC:5,LA:5,CGB.FRR:5,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:3,HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,TC:3,RA.OA:1,FVC:7,LA:1,Periphery.HR:4,ROS:4</availability>
-		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+		<model name='JVN-10P'>
 			<roles>recon</roles>
-			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
-		</model>
-		<model name='JVN-11D'>
-			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3,CDP:3</availability>
+			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:4,MERC:6,CDP:6,TC:6</availability>
 		</model>
 		<model name='JVN-11F'>
 			<roles>recon</roles>
 			<availability>FS:6</availability>
 		</model>
+		<model name='JVN-10F &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
+		</model>
 		<model name='JVN-10N'>
 			<roles>recon</roles>
 			<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
 			<roles>recon</roles>
-			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:4,MERC:6,CDP:6,TC:6</availability>
+			<availability>FVC:3,LA:3,ROS:3,FS:3,MERC:3,CDP:3</availability>
+		</model>
+		<model name='JVN-11D'>
+			<roles>recon</roles>
+			<availability>ROS:6,FS:6</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -8446,14 +8446,14 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -8464,67 +8464,59 @@
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
+		<model name='B'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CCC:6,CDS:6,CW:6,ROS:4,CNC:8,CCO:5,DC:3</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>CCC:6,CNC:6</availability>
 		</model>
-		<model name='3'>
+		<model name='(Standard)'>
+			<availability>CW:4,CNC:4,CLAN:1</availability>
+		</model>
+		<model name='2'>
 			<availability>CCC:6,CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:7,CNC:8,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CW:4,CNC:4,CLAN:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>CC:1-,Periphery.DD:5,FS.RR:5,HL:2,IS:3,MERC:4,Periphery.OS:5,FS:4,RA:4,Periphery:3,CGB.FRR:8,FS.DMM:5,FWL:1-,DC:8</availability>
-		<model name='JR7-K'>
+		<model name='JR7-C4'>
 			<roles>raider</roles>
-			<availability>MOC:3,RA.OA:3,CGB.FRR:8,MERC:3,RA:2,DC:3,TC:3</availability>
-		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>General:1-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>ROS:4,DC:6</availability>
-		</model>
-		<model name='JR7-C3'>
-			<roles>raider</roles>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+			<availability>DC:3</availability>
 		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>General:1-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='JR7-C3'>
+			<roles>raider</roles>
+			<availability>ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='JR7-K'>
+			<roles>raider</roles>
+			<availability>MOC:3,RA.OA:3,CGB.FRR:8,MERC:3,RA:2,DC:3,TC:3</availability>
+		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
 			<availability>MERC:6,FS:6,DC:5</availability>
 		</model>
-		<model name='JR7-C4'>
+		<model name='JR7-C2'>
 			<roles>raider</roles>
-			<availability>DC:3</availability>
+			<availability>ROS:4,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:6,TC:4</availability>
-		<model name='JI-50 (Q-Vehicle)'>
-			<roles>support</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='JI-50'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='JI-50 (ML)'>
+		<model name='JI-50 (Hoist)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8532,21 +8524,29 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='JI-50 (Hoist)'>
+		<model name='JI-50'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Q-Vehicle)'>
+			<roles>support</roles>
+			<availability>TC:2</availability>
+		</model>
+		<model name='JI-50 (ML)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:6,MOC:5,TC:4</availability>
-		<model name='JN-G8A'>
-			<availability>General:8</availability>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
+		<model name='JN-G8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Joust Medium Tank' unitType='Tank'>
@@ -8562,11 +8562,11 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
@@ -8578,8 +8578,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -8599,32 +8599,31 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CJF:4</availability>
 		</model>
+		<model name='3'>
+			<availability>CJF:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>ROS:3,DC:6</availability>
-		<model name='KBO-7B'>
+		<model name='KBO-7A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='KBO-7A'>
+		<model name='KBO-7B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+		<model name='C' mechanized='true'>
+			<availability>DC:3</availability>
 		</model>
-		<model name='(DEST)' mechanized='true'>
+		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
@@ -8632,28 +8631,29 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C' mechanized='true'>
-			<availability>DC:3</availability>
+		<model name='[MG]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
+		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='(Space)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='(Vibro-Claw)' mechanized='true'>
+		<model name='[ECM]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
+			<availability>MERC:2,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -8665,6 +8665,13 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Salvage Arm]' mechanized='false'>
+			<roles>support</roles>
+			<availability>DC.NSR:6,DC.SL:6,General:6</availability>
+		</model>
 		<model name='[Industrial Drill]' mechanized='false'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -8672,23 +8679,16 @@
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Salvage Arm]' mechanized='false'>
-			<roles>support</roles>
-			<availability>DC.NSR:6,DC.SL:6,General:6</availability>
-		</model>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>CGB:6</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
@@ -8710,38 +8710,38 @@
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(AC)'>
+			<availability>MH:5,MERC:5</availability>
+		</model>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,HL:3,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
+		</model>
+		<model name='(Heavy Stealth)'>
+			<availability>PIR:3</availability>
+		</model>
 		<model name='(3055 Upgrade)'>
 			<roles>cargo</roles>
 			<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
-		</model>
-		<model name='(AC)'>
-			<availability>MH:5,MERC:5</availability>
 		</model>
 		<model name='(BA)'>
 			<roles>apc</roles>
 			<availability>FWL:5,IS:6</availability>
 		</model>
-		<model name='(Heavy Stealth)'>
-			<availability>PIR:3</availability>
-		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,HL:3,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
 		<availability>DC.GHO:6,CGB.FRR:2,DC:6</availability>
+		<model name='CRK-5003-2'>
+			<availability>CGB.FRR:8,DC:2-</availability>
+		</model>
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:6,DC:6</availability>
 		</model>
-		<model name='CRK-5003-2'>
-			<availability>CGB.FRR:8,DC:2-</availability>
+		<model name='CRK-5003-C'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='CRK-5003-CM'>
 			<roles>spotter</roles>
 			<availability>DC:7</availability>
-		</model>
-		<model name='CRK-5003-C'>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kestrel VTOL' unitType='VTOL'>
@@ -8750,21 +8750,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
@@ -8772,23 +8772,23 @@
 		<model name='KGC-001'>
 			<availability>LA:4,IS:4,MH:6</availability>
 		</model>
-		<model name='KGC-008B'>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='KGC-005r'>
-			<availability>ROS:3,MERC:3</availability>
-		</model>
 		<model name='KGC-000b'>
 			<availability>CGB.FRR:5,ROS:6,CLAN:4,BAN:2,DC:5</availability>
+		</model>
+		<model name='KGC-007'>
+			<availability>LA:8,ROS:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='KGC-0000'>
 			<availability>IS:2-</availability>
 		</model>
+		<model name='KGC-008B'>
+			<availability>ROS:4</availability>
+		</model>
 		<model name='KGC-000'>
 			<availability>CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,BAN:8,DC:8</availability>
 		</model>
-		<model name='KGC-007'>
-			<availability>LA:8,ROS:8,FS:8,MERC:8</availability>
+		<model name='KGC-005r'>
+			<availability>ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
@@ -8796,26 +8796,26 @@
 		<model name='C'>
 			<availability>General:5,CGB:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6,CGB:5</availability>
-		</model>
 		<model name='E'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
+		<model name='D'>
+			<availability>General:6,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kinnol MBT' unitType='Tank'>
@@ -8829,11 +8829,11 @@
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>DC.GHO:5,CGB.FRR:4,ROS:6,NIOPS:7,FS:2,MERC:4,DC:4</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:6</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:3,DC.SL:4,ROS:4,CLAN:6,NIOPS:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-18'>
 			<availability>:0,FS:2-,MERC:2-</availability>
@@ -8844,29 +8844,29 @@
 		<model name='KTO-20'>
 			<availability>CGB.FRR:3,MERC:5,DC:4</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:6</availability>
+		<model name='KTO-19b'>
+			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,BAN:7,CWIE:5,CGB:7</availability>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -8896,13 +8896,24 @@
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
 		<availability>CGB.FRR:6,CGB:1-</availability>
-		<model name='[GL/Flamer]' mechanized='true'>
-			<availability>CGB.FRR:6</availability>
+		<model name='[GL]' mechanized='true'>
+			<availability>CGB.FRR:4</availability>
+		</model>
+		<model name='[SL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CGB.FRR:8</availability>
+		</model>
+		<model name='(GB) [GL/Flamer]' mechanized='true'>
+			<availability>CGB:1</availability>
+		</model>
+		<model name='(GB) [SL/Flamer]' mechanized='true'>
+			<availability>CGB:1</availability>
 		</model>
 		<model name='[SL/Flamer]' mechanized='true'>
 			<availability>CGB.FRR:6</availability>
 		</model>
-		<model name='(GB) [SL/Flamer]' mechanized='true'>
+		<model name='(GB) [SL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
 			<availability>CGB:1</availability>
 		</model>
 		<model name='(GB) [GL]' mechanized='true'>
@@ -8912,19 +8923,8 @@
 			<roles>spotter</roles>
 			<availability>CGB:1</availability>
 		</model>
-		<model name='[SL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CGB.FRR:8</availability>
-		</model>
-		<model name='[GL]' mechanized='true'>
-			<availability>CGB.FRR:4</availability>
-		</model>
-		<model name='(GB) [SL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CGB:1</availability>
-		</model>
-		<model name='(GB) [GL/Flamer]' mechanized='true'>
-			<availability>CGB:1</availability>
+		<model name='[GL/Flamer]' mechanized='true'>
+			<availability>CGB.FRR:6</availability>
 		</model>
 		<model name='[GL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
@@ -8933,6 +8933,9 @@
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>CCC:3,ROS:4,CCO:3,RA:6,CGB:8</availability>
+		<model name='5'>
+			<availability>CGB:4</availability>
+		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
 			<availability>RA:5</availability>
@@ -8942,9 +8945,6 @@
 		</model>
 		<model name='4'>
 			<availability>ROS:4,CGB:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
@@ -8956,9 +8956,6 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='KIM-2'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>General:8,DC:4</availability>
@@ -8967,30 +8964,26 @@
 			<roles>spotter</roles>
 			<availability>DC:2</availability>
 		</model>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>OP:5,DoO:5,ROS:5,FWL:4,DO:5,TP:5,MERC:4</availability>
-		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='(AI Mk II)' mechanized='false'>
+			<availability>OP:4,DoO:4,DO:4,TP:4</availability>
 		</model>
 		<model name='(Anti-Infantry)' mechanized='false'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(AI Mk II)' mechanized='false'>
-			<availability>OP:4,DoO:4,DO:4,TP:4</availability>
+		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,DTA:3,ROS:3,MERC:4</availability>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
-			<availability>MERC:4</availability>
-		</model>
 		<model name='KSC-4I'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='KSC-4L'>
 			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='KSC-5I'>
@@ -8999,28 +8992,39 @@
 		<model name='KSC-5MC'>
 			<availability>MOC:8,CC:8,MERC:3</availability>
 		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:4</availability>
+		</model>
+		<model name='KSC-4L'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CSA:5,CHH:5,MERC.WD:5,CDS:5,CW:5,IS:4+,CCO:1,CJF:4,BAN:6,RA:5</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>CDS:3,CW:7,General:4,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<roles>recon</roles>
-			<availability>CSA:3,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
+		<model name='F'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,CLAN:5,IS:3</availability>
 		</model>
-		<model name='E'>
+		<model name='Prime'>
 			<roles>recon</roles>
-			<availability>CLAN:5,IS:3,CCO:6</availability>
+			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,CLAN:5,IS:3</availability>
 		</model>
 		<model name='G'>
 			<roles>recon,anti_infantry</roles>
@@ -9030,22 +9034,18 @@
 			<roles>recon</roles>
 			<availability>CSA:6,CDS:6,CW:6,General:5,CCO:4,CWIE:5,CGB:5</availability>
 		</model>
-		<model name='P'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CLAN:2,IS:2</availability>
+			<availability>CSA:3,CDS:5,CW:7,CNC:2,General:3,CCO:2,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
-		<model name='Prime'>
+		<model name='E'>
 			<roles>recon</roles>
-			<availability>CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CSA:4,CCC:2,CNC:3,General:2</availability>
+			<availability>CLAN:5,IS:3,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Koshi' unitType='Mek'>
 		<availability>CLAN:4,IS:3</availability>
-		<model name='(Standard) 2'>
+		<model name='(Standard) 3'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9053,7 +9053,7 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard) 3'>
+		<model name='(Standard) 2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9093,12 +9093,12 @@
 	</chassis>
 	<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
 		<availability>CSA:6,CHH:6,CDS:2,CW:4,CNC:2,CJF:4,RA:6,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(IFV) &apos;Turhan II&apos;'>
 			<roles>apc</roles>
 			<availability>CHH:8,CJF:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kuan Ti' unitType='Dropship'>
@@ -9110,11 +9110,11 @@
 	</chassis>
 	<chassis name='Kuma' unitType='Mek'>
 		<availability>CGB.FRR:3,CGB:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
@@ -9160,33 +9160,33 @@
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>CC:3,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:3,MERC:3,DTA:6,FVC:3,RF:6,LA:3,ROS:3,Periphery.MW:3,Periphery.CM:3,PG:6,Periphery.ME:3,FWL:6,MH:3,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
-		<model name='LX-2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LX-2A'>
 			<availability>OP:5,PR:5,DoO:5,DO:5,MERC:5,DTA:5,RF:5,LA:5,ROS:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
 		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
+		<model name='LX-2'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:8,MOC:6,FS:4,TC:4</availability>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3B'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:6</availability>
-		</model>
 		<model name='LHU-4E'>
 			<availability>CC:4</availability>
 		</model>
 		<model name='LHU-3L'>
 			<availability>CC:6,MOC:7,FS:8</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-3B'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -9198,21 +9198,21 @@
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>ROS:4,FS:8,MERC:4</availability>
-		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGN-2F'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
+		</model>
+		<model name='LGN-2XU'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-2XA'>
 			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leonidas Battle Armor' unitType='BattleArmor'>
@@ -9223,13 +9223,13 @@
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>RA.OA:8,HL:6,IS:7,Periphery.Deep:6,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>CC:8,OP:8,PR:8,DoO:8,DO:8,FS:8,DTA:8,RF:8,LA:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:5-</availability>
+		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>CC:8,OP:8,PR:8,DoO:8,DO:8,FS:8,DTA:8,RF:8,LA:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
@@ -9279,27 +9279,27 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
-		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:3,FWL:8,IS:3</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:3</availability>
+		<model name='Owl'>
+			<availability>LA:1,ROS:1,MERC:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:2,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1,ROS:1,MERC:1</availability>
+		<model name='Comet'>
+			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:3,HL:5,LA:3</availability>
 		</model>
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
+		</model>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:3,FWL:8,IS:3</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -9310,9 +9310,6 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CLAN:3,NIOPS:2,CJF:4</availability>
-		<model name='(ERSL)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8,CLAN:6</availability>
 		</model>
@@ -9320,29 +9317,32 @@
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='LTN-G15b'>
-			<availability>CC:5,MOC:5,CLAN:3,IS:3,MERC:4</availability>
-		</model>
-		<model name='LTN-G16L'>
-			<availability>CC:6,MOC:6,PR:4,RF:4,PG:4,MSC:4,MERC:4,DA:6,RFS:4</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:4-</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='LTN-G16S'>
-			<availability>LA:6</availability>
+		<model name='LTN-G15b'>
+			<availability>CC:5,MOC:5,CLAN:3,IS:3,MERC:4</availability>
 		</model>
 		<model name='LTN-G16D'>
 			<availability>ROS:6,FS:6,MERC:4</availability>
 		</model>
+		<model name='LTN-G16L'>
+			<availability>CC:6,MOC:6,PR:4,RF:4,PG:4,MSC:4,MERC:4,DA:6,RFS:4</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='LTN-G16O'>
 			<availability>RA.OA:6,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G16S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
@@ -9350,11 +9350,14 @@
 		<model name='B'>
 			<availability>CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
+		<model name='A'>
+			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:4,CW:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
@@ -9362,26 +9365,23 @@
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,CW:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CLAN:4,General:3</availability>
+		<model name='D'>
+			<availability>CW:6,General:5,CWIE:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lineholder' unitType='Mek'>
 		<availability>CC:4,HL:2,ROS:4,FWL:4,IS:3,FS:5,TC:6,Periphery:3</availability>
-		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
-			<availability>ROS:6,FS:7,MERC:6,CDP:4</availability>
-		</model>
 		<model name='KW1-LH3'>
 			<availability>General:2,FS:3</availability>
 		</model>
 		<model name='KW1-LH2'>
 			<availability>General:5,FS:2</availability>
+		</model>
+		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
+			<availability>ROS:6,FS:7,MERC:6,CDP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -9415,75 +9415,74 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,CW:7,ROS:3,CJF:6,DC:3,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CW:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CSA:4,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
-		</model>
 		<model name='6'>
 			<availability>CW:5,CGB:5</availability>
-		</model>
-		<model name='5'>
-			<availability>CHH:4,CW:4,ROS:4,CCO:4,CGB:4</availability>
 		</model>
 		<model name='9'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='7'>
-			<availability>CHH:4,ROS:2</availability>
+		<model name='(Standard)'>
+			<availability>CW:3</availability>
 		</model>
 		<model name='8'>
 			<availability>ROS:5,CGB:6,DC:5</availability>
 		</model>
+		<model name='7'>
+			<availability>CHH:4,ROS:2</availability>
+		</model>
+		<model name='4'>
+			<availability>CSA:4,CCC:4,CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
 		<model name='2'>
 			<availability>CCC:2,CJF:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CHH:4,CW:4,ROS:4,CCO:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>HL:5,CLAN:2-,IS:7,NIOPS:2-,Periphery.Deep:5,Periphery:4</availability>
-		<model name='LCT-3M'>
+		<model name='LCT-6M'>
 			<roles>recon</roles>
-			<availability>MOC:3,OP:5,PR:5,DoO:5,IS:3,DO:5,MERC:5,DTA:5,RF:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+			<availability>ROS:2,FWL:4,MSC:5,MERC:3</availability>
+		</model>
+		<model name='LCT-5M2'>
+			<availability>ROS:3,MSC:3</availability>
 		</model>
 		<model name='LCT-5T'>
 			<roles>recon,anti_infantry</roles>
 			<availability>MOC:4,CC:4,FVC:4,TC:6</availability>
 		</model>
-		<model name='LCT-5M2'>
-			<availability>ROS:3,MSC:3</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:4,ROS:4,PIR:4,FWL:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='LCT-6M'>
-			<roles>recon</roles>
-			<availability>ROS:2,FWL:4,MSC:5,MERC:3</availability>
-		</model>
-		<model name='LCT-5W2'>
-			<roles>recon,spotter</roles>
-			<availability>LA:4,ROS:4,CLAN:3,IS:3,FS:4,DC:4</availability>
+		<model name='LCT-5M3'>
+			<availability>ROS:4,MSC:4</availability>
 		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CC:5,MOC:3,CLAN:6,FWL:3,MERC:3,BAN:2</availability>
 		</model>
-		<model name='LCT-5V'>
+		<model name='LCT-3V'>
 			<roles>recon</roles>
-			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:3,TC:4,Periphery:3</availability>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='LCT-5M'>
+			<roles>recon</roles>
+			<availability>FVC:4,ROS:4,PIR:4,FWL:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='LCT-1V2'>
+			<roles>recon</roles>
+			<availability>PIR:4,MH:4,MERC:2</availability>
+		</model>
+		<model name='LCT-5W2'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4,ROS:4,CLAN:3,IS:3,FS:4,DC:4</availability>
 		</model>
 		<model name='LCT-1V'>
 			<roles>recon</roles>
 			<availability>LA:2-,General:2-,FS:2-</availability>
 		</model>
-		<model name='LCT-3V'>
+		<model name='LCT-5V'>
 			<roles>recon</roles>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
+			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:3,TC:4,Periphery:3</availability>
 		</model>
 		<model name='LCT-1E'>
 			<roles>recon</roles>
@@ -9493,25 +9492,26 @@
 			<roles>recon</roles>
 			<availability>LA:8,CGB.FRR:6,MERC:6</availability>
 		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:3,OP:5,PR:5,DoO:5,IS:3,DO:5,MERC:5,DTA:5,RF:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+		</model>
 		<model name='LCT-1S'>
 			<roles>recon</roles>
 			<availability>LA:2-,MERC:2-</availability>
 		</model>
-		<model name='LCT-5M3'>
-			<availability>ROS:4,MSC:4</availability>
-		</model>
-		<model name='LCT-1V2'>
+		<model name='LCT-3D'>
 			<roles>recon</roles>
-			<availability>PIR:4,MH:4,MERC:2</availability>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CW:4,IS:1+,CJF:1,BAN:5,CWIE:4</availability>
-		<model name='A'>
-			<availability>General:7,CGB:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9,CGB:8</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,General:4,CCO:6,CWIE:5,CGB:5</availability>
@@ -9522,15 +9522,15 @@
 		<model name='B'>
 			<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -9546,9 +9546,9 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6,CGB:3</availability>
-		<model name='LGB-14C2'>
+		<model name='LGB-7V'>
 			<roles>fire_support</roles>
-			<availability>IS:4</availability>
+			<availability>MOC:3,FVC:4,FWL:4,IS:3,Periphery:3</availability>
 		</model>
 		<model name='LGB-0W'>
 			<roles>fire_support</roles>
@@ -9558,47 +9558,47 @@
 			<roles>missile_artillery,fire_support</roles>
 			<availability>LA:4,CGB.FRR:4,FWL:4,IS:3,FS:5,MERC:4,CGB:3</availability>
 		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:5,LA:5,IS:3,FS:5,MERC:5,DC:5,Periphery:3</availability>
-		</model>
-		<model name='LGB-13NAIS'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGB-12R'>
 			<roles>fire_support</roles>
 			<availability>DTA:4,LA:4,ROS:8,FS:4,DC:3</availability>
-		</model>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,FVC:4,FWL:4,IS:3,Periphery:3</availability>
-		</model>
-		<model name='LGB-12C'>
-			<roles>fire_support</roles>
-			<availability>CC:5,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CDP:3,TC:3</availability>
-		</model>
-		<model name='LGB-13C'>
-			<roles>fire_support</roles>
-			<availability>CC:6,MOC:4,OP:6,DoO:6,DO:6,FS:6,MERC:6,ROS:6,MSC:6,TP:6,DA:6,RCM:6,DC:6</availability>
 		</model>
 		<model name='LGB-7Q'>
 			<roles>fire_support</roles>
 			<availability>MOC:2-,General:2-,TC:2-,Periphery:2-</availability>
 		</model>
+		<model name='LGB-12C'>
+			<roles>fire_support</roles>
+			<availability>CC:5,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CDP:3,TC:3</availability>
+		</model>
+		<model name='LGB-13NAIS'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='LGB-13C'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:4,OP:6,DoO:6,DO:6,FS:6,MERC:6,ROS:6,MSC:6,TP:6,DA:6,RCM:6,DC:6</availability>
+		</model>
+		<model name='LGB-14C2'>
+			<roles>fire_support</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:5,LA:5,IS:3,FS:5,MERC:5,DC:5,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>OP:8,PR:8,DoO:8,DO:8,DTA:8,RF:8,PG:8,FWL:8,MH:6,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>FWL:6</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -9612,41 +9612,41 @@
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
-		<model name='LCF-R16K'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>MOC:1,RA.OA:1,Periphery.R:4,FVC:2,HL:4,LA:6,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
+		<model name='LCF-R16'>
+			<availability>LA:8,MH:3,MERC:6</availability>
+		</model>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,Periphery.Deep:4,MERC:4-,Periphery:2-</availability>
 		</model>
 		<model name='LCF-R20'>
 			<availability>LA:2-,FS:2-</availability>
 		</model>
-		<model name='LCF-R16'>
-			<availability>LA:8,MH:3,MERC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,HL:2,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM5/M'>
-			<availability>LA:2-</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='LM5/M'>
+			<availability>LA:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -9687,13 +9687,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3</availability>
-		<model name='(Standard)'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='M1'>
 			<roles>escort</roles>
 			<availability>FWL:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -9724,20 +9724,23 @@
 	</chassis>
 	<chassis name='Mackie' unitType='Mek'>
 		<availability>PR:2-,RF:2-,LA:1-,PG:2-,FWL:1-,RFS:2-</availability>
-		<model name='MSK-5S'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='MSK-6S'>
 			<availability>PR:8,RF:8,PG:8,FWL:8,RFS:8</availability>
 		</model>
 		<model name='MSK-9H'>
 			<availability>General:8</availability>
 		</model>
+		<model name='MSK-5S'>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,MERC.KH:3+,MERC.WD:6,CDS:4,CW:6,ROS:2+,CLAN:2,MERC:1+,CCO:4,CJF:4,BAN:2,CWIE:6</availability>
-		<model name='Prime'>
-			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CCO:6,CJF:8,CGB:7</availability>
+		<model name='B'>
+			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -9747,32 +9750,30 @@
 			<roles>spotter</roles>
 			<availability>CHH:4,CW:5,CNC:4,CLAN:5,General:5,CCO:6,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:3,General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:3,General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5,CGB:5</availability>
+		<model name='Prime'>
+			<availability>CSA:6,CCC:7,CDS:8,CNC:7,General:8,CCO:6,CJF:8,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat III' unitType='Mek'>
 		<availability>CDS:4,LA:4,ROS:4,CNC:3,IS:3,CWIE:3,DC:4</availability>
-		<model name='2'>
-			<availability>General:6</availability>
+		<model name='4'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
@@ -9782,9 +9783,8 @@
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='4'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='2'>
+			<availability>General:6</availability>
 		</model>
 		<model name='3'>
 			<roles>fire_support</roles>
@@ -9796,48 +9796,48 @@
 		<model name='Enhanced'>
 			<availability>CGB.FRR:6,CLAN:6,CNC:4,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CDS:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
 		<availability>LA:6,IS:4,FS:4,MERC:4,DC:6</availability>
-		<model name='MTR-6E'>
-			<roles>recon,spotter</roles>
-			<availability>DC:1</availability>
+		<model name='MTR-5K'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='MTR-5K'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='MTR-6E'>
+			<roles>recon,spotter</roles>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>CC:3,MOC:3,OP:8,Periphery.MM:3,PR:8,DoO:8,DO:8,MERC:3,DTA:8,RF:8,LA:3,ROS:3,Periphery.CM:3,PG:8,Periphery.ME:3,FWL:8,MH:3,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>MOC:4,IS:4</availability>
+		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(XL)'>
-			<availability>MOC:4,IS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Malaika' unitType='Aero'>
@@ -9862,9 +9862,6 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,MERC.WD:6,CDS:6,CW:6,CNC:2,CJF:6,BAN:5,CWIE:6</availability>
-		<model name='E'>
-			<availability>CLAN:6,General:3,CCO:5</availability>
-		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
 		</model>
@@ -9875,17 +9872,20 @@
 		<model name='G'>
 			<availability>General:2</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:3,CCO:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='A'>
+			<availability>CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
@@ -9893,14 +9893,14 @@
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
 		<availability>MERC.KH:3,PR:3,RF:3,LA:3,ROS:3,PG:3,MERC:3,RFS:3,CWIE:5</availability>
+		<model name='MNL-4S'>
+			<availability>General:4</availability>
+		</model>
 		<model name='MNL-3L'>
 			<availability>MERC.KH:6,ROS:5,CWIE:6</availability>
 		</model>
 		<model name='MNL-3W'>
 			<availability>ROS:2,CWIE:4</availability>
-		</model>
-		<model name='MNL-4S'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -9917,28 +9917,40 @@
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
+		<model name='D'>
+			<roles>apc</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
+		<model name='E'>
 			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,FS:6,Periphery:6,TC:6,CWIE:6,RA.OA:6,LA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
+		<model name='(LB-X)'>
+			<availability>LA:8,ROS:8,FS:8</availability>
+		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,PR:8,RF:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:2,LA:1-,General:2-,Periphery.Deep:6,FS:1-,DC:1-,Periphery:4</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -9946,18 +9958,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:3,MOC:3,DTA:3,LA:3,ROS:5,FS:5,MERC:3,DC:5</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>LA:8,ROS:8,FS:8</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,PR:8,RF:8,LA:8,ROS:8,PG:8,FS:8,MERC:8,RFS:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:2,LA:1-,General:2-,Periphery.Deep:6,FS:1-,DC:1-,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mantis Light Attack VTOL' unitType='VTOL'>
@@ -9971,26 +9971,26 @@
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CSA:6,MERC.WD:6,CW:5,CNC:5,CJF:6,RA:5,CWIE:5,CGB:6</availability>
-		<model name='3'>
-			<availability>CSA:2,CJF:5,CGB:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CW:5,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:8,CJF:4,CGB:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CSA:4,CCC:2,CJF:3,CGB:3</availability>
 		</model>
 		<model name='5'>
 			<availability>CJF:4,CWIE:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CNC:6,RA:3,CGB:4</availability>
+		<model name='6'>
+			<availability>CW:5,CJF:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:2,CJF:5,CGB:5</availability>
 		</model>
 		<model name='7'>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:4,CCC:2,CJF:3,CGB:3</availability>
+		</model>
+		<model name='4'>
+			<availability>CNC:6,RA:3,CGB:4</availability>
 		</model>
 		<model name='8'>
 			<availability>CJF:4,CGB:4</availability>
@@ -9998,8 +9998,8 @@
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,MOC:3,FS:6,MERC:6,TC:4,MERC.WD:6,LA:3,CGB.FRR:5,ROS:6,PIR:4,FWL:6,MH:4,DC:6</availability>
-		<model name='MAD-4H'>
-			<availability>PIR:6,MH:6,TC:6</availability>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
@@ -10007,111 +10007,111 @@
 		<model name='MAD-6M'>
 			<availability>ROS:4,FWL:5,MERC:5</availability>
 		</model>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:4</availability>
-		</model>
 		<model name='MAD-4L'>
 			<availability>CC:6,MOC:6</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:5</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>LA:8,CGB.FRR:5,ROS:6,CNC:8,FWL:2,FS:6,MERC:7,DC:2</availability>
 		</model>
+		<model name='MAD-5C'>
+			<availability>MERC.WD:1</availability>
+		</model>
 		<model name='MAD-4K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='MAD-5C'>
-			<availability>MERC.WD:1</availability>
+		<model name='MAD-4H'>
+			<availability>PIR:6,MH:6,TC:6</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,MOC:2,IS:1-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:6,OP:6,DoO:6,DO:6,MSC:6,TP:6,MERC:3,DA:6</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:4,CGB.FRR:6,FS:3,MERC:3,DC:6</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>LA:6,CGB.FRR:4,ROS:4,MH:3,MERC:4,CGB:3</availability>
+		<model name='MAD-3D'>
+			<availability>FVC:2-,MH:2-,FS:2-</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>OP:5,PR:5,RF:5,DoO:5,ROS:4,PG:5,DO:5,TP:5,MERC:4,DA:5,RFS:5,DC:3</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:5,ROS:4,FS:5,MERC:4,DC:5</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:5,MOC:4</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>FVC:3,LA:5,CGB.FRR:3,FS:3,MERC:4</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>DTA:6,OP:6,DoO:6,DO:6,MSC:6,TP:6,MERC:3,DA:6</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:2-,Periphery.MW:2-,PIR:2-,Periphery.ME:2-,FWL:1-,MH:2-,MERC:2-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:4,CGB.FRR:6,FS:3,MERC:3,DC:6</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>MOC:4,ROS:4,FWL:7,MERC:4</availability>
 		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:2-,MH:2-,FS:2-</availability>
+		<model name='MAD-6L'>
+			<availability>CC:5,MOC:4</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:3-,TC:3-</availability>
 		</model>
-		<model name='MAD-5L'>
-			<availability>CC:6,MOC:5</availability>
+		<model name='MAD-9S'>
+			<availability>LA:6,CGB.FRR:4,ROS:4,MH:3,MERC:4,CGB:3</availability>
 		</model>
 		<model name='MAD-2R'>
 			<availability>MOC:3,RA.OA:3,MH:3,MERC:3,BAN:1,TC:4</availability>
 		</model>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:2-,Periphery.MW:2-,PIR:2-,Periphery.ME:2-,FWL:1-,MH:2-,MERC:2-</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:6,MOC:5</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>FVC:3,LA:5,CGB.FRR:3,FS:3,MERC:4</availability>
+		</model>
+		<model name='MAD-9W2'>
+			<availability>LA:5,ROS:4,FS:5,MERC:4,DC:5</availability>
+		</model>
+		<model name='MAD-7D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
 		<availability>CHH:4,LA:6,IS:4</availability>
-		<model name='(Light PPC)'>
-			<roles>artillery</roles>
-			<availability>LA:8,IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CHH:8,BAN:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>artillery</roles>
+			<availability>LA:8,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Marksman MBT' unitType='Tank'>
 		<availability>ROS:5,IS:3</availability>
-		<model name='M1A'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='M1'>
 			<availability>ROS:2,ROS.pm:8,General:8</availability>
+		</model>
+		<model name='M1A'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>LA:4,ROS:5,CLAN:7</availability>
-		<model name='(HAG)'>
-			<availability>CHH:4,CDS:4,ROS:4,CGB:4</availability>
-		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CCO:6,CJF:2</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CSA:4,CHH:4,CCC:3,ROS:4,CSL:4,CCO:3,CGB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ATM)'>
+			<availability>General:5,CCO:6,CJF:2</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:4,CDS:4,ROS:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -10122,11 +10122,11 @@
 	</chassis>
 	<chassis name='Marshal' unitType='Mek'>
 		<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
-		<model name='MHL-6MC'>
-			<availability>MOC:4,CC:3</availability>
-		</model>
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:4,CC:3</availability>
 		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,HL:2,PIR:4,MERC:4,TC:4,Periphery:4</availability>
@@ -10134,36 +10134,36 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3,IS:2,FS:3,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CSA:2,MERC.WD:2,CDS:5,CW:3,CNC:2,MERC:2+,CJF:4,RA:3,BAN:3,CGB:4</availability>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:8,General:5</availability>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CDS:8,General:5,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:5,CW:6,General:4,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:8,General:5</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,General:4,CCO:6,CGB:5</availability>
@@ -10171,11 +10171,11 @@
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
@@ -10183,41 +10183,41 @@
 		<model name='MAL-1R'>
 			<availability>CGB.FRR:8,MERC:6,DC:1</availability>
 		</model>
-		<model name='MAL-1K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='MAL-C'>
 			<availability>DC:3</availability>
 		</model>
 		<model name='MAL-3R'>
 			<availability>DC:5</availability>
 		</model>
+		<model name='MAL-1K'>
+			<availability>DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:3,CLAN:1,MH:4,TC:6</availability>
-		<model name='(Intermediate)'>
+		<model name='(Fusion)'>
 			<roles>apc</roles>
-			<availability>TC:1</availability>
-		</model>
-		<model name='(Basic)'>
-			<roles>apc</roles>
-			<availability>TC:1-</availability>
-		</model>
-		<model name='(BA)'>
-			<roles>apc</roles>
-			<availability>TC:6</availability>
+			<availability>TC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CC:8,MOC:8,CLAN:8,MH:8,TC:8</availability>
 		</model>
+		<model name='(Intermediate)'>
+			<roles>apc</roles>
+			<availability>TC:1</availability>
+		</model>
 		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Fusion)'>
+		<model name='(BA)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:6</availability>
+		</model>
+		<model name='(Basic)'>
+			<roles>apc</roles>
+			<availability>TC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -10237,70 +10237,70 @@
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Company Command)'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
 		<availability>MOC:1,CC:1,CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,TC:1,RA.OA:1,LA:2,CGB.FRR:2,ROS:1,FWL:1,NIOPS:2-,DC:1</availability>
-		<model name='(C3M)'>
-			<roles>apc,spotter</roles>
-			<availability>IS:2</availability>
-		</model>
-		<model name='(BA Field Upgrade)'>
-			<roles>apc,spotter</roles>
-			<availability>CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
-		</model>
-		<model name='(BA Factory Upgrade)'>
-			<roles>apc</roles>
-			<availability>CC:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
-		</model>
 		<model name='(SRM2)'>
 			<roles>apc</roles>
 			<availability>IS:1-,Periphery:2-</availability>
 		</model>
-		<model name='(SRM4)'>
-			<roles>apc</roles>
-			<availability>IS:1-,Periphery:2-</availability>
-		</model>
-		<model name='(Anti-Infantry)'>
-			<roles>apc,spotter,anti_infantry</roles>
-			<availability>IS:2,DC:3</availability>
-		</model>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
-		<model name='(C3S)'>
+		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
-			<availability>IS:4</availability>
+			<availability>IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
+		<model name='(BA Field Upgrade)'>
+			<roles>apc,spotter</roles>
+			<availability>CGB.FRR:3,IS:2,MERC:3,DC:4</availability>
+		</model>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>FVC:4,LA:4,IS:2,FS:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='(BA Factory Upgrade)'>
+			<roles>apc</roles>
+			<availability>CC:5,CGB.FRR:5,FWL:5,IS:4,DC:5</availability>
+		</model>
+		<model name='(C3S)'>
+			<roles>apc,spotter</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Anti-Infantry)'>
+			<roles>apc,spotter,anti_infantry</roles>
+			<availability>IS:2,DC:3</availability>
+		</model>
+		<model name='(SRM4)'>
+			<roles>apc</roles>
+			<availability>IS:1-,Periphery:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Mk II Transport' unitType='Tank'>
 		<availability>LA:3,ROS:4,MERC:2</availability>
-		<model name='(Standard)'>
+		<model name='(ECM)'>
 			<roles>apc</roles>
-			<availability>LA:8,ROS:8</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Infantry Support) &apos;Shiloh&apos;'>
 			<roles>apc</roles>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>General:4</availability>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -10324,12 +10324,12 @@
 			<roles>interceptor</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<roles>interceptor</roles>
 			<availability>FVC:1,CGB.FRR:1,MERC:1,Periphery:1,DC:1</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -10344,8 +10344,11 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -10354,11 +10357,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -10366,35 +10366,35 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>HL:6,IS:7,Periphery.Deep:6,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -10407,11 +10407,11 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -10446,11 +10446,11 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5+</availability>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -10458,21 +10458,21 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='MS1-OU'>
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='MS1-OA'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
@@ -10528,14 +10528,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>RA.OA:8,HL:3,MERC:6,RA:5,Periphery:4</availability>
-		<model name='MLN-1C'>
-			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
-		</model>
 		<model name='MLN-1A'>
 			<availability>General:3-</availability>
 		</model>
 		<model name='MLN-1B'>
 			<availability>RA.OA:8,HL:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='MLN-1C'>
+			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -10544,6 +10544,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,ROS:6</availability>
+		</model>
+		<model name='(Gauss) &apos;Sandblaster&apos;'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
@@ -10555,25 +10560,20 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Gauss) &apos;Sandblaster&apos;'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CSA:6,CHH:8,CCC:8,CSL:8,RA:3</availability>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='P2'>
-			<availability>CHH:5</availability>
-		</model>
 		<model name='XP'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CSA:6,CHH:8,CCC:6,CSL:8</availability>
+		</model>
+		<model name='P2'>
+			<availability>CHH:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -10608,34 +10608,34 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:5,ROS:4,FS:3,MERC:3</availability>
-		<model name='MLR-BX'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='MLR-B2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MLR-BX'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -10658,15 +10658,15 @@
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
 		<availability>CC:4,MOC:4,OP:4,PR:4,DoO:4,DO:4,MERC:4,DTA:4,RF:4,PG:4,TP:4,DA:6,RCM:4,RFS:4</availability>
-		<model name='M2'>
-			<availability>General:6</availability>
-		</model>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
 			<availability>FWL:2,DA:4</availability>
+		</model>
+		<model name='M2'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>
@@ -10721,9 +10721,6 @@
 		<model name='(2776)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
 		<availability>ROS:4</availability>
@@ -10733,20 +10730,20 @@
 	</chassis>
 	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:4,LA:5,CWIE:4</availability>
-		<model name='MR-1S'>
-			<availability>General:8</availability>
-		</model>
-		<model name='MR-1SA'>
-			<roles>interceptor,ground_support</roles>
+		<model name='MR-1SB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MR-1SD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='MR-1SB'>
-			<availability>General:7</availability>
+		<model name='MR-1S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='MR-1SC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SA'>
+			<roles>interceptor,ground_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -10763,6 +10760,10 @@
 	</chassis>
 	<chassis name='Morrigan' unitType='Mek'>
 		<availability>CDS:1,ROS:1,CNC:3,DC:2</availability>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<roles>specops</roles>
 			<availability>IS:4</availability>
@@ -10770,10 +10771,6 @@
 		<model name='2'>
 			<roles>recon</roles>
 			<availability>CLAN:4,IS:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
@@ -10808,33 +10805,33 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>HL:8,IS:9,Periphery.Deep:8,Periphery:9</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>HL:3,General:6,Periphery.Deep:5,Periphery:5</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mountaineer' unitType='Infantry'>
@@ -10860,29 +10857,29 @@
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='(Armor)'>
-			<roles>spotter</roles>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Armor)'>
+			<roles>spotter</roles>
+			<availability>FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:5,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
-		<model name='Type 2'>
-			<availability>CC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>ROS:5,FS:4,MERC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='NL-45 Gunboat' unitType='Small Craft'>
@@ -10905,36 +10902,36 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,MERC.WD:4,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>ROS:4,MERC:4,DC:6</availability>
-		<model name='NG-C3A'>
-			<roles>fire_support,spotter</roles>
-			<availability>DC:8</availability>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+		<model name='NG-C3A'>
+			<roles>fire_support,spotter</roles>
+			<availability>DC:8</availability>
 		</model>
 		<model name='NG-C3B'>
 			<roles>spotter</roles>
@@ -10972,11 +10969,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -10988,11 +10985,17 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CSA:3,CCC:3,CJF:5</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:7,CLAN:5,IS:3</availability>
@@ -11000,28 +11003,22 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='F'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>RA.OA:3,FVC:3,CW:4,LA:5,ROS:4,CLAN:2,MERC:3,CGB:4</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Wolf' unitType='Mek'>
@@ -11055,6 +11052,9 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>ROS:6</availability>
@@ -11063,29 +11063,26 @@
 			<roles>apc</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>OP:5,PR:5,DoO:5,DO:5,FS:7,MERC:6,Periphery.R:2,RF:5,LA:8,ROS:6,PG:5,TP:5,RFS:5</availability>
-		<model name='NGS-4T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-4S'>
 			<availability>:0,OP:4,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,RF:4,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 		</model>
-		<model name='NGS-5T'>
-			<availability>OP:5,PR:5,RF:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
+		<model name='NGS-4T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6T'>
 			<availability>PR:6,RF:6,LA:6,ROS:6,PG:6,MERC:6,FS:6,RFS:6</availability>
 		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
+		<model name='NGS-5T'>
+			<availability>OP:5,PR:5,RF:5,LA:4,DoO:5,ROS:5,PG:5,DO:5,TP:5,FS:4,MERC:4,RFS:5</availability>
 		</model>
 		<model name='NGS-6S'>
 			<availability>LA:7,ROS:6,MERC:3</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -11093,11 +11090,11 @@
 		<model name='NSR-9FC'>
 			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
-		<model name='NSR-9SS'>
-			<availability>LA:4,MERC:2,FS:4</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9SS'>
+			<availability>LA:4,MERC:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nike Air Defense Platform' unitType='Tank'>
@@ -11111,11 +11108,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-4'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='NJT-3'>
 			<availability>General:2</availability>
+		</model>
+		<model name='NJT-4'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -11127,31 +11124,40 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>DC.LV:8,DC.SL:2,LA:3,CGB.FRR:4,ROS:5,MERC:3,DC:7,CGB:4</availability>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
-		</model>
-		<model name='NDA-2KC'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
+		<model name='NDA-2KO'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
+		<model name='NDA-2KC'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
+		</model>
 		<model name='NDA-1K'>
 			<availability>CGB.FRR:5,ROS:6,MERC:5,DC:5,CGB:4</availability>
 		</model>
-		<model name='NDA-2KO'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CCC:6,ROS:2+,CNC:8</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
+		</model>
+		<model name='N'>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -11160,18 +11166,9 @@
 			<roles>recon</roles>
 			<availability>CCC:1,General:4</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -11183,6 +11180,15 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CDS:6,ROS:4+,CNC:9,CLAN:3,CWIE:4</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -11191,36 +11197,24 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-	</chassis>
-	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
-		<availability>RA.OA:3,RA:4-</availability>
-		<model name='2 &apos;Numantia&apos;'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
 		<availability>RA.OA:6,RA:8-</availability>
+		<model name='2 &apos;Numantia&apos;'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
@@ -11228,10 +11222,6 @@
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>DTA:3,LA:3,ROS:5,MERC:3,FS:3,DC:4,CGB:3</availability>
-		<model name='NX-80C'>
-			<roles>recon</roles>
-			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -11244,46 +11234,50 @@
 			<roles>recon</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='NX-80C'>
+			<roles>recon</roles>
+			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='OBK-M12'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>DC:2</availability>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
+		<model name='OBK-M12'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ocelot' unitType='Mek'>
 		<availability>CDS:4,ROS:3,CNC:6,DC:3,CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CNC:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CNC:2,DC:2</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CNC:4</availability>
 		</model>
+		<model name='4'>
+			<availability>CNC:2,DC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
 		<availability>ROS:4,CLAN:5,CJF:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8,ROS:8,CLAN:8</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>recon,spotter</roles>
 			<availability>CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8,ROS:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Odyssey Jumpship' unitType='Jumpship'>
@@ -11322,53 +11316,53 @@
 	</chassis>
 	<chassis name='Oni' unitType='Aero'>
 		<availability>CGB.FRR:4,CNC:4,DC:5</availability>
-		<model name='ON-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ON-2'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='ON-1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:7,CC:5,HL:2,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4,DC:3</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:6,CNC:8,IS:6</availability>
+		<model name='HEAT'>
+			<availability>PR:2,RF:2,LA:2,ROS:2,PG:2,FS:2,RFS:2</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
+		<model name='(Fusion)'>
+			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:5,IS:5</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1</availability>
+		<model name='(MML)'>
+			<availability>MOC:5,IS:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,General:2,Periphery.Deep:8,Periphery:5</availability>
 		</model>
-		<model name='HEAT'>
-			<availability>PR:2,RF:2,LA:2,ROS:2,PG:2,FS:2,RFS:2</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:6,CNC:8,IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:6,CSL:5,CCO:4</availability>
+		<model name='3'>
+			<availability>CHH:4,CSL:4</availability>
+		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:4,CSL:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<availability>CHH:4,CSL:4</availability>
 		</model>
 	</chassis>
@@ -11380,42 +11374,42 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,CW:2,LA:1,CGB.FRR:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:4-,DC:4</availability>
-		<model name='ON1-MD'>
-			<availability>MOC:4,CC:4,PR:4,RF:4,ROS:4,PG:4,FWL:4,MSC:4,MERC:2,FS:2,RFS:4</availability>
-		</model>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2,MOC:2,OP:4,DoO:4,DO:4,MERC:2,ROS:4,FWL:4,MSC:4,TP:4,DA:4,RCM:4,DC:2</availability>
-		</model>
-		<model name='ON2-M'>
-			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3</availability>
-		</model>
-		<model name='ON1-V-DC'>
-			<availability>FWL:1-</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
-		</model>
-		<model name='ON1-V'>
-			<availability>IS:1-,MH:1-,CDP:1-,TC:1-</availability>
-		</model>
-		<model name='ON1-VA'>
-			<availability>IS:1-</availability>
-		</model>
-		<model name='ON1-M-DC'>
-			<availability>IS:5,DC:8</availability>
-		</model>
 		<model name='ON3-M'>
 			<roles>spotter</roles>
 			<availability>CC:4,FWL:4,MERC:4</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		</model>
+		<model name='ON1-MC'>
+			<availability>CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
+		</model>
+		<model name='ON1-V'>
+			<availability>IS:1-,MH:1-,CDP:1-,TC:1-</availability>
+		</model>
+		<model name='ON1-V-DC'>
+			<availability>FWL:1-</availability>
+		</model>
+		<model name='ON1-MB'>
+			<availability>CC:2,MOC:2,OP:4,DoO:4,DO:4,MERC:2,ROS:4,FWL:4,MSC:4,TP:4,DA:4,RCM:4,DC:2</availability>
+		</model>
 		<model name='ON1-K'>
 			<availability>General:2-,CLAN:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='ON1-M'>
+			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:4,CC:4,PR:4,RF:4,ROS:4,PG:4,FWL:4,MSC:4,MERC:2,FS:2,RFS:4</availability>
+		</model>
+		<model name='ON1-VA'>
+			<availability>IS:1-</availability>
+		</model>
+		<model name='ON2-M'>
+			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3</availability>
+		</model>
+		<model name='ON1-M-DC'>
+			<availability>IS:5,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -11436,14 +11430,14 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,ROS:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='OSR-5D'>
 			<availability>FS:5</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -11451,16 +11445,25 @@
 		<model name='OSP-26'>
 			<availability>CC:4,ROS:8</availability>
 		</model>
-		<model name='OSP-25'>
-			<availability>General:6</availability>
-		</model>
 		<model name='OSP-15'>
 			<roles>fire_support,urban</roles>
 			<availability>CC:2</availability>
 		</model>
+		<model name='OSP-25'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,LA:4,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,TC:4,Periphery:2,DC:5</availability>
+		<model name='OSR-3C'>
+			<availability>FVC:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
+		</model>
+		<model name='OSR-4K'>
+			<availability>ROS:4,MERC:3,DC:5</availability>
+		</model>
+		<model name='OSR-5C'>
+			<availability>TC:4</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
@@ -11468,15 +11471,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2,Periphery:2</availability>
-		</model>
-		<model name='OSR-5C'>
-			<availability>TC:4</availability>
-		</model>
-		<model name='OSR-4K'>
-			<availability>ROS:4,MERC:3,DC:5</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>FVC:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='OSR-2D'>
 			<availability>HL:2,ROS:6,IS:4,Periphery:4</availability>
@@ -11490,11 +11484,11 @@
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>RA:2,CGB:3</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
@@ -11505,9 +11499,9 @@
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,OP:4,PR:4,DoO:4,DO:4,FS:2,MERC:3,FVC:2,RF:4,LA:2,CGB.FRR:3,ROS:4,PG:4,NIOPS:3,FWL:2,TP:4,RFS:4,DC:3</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='OTT-7K'>
+			<roles>recon,spotter</roles>
+			<availability>FVC:8,IS:8,DC:8</availability>
 		</model>
 		<model name='OTT-7J'>
 			<roles>recon</roles>
@@ -11521,9 +11515,9 @@
 			<roles>recon,spotter</roles>
 			<availability>CC:3,OP:4,PR:4,DoO:4,DO:4,MERC:5,FS:3,RF:4,LA:7,ROS:5,PG:4,TP:4,RFS:4,DC:3</availability>
 		</model>
-		<model name='OTT-7K'>
-			<roles>recon,spotter</roles>
-			<availability>FVC:8,IS:8,DC:8</availability>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -11531,23 +11525,8 @@
 		<model name='OTL-7M'>
 			<availability>DTA:8,OP:8,DoO:8,ROS:6,FWL:6,DO:8,MSC:8,TP:8,MERC:4</availability>
 		</model>
-		<model name='OTL-5D'>
-			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:3,Periphery:3</availability>
-		</model>
 		<model name='OTL-9M'>
 			<availability>ROS:4,FWL:4</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:6,ROS:6,MERC:5</availability>
-		</model>
-		<model name='OTL-5M'>
-			<availability>FWL:4,MERC:4</availability>
-		</model>
-		<model name='OTL-8M'>
-			<availability>DTA:6,PR:6,RF:6,PG:6,MSC:6,MERC:3,RFS:6</availability>
 		</model>
 		<model name='OTL-8D'>
 			<availability>FS:6</availability>
@@ -11555,25 +11534,40 @@
 		<model name='OTL-4D'>
 			<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 		</model>
+		<model name='OTL-6D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-5M'>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
+		<model name='OTL-8M'>
+			<availability>DTA:6,PR:6,RF:6,PG:6,MSC:6,MERC:3,RFS:6</availability>
+		</model>
+		<model name='OTL-9R'>
+			<availability>DTA:6,ROS:6,MERC:5</availability>
+		</model>
+		<model name='OTL-5D'>
+			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:3,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>MOC:2-,PR:5,RF:5,LA:2-,PG:5,FWL:2,MERC:2-,RFS:5,DC:2-</availability>
-		<model name='OWR-2M'>
-			<availability>General:8,FWL:2-</availability>
-		</model>
 		<model name='OWR-3M'>
 			<availability>PR:8,RF:8,PG:8,RFS:8</availability>
+		</model>
+		<model name='OWR-2M'>
+			<availability>General:8,FWL:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:8,CW:4,CSL:6</availability>
-		<model name='(3063)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(3070)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:7</availability>
+		</model>
+		<model name='(3063)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
@@ -11589,41 +11583,37 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,HL:3,CLAN:8,IS:5,Periphery.Deep:4,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
-		<model name='A3A'>
-			<availability>LA:2,ROS:2,FS:2</availability>
-		</model>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:3,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:7,IS:3,FS:7</availability>
+		</model>
+		<model name='A3A'>
+			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 		<model name='A3'>
 			<roles>assault</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:3,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,FWL:4,FS:4,MERC:4,DC:6</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='OW-1C'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -11631,13 +11621,17 @@
 			<roles>recon,spotter</roles>
 			<availability>General:2,CLAN:6</availability>
 		</model>
-		<model name='OW-1A'>
+		<model name='OW-1E'>
 			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='OW-1F'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='PAB-28 Sniper Suit' unitType='BattleArmor'>
@@ -11655,17 +11649,17 @@
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CWIE:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CSA:2,CHH:2,CCC:2,CDS:4,CNC:2,CCO:2,CWIE:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CDS:5,CWIE:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CWIE:4</availability>
@@ -11673,16 +11667,12 @@
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CDS:5,CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:2-,CC:3-,HL:2-,IS:3-,Periphery.Deep:4,FS:5-,FS.CrMM:6-,Periphery:3-,TC:3-,RA.OA:3-,FVC:6-,LA:5-,FS.PMM:6-,CGB.FRR:3-,FS.CMM:6-,FS.DMM:6-,FWL:3-,NIOPS:6,DC:3-</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -11691,13 +11681,17 @@
 			<roles>recon,raider</roles>
 			<availability>CC:2,CGB.FRR:2,PIR:2,General:2,FWL:2,Periphery.Deep:6,MERC:2,FS:2,Periphery:3,DC:2</availability>
 		</model>
-		<model name='&apos;Gespenst&apos;'>
-			<roles>recon,specops</roles>
-			<availability>LA:2</availability>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
 			<availability>FWL.pm:4,RF.pm:4,MSC.pm:4,DA:3-,RCM.pm:4</availability>
+		</model>
+		<model name='&apos;Gespenst&apos;'>
+			<roles>recon,specops</roles>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -11709,17 +11703,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:3</availability>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>OP:3,LA:3,DoO:3,ROS:3,DO:3,TP:3,FS:3,DC:3</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>OP:3,LA:3,DoO:3,ROS:3,DO:3,TP:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pandarus' unitType='Mek'>
@@ -11745,68 +11739,64 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:4,HL:2,MERC:4,FS:1,Periphery.OS:5,Periphery:3,RA:1,CGB.FRR:6,ROS:4,FS.DMM:4,CNC:1,NIOPS:2,DC:8,CGB:1</availability>
-		<model name='PNT-16K'>
-			<roles>fire_support</roles>
-			<availability>DC:6</availability>
-		</model>
 		<model name='PNT-10KA'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:2,CGB.FRR:2,PIR:2,CNC:8,FS.DMM:2,MERC:2,DC:2,TC:2</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,FVC:3,CGB.FRR:5,PIR:3,CNC:4,FS.DMM:3,MERC:3,DC:4,TC:3</availability>
-		</model>
-		<model name='PNT-10K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:2,CGB.FRR:2,ROS:2,FS.DMM:2,MERC:2,RA:2,DC:3,TC:2,CGB:0</availability>
-		</model>
-		<model name='PNT-CA'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:1,FS.DMM:1,MERC:1,DC:1</availability>
-		</model>
-		<model name='PNT-13K'>
-			<roles>fire_support</roles>
-			<availability>CGB.FRR:4,DC:5,CGB:1</availability>
 		</model>
 		<model name='PNT-12A'>
 			<roles>fire_support</roles>
 			<availability>ROS:3,DC:3</availability>
 		</model>
-		<model name='PNT-C'>
+		<model name='PNT-12K2'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:2,CGB.FRR:2,FS.DMM:2,MERC:2,DC:2</availability>
+			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4,CGB:1</availability>
 		</model>
-		<model name='PNT-9R'>
+		<model name='PNT-CA'>
 			<roles>fire_support</roles>
-			<availability>IS:2-,Periphery.Deep:8,MERC:2-,Periphery:3-,DC:2-</availability>
+			<availability>FS.RR:1,FS.DMM:1,MERC:1,DC:1</availability>
+		</model>
+		<model name='PNT-10K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:2,CGB.FRR:2,ROS:2,FS.DMM:2,MERC:2,RA:2,DC:3,TC:2,CGB:0</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,FVC:3,CGB.FRR:5,PIR:3,CNC:4,FS.DMM:3,MERC:3,DC:4,TC:3</availability>
 		</model>
 		<model name='PNT-12K'>
 			<roles>fire_support</roles>
 			<availability>FS.RR:4,CGB.FRR:4,FS.DMM:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='PNT-12K2'>
+		<model name='PNT-16K'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:4,ROS:4,FS.DMM:4,MERC:4,DC:4,CGB:1</availability>
+			<availability>DC:6</availability>
+		</model>
+		<model name='PNT-9R'>
+			<roles>fire_support</roles>
+			<availability>IS:2-,Periphery.Deep:8,MERC:2-,Periphery:3-,DC:2-</availability>
+		</model>
+		<model name='PNT-13K'>
+			<roles>fire_support</roles>
+			<availability>CGB.FRR:4,DC:5,CGB:1</availability>
+		</model>
+		<model name='PNT-C'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,CGB.FRR:2,FS.DMM:2,MERC:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
 		<availability>FWL:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MFB)'>
 			<roles>support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Parash' unitType='Mek'>
 		<availability>CHH:6</availability>
-		<model name='3'>
-			<roles>recon,spotter</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
@@ -11815,23 +11805,27 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='3'>
+			<roles>recon,spotter</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,HL:4,LA:7,CGB.FRR:4,CNC:5,IS:5,FS:8,DC:6,Periphery:5,CWIE:5</availability>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:5,FS:5</availability>
-		</model>
 		<model name='(Quad RAC)'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:5,FS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>HL:2,IS:4,Periphery:4</availability>
 		</model>
-		<model name='(Company Command)'>
+		<model name='(Lance Command)'>
 			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:2,FS:2</availability>
+			<availability>ROS:5,FS:5</availability>
 		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
@@ -11840,31 +11834,31 @@
 		<model name='(Cell)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>ROS:2,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:3-,CC:1-,HL:2-,IS:2-,Periphery.Deep:9,FS:3-,Periphery:3-,TC:3-,RA.OA:2-,CDS:1,LA:2-,FWL:2-,DC:1-</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:2-,Periphery:2-</availability>
-		</model>
-		<model name='(C3)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:2-,Periphery:2-</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:1-,Periphery:3-</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -11906,11 +11900,11 @@
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
 		<availability>FVC:5,PR:5,RF:5,LA:6,CGB.FRR:4,ROS:5,PG:5,FS:5,MERC:4,RFS:5,CWIE:5</availability>
-		<model name='(Standard)'>
-			<availability>HL:2,IS:2-,Periphery:4</availability>
-		</model>
 		<model name='(Ultra)'>
 			<availability>LA:8,General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>HL:2,IS:2-,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Peacekeeper' unitType='Mek'>
@@ -11924,13 +11918,21 @@
 	</chassis>
 	<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
 		<availability>MOC:1,RA.OA:1,LA:6,ROS:6,FWL:1,Periphery.Deep:8,FS:6,Periphery:1,TC:1,DC:6</availability>
+		<model name='(C3)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:4,FS:4,DC:8</availability>
+		</model>
 		<model name='(Unarmed)'>
 			<roles>recon</roles>
 			<availability>FVC:1</availability>
 		</model>
-		<model name='(C3)'>
+		<model name='(MRM)'>
+			<roles>recon</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='(Sealed)'>
 			<roles>recon,spotter</roles>
-			<availability>LA:4,FS:4,DC:8</availability>
+			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
 		<model name='X-Pulse'>
 			<roles>recon</roles>
@@ -11944,14 +11946,6 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:6,FS:8,DC:7</availability>
 		</model>
-		<model name='(MRM)'>
-			<roles>recon</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Sealed)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Pendragon' unitType='Mek'>
 		<availability>FS:4</availability>
@@ -11962,20 +11956,20 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='PTR-6T'>
-			<availability>FS.DBG:8,FS:4</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-6T'>
+			<availability>FS.DBG:8,FS:4</availability>
+		</model>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Penthesilea' unitType='Mek'>
@@ -12005,31 +11999,31 @@
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,OP:6,DoO:6,ROS:4,FWL:5,DO:6,MSC:6,TP:6</availability>
-		<model name='P1E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='P1D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1'>
-			<availability>General:8</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='P1B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1W'>
 			<availability>General:2</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -12046,101 +12040,100 @@
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,FWL:5,IS:3,FS:4,MERC:4,DC:4</availability>
+		<model name='(Prototype)'>
+			<availability>OP:1,LA:2</availability>
+		</model>
 		<model name='(Production)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Prototype)'>
-			<availability>OP:1,LA:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CCC:6,CW:8,CSL:7,CCO:4,CJF:7,RA:6,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>CSA:7,General:8,CCO:9,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CSA:7,General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CLAN:4,General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>CSA:5,General:5,CCO:4,CGB:4</availability>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>CSA:7,General:8,CCO:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CSA:6,General:6,CCO:7,CGB:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CCO:6</availability>
-		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='C'>
+			<availability>CSA:5,CDS:4,CNC:6,General:5,CCO:4,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CC:3,CCC:5,CLAN:3,MERC:3,FS:3,CCO:5,RA:5,CSA:3,DTA:3,CDS:5,RF:3,LA:3,ROS:4,MSC:3,DC:3</availability>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>DTA:3,CDS:7,RF:3,LA:3,ROS:3,MSC:3,FS:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:3,CNC:3,IS:2,CCO:2,DC:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:6,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
-		</model>
-		<model name='6'>
-			<availability>CDS:6,CGB:6</availability>
 		</model>
 		<model name='7'>
 			<availability>CDS:5,General:4,CGB:6,DC:4</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:4</availability>
+		<model name='4'>
+			<availability>CDS:6,LA:3,ROS:3,FS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='3'>
+			<availability>DTA:3,CDS:7,RF:3,LA:3,ROS:3,MSC:3,FS:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='6'>
+			<availability>CDS:6,CGB:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CCC:2,CDS:2,CNC:2,CCO:2,RA:4</availability>
 		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
-        <availability>IS:2</availability>
-        <model name='PHX-HK1'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK1R'>
-            <availability>IS:2</availability>
-        </model>
-    </chassis>
-    <chassis name='Phoenix Hawk LAM' unitType='Mek'>
-        <availability>IS:3</availability>
-        <model name='PHX-HK2'>
-            <availability>IS:4</availability>
-        </model>
-        <model name='PHX-HK2M'>
-            <availability>IS:2,FWL:4</availability>
-        </model>
-    </chassis>
+		<availability>IS:2</availability>
+		<model name='PHX-HK1'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK1R'>
+			<availability>IS:2</availability>
+		</model>
+	</chassis>
+	<chassis name='Phoenix Hawk LAM' unitType='Mek'>
+		<availability>IS:3</availability>
+		<model name='PHX-HK2'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='PHX-HK2M'>
+			<availability>IS:2,FWL:4</availability>
+		</model>
+	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>HL:5,IS:8,FWL:9,NIOPS:5,Periphery.Deep:4,Periphery:6,CGB:3</availability>
-		<model name='PXH-6D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CC:3,OP:4,DoO:4,CLAN:3,FWL:4,DO:4,MSC:5,TP:4,MERC:3,DA:4,RCM:4</availability>
+		<model name='PXH-7K'>
+			<availability>OP:4,DoO:4,DO:4,TP:4,DC:4</availability>
 		</model>
 		<model name='PXH-7S'>
 			<availability>PR:3,RF:3,LA:6,ROS:4,PG:3,MERC:5,RFS:3</availability>
+		</model>
+		<model name='PXH-4W'>
+			<availability>MOC:4,TC:4</availability>
 		</model>
 		<model name='PXH-4L'>
 			<availability>CC:7,MOC:4,MH:4,DA:4,TC:4</availability>
@@ -12149,48 +12142,49 @@
 			<roles>recon</roles>
 			<availability>FVC:2-,PIR:2-,FS:2-,MERC:2-</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,FS:6,MERC:4</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>General:2-,BAN:6,Periphery:2-</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>ROS:2,CGB.FRR:4,CGB:1,DC:2</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
 		<model name='PXH-5L'>
 			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>OP:8,PR:8,DoO:8,IS:4,DO:8,DTA:8,RF:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
-		</model>
-		<model name='PXH-1K'>
-			<roles>recon</roles>
-			<availability>DC:1-</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>CGB.FRR:8,DC:8,CGB:1</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:5,FWL:4,MSC:6,BAN:1</availability>
 		</model>
+		<model name='PXH-1K'>
+			<roles>recon</roles>
+			<availability>DC:1-</availability>
+		</model>
+		<model name='PXH-6D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>CGB.FRR:8,DC:8,CGB:1</availability>
+		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:5,MERC:4</availability>
 		</model>
-		<model name='PXH-7K'>
-			<availability>OP:4,DoO:4,DO:4,TP:4,DC:4</availability>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>OP:8,PR:8,DoO:8,IS:4,DO:8,DTA:8,RF:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:4,TC:4</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,FS:6,MERC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>ROS:2,CGB.FRR:4,CGB:1,DC:2</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>General:2-,BAN:6,Periphery:2-</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CC:3,OP:4,DoO:4,CLAN:3,FWL:4,DO:4,MSC:5,TP:4,MERC:3,DA:4,RCM:4</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -12204,17 +12198,17 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>MOC:2,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,FS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-,DC:2-</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>CC:8,MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>HL:2,IS:2,Periphery:4</availability>
 		</model>
 		<model name='(RAC) &apos;Assault Pike&apos;'>
 			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
 		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
+		<model name='(Standard)'>
+			<availability>HL:2,IS:2,Periphery:4</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -12222,6 +12216,9 @@
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,MOC:3,MERC.WD:4,MERC.KH:4,ROS:4,CNC:6,NIOPS:4,MERC:4</availability>
+		<model name='PLG-5Z'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
@@ -12232,19 +12229,16 @@
 		<model name='PLG-3Z'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PLG-5Z'>
-			<availability>CC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,ROS:5,FS:7,MERC:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -12267,9 +12261,6 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:5,CDS:4,RA:3,CWIE:3</availability>
-		<model name='2'>
-			<availability>CHH:6,CDS:6</availability>
-		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4</availability>
@@ -12279,6 +12270,9 @@
 		</model>
 		<model name='3'>
 			<availability>CDS:6,RA:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:6,CDS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -12296,9 +12290,6 @@
 	</chassis>
 	<chassis name='Plainsman Medium Hovertank' unitType='Tank'>
 		<availability>MERC.WD:3,HL:2,LA:5,CGB.FRR:6,FWL:4,IS:3,TC:8,Periphery:3,CGB:3</availability>
-		<model name='(Sealed)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>HL:2,IS:6,TC:6,Periphery:4</availability>
 		</model>
@@ -12308,6 +12299,9 @@
 		</model>
 		<model name='(Standard)'>
 			<availability>HL:3,IS:5,Periphery:5</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
@@ -12352,67 +12346,67 @@
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
 		<availability>CC:6,MOC:4,DA:4</availability>
-		<model name='(Stealth)'>
-			<availability>CC:3,MOC:3</availability>
-		</model>
 		<model name='(Gauss)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CC:6,MOC:6</availability>
+		<model name='(Stealth)'>
+			<availability>CC:3,MOC:3</availability>
 		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>MOC:4,CC:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CC:6,MOC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Poignard' unitType='Aero'>
 		<availability>DTA:4,ROS:4,FWL:4,MSC:5,RCM:4,MERC:3</availability>
-		<model name='PGD-R3'>
-			<roles>ground_support</roles>
+		<model name='PGD-L3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='PGD-Y3'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PGD-L3'>
+		<model name='PGD-R3'>
+			<roles>ground_support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CSA:1,CHH:1,CCC:2,CDS:5,NIOPS:1,CCO:2,RA:5,CWIE:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CSA:6,CHH:4,CCC:4,CW:8,CNC:4,CSL:4,CCO:6,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>CDS:6,General:8,CJF:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CSA:3,General:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CDS:6,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CSA:3,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:3,General:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
@@ -12439,10 +12433,16 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:6,CSL:6,CCO:6</availability>
-		<model name='3'>
-			<availability>CCO:4</availability>
+		<model name='(Quad)'>
+			<availability>CHH:5+</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:1,CCO:1</availability>
 		</model>
 		<model name='4'>
+			<availability>CCO:4</availability>
+		</model>
+		<model name='3'>
 			<availability>CCO:4</availability>
 		</model>
 		<model name='(Standard)'>
@@ -12450,12 +12450,6 @@
 		</model>
 		<model name='5'>
 			<availability>CCO:4</availability>
-		</model>
-		<model name='(Quad)'>
-			<availability>CHH:5+</availability>
-		</model>
-		<model name='2'>
-			<availability>CHH:1,CCO:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -12466,7 +12460,7 @@
 		</model>
 	</chassis>
 	<chassis name='Protector Combat Support Fighter' unitType='Conventional Fighter'>
-		<availability>MOC:5,FS:2,Periphery:4,DC:2,OA.RA:5</availability>
+		<availability>MOC:5,OA.RA:5,FS:2,Periphery:4,DC:2</availability>
 		<model name='ASF-23'>
 			<availability>General:6</availability>
 		</model>
@@ -12477,17 +12471,9 @@
 			<roles>apc</roles>
 			<availability>IS:2,Periphery:2</availability>
 		</model>
-		<model name='(RAF)'>
-			<roles>apc</roles>
-			<availability>ROS:6</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>IS:2,Periphery:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
@@ -12497,9 +12483,24 @@
 			<roles>support</roles>
 			<availability>IS:4,Periphery:4,CGB:4,RA:4</availability>
 		</model>
+		<model name='(RAF)'>
+			<roles>apc</roles>
+			<availability>ROS:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:7,MERC:2+,CCO:6,RA:7,BAN:6,CWIE:8,CSA:8,MERC.WD:5,CDS:8,CW:8,ROS:3+,CNC:8,CJF:5,CGB:6</availability>
+		<model name='H'>
+			<availability>CHH:6,CCC:5,CW:6,CLAN:4,General:3,CJF:6</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
 		<model name='D'>
 			<availability>CSA:6,CDS:5,CW:5,General:4,CGB:3</availability>
 		</model>
@@ -12507,25 +12508,18 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,CDS:7,CW:6,CNC:4,General:5,CCO:6,CJF:6,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:6,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CSA:5,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,CDS:6,CW:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CHH:6,CCC:5,CW:6,CLAN:4,General:3,CJF:6</availability>
+		<model name='E'>
+			<availability>CSA:5,CDS:5,CW:5,CLAN:4,General:3,CCO:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -12542,15 +12536,15 @@
 	</chassis>
 	<chassis name='Purifier Adaptive Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:5</availability>
-		<model name='[Laser] (RAF)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[PPC] (RAF)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[TAG] (RAF)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='[PPC] (RAF)' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (RAF)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
@@ -12577,40 +12571,40 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>PR:6,HL:3,DoO:6,Periphery.Deep:4,DO:6,FS:4,CDP:3,RA.OA:3,CGB.FRR:7,FWL:6,NIOPS:3-,MSC:6,RFS:6,CGB:1,MOC:3,CC:4,OP:6,IS:3,Periphery:4,TC:3,DTA:6,FVC:3,RF:6,LA:3,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
-		<model name='QKD-4H'>
-			<availability>General:2-</availability>
+		<model name='QKD-5K2'>
+			<availability>MERC:1,DC:1</availability>
+		</model>
+		<model name='QKD-5K'>
+			<availability>CGB.FRR:4,MERC:5,DC:5</availability>
 		</model>
 		<model name='QKD-5A'>
 			<availability>MERC:2-,DC:2-,Periphery:2-</availability>
-		</model>
-		<model name='QKD-8K'>
-			<availability>CGB.FRR:5,ROS:5,MERC:4,DC:8,CGB:1</availability>
 		</model>
 		<model name='QKD-8P'>
 			<roles>spotter</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>CGB.FRR:4,MERC:5,DC:5</availability>
-		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:5,FWL:7</availability>
-		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:7,FVC:7,Periphery.CM:7,Periphery.ME:7,FWL:8,IS:7,MH:7,TC:7,Periphery:3</availability>
-		</model>
-		<model name='QKD-5K2'>
-			<availability>MERC:1,DC:1</availability>
-		</model>
 		<model name='QKD-9M'>
 			<roles>spotter</roles>
 			<availability>CC:3,MOC:3,ROS:2,DA:3,FS:2</availability>
 		</model>
-		<model name='QKD-4G'>
-			<availability>MOC:3-,Periphery.Deep:8,FWL:2-,IS:2-,Periphery:3-,DC:2-,TC:3-</availability>
+		<model name='QKD-8K'>
+			<availability>CGB.FRR:5,ROS:5,MERC:4,DC:8,CGB:1</availability>
 		</model>
 		<model name='QKD-C'>
 			<availability>CGB.FRR:8,MERC:6,DC:8</availability>
+		</model>
+		<model name='QKD-4G'>
+			<availability>MOC:3-,Periphery.Deep:8,FWL:2-,IS:2-,Periphery:3-,DC:2-,TC:3-</availability>
+		</model>
+		<model name='QKD-4H'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:7,FVC:7,Periphery.CM:7,Periphery.ME:7,FWL:8,IS:7,MH:7,TC:7,Periphery:3</availability>
+		</model>
+		<model name='QKD-5Mr'>
+			<availability>General:5,FWL:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Quirinus Battle Armor' unitType='BattleArmor'>
@@ -12648,39 +12642,39 @@
 	</chassis>
 	<chassis name='Rabid Coyote' unitType='Mek'>
 		<availability>CCC:3,CW:4,CCO:5-</availability>
-		<model name='2'>
-			<availability>CW:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CCC:8,CCO:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:7</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:3,ROS:3,MERC:3,FS:4</availability>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='MDG-1Ar'>
 			<availability>ROS:8,FS:4,MERC:4</availability>
@@ -12688,23 +12682,19 @@
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>FVC:5,LA:4,ROS:5,ROS.pm:7,FWL:4,MH:6,MERC:6,FS:4,CDP:5,DC:4</availability>
-		<model name='VV1'>
+		<model name='VV1 (MG)'>
 			<roles>urban</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VV1 (Interdictor)'>
 			<roles>urban</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='VV2'>
 			<roles>urban</roles>
@@ -12714,17 +12704,21 @@
 			<roles>urban</roles>
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
+		<model name='VV1'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:5,ROS:5,CLAN:2,NIOPS:6</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='RPR-100'>
+			<availability>General:3,NIOPS:8</availability>
 		</model>
 		<model name='RPR-300S'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>General:3,NIOPS:8</availability>
+		<model name='RPR-100b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='RPR-300'>
 			<availability>LA:6,ROS:6,MERC:3</availability>
@@ -12732,6 +12726,10 @@
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
 		<availability>ROS:4</availability>
+		<model name='RPT-2X'>
+			<roles>specops</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='RPT-5X'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
@@ -12744,24 +12742,32 @@
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='RPT-2X'>
-			<roles>specops</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>FS:4,DC:6</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='RTX1-OU'>
-			<availability>General:2</availability>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
@@ -12769,18 +12775,6 @@
 		<model name='RTX1-OD'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
@@ -12794,40 +12788,40 @@
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:7,MOC:3,FWL:3,MERC:6,DA:3,TC:3</availability>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:5,MOC:3</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:3,MOC:2,FWL:1,MERC:2,DC:2,TC:2</availability>
-		</model>
 		<model name='RVN-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:2,MOC:3,FWL:3,MERC:3,TC:3</availability>
 		</model>
-		<model name='RVN-4L'>
+		<model name='RVN-4Lr'>
 			<roles>spotter</roles>
-			<availability>CC:6,MOC:6,DA:6,TC:6</availability>
+			<availability>CC:5,MOC:3</availability>
 		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
 		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:3,MOC:2,FWL:1,MERC:2,DC:2,TC:2</availability>
+		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6,DA:6,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>OP:4,PR:4,DoO:4,DO:4,MERC:4,FS:4,RF:4,LA:6,ROS:4,CGB.FRR:5,PG:4,MH:4,TP:4,DA:4,RFS:4</availability>
-		<model name='RZK-9S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RZK-10T'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='RZK-10S'>
-			<availability>LA:4</availability>
+		<model name='RZK-9S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Recon Infantry' unitType='Infantry'>
@@ -12855,99 +12849,113 @@
 		<model name='(Stealth)'>
 			<availability>CC:6</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>ROS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,HL:9,CLAN:4,Periphery.Deep:9,IS:5,FS:6,MERC:7,Periphery:10,TC:7,RA.OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:1,CW:1,General:8,CNC:1</availability>
 		</model>
-		<model name='(ML)'>
+		<model name='(MG)'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(ML)'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>HL:4,IS:6,Periphery.Deep:5,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>PR:7,DoO:8,DO:8,FS:2,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:8,RFS:7,MOC:2,CC:2,OP:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,RF:7,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
+		<model name='F-700a'>
+			<availability>CC:7,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:5,MERC:7,DTA:6,RF:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
+		</model>
+		<model name='F-100b'>
+			<availability>CGB.FRR:1-,DC:1-</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>FVC:3-,FWL:2-,MERC:2-,Periphery:3-</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:8,MOC:3,OP:8,PR:8,DoO:8,DO:8,MERC:8,DTA:8,RF:8,ROS:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 		</model>
-		<model name='F-100b'>
-			<availability>CGB.FRR:1-,DC:1-</availability>
+		<model name='F-700b'>
+			<availability>MOC:3,CC:3,DTA:8,OP:8,DoO:8,ROS:6,FWL:6,DO:8,MSC:8,TP:8,MERC:6,DC:6</availability>
 		</model>
 		<model name='F-100'>
 			<availability>FVC:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
 		</model>
-		<model name='F-700a'>
-			<availability>CC:7,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:5,MERC:7,DTA:6,RF:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
-		</model>
-		<model name='F-700b'>
-			<availability>MOC:3,CC:3,DTA:8,OP:8,DoO:8,ROS:6,FWL:6,DO:8,MSC:8,TP:8,MERC:6,DC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CSA:5,CHH:5,CDS:5,CNC:5,IS:3,RA:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CNC:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CSA:6,CHH:4,CDS:4</availability>
-		</model>
 		<model name='8'>
 			<availability>CC:3,OP:3,DoO:3,IS:3,DO:3,FS:3,MERC:3,CDS:4,LA:3,MSC:3,TP:3,DC:3,CGB:6</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:5,CCC:6,CDS:4,ROS:4,MERC:4,FS:4</availability>
-		</model>
-		<model name='7'>
-			<availability>ROS:4,CNC:6,DC:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:2,CNC:2,CLAN:1,RA:2</availability>
 		</model>
 		<model name='5'>
 			<availability>CSA:6,CDS:4,IS:4,CLAN.HW:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:2,CNC:2,CLAN:1,RA:2</availability>
+		</model>
+		<model name='7'>
+			<availability>ROS:4,CNC:6,DC:5</availability>
+		</model>
 		<model name='4'>
 			<availability>CSA:6,CCC:5,ROS:4,FS:4</availability>
+		</model>
+		<model name='6'>
+			<availability>CSA:6,CHH:4,CDS:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CSA:5,CCC:6,CDS:4,ROS:4,MERC:4,FS:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:5,CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
+		<model name='RFL-7M'>
+			<availability>MOC:3,OP:7,PR:7,DoO:7,IS:3,DO:7,CDP:3,TC:3,DTA:7,RF:7,CGB.FRR:5,PG:7,FWL:7,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
+		</model>
+		<model name='RFL-4D'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>FVC:1-,FS:1-</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='RFL-5D'>
+			<availability>FVC:4,LA:3,FS:3,MERC:4</availability>
+		</model>
+		<model name='RFL-3Cr'>
+			<availability>FS:2</availability>
+		</model>
 		<model name='RFL-1N'>
 			<roles>fire_support</roles>
 			<availability>CC:2-,MOC:2-,OP:2-,DoO:2-,PIR:2-,MH:2-,DO:2-,TP:2-,FS:2-,DA:2-,RCM:2-</availability>
 		</model>
-		<model name='RFL-7M'>
-			<availability>MOC:3,OP:7,PR:7,DoO:7,IS:3,DO:7,CDP:3,TC:3,DTA:7,RF:7,CGB.FRR:5,PG:7,FWL:7,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:4,LA:3,FS:3,MERC:4</availability>
+		<model name='C 2'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='RFL-8D'>
 			<availability>FS:4</availability>
@@ -12958,79 +12966,69 @@
 		<model name='RFL-8X'>
 			<availability>ROS:4,MERC:4</availability>
 		</model>
+		<model name='RFL-6X'>
+			<availability>FVC:2,FS:2,MERC:2</availability>
+		</model>
 		<model name='RFL-7X'>
 			<roles>fire_support</roles>
 			<availability>ROS:4,MERC:4</availability>
 		</model>
-		<model name='C 2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='RFL-5M'>
 			<availability>CC:3,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:3,MH:3,MERC:3,DC:3</availability>
-		</model>
-		<model name='RFL-3Cr'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RFL-4D'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>FVC:1-,FS:1-</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:2,FS:2,MERC:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,FVC:4,LA:5,CGB.FRR:5,ROS:6,CLAN:2,NIOPS:6,FS:5,DC:5</availability>
-		<model name='(SPL)'>
-			<roles>apc</roles>
-			<availability>FVC:4,IS:4</availability>
-		</model>
-		<model name='(ERML)'>
-			<roles>apc</roles>
-			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
-		</model>
-		<model name='(Light PPC)'>
-			<roles>apc</roles>
-			<availability>CNC:3,FS:3,DC:5</availability>
-		</model>
-		<model name='(Infantry)'>
-			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8,BAN:2</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc</roles>
-			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
 		<model name='(Royal)'>
 			<roles>apc</roles>
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>apc</roles>
+			<availability>CNC:3,FS:3,DC:5</availability>
+		</model>
+		<model name='(ERML)'>
+			<roles>apc</roles>
+			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc</roles>
+			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
+		</model>
+		<model name='(Infantry)'>
+			<roles>apc</roles>
+			<availability>LA:5,ROS:4,FS:3</availability>
+		</model>
+		<model name='(SPL)'>
+			<roles>apc</roles>
+			<availability>FVC:4,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CCC:4,CHH:4,CNC:7,CSL:4,CCO:8,RA:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>CCC:6,CNC:6,CSL:6,CCO:8,RA:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CNC:4,CCO:4,RA:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CCO:4,RA:6</availability>
 		</model>
-		<model name='2'>
-			<availability>CCC:6,CNC:6,CSL:6,CCO:8,RA:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>CGB:6-</availability>
+		<model name='HR' mechanized='true'>
+			<roles>recon</roles>
+			<availability>CGB:1</availability>
+		</model>
 		<model name='(Hybrid)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
@@ -13038,25 +13036,21 @@
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HR' mechanized='true'>
-			<roles>recon</roles>
-			<availability>CGB:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>PR:4,FS:4,MERC:2,CWIE:6,TC:6,RA.OA:5,FVC:4,RF:4,LA:6,CGB.FRR:4,ROS:4,PG:4,RFS:4</availability>
+		<model name='(Gauss)'>
+			<availability>FRR:0,General:8</availability>
+		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>FRR:0,General:8</availability>
+		<model name='(Standard)'>
+			<availability>RF:0,ROS:0,General:2,TC:0,CWIE:0</availability>
 		</model>
 		<model name='(Howitzer) Production'>
 			<roles>artillery,fire_support</roles>
 			<availability>LA:3,CWIE:3</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>RF:0,ROS:0,General:2,TC:0,CWIE:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Rondel' unitType='Aero'>
@@ -13070,14 +13064,14 @@
 		<model name='NH-3X'>
 			<availability>FS:4</availability>
 		</model>
+		<model name='NH-2'>
+			<availability>General:8</availability>
+		</model>
 		<model name='NH-1X &apos;Rook-X&apos;'>
 			<availability>FS:2-</availability>
 		</model>
 		<model name='NH-1A'>
 			<availability>General:2-</availability>
-		</model>
-		<model name='NH-2'>
-			<availability>General:8</availability>
 		</model>
 		<model name='NH-1B'>
 			<availability>ROS:4-,MERC:4-,FS:4-</availability>
@@ -13096,16 +13090,16 @@
 			<roles>urban</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='(Firedrake)' mechanized='false'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>LA:5</availability>
 		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>LA:7</availability>
+		</model>
+		<model name='(Firedrake)' mechanized='false'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -13118,47 +13112,47 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,MERC.WD:6,CDS:5,CLAN:5,MERC:3+,CJF:5,RA:6,BAN:6,CWIE:6,DC:4+</availability>
-		<model name='G'>
-			<availability>CHH:5,General:3</availability>
+		<model name='D'>
+			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<availability>CCC:6,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
 		</model>
+		<model name='A'>
+			<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
+		</model>
 		<model name='H'>
 			<availability>CSA:5,CCC:5,CLAN:3,General:2</availability>
-		</model>
-		<model name='I'>
-			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CDS:5,CW:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
+		<model name='F'>
+			<availability>General:3,CJF:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
+		<model name='I'>
+			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CDS:6,CNC:4,General:5,CCO:7,CJF:4,RA:6,CWIE:6</availability>
 		</model>
-		<model name='F'>
-			<availability>General:3,CJF:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5,RA:6,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ryoken II' unitType='Mek'>
 		<availability>CHH:3,CDS:3,ROS:2,IS:2,CGB:4</availability>
-		<model name='2'>
-			<availability>ROS:6,CGB:6</availability>
+		<model name='3'>
+			<availability>CHH:8,ROS:4,CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CDS:8,IS:8,CGB:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CHH:8,ROS:4,CGB:4</availability>
+		<model name='2'>
+			<availability>ROS:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
@@ -13199,13 +13193,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,DC:6,Periphery:6</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,DC:8,Periphery:4</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -13222,33 +13216,27 @@
 		<model name='SB-29'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='SB-31D'>
-			<roles>escort</roles>
-			<availability>DC:5</availability>
+		<model name='SB-28'>
+			<availability>LA:8,ROS:5,NIOPS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:6</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>LA:8,ROS:5,NIOPS:6,FS:6,MERC:6</availability>
+		<model name='SB-31D'>
+			<roles>escort</roles>
+			<availability>DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
+		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='X'>
-			<availability>General:1,CJF:3,RA:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -13257,14 +13245,20 @@
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='X'>
+			<availability>General:1,CJF:3,RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
 		<availability>FVC:5,ROS:4,FS:6,MERC:4</availability>
-		<model name='SGT-10X'>
-			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='SGT-8R'>
 			<availability>FVC:8,FS:6</availability>
+		</model>
+		<model name='SGT-10X'>
+			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='SGT-9D'>
 			<roles>spotter</roles>
@@ -13282,8 +13276,8 @@
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CDS:4,CW:4,CGB.FRR:6,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
-		<model name='S-7'>
-			<availability>ROS:6,CNC:6,DC:6</availability>
+		<model name='S-4C'>
+			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
 		<model name='S-3'>
 			<availability>DC:1-</availability>
@@ -13294,43 +13288,51 @@
 		<model name='S-4'>
 			<availability>CGB.FRR:6,ROS:6,FS:5,DC:6</availability>
 		</model>
-		<model name='S-4C'>
-			<availability>ROS:4,CLAN:8,DC:4</availability>
+		<model name='S-7'>
+			<availability>ROS:6,CNC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:5,Periphery.DD:3,DC.AL:9,IS:5,MERC:5,Periphery.OS:3,FS:4,Periphery:2,RA.OA:2,LA:5,CGB.FRR:6,FWL:5,CJF:4,DC:8</availability>
-		<model name='(Armor)'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
-		<model name='(Ultra)'>
-			<availability>IS:8,DC:8</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
+		<model name='(LB-X)'>
+			<availability>IS:6,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:4-,Periphery:4-</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>IS:6,DC:8</availability>
+		<model name='(Armor)'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>anti_infantry</roles>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='(Laser)' mechanized='true'>
 			<availability>CW:6,RA:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>anti_infantry</roles>
+			<availability>CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:7,ROS:4,FS:5,MERC:5</availability>
+		<model name='PPR-5T'>
+			<roles>fire_support</roles>
+			<availability>LA:5,MERC:3,FS:3</availability>
+		</model>
+		<model name='PPR-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
+		</model>
 		<model name='PPR-6T'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4,FS:4</availability>
@@ -13339,17 +13341,9 @@
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='PPR-5T'>
-			<roles>fire_support</roles>
-			<availability>LA:5,MERC:3,FS:3</availability>
-		</model>
 		<model name='PPR-6S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,FS:2,MERC:2</availability>
-		</model>
-		<model name='PPR-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -13399,42 +13393,42 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CCC:3,CNC:3,CCO:7,RA:4</availability>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CNC:4,RA:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CNC:4,RA:4</availability>
+		</model>
 		<model name='XP'>
 			<availability>CNC:8</availability>
-		</model>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CSA:4,CCC:4,CHH:3,CW:5,CCO:10</availability>
-		<model name='Prime'>
-			<availability>CSA:3,General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CSA:8,CLAN:6</availability>
-		</model>
-		<model name='W'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>CHH:3,CW:3</availability>
+		<model name='B'>
+			<availability>CSA:3,General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>CSA:3,General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>CSA:3,General:7</availability>
+		<model name='C'>
+			<availability>CSA:8,CLAN:6</availability>
 		</model>
 		<model name='J'>
 			<availability>CHH:4,CW:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CSA:3,General:8</availability>
+		</model>
+		<model name='W'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>CHH:3,CW:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
@@ -13456,42 +13450,46 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MASH)'>
-			<roles>apc,support</roles>
-			<availability>General:4</availability>
+		<model name='(HQ)'>
+			<roles>apc,support,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(HQ)'>
-			<roles>apc,support,spotter</roles>
-			<availability>General:2</availability>
+		<model name='(MASH)'>
+			<roles>apc,support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>PR:5,RF:5,LA:4,ROS:5,PG:5,FS:6,MERC:4,DA:5,RFS:5</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>PR:5,RF:5,LA:6,ROS:4,PG:5,FS:3,MERC:5,DA:5,RFS:5</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>PR:5,RF:5,LA:6,ROS:4,PG:5,FS:3,MERC:5,DA:5,RFS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Scarecrow' unitType='Mek'>
 		<availability>FS:2</availability>
-		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
-			<availability>General:4</availability>
-		</model>
 		<model name='UCU-F4'>
 			<roles>anti_infantry</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,OP:4,DoO:4,CGB.FRR:4,ROS:5,FWL:4,DO:4,TP:4,FS:4,MERC:4,DC:4,CGB:4</availability>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -13499,6 +13497,10 @@
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support,spotter</roles>
@@ -13508,14 +13510,6 @@
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
@@ -13523,16 +13517,16 @@
 	</chassis>
 	<chassis name='Schrack' unitType='Aero' omni='IS'>
 		<availability>ROS:5</availability>
-		<model name='SCK-OA'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='SCK-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='SCK-OA'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Schrek AC Carrier' unitType='Tank'>
@@ -13543,6 +13537,10 @@
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>MOC:2,CC:1,HL:3,IS:2,Periphery.Deep:5,MERC:2,FS:2,Periphery:4,TC:2,RA:4,RA.OA:3,LA:2,CGB.FRR:2,CNC:4,FWL:2,DC:1</availability>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -13550,10 +13548,6 @@
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:4</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>CNC:7,IS:5,RA:7</availability>
@@ -13577,11 +13571,8 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,HL:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(MRM)'>
-			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:5,MOC:4,LA:5,ROS:5,FWL:5,IS:4,MH:4,FS:5,MERC:5,CDP:4,DC:5,TC:4</availability>
+		<model name='(LRM)'>
+			<availability>General:2-</availability>
 		</model>
 		<model name='(Minesweeper)'>
 			<roles>minesweeper</roles>
@@ -13590,14 +13581,17 @@
 		<model name='(Standard)'>
 			<availability>General:4-</availability>
 		</model>
-		<model name='(ML)'>
-			<availability>General:2-</availability>
+		<model name='(LAC)'>
+			<availability>CC:5,MOC:4,LA:5,ROS:5,FWL:5,IS:4,MH:4,FS:5,MERC:5,CDP:4,DC:5,TC:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:4-</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:2-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>HL:2,IS:5,DC:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -13605,18 +13599,18 @@
 		<model name='SCP-1N'>
 			<availability>FRR:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
 		</model>
-		<model name='SCP-10M'>
-			<availability>CC:4,MOC:3,CGB.FRR:4,ROS:4,FWL:6,MERC:4,DC:4</availability>
-		</model>
-		<model name='SCP-12S'>
-			<availability>LA:3,ROS:2,MERC:2</availability>
-		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
 		<model name='SCP-1O'>
 			<availability>HL:2,IS:4,Periphery.Deep:1,Periphery:4</availability>
+		</model>
+		<model name='SCP-12S'>
+			<availability>LA:3,ROS:2,MERC:2</availability>
+		</model>
+		<model name='SCP-10M'>
+			<availability>CC:4,MOC:3,CGB.FRR:4,ROS:4,FWL:6,MERC:4,DC:4</availability>
 		</model>
 		<model name='SCP-1TB'>
 			<availability>ROS:4,MERC:4</availability>
@@ -13637,14 +13631,14 @@
 	</chassis>
 	<chassis name='Scylla' unitType='Mek'>
 		<availability>CHH:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scytha' unitType='Aero'>
@@ -13658,27 +13652,30 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
+		</model>
 		<model name='(SRM6)'>
 			<availability>General:3</availability>
 		</model>
@@ -13687,9 +13684,6 @@
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:3</availability>
-		</model>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SeaBuster Strike Fighter' unitType='Conventional Fighter'>
@@ -13732,37 +13726,37 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,CC:4,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,LA:7,CGB.FRR:2,ROS:7,MH:2,CGB:0</availability>
-		<model name='SYD-21'>
+		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
-			<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>RA.OA:2-,HL:3-,ROS:2-,Periphery:5-,TC:2-</availability>
-		</model>
-		<model name='SYD-Z4'>
-			<availability>CC:8,FVC:4,HL:2,LA:6,CGB.FRR:2,ROS:4,MERC:5,FS:4,Periphery:4</availability>
-		</model>
-		<model name='SYD-45X &apos;Starling&apos;'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='SYD-Z3'>
-			<roles>interceptor</roles>
-			<availability>LA:1-</availability>
+			<availability>LA:2-,Periphery.Deep:8,Periphery:2-</availability>
 		</model>
 		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
 			<availability>LA:8,CGB.FRR:6,ROS:4,FS:8,MERC:6,CGB:1</availability>
 		</model>
-		<model name='SYD-Z2'>
+		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
-			<availability>LA:2-,Periphery.Deep:8,Periphery:2-</availability>
+			<availability>RA.OA:2-,HL:3-,ROS:2-,Periphery:5-,TC:2-</availability>
+		</model>
+		<model name='SYD-Z3A'>
+			<availability>LA:6,CGB.FRR:3,ROS:3,MERC:3,FS:3,CGB:1</availability>
+		</model>
+		<model name='SYD-45X &apos;Starling&apos;'>
+			<availability>LA:1</availability>
+		</model>
+		<model name='SYD-Z4'>
+			<availability>CC:8,FVC:4,HL:2,LA:6,CGB.FRR:2,ROS:4,MERC:5,FS:4,Periphery:4</availability>
+		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
 		</model>
 		<model name='SYD-Z2B'>
 			<availability>RA.OA:4,LA:4,ROS:4,PIR:3,FS:4,MERC:4,RA:4</availability>
 		</model>
-		<model name='SYD-Z3A'>
-			<availability>LA:6,CGB.FRR:3,ROS:3,MERC:3,FS:3,CGB:1</availability>
+		<model name='SYD-Z3'>
+			<roles>interceptor</roles>
+			<availability>LA:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
@@ -13771,27 +13765,27 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='SYU-4B'>
+		<model name='SYU-6B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SYU-6B'>
+		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat II' unitType='Mek'>
 		<availability>CJF:5</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='3'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
+		</model>
+		<model name='3'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
@@ -13803,94 +13797,94 @@
 			<roles>recon</roles>
 			<availability>CW:3,General:6,RA:8</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8,RA:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:8,CLAN:6,IS:3</availability>
-		</model>
-		<model name='J'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CW:3,General:6,RA:3</availability>
 		</model>
+		<model name='J'>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:8,CLAN:6,IS:3</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8,RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>PR:3,CHH:5,DoO:3,DO:3,FS:3,CWIE:5,RA.OA:3,CDS:5,CGB.FRR:4,FWL:3,MSC:3,RFS:3,CGB:5,OP:3,IS:2,MERC:4,RA:5,DTA:3,RF:3,LA:3,ROS:4,PG:3,CNC:5,TP:3,RCM:3,DA:3,DC:3</availability>
+		<model name='8'>
+			<availability>CDS:4,LA:4,CNC:5,IS:3,CWIE:5</availability>
+		</model>
 		<model name='2'>
 			<availability>CSA:2,CCC:2,CGB:3</availability>
-		</model>
-		<model name='3'>
-			<availability>CSA:4,CDS:5,CNC:5,IS:4</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:6</availability>
 		</model>
 		<model name='7'>
 			<availability>RA.OA:6,RA:6</availability>
 		</model>
-		<model name='5'>
-			<availability>CDS:8,LA:8,CGB.FRR:6,FWL:8,IS:6,FS:8,MERC:8,DC:8,CGB:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:5,IS:4,RA:4</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:4,LA:4,CNC:5,IS:3,CWIE:5</availability>
+		<model name='3'>
+			<availability>CSA:4,CDS:5,CNC:5,IS:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:8,LA:8,CGB.FRR:6,FWL:8,IS:6,FS:8,MERC:8,DC:8,CGB:4</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
 		<availability>HL:5,IS:4,NIOPS:4-,Periphery.Deep:5,BAN:4,Periphery:6,CGB:4</availability>
-		<model name='SHD-2D2'>
-			<availability>FVC:6,FS:5</availability>
-		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,ROS:4,CLAN:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
-		</model>
-		<model name='SHD-2H'>
-			<availability>General:2-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
-		</model>
 		<model name='SHD-2K'>
 			<availability>MERC:1-,DC:2-</availability>
 		</model>
-		<model name='SHD-9D'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='SHD-5M'>
-			<availability>CC:6,CGB.FRR:6,Periphery.MW:4,Periphery.ME:4,FWL:5,MERC:6,Periphery:3,DC:6</availability>
-		</model>
-		<model name='SHD-3K'>
-			<availability>CGB.FRR:4,DC:6,CGB:2</availability>
-		</model>
-		<model name='SHD-5D'>
-			<availability>LA:4,ROS:4,FS:6,MERC:5</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,OP:6,DoO:6,DO:6,MERC:4,CDP:3,TC:3,DTA:6,FVC:3,ROS:4,MSC:6,TP:6,RCM:6</availability>
-		</model>
-		<model name='SHD-12C'>
-			<availability>CGB.FRR:6,ROS:3,CGB:4,DC:3</availability>
+		<model name='SHD-2D2'>
+			<availability>FVC:6,FS:5</availability>
 		</model>
 		<model name='SHD-1R'>
 			<availability>CC:2-,MOC:2-,FWL:2-,MH:3-,MERC:2-</availability>
 		</model>
+		<model name='SHD-2H'>
+			<availability>General:2-,Periphery.Deep:8,BAN:1,Periphery:3-</availability>
+		</model>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,ROS:4,CLAN:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
+		</model>
+		<model name='SHD-12C'>
+			<availability>CGB.FRR:6,ROS:3,CGB:4,DC:3</availability>
+		</model>
+		<model name='SHD-5M'>
+			<availability>CC:6,CGB.FRR:6,Periphery.MW:4,Periphery.ME:4,FWL:5,MERC:6,Periphery:3,DC:6</availability>
+		</model>
 		<model name='SHD-8L'>
 			<availability>CC:6</availability>
+		</model>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,OP:6,DoO:6,DO:6,MERC:4,CDP:3,TC:3,DTA:6,FVC:3,ROS:4,MSC:6,TP:6,RCM:6</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:4,ROS:4,FS:6,MERC:5</availability>
+		</model>
+		<model name='SHD-3K'>
+			<availability>CGB.FRR:4,DC:6,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CSA:5,CDS:5,CW:5,ROS:4,CLAN:3,CGB:5</availability>
+		<model name='(Flamer)'>
+			<availability>CDS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Interdictor)'>
 			<availability>CHH:4,CDS:4,CW:4,ROS:8,CNC:4,CJF:4,RA:4,CGB:6,CWIE:4</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CDS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shandra Advanced Scout Vehicle' unitType='Tank'>
@@ -13909,20 +13903,20 @@
 		<model name='[MRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[Interdictor]' mechanized='false'>
+			<availability>General:4</availability>
+		</model>
 		<model name='[Pop-Up Mine]' mechanized='false'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Interdictor]' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='[David Light Gauss]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shen Yi' unitType='Mek'>
@@ -13950,11 +13944,11 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
-		<model name='SL-17'>
-			<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
 		<model name='SL-18'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
+		</model>
+		<model name='SL-17'>
+			<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>RA.OA:2,CGB.FRR:2,ROS:2,MERC:2,RA:2,DC:2</availability>
@@ -13968,11 +13962,14 @@
 	</chassis>
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>OP:6,PR:6,DoO:6,DO:6,DTA:6,RF:6,ROS:4,PG:6,FWL:5,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
-		<model name='SHV-OB'>
+		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
+		</model>
+		<model name='SHV-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -13980,30 +13977,27 @@
 		<model name='SHV-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SHV-OA'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shockwave' unitType='Mek'>
 		<availability>CC:3,DTA:4,OP:4,DoO:4,ROS:3,FWL:4,DO:4,MSC:4,TP:4,FS:2,RCM:3,DC:2</availability>
-		<model name='SKW-4G'>
-			<availability>General:2</availability>
-		</model>
 		<model name='SKW-2F'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SKW-4G'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,CDS:4,CW:3,ROS:3,CNC:5,CGB:4,CWIE:3,DC:3</availability>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:6,DC:6</availability>
+		</model>
 		<model name='(Streak)'>
 			<availability>CDS:4,CW:6,ROS:4,CNC:6,CJF:6,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -14032,28 +14026,40 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverback Coastal Cutter' unitType='Naval'>
+		<availability>LA:7</availability>
+		<model name='(Standard)'>
+			<availability>LA:7</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Siren' unitType='ProtoMek'>
 		<availability>CSA:5,CCC:7,CCO:4</availability>
+		<model name='2'>
+			<availability>CSA:8,CCC:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CSA:6,CCC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CSA:4,CCC:4,CCO:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CSA:8,CCC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,OP:5,DoO:5,ROS:3,DO:5,MSC:5,TP:5,MERC:3</availability>
-		<model name='SRC-6C'>
-			<availability>DTA:5,OP:5,DoO:5,ROS:1,FWL:5,DO:5,MSC:5,TP:5</availability>
-		</model>
 		<model name='SRC-5C'>
 			<availability>DTA:5,OP:5,DoO:5,ROS:5,FWL:5,DO:5,MSC:5,TP:5</availability>
 		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-6C'>
+			<availability>DTA:5,OP:5,DoO:5,ROS:1,FWL:5,DO:5,MSC:5,TP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Skadi Swift Attack VTOL' unitType='VTOL'>
@@ -14077,9 +14083,9 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:2,Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,FS:2,RA.OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,FWL:2,NIOPS:3-,DC:5</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:4,IS.pm:4</availability>
+			<availability>General:4-</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -14089,9 +14095,9 @@
 			<roles>recon</roles>
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:4-</availability>
+			<availability>FVC:4,IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
@@ -14099,23 +14105,23 @@
 		<model name='SL-15R'>
 			<availability>RA.OA:6,CGB.FRR:8,ROS:6,FS:6,MERC:6,CDP:4,RA:6,DC:8,TC:4,CGB:6</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
-		</model>
 		<model name='SL-15K'>
 			<availability>CGB.FRR:4,ROS:4,MERC:4,DC:4,CGB:4</availability>
+		</model>
+		<model name='SL-15'>
+			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		<model name='(Huntsman)' mechanized='false'>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>LA:2</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Huntsman)' mechanized='false'>
+			<availability>LA:4,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Snake' unitType='Mek'>
@@ -14146,11 +14152,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CNC:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sokar Urban Combat Unit' unitType='Tank'>
@@ -14177,11 +14183,11 @@
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
 		<availability>CCC:3,CDS:6+,CGB:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sortek Assault Craft' unitType='Tank'>
@@ -14200,18 +14206,14 @@
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Spad' unitType='Aero'>
 		<availability>RA.OA:2,ROS:4,NIOPS:6,RA:1</availability>
-		<model name='SPD-504'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='SPD-503'>
 			<availability>ROS:6,BAN:2</availability>
@@ -14219,15 +14221,15 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+		<model name='SPR-6D'>
+			<availability>FVC:7,LA:4,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
+		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:2-,Periphery.Deep:8,FS:2-,MERC:2-,CDP:2-,TC:2-</availability>
 		</model>
 		<model name='SPR-7D'>
 			<availability>ROS:5,FS:5,MERC:5</availability>
-		</model>
-		<model name='SPR-6D'>
-			<availability>FVC:7,LA:4,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
 		</model>
 		<model name='SPR-DH'>
 			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:2-</availability>
@@ -14255,11 +14257,11 @@
 	</chassis>
 	<chassis name='Spectre Stealth Battle Armor' unitType='BattleArmor'>
 		<availability>FVC:4,CDP:4,RA:2</availability>
-		<model name='(RA)' mechanized='true'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(RA)' mechanized='true'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sphinx' unitType='Mek'>
@@ -14282,39 +14284,39 @@
 		<model name='SDR-5V'>
 			<availability>IS:1-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
+		<model name='SDR-5K'>
+			<roles>anti_infantry</roles>
+			<availability>CGB.FRR:2-,DC:2-</availability>
+		</model>
+		<model name='SDR-7Kr'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='SDR-7K'>
+			<availability>ROS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='SDR-7M'>
 			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,DC:6</availability>
 		</model>
-		<model name='SDR-7K2'>
-			<availability>ROS:3,MERC:3,DC:4</availability>
+		<model name='SDR-7KC'>
+			<availability>ROS:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:5</availability>
 		</model>
 		<model name='SDR-8K'>
 			<availability>ROS:3,MERC:3,DC:3</availability>
 		</model>
+		<model name='SDR-7K2'>
+			<availability>ROS:3,MERC:3,DC:4</availability>
+		</model>
 		<model name='SDR-8R'>
 			<availability>ROS:3,MERC:3</availability>
-		</model>
-		<model name='SDR-7Kr'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
 		<model name='SDR-8M'>
 			<availability>MOC:3,CC:3,FWL:8,MH:3,MERC:2</availability>
 		</model>
 		<model name='SDR-8X'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:5,FWL:5,FS:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='SDR-7K'>
-			<availability>ROS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='SDR-5K'>
-			<roles>anti_infantry</roles>
-			<availability>CGB.FRR:2-,DC:2-</availability>
-		</model>
-		<model name='SDR-7KC'>
-			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Spindrift Aquatic SecurityMech' unitType='Mek'>
@@ -14325,34 +14327,34 @@
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
 		<availability>CJF:5-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>MOC:3,FVC:3,LA:7,CGB.FRR:7,ROS:7,IS:6,MH:2,FS:7,DC:7</availability>
-		<model name='(Interdictor)'>
-			<roles>spotter</roles>
-			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,DC:4</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>CGB.FRR:5,IS:4,DC:6</availability>
+		</model>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Interdictor)'>
+			<roles>spotter</roles>
+			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,DC:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -14363,17 +14365,20 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:5,CC:4,HL:9,CLAN:2,IS:5,Periphery.Deep:9,FS:5,Periphery:10,TC:7,RA.OA:7,LA:6,CGB.FRR:5,ROS:4,FWL:7,NIOPS:5,DC:4</availability>
-		<model name='STK-3H'>
-			<availability>MOC:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		<model name='STK-8S'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-7D'>
-			<availability>ROS:4,FS:4,MERC:3</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:2,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
+		<model name='STK-4P'>
+			<availability>MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='STK-7D'>
+			<availability>ROS:4,FS:4,MERC:3</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
@@ -14381,30 +14386,27 @@
 		<model name='STK-3Fb'>
 			<availability>CC:3,MOC:3,OP:3,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,RF:3,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:2,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:2-,IS:2-,TC:2-,Periphery:2-</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-6M'>
 			<availability>CC:5,MOC:5,OP:6,PR:6,DoO:6,DO:6,MERC:6,RF:6,ROS:6,PG:6,FWL:6,TP:6,DA:5,RCM:6,RFS:6</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>MERC:1,Periphery:1</availability>
-		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CJF:3,TC:4</availability>
-		</model>
-		<model name='STK-8S'>
-			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stalking Spider' unitType='Mek'>
 		<availability>CCC:6+</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='2'>
 			<roles>spotter</roles>
 			<availability>CCC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CCC:4</availability>
@@ -14428,12 +14430,12 @@
 			<roles>raider</roles>
 			<availability>MOC:5,CC:3,OP:3,LA:5,DoO:3,ROS:3,DO:3,TP:3,FS:3,MERC:5</availability>
 		</model>
+		<model name='STY-3Dr'>
+			<availability>CC:6,MOC:6,PR:6,RF:6,LA:5,ROS:6,PG:6,MERC:6,RFS:6</availability>
+		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>CC:6,MOC:6,PR:6,RF:6,LA:5,ROS:6,PG:6,MERC:6,RFS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
@@ -14442,32 +14444,32 @@
 			<roles>recon,spotter</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='STH-3S'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='STH-1D'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-2D'>
 			<roles>recon</roles>
 			<availability>FS:6,MERC:4</availability>
 		</model>
+		<model name='STH-3S'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='STH-2D1'>
+			<roles>recon</roles>
+			<availability>FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:4,LA:4</availability>
+		<model name='STM-OB'>
+			<availability>General:7</availability>
+		</model>
 		<model name='STM-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='STM-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='STM-OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -14476,14 +14478,14 @@
 		<model name='STO-4C'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='STO-6S'>
-			<availability>LA:4</availability>
+		<model name='STO-4B'>
+			<availability>General:4</availability>
 		</model>
 		<model name='STO-4A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='STO-4B'>
-			<availability>General:4</availability>
+		<model name='STO-6S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger IIC' unitType='Mek'>
@@ -14501,62 +14503,65 @@
 	</chassis>
 	<chassis name='Stinger LAM' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='STG-A10'>
-			<availability>IS:2,DC:4</availability>
-		</model>
 		<model name='STG-A5'>
 			<availability>IS:3</availability>
+		</model>
+		<model name='STG-A10'>
+			<availability>IS:2,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,HL:5,CGB.FRR:4,IS:8,NIOPS:2-,Periphery.Deep:5,MERC:8,Periphery:6,DC:5,CGB:2-</availability>
-		<model name='STG-5R'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FVC:4,HL:2,PIR:4,MERC:4,CDP:4,TC:4,Periphery:4</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FVC:2,FWL:8,FS:6,MERC:6,CDP:2,DC:6</availability>
-		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:5,CC:4,FVC:4,HL:2,MERC:4,DA:4,TC:4,Periphery:4</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>IS:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
-		</model>
-		<model name='STG-6L'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:4,DA:4</availability>
-		</model>
-		<model name='STG-7S'>
-			<roles>recon</roles>
-			<availability>LA:5,ROS:5,MERC:3,FS:3</availability>
 		</model>
 		<model name='STG-5G'>
 			<roles>recon</roles>
 			<availability>CC:4,OP:4,DoO:4,DO:4,MERC:1,FS:4,CDP:4,TC:4,FVC:4,ROS:4,FWL:1,MH:4,TP:4,RCM:4,DA:4</availability>
 		</model>
+		<model name='STG-6S'>
+			<roles>recon</roles>
+			<availability>LA:6,ROS:5,MERC:6,FS:4</availability>
+		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CC:3,OP:6,DoO:6,CLAN:8,FWL:5,DO:6,MSC:6,TP:6,RCM:6,DA:6,MERC:3,BAN:2</availability>
 		</model>
-		<model name='STG-3P'>
+		<model name='STG-5M'>
 			<roles>recon</roles>
-			<availability>HL:2,LA:2,ROS:5,IS:4,MERC:5,DC:2,Periphery:4,CGB:3</availability>
-		</model>
-		<model name='STG-6S'>
-			<roles>recon</roles>
-			<availability>LA:6,ROS:5,MERC:6,FS:4</availability>
+			<availability>CC:6,MOC:6,FVC:2,FWL:8,FS:6,MERC:6,CDP:2,DC:6</availability>
 		</model>
 		<model name='STG-3G'>
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 		</model>
+		<model name='STG-6L'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:4,DA:4</availability>
+		</model>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:5,CC:4,FVC:4,HL:2,MERC:4,DA:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='STG-3P'>
+			<roles>recon</roles>
+			<availability>HL:2,LA:2,ROS:5,IS:4,MERC:5,DC:2,Periphery:4,CGB:3</availability>
+		</model>
+		<model name='STG-5R'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,FVC:4,HL:2,PIR:4,MERC:4,CDP:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='STG-7S'>
+			<roles>recon</roles>
+			<availability>LA:5,ROS:5,MERC:3,FS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,RA.OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:6,RFS:5,MOC:3,CC:5,OP:6,IS:3,MERC:5,TC:3,DTA:6,RF:5,LA:5,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
+		<model name='F-95'>
+			<availability>CC:4,OP:6,PR:6,DoO:6,DO:6,MERC:4,DTA:6,RF:6,LA:4,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
+		</model>
 		<model name='F-94'>
 			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,IS:4,MH:4</availability>
 		</model>
@@ -14566,35 +14571,32 @@
 		<model name='F-90'>
 			<availability>IS:3-,Periphery:3-</availability>
 		</model>
-		<model name='F-95'>
-			<availability>CC:4,OP:6,PR:6,DoO:6,DO:6,MERC:4,DTA:6,RF:6,LA:4,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>CGB:3</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>:0,CLAN:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='F'>
+		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>:0,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -14621,47 +14623,51 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,LA:5,ROS:6,FWL:5,FS:6,MERC:5,DA:4,DC:7</availability>
-		<model name='SR1-OA'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SR1-OD'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
+		<model name='SR1-OG'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SR1-OR'>
 			<availability>CLAN:6,General:3</availability>
 		</model>
-		<model name='SR1-OG'>
-			<availability>General:4</availability>
-		</model>
 		<model name='SR1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OF'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,LA:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2,CGB:1</availability>
+		<model name='(Narc)'>
+			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:4-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>FVC:3-,IS:2-</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,CDS:5,LA:6,ROS:6,CNC:5,FS:7,DC:5,CWIE:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2</availability>
@@ -14672,30 +14678,26 @@
 		<model name='(SRM)'>
 			<availability>FVC:2-,IS:2-</availability>
 		</model>
-		<model name='(Narc)'>
-			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(3061 Upgrade)'>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:4-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,CDS:5,LA:6,ROS:6,CNC:5,FS:7,DC:5,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:4,MOC:4,LA:2-,NIOPS:4</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>CC:2-,General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stuka' unitType='Aero'>
@@ -14715,12 +14717,12 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>PR:4,HL:2,MERC:1,FS:3,CWIE:3,Periphery.R:3,CDS:2,RF:4,LA:5,ROS:4,PG:4,CNC:3,RFS:4</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Heavy Gauss)'>
 			<availability>PR:4,RF:4,LA:6,PG:4,CNC:6,RFS:4,CWIE:6</availability>
@@ -14728,13 +14730,13 @@
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,IS:2,Periphery:2</availability>
-		<model name='(Standard)'>
-			<roles>recon,fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
@@ -14742,14 +14744,14 @@
 		<model name='E'>
 			<availability>CW:5,CLAN:2,CGB:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>CSA:6,General:2,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:6,General:2,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CSA:6,General:2,CJF:6,CGB:6</availability>
@@ -14760,21 +14762,24 @@
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
 		<availability>CDS:3,CW:5,ROS:3,FS:3,MERC:2</availability>
-		<model name='(Standard)'>
-			<availability>CDS:4,CW:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CDS:8,ROS:8,MERC:8,FS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:4,CW:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,ROS:5,FS:5,MERC:4,DC:7</availability>
-		<model name='SD1-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='SD1-OX'>
+			<availability>General:1</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SD1-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='SD1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
@@ -14785,9 +14790,6 @@
 		</model>
 		<model name='SD1-OD'>
 			<availability>General:6,FS:7,DC:7</availability>
-		</model>
-		<model name='SD1-OX'>
-			<availability>General:1</availability>
 		</model>
 		<model name='SD1-OC'>
 			<availability>General:6,DC:7</availability>
@@ -14804,11 +14806,11 @@
 		<model name='3'>
 			<availability>ROS:6,CNC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='4'>
 			<availability>ROS:5,CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Suzaku' unitType='Aero'>
@@ -14834,28 +14836,28 @@
 	</chassis>
 	<chassis name='Svartalfa Ultra ProtoMech' unitType='ProtoMek'>
 		<availability>CHH:4+</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM Variant)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swallow Attack WIGE' unitType='Tank'>
 		<availability>RF:3,LA:4,ROS:3,FWL:3,FS:3,MERC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<availability>LA:4,MERC:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:1,MOC:1,DA:1,CDP:1,TC:1</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -14867,37 +14869,37 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:2</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>ROS:5,CLAN:4,NIOPS:8</availability>
-		<model name='C'>
-			<availability>CCC:9,CLAN:8,RA:9</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>ROS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CCC:9,CLAN:8,RA:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CSA:2,CCC:6,CDS:2,RA:4</availability>
-		<model name='(Standard)' mechanized='true'>
+		<model name='(Upgrade)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Enhanced)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>RA:4</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='XR' mechanized='true'>
 			<roles>recon</roles>
@@ -14935,11 +14937,11 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:5,MERC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(RL)'>
 			<availability>MOC:4</availability>
@@ -14950,53 +14952,53 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,DTA:6,OP:6,DoO:6,ROS:4,FWL:6,DO:6,MSC:6,TP:6,MERC:4,DC:6</availability>
-		<model name='ZPH-3A'>
-			<roles>recon</roles>
-			<availability>DTA:8,OP:8,DoO:8,ROS:5,FWL:8,DO:8,MSC:8,TP:8,MERC:4,DC:4</availability>
-		</model>
 		<model name='ZPH-2A'>
 			<roles>recon</roles>
 			<availability>MOC:4,CC:5,ROS:5,FWL:5,MERC:5,DC:5</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:8,OP:8,DoO:8,ROS:6,DO:8,MSC:8,TP:8,MERC:6,DC:8</availability>
 		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='ZPH-3A'>
+			<roles>recon</roles>
+			<availability>DTA:8,OP:8,DoO:8,ROS:5,FWL:8,DO:8,MSC:8,TP:8,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Targe' unitType='Mek'>
 		<availability>ROS:3</availability>
-		<model name='TRG-1N'>
-			<roles>recon</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='TRG-2N'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
 		</model>
+		<model name='TRG-1N'>
+			<roles>recon</roles>
+			<availability>ROS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>CC:1,CGB.FRR:5,ROS:4,CNC:4,DC:6</availability>
+		<model name='MIK-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-O'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tatsumaki Destroyer' unitType='Warship'>
@@ -15008,8 +15010,8 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>OP:8,PR:8,DoO:8,DO:8,MERC:4,DTA:8,RF:8,ROS:5,Periphery.MW:3,PG:8,Periphery.ME:3,FWL:8,MH:3,MSC:8,TP:8,RFS:8</availability>
-		<model name='TMP-3G'>
-			<availability>ROS:2,FWL:2,MERC:2</availability>
+		<model name='TMP-3M'>
+			<availability>HL:6,ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>PR:4,RF:4,ROS:4,PG:4,MSC:4,MERC:4,RFS:4</availability>
@@ -15017,8 +15019,8 @@
 		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
 			<availability>DTA:6,OP:6,DoO:6,ROS:6,DO:6,MSC:6,TP:6,MERC:3</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>HL:6,ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		<model name='TMP-3G'>
+			<availability>ROS:2,FWL:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
@@ -15026,38 +15028,38 @@
 		<model name='TLR1-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OH'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OB'>
 			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OG'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OI'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OE'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
+		<model name='TLR1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OF'>
 			<roles>spotter</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OI'>
-			<availability>General:5</availability>
+		<model name='TLR1-OG'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OU'>
-			<availability>General:2</availability>
+		<model name='TLR1-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Teppo Artillery Vehicle' unitType='Tank'>
@@ -15073,36 +15075,36 @@
 			<roles>recon,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
 		</model>
-		<model name='TSN-C3M'>
+		<model name='TSN-1Cr'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='TSN-1Cr'>
+		<model name='TSN-C3M'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CW:1,CCO:1,CJF:1,RA:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
 		<availability>LA:6,ROS:4,MH:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='TNS-4T'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='TNS-6S'>
 			<availability>LA:5,IS:4</availability>
+		</model>
+		<model name='TNS-4T'>
+			<availability>IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thang-Ta APC' unitType='Tank'>
@@ -15121,43 +15123,43 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,CLAN:2,CCO:2,RA:2,BAN:4,CWIE:4,CSA:2,MERC.WD:3,CDS:2,CW:2,ROS:2+,CNC:3,CJF:5,CGB:2</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CHH:4,CDS:4,CW:6,CNC:4,General:2,CCO:3,CJF:5,CWIE:5,CGB:4</availability>
 		</model>
-		<model name='HH'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
+		<model name='D'>
+			<availability>CW:8,CNC:6,General:5,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:3,CCO:6,CWIE:5</availability>
+		<model name='A'>
+			<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CCC:6,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:8,CNC:6,General:5,CWIE:6,CGB:8</availability>
+		<model name='HH'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:1,CJF:5</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CW:6,General:5,CJF:6,CGB:6</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:3,CCO:6,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -15173,9 +15175,6 @@
 	</chassis>
 	<chassis name='Thor II (Grand Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,CW:4,CJF:5,CGB:4</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -15186,55 +15185,58 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>ROS:6</availability>
-		<model name='THE-N1'>
+		<model name='THE-N2'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='THE-N2'>
+		<model name='THE-N1'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,RA:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>CC:2-,FVC:3-,HL:2-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:4-</availability>
+		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:4,MERC:3</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:4,FVC:2,FWL:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>CC:2-,FVC:3-,HL:2-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:4-</availability>
-		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>CHH:2,PR:5,CLAN:3,FS:2,CWIE:4,DC.GHO:4,RA.OA:4,CDS:2,Periphery.MW:2,FWL:5,NIOPS:8,MH:3,MSC:5,RFS:5,CGB:4,MOC:3,IS:4,CW:4,RF:5,ROS:5,PG:5,PIR:2,CNC:2,Periphery.ME:2,DA:5,CJF:4</availability>
-		<model name='THG-11Eb'>
-			<availability>ROS:6,CLAN:4,FWL:6,MSC:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>MOC:8,CLAN:6,IS:8,FS:8,BAN:8,DC.GHO:8,RA.OA:8,CGB.FRR:6,ROS:8,PG:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,NIOPS:4,DC:8</availability>
 		</model>
-		<model name='THG-12K'>
-			<availability>ROS:5,DC:8</availability>
+		<model name='THG-11Eb'>
+			<availability>ROS:6,CLAN:4,FWL:6,MSC:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>MOC:2-,RF:2-,PIR:2-,FWL:2-,MH:2-,MSC:2-,MERC:2-,DA:2-,Periphery:4</availability>
+		</model>
+		<model name='THG-12K'>
+			<availability>ROS:5,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -15254,9 +15256,6 @@
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
 		<availability>LA:4,ROS:5,DC:4</availability>
-		<model name='TFT-L8'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='TFT-A9'>
 			<availability>ROS:8,General:4</availability>
 		</model>
@@ -15264,12 +15263,12 @@
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='TFT-L8'>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,ROS:5,MERC:4</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -15279,6 +15278,9 @@
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -15295,30 +15297,30 @@
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,PR:5,RF:5,PG:5,MERC:4,DA:5,RFS:5,TC:4</availability>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-C4'>
-			<availability>CC:3,MOC:3,CC.LCC:5</availability>
-		</model>
 		<model name='THR-1L'>
 			<availability>General:6</availability>
+		</model>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='THR-C4'>
+			<availability>CC:3,MOC:3,CC.LCC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:6</availability>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
 		<model name='[Upgrade](ER Laser)' mechanized='true'>
 			<availability>General:4</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 		<model name='[Pulse Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -15326,29 +15328,29 @@
 		<model name='(Upgrade)[LBX]' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
-		<model name='[AP Gauss]' mechanized='true'>
+		<model name='[ER Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CC:4,MOC:4,LA:8,ROS:8,CGB.FRR:6,MH:4,MERC:6</availability>
-		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:3-</availability>
-		</model>
-		<model name='TRB-D36b'>
-			<roles>ground_support</roles>
-			<availability>CLAN:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='TRB-D56'>
 			<availability>LA:6,ROS:4,MERC:4</availability>
 		</model>
 		<model name='TRB-D50'>
 			<availability>TC:6</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CC:4,MOC:4,LA:8,ROS:8,CGB.FRR:6,MH:4,MERC:6</availability>
+		</model>
+		<model name='TRB-D36b'>
+			<roles>ground_support</roles>
+			<availability>CLAN:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbolt IIC' unitType='Mek'>
@@ -15359,32 +15361,20 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:5,HL:2,IS:3,Periphery.Deep:6,FS:5,MERC:6,Periphery:3,TC:4,LA:6,ROS:5,NIOPS:3-,MH:4,DC:4</availability>
-		<model name='TDR-9NAIS'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='TDR-9M'>
-			<availability>MOC:3,CC:3,OP:5,DoO:5,DO:5,MERC:3,DTA:5,PIR:3,FWL:3,MH:3,MSC:5,TP:5,DA:5</availability>
-		</model>
-		<model name='TDR-9S'>
-			<availability>FVC:4,LA:5,FS:3,MERC:3</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>CC:2-,MOC:2-,LA:2-,MERC:2-,TC:2-</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,ROS:3,PIR:2,MH:2,MERC:3,FS:3</availability>
 		</model>
 		<model name='TDR-60-RLA'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='TDR-5SS'>
-			<availability>LA:2-,MERC:1-</availability>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
 		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
+		<model name='TDR-9S'>
+			<availability>FVC:4,LA:5,FS:3,MERC:3</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2</availability>
 		</model>
 		<model name='TDR-9T'>
 			<availability>TC:4</availability>
@@ -15392,29 +15382,41 @@
 		<model name='TDR-5S'>
 			<availability>CC:2-,LA:1-,General:2-,Periphery.Deep:8,Periphery:3-</availability>
 		</model>
-		<model name='TDR-10S'>
-			<availability>LA:4,MERC:4</availability>
+		<model name='TDR-7M'>
+			<availability>CC:5,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:6,MH:3,MERC:5</availability>
 		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		<model name='TDR-9M'>
+			<availability>MOC:3,CC:3,OP:5,DoO:5,DO:5,MERC:3,DTA:5,PIR:3,FWL:3,MH:3,MSC:5,TP:5,DA:5</availability>
 		</model>
-		<model name='TDR-10M'>
-			<availability>CC:4,ROS:6,FWL:4,MERC:4</availability>
+		<model name='TDR-5SS'>
+			<availability>LA:2-,MERC:1-</availability>
 		</model>
 		<model name='C'>
 			<availability>CSA:6,CCC:6</availability>
 		</model>
-		<model name='TDR-7M'>
-			<availability>CC:5,MOC:3,Periphery.MW:3,Periphery.ME:3,FWL:6,MH:3,MERC:5</availability>
+		<model name='TDR-5Sb'>
+			<availability>TC:5</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2</availability>
+		<model name='TDR-7SE'>
+			<availability>CC:3,ROS:3,PIR:2,MH:2,MERC:3,FS:3</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>FS:3,MERC:3</availability>
 		</model>
+		<model name='TDR-10M'>
+			<availability>CC:4,ROS:6,FWL:4,MERC:4</availability>
+		</model>
+		<model name='TDR-10S'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
 		<model name='TDR-17S'>
 			<availability>LA:5</availability>
+		</model>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
+		</model>
+		<model name='TDR-9NAIS'>
+			<availability>FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
@@ -15422,15 +15424,15 @@
 		<model name='TSG-9J'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TSG-9H'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='TSG-9DDC'>
+			<availability>CC:4,CC.WHO:6</availability>
 		</model>
 		<model name='TSG-9C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
-		<model name='TSG-9DDC'>
-			<availability>CC:4,CC.WHO:6</availability>
+		<model name='TSG-9H'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat Pocket Warship' unitType='Dropship'>
@@ -15471,6 +15473,10 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CLAN:4,NIOPS:3,RA:5</availability>
+		<model name='(2647)'>
+			<roles>asf_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Monitor)'>
 			<roles>assault</roles>
 			<availability>RA:6</availability>
@@ -15479,47 +15485,43 @@
 			<roles>asf_carrier</roles>
 			<availability>CLAN:8,RA:4</availability>
 		</model>
-		<model name='(2647)'>
-			<roles>asf_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,ROS:5,CNC:6,DC:8</availability>
-		<model name='(C3)'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='TKG-150'>
-			<availability>CGB.FRR:2-,DC:2-</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>CGB.FRR:4-,DC:4-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>CDS:8,ROS:6,CNC:8,DC:6</availability>
+		<model name='(C3)'>
+			<availability>ROS:5,DC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>ROS:8,DC:8</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>CDS:8,ROS:6,CNC:8,DC:6</availability>
 		</model>
 		<model name='(MRM)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='TKG-150'>
+			<availability>CGB.FRR:2-,DC:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Tomahawk II' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,CW:4</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>urban</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>urban</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -15528,15 +15530,15 @@
 		<model name='CH'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>ROS:8</availability>
+		<model name='THK-63'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
 		</model>
-		<model name='THK-63'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
+		<model name='THK-63CS'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
@@ -15547,10 +15549,10 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -15563,23 +15565,23 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>FWL:2,MH:1</availability>
-		<model name='G13 [Grenade Launcher]' mechanized='true'>
-			<availability>MH:4</availability>
-		</model>
-		<model name='G13 [Machine Gun]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 		<model name='G12' mechanized='true'>
 			<roles>specops</roles>
 			<availability>FWL:8</availability>
 		</model>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>MH:4</availability>
+		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Machine Gun]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 	</chassis>
@@ -15592,13 +15594,13 @@
 	</chassis>
 	<chassis name='Trajan Assault Infantry Fighting Vehicle' unitType='Tank'>
 		<availability>ROS:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>apc</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -15609,43 +15611,40 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,PR:3,RF:3,Periphery.CM:2,PG:3,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
-		<model name='TR-14 &apos;AC&apos;'>
-			<availability>General:2-</availability>
-		</model>
-		<model name='TR-16'>
-			<availability>CC:7,MOC:5,PR:8,RF:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
-		</model>
-		<model name='TR-13'>
-			<availability>CC:2-,MERC:2-,Periphery:3-</availability>
-		</model>
 		<model name='TR-13A'>
 			<availability>CC:8,MOC:7,General:5</availability>
+		</model>
+		<model name='TR-14 &apos;AC&apos;'>
+			<availability>General:2-</availability>
 		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13'>
+			<availability>CC:2-,MERC:2-,Periphery:3-</availability>
+		</model>
+		<model name='TR-16'>
+			<availability>CC:7,MOC:5,PR:8,RF:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:1,TC:3</availability>
-		<model name='TR-10'>
-			<availability>CC:3,MOC:4,General:6,TC:4</availability>
-		</model>
-		<model name='TR-12'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
 		<model name='TR-11'>
 			<roles>recon</roles>
 			<availability>General:1</availability>
 		</model>
+		<model name='TR-12'>
+			<availability>CC:6,MOC:4</availability>
+		</model>
 		<model name='TR-13G'>
 			<roles>ground_support,assault</roles>
 			<availability>CC:5</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>CC:3,MOC:4,General:6,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Transportable Field Repair Unit' unitType='Tank'>
@@ -15657,11 +15656,11 @@
 	</chassis>
 	<chassis name='Trebaruna' unitType='Mek'>
 		<availability>CC:4,DTA:3,OP:3,DoO:3,ROS:4,DO:3,MSC:3,TP:3,MERC:3</availability>
-		<model name='TR-XJ'>
-			<availability>DTA:8,OP:8,DoO:8,DO:8,MSC:8,TP:8,MERC:4</availability>
-		</model>
 		<model name='TR-XB'>
 			<availability>CC:4,DTA:4,ROS:8,MSC:4,MERC:4</availability>
+		</model>
+		<model name='TR-XJ'>
+			<availability>DTA:8,OP:8,DoO:8,DO:8,MSC:8,TP:8,MERC:4</availability>
 		</model>
 		<model name='TR-XL'>
 			<availability>CC:8</availability>
@@ -15669,38 +15668,38 @@
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>CC:2,MOC:2,PR:6,IS:2,FS:1,MERC:2,Periphery:4,TC:4,RA.OA:2,RF:6,LA:2,CGB.FRR:4,Periphery.MW:4,ROS:4,PG:6,Periphery.ME:4,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
-		<model name='TBT-5J'>
-			<availability>FWL:1-</availability>
-		</model>
-		<model name='TBT-5S'>
-			<availability>RF:4,Periphery.Deep:4,CDP:2-,TC:2-</availability>
-		</model>
-		<model name='TBT-7M'>
+		<model name='TBT-5N'>
 			<roles>fire_support</roles>
-			<availability>CC:4,CGB.FRR:4,FWL:5,MH:4,FS:4,MERC:4,TC:3,DC:4</availability>
-		</model>
-		<model name='TBT-9K'>
-			<roles>fire_support</roles>
-			<availability>DC:7</availability>
-		</model>
-		<model name='TBT-K7R'>
-			<availability>ROS:2</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>ROS:5,MSC:5,MERC:4</availability>
+			<availability>CC:1-,MOC:4-,LA:1-,FWL:1-,IS:2-,NIOPS:2-,FS:1-,MERC:2-,DC:1-,Periphery:4-</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>PR:4,RF:4,ROS:5,PG:4,NIOPS:5,MSC:4,MERC:4,RFS:4</availability>
 		</model>
+		<model name='TBT-K7R'>
+			<availability>ROS:2</availability>
+		</model>
+		<model name='TBT-7M'>
+			<roles>fire_support</roles>
+			<availability>CC:4,CGB.FRR:4,FWL:5,MH:4,FS:4,MERC:4,TC:3,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>ROS:5,MSC:5,MERC:4</availability>
+		</model>
+		<model name='TBT-9K'>
+			<roles>fire_support</roles>
+			<availability>DC:7</availability>
+		</model>
 		<model name='TBT-XK7'>
 			<roles>fire_support</roles>
 			<availability>TC:4</availability>
 		</model>
-		<model name='TBT-5N'>
-			<roles>fire_support</roles>
-			<availability>CC:1-,MOC:4-,LA:1-,FWL:1-,IS:2-,NIOPS:2-,FS:1-,MERC:2-,DC:1-,Periphery:4-</availability>
+		<model name='TBT-5J'>
+			<availability>FWL:1-</availability>
+		</model>
+		<model name='TBT-5S'>
+			<availability>RF:4,Periphery.Deep:4,CDP:2-,TC:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -15714,17 +15713,8 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,MOC:8,MH:4,TC:8</availability>
-		<model name='(Theseus RL)[LRR]' mechanized='true'>
-			<availability>MOC:6</availability>
-		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
-			<availability>TC:5</availability>
-		</model>
-		<model name='(Asterion)[PPC]' mechanized='true'>
-			<availability>MH:4,TC:4</availability>
-		</model>
-		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
-			<availability>MOC:6</availability>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Asterion)[MRR]' mechanized='true'>
 			<availability>MH:4,TC:4</availability>
@@ -15732,11 +15722,20 @@
 		<model name='(Ying Long)(Plasma)' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
+		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
+			<availability>MOC:6</availability>
+		</model>
 		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:5</availability>
 		</model>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
+		<model name='(Theseus RL)[LRR]' mechanized='true'>
+			<availability>MOC:6</availability>
+		</model>
+		<model name='(Asterion)[PPC]' mechanized='true'>
+			<availability>MH:4,TC:4</availability>
+		</model>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+			<availability>TC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Trireme Infantry Transport' unitType='VTOL'>
@@ -15763,14 +15762,14 @@
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
 		<availability>CC:5,MOC:6,FVC:3,HL:2,Periphery.CM:4,Periphery.ME:4,MERC:3,DA:3,TC:6,Periphery:3</availability>
+		<model name='CMT-3T'>
+			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
+		</model>
 		<model name='CMT-4U'>
 			<availability>General:5</availability>
 		</model>
 		<model name='CMT-6T'>
 			<availability>MOC:5,CC:5,MERC:4,DA:4</availability>
-		</model>
-		<model name='CMT-3T'>
-			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Trojan' unitType='Dropship'>
@@ -15782,10 +15781,10 @@
 	</chassis>
 	<chassis name='Tsunami' unitType='Mek'>
 		<availability>MERC:3</availability>
-		<model name='TS-P1D'>
+		<model name='TS-P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TS-P1'>
+		<model name='TS-P1D'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -15802,17 +15801,17 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CW:5+,ROS:3,CWIE:3</availability>
-		<model name='4'>
-			<availability>General:8</availability>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
 		</model>
 		<model name='3'>
 			<availability>CW:3,ROS:2</availability>
 		</model>
+		<model name='4'>
+			<availability>General:8</availability>
+		</model>
 		<model name='5'>
 			<availability>CW:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
@@ -15820,35 +15819,35 @@
 	</chassis>
 	<chassis name='Turhan Urban Combat Vehicle' unitType='Tank'>
 		<availability>ROS:4,DC:4</availability>
-		<model name='(Standard)'>
-			<roles>apc,urban</roles>
-			<availability>:0,General:4</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>apc,urban,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc,urban</roles>
+			<availability>:0,General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2,CGB:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:2,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>CLAN:2,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CGB:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
@@ -15856,11 +15855,21 @@
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
+		<model name='Prime'>
+			<availability>CHH:8,CW:8,CNC:8,CJF:8,CCO:8</availability>
+		</model>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
 		</model>
 		<model name='B'>
 			<availability>CW:9,General:7,CGB:9</availability>
@@ -15868,19 +15877,13 @@
 		<model name='H'>
 			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CW:8,CNC:8,CJF:8,CCO:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,ROS:3,FS:6,MERC:3</availability>
+		<model name='(RAC)'>
+			<roles>urban</roles>
+			<availability>General:4,FS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
@@ -15888,10 +15891,6 @@
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>urban</roles>
-			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -15903,57 +15902,30 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,CDS:4,CGB.FRR:2,ROS:3,CGB:5,DC:2</availability>
-		<model name='(Kurita)'>
-			<roles>apc</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>CGB.FRR:8,CLAN:8</availability>
 		</model>
+		<model name='(Kurita)'>
+			<roles>apc</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='3'>
 			<roles>assault</roles>
 			<availability>CHH:6,CGB:3</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CCC:7,CHH:3,MERC.WD:2,CW:3,MERC:1+,CCO:1,CJF:5,RA:5,CWIE:3</availability>
-		<model name='B'>
-			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>CSA:5,CCC:6,General:5,CCO:4,RA:6</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
-		</model>
 		<model name='F'>
 			<availability>CHH:6,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
 		</model>
@@ -15961,8 +15933,35 @@
 			<roles>fire_support</roles>
 			<availability>CHH:5,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CW:6,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CCO:5,CWIE:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
+		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>CSA:5,CCC:6,General:5,CCO:4,RA:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CSA:7,CDS:8,CW:6,General:7,CCO:5,CWIE:6,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
+		</model>
+		<model name='H'>
+			<availability>CSA:6,CCC:5,CDS:5,CLAN:4,IS:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
@@ -15994,24 +15993,24 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:3</availability>
-		<model name='(3065)'>
-			<roles>troop_carrier</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(3071)'>
 			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(3065)'>
+			<roles>troop_carrier</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:3,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:8,IS:6,FS:8</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:3,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech IIC' unitType='Mek'>
@@ -16027,6 +16026,10 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,HL:3-,IS:4-,FS:4-,Periphery:4-,TC:3-,RA.OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+		<model name='UM-R80'>
+			<roles>urban,spotter</roles>
+			<availability>CC:4,MOC:4,IS:3,FWL:3,MERC:3,Periphery:3</availability>
+		</model>
 		<model name='UM-R69'>
 			<roles>urban</roles>
 			<availability>FWL:6,IS:6,Periphery:6</availability>
@@ -16039,26 +16042,22 @@
 			<roles>urban</roles>
 			<availability>CC:2-,FVC:1,Periphery:2</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:6,IS:3,Periphery:3</availability>
-		</model>
-		<model name='UM-R80'>
-			<roles>urban,spotter</roles>
-			<availability>CC:4,MOC:4,IS:3,FWL:3,MERC:3,Periphery:3</availability>
-		</model>
-		<model name='UM-R63'>
+		<model name='UM-R60'>
 			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+			<availability>CC:2-,HL:2-,Periphery.Deep:8,Periphery:4-</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>CC:3,MOC:3,FS.CMM:6,MSC:3,FS:4</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R63'>
 			<roles>urban</roles>
-			<availability>CC:2-,HL:2-,Periphery.Deep:8,Periphery:4-</availability>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:6,IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursus II' unitType='Mek'>
@@ -16069,23 +16068,23 @@
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
 		<availability>CHH:3,ROS:4,CGB:7</availability>
-		<model name='(Standard)'>
+		<model name='3'>
+			<roles>anti_infantry,specops</roles>
 			<deployedWith>IS</deployedWith>
-			<availability>General:8</availability>
+			<availability>CGB:2</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>CGB:2</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>CGB:2</availability>
-		</model>
-		<model name='3'>
-			<roles>anti_infantry,specops</roles>
+		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
-			<availability>CGB:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -16103,8 +16102,8 @@
 	</chassis>
 	<chassis name='Valiant' unitType='Mek'>
 		<availability>LA:6,IS:5,FS:6,MERC:5,CDP:5,DC:6</availability>
-		<model name='V4-LNT-J3'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
+		<model name='V4-LNT-K7'>
+			<availability>General:8</availability>
 		</model>
 		<model name='VLT-3E'>
 			<availability>ROS:4</availability>
@@ -16112,35 +16111,31 @@
 		<model name='VLN-3T'>
 			<availability>LA:2,General:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='V4-LNT-K7'>
-			<availability>General:8</availability>
+		<model name='V4-LNT-J3'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:3,ROS:4,FS:9,MERC:4,CDP:4,TC:4</availability>
-		<model name='VLK-QD4'>
+		<model name='VLK-QF'>
 			<roles>recon,fire_support</roles>
-			<availability>ROS:6,FS:4</availability>
-		</model>
-		<model name='VLK-QD2'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4,FS:4</availability>
+			<availability>FS:1-,MERC:1-</availability>
 		</model>
 		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
 			<availability>LA:5,ROS:4,MERC:3</availability>
 		</model>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:3-,FS:2-,MERC:2-,CDP:3-,TC:2-</availability>
-		</model>
-		<model name='VLK-QF'>
-			<roles>recon,fire_support</roles>
-			<availability>FS:1-,MERC:1-</availability>
-		</model>
 		<model name='VLK-QD'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:5,LA:5,ROS:6,FS:6,MERC:6</availability>
+		</model>
+		<model name='VLK-QD2'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,FS:4</availability>
+		</model>
+		<model name='VLK-QA'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:3-,FS:2-,MERC:2-,CDP:3-,TC:2-</availability>
 		</model>
 		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
@@ -16154,6 +16149,10 @@
 			<roles>recon,fire_support</roles>
 			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='VLK-QD4'>
+			<roles>recon,fire_support</roles>
+			<availability>ROS:6,FS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
 		<availability>FS:2</availability>
@@ -16164,27 +16163,27 @@
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>General:5,RA:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>General:5,RA:6</availability>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -16196,35 +16195,35 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CHH:1,HL:9,CW:1,IS:10,Periphery.Deep:8,CJF:1,Periphery:10</availability>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
+		</model>
 		<model name='(Liao)'>
 			<availability>CC:2-</availability>
-		</model>
-		<model name='V-G7X'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='V7'>
-			<availability>LA:4,ROS:4,FS:4,MERC:5</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>CC:8,MOC:8,FVC:5,Periphery.CM:5,Periphery.HR:5,PIR:5,MH:5,CDP:5,TC:8,Periphery:4</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>IS:4,FS:6</availability>
-		</model>
 		<model name='(LB-X)'>
 			<availability>CC:5,MOC:5,DTA:5,PR:5,RF:5,PG:5,DA:5,RCM:5,CDP:5,RFS:5,TC:5</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>IS:2</availability>
+		<model name='(RAC)'>
+			<availability>IS:4,FS:6</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>CC:1-,General:1-</availability>
 		</model>
+		<model name='(Light Gauss)'>
+			<availability>IS:2</availability>
+		</model>
+		<model name='V-G7X'>
+			<availability>LA:2</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
+		<model name='V7'>
+			<availability>LA:4,ROS:4,FS:4,MERC:5</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>CC:5,LA:4,FWL:5,IS:4,FS:4,MERC:5,DC:4,Periphery:3</availability>
@@ -16232,6 +16231,10 @@
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:2,CC:4,RA.OA:1,LA:4,CGB.FRR:4,IS:1,FWL:4,NIOPS:5,FS:4,Periphery:1,TC:1,DC:4</availability>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:3,CC:3</availability>
 		</model>
@@ -16239,73 +16242,41 @@
 			<roles>asf_carrier</roles>
 			<availability>IS:3,FS:8</availability>
 		</model>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
 		<availability>CGB.FRR:5,ROS:4,CNC:2,MERC:3,RCM:4,DC:8</availability>
+		<model name='SDR-9KC'>
+			<availability>ROS:6,FWL:6,MERC:6,RCM:6,DC:6</availability>
+		</model>
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
-		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,RCM:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,RCM:5,DC:5</availability>
 		</model>
-		<model name='SDR-9KC'>
-			<availability>ROS:6,FWL:6,MERC:6,RCM:6,DC:6</availability>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,RCM:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:3,LA:3,ROS:3,CWIE:2</availability>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:3</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:3,CC:6,HL:3,IS:2-,Periphery.Deep:4,FS:8,Periphery.OS:3,Periphery:4,TC:3,RA.OA:3,LA:4,CGB.FRR:6,Periphery.HR:3,FWL:3,NIOPS:3-,DC:5</availability>
-		<model name='VTR-C'>
-			<availability>CC:4,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
-		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='VTR-9B'>
 			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-9D'>
-			<availability>CC:1,FVC:2,LA:1,FS:1,CDP:2</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-10D'>
-			<availability>ROS:5,FS:6,MERC:2</availability>
-		</model>
-		<model name='VTR-11D'>
-			<roles>urban</roles>
-			<availability>ROS:2,FS:2,MERC:1</availability>
-		</model>
-		<model name='VTR-Cr'>
-			<availability>FS:1,DC:2</availability>
-		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='VTR-9K'>
 			<availability>MOC:4,FVC:4,HL:2,CGB.FRR:8,ROS:4,FWL:4,MH:4,MERC:4,TC:4,Periphery:4,DC:8</availability>
@@ -16313,8 +16284,36 @@
 		<model name='VTR-9Ka'>
 			<availability>CC:2,FVC:3,ROS:3,FS:3,MERC:3,DC:3,Periphery:2</availability>
 		</model>
+		<model name='VTR-Cr'>
+			<availability>FS:1,DC:2</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-C'>
+			<availability>CC:4,CGB.FRR:6,ROS:5,MERC:4,FS:4,DC:6</availability>
+		</model>
+		<model name='VTR-11D'>
+			<roles>urban</roles>
+			<availability>ROS:2,FS:2,MERC:1</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>FVC:1,Periphery:1</availability>
+		</model>
 		<model name='VTR-9S'>
 			<availability>LA:1-</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='VTR-10D'>
+			<availability>ROS:5,FS:6,MERC:2</availability>
+		</model>
+		<model name='VTR-9D'>
+			<availability>CC:1,FVC:2,LA:1,FS:1,CDP:2</availability>
+		</model>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vidar Heavy Defense Tank' unitType='Tank'>
@@ -16332,12 +16331,12 @@
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>CGB.FRR:7,ROS:6,MERC:5,CGB:5</availability>
+		<model name='VKG-2G'>
+			<availability>CGB.FRR:6,ROS:6,MERC:6,CGB:6</availability>
+		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-2G'>
-			<availability>CGB.FRR:6,ROS:6,MERC:6,CGB:6</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
@@ -16357,26 +16356,26 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,PIR:3,MERC:4,TC:6</availability>
-		<model name='VND-1SIC'>
-			<availability>CC:1</availability>
+		<model name='VND-5L'>
+			<availability>CC:3,MOC:2,MERC:2,TC:1</availability>
 		</model>
 		<model name='VND-4L'>
 			<availability>CC:8,MOC:6</availability>
 		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:4,MOC:4,PIR:2,MERC:4,TC:4</availability>
+		<model name='VND-1R'>
+			<availability>CGB.FRR:0,General:2</availability>
 		</model>
 		<model name='VND-3L'>
 			<availability>CC:5,MOC:3,General:3,TC:3</availability>
 		</model>
-		<model name='VND-5L'>
-			<availability>CC:3,MOC:2,MERC:2,TC:1</availability>
+		<model name='VND-1SIC'>
+			<availability>CC:1</availability>
 		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
 		</model>
-		<model name='VND-1R'>
-			<availability>CGB.FRR:0,General:2</availability>
+		<model name='VND-3Lr'>
+			<availability>CC:4,MOC:4,PIR:2,MERC:4,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Violator' unitType='Mek'>
@@ -16399,23 +16398,23 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:6,CJF:8,BAN:6</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:2,CJF:6,RA:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CJF:6,RA:6</availability>
+		</model>
 		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
@@ -16423,27 +16422,27 @@
 		<model name='(Standard)'>
 			<availability>CLAN:2,CJF:4</availability>
 		</model>
-		<model name='5'>
+		<model name='4'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:5,DC:6+</availability>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Nova Cat)' mechanized='true'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='(Nova Cat)' mechanized='true'>
+			<availability>CNC:8</availability>
+		</model>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
@@ -16457,18 +16456,14 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>CGB.FRR:4,PIR:2,FS:2,DC:3</availability>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
-		</model>
 		<model name='VNL-K75N'>
 			<availability>LA:8,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
+		</model>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -16482,9 +16477,17 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>CC:2,MOC:4,LA:5,CGB.FRR:4,FWL:5,IS:3,NIOPS:3,Periphery:4,CGB:1,TC:4</availability>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>OP:6,DoO:6,DO:6,TP:6,DA:6,RCM:6</availability>
+		</model>
 		<model name='VL-2T'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:2-,General:3-,FS:2-</availability>
+		</model>
+		<model name='VL-5T'>
+			<roles>anti_infantry</roles>
+			<availability>MOC:2,FVC:2,PIR:2,IS:2,FS:2-,Periphery:2,TC:2</availability>
 		</model>
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
@@ -16494,26 +16497,27 @@
 			<roles>anti_infantry</roles>
 			<availability>FVC:5,LA:5,CGB.FRR:5,ROS:6,MH:4,FS:5,MERC:5,CGB:1</availability>
 		</model>
-		<model name='VL-5T'>
-			<roles>anti_infantry</roles>
-			<availability>MOC:2,FVC:2,PIR:2,IS:2,FS:2-,Periphery:2,TC:2</availability>
-		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:4,LA:8,CGB.FRR:5,MH:4,FS:4,MERC:5</availability>
 		</model>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>OP:6,DoO:6,DO:6,TP:6,DA:6,RCM:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:6,MERC.WD:5,ROS:3+,CLAN:5,MERC:1+,CCO:5,CJF:5,BAN:6,CWIE:5,CGB:6,DC:3+</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CNC:7,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CDS:5,General:4,CCO:6,RA:5,CGB:5</availability>
@@ -16523,15 +16527,6 @@
 		</model>
 		<model name='U'>
 			<availability>General:2</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:5,CDS:7,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CSA:6,CCC:5,CDS:5,CNC:5,CLAN:4,General:2</availability>
@@ -16554,106 +16549,106 @@
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>MOC:2,CLAN:7,IS:3,TC:2</availability>
+		<model name='9'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:5,IS:4</availability>
+		</model>
+		<model name='10'>
+			<availability>MOC:1,CLAN:1,IS:1,TC:1</availability>
+		</model>
+		<model name='8'>
+			<availability>MOC:5,CLAN:5,IS:5,TC:5</availability>
+		</model>
 		<model name='6'>
 			<availability>RA:6,CGB:6</availability>
+		</model>
+		<model name='7'>
+			<availability>RA:5</availability>
+		</model>
+		<model name='4'>
+			<availability>CC:3,CHH:4,FS:3,CCO:5,RA:4,CWIE:5,CSA:5,CDS:6,LA:3,ROS:3,CNC:5,CGB:5,DC:3</availability>
+		</model>
+		<model name='3'>
+			<availability>CC:3,CDS:5,LA:3,ROS:3,FWL:3,DC:3</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>IS:3</availability>
 		</model>
-		<model name='9'>
-			<availability>CDS:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CC:3,CDS:5,LA:3,ROS:3,FWL:3,DC:3</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:5,IS:4</availability>
-		</model>
-		<model name='8'>
-			<availability>MOC:5,CLAN:5,IS:5,TC:5</availability>
-		</model>
-		<model name='7'>
-			<availability>RA:5</availability>
-		</model>
 		<model name='11'>
 			<availability>MOC:1,CLAN:1,IS:1,TC:1</availability>
-		</model>
-		<model name='10'>
-			<availability>MOC:1,CLAN:1,IS:1,TC:1</availability>
-		</model>
-		<model name='4'>
-			<availability>CC:3,CHH:4,FS:3,CCO:5,RA:4,CWIE:5,CSA:5,CDS:6,LA:3,ROS:3,CNC:5,CGB:5,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>HL:5,LA:8,IS:7,FWL:8,NIOPS:4-,Periphery.Deep:5,TC:8,Periphery:6</availability>
-		<model name='WHM-6R'>
-			<availability>General:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
-		</model>
-		<model name='WHM-10T'>
-			<availability>FS:3,TC:7</availability>
-		</model>
 		<model name='WHM-6L'>
 			<availability>CC:1-</availability>
+		</model>
+		<model name='WHM-9S'>
+			<availability>LA:6,ROS:4,MH:3,MERC:4</availability>
+		</model>
+		<model name='WHM-8M'>
+			<availability>PR:6,RF:6,PG:6,FWL:4,RFS:6</availability>
 		</model>
 		<model name='WHM-7K'>
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:6,MERC:3</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='WHM-8M'>
-			<availability>PR:6,RF:6,PG:6,FWL:4,RFS:6</availability>
-		</model>
-		<model name='WHM-11T'>
-			<availability>MOC:3,TC:4</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:5</availability>
-		</model>
-		<model name='WHD-10CT'>
-			<availability>CC:3,OP:3,LA:3,DoO:3,ROS:3,DO:3,TP:3</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>FVC:3,CLAN:4,MERC:3,BAN:2,TC:5,Periphery:3</availability>
-		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:3,PIR:4,IS:2,MH:3,FS:3,MERC:3,CDP:3,TC:4</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:5,LA:5,FS:4,MERC:4</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CC:3,FVC:3,CGB.FRR:1,ROS:4,FWL:6,MERC:3,DC:1,Periphery:3</availability>
-		</model>
-		<model name='WHM-9S'>
-			<availability>LA:6,ROS:4,MH:3,MERC:4</availability>
+		<model name='WHM-6R'>
+			<availability>General:2-,Periphery.Deep:8,BAN:8,Periphery:3-</availability>
 		</model>
 		<model name='WHM-6K'>
 			<availability>FS.RR:1-,FVC:1-,FS.DMM:1-,FS:1-</availability>
 		</model>
+		<model name='WHM-4L'>
+			<availability>CC:6,MOC:3</availability>
+		</model>
+		<model name='WHM-11T'>
+			<availability>MOC:3,TC:4</availability>
+		</model>
+		<model name='WHM-8K'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='WHD-10CT'>
+			<availability>CC:3,OP:3,LA:3,DoO:3,ROS:3,DO:3,TP:3</availability>
+		</model>
 		<model name='WHM-8D2'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='WHM-4L'>
-			<availability>CC:6,MOC:3</availability>
+		<model name='WHM-5L'>
+			<availability>CC:5</availability>
 		</model>
 		<model name='WHM-6D'>
 			<availability>FVC:2-,FS:1-</availability>
 		</model>
+		<model name='WHM-7M'>
+			<availability>CC:3,FVC:3,CGB.FRR:1,ROS:4,FWL:6,MERC:3,DC:1,Periphery:3</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:5,LA:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:6,MERC:3</availability>
+		</model>
+		<model name='WHM-10T'>
+			<availability>FS:3,TC:7</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>FVC:3,CLAN:4,MERC:3,BAN:2,TC:5,Periphery:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:6,ROS:4,FS:5</availability>
-		<model name='BLR-2G'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BLR-2D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BLR-2G'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:5</availability>
@@ -16668,17 +16663,17 @@
 			<roles>apc</roles>
 			<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
 		</model>
-		<model name='H-7C'>
-			<availability>IS:1-,Periphery:1-</availability>
-		</model>
 		<model name='H-8'>
 			<availability>HL:4,LA:4,FS.CH:8,CGB.FRR:6,ROS:6,IS:3,Periphery.Deep:4,FWL:4,FS:6,MERC:6,Periphery:6,RA:8</availability>
 		</model>
-		<model name='H-9'>
-			<availability>LA:5</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>IS:2-,Periphery:2-</availability>
+		</model>
+		<model name='H-7C'>
+			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='H-9'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Stealth Helicopter' unitType='VTOL'>
@@ -16690,30 +16685,58 @@
 	</chassis>
 	<chassis name='Wasp LAM Mk I' unitType='Mek'>
 		<availability>IS:2</availability>
-		<model name='WSP-100'>
-			<availability>IS:3</availability>
-		</model>
 		<model name='WSP-100A'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='WSP-100b'>
 			<availability>IS:2</availability>
 		</model>
+		<model name='WSP-100'>
+			<availability>IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp LAM' unitType='Mek'>
 		<availability>IS:3</availability>
-		<model name='WSP-105'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='WSP-105M'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='WSP-105'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>HL:5,IS:8,Periphery.Deep:5,Periphery:6,RA:4</availability>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:5,CC:4,DA:4,TC:4</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='WSP-8T'>
+			<roles>recon</roles>
+			<availability>CC:4,MOC:4,ROS:2,IS:3,TC:6</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
+		</model>
 		<model name='WSP-1A'>
 			<roles>recon</roles>
 			<availability>General:2-</availability>
+		</model>
+		<model name='WSP-1S'>
+			<roles>recon</roles>
+			<availability>FVC:4,LA:5,FS:4,MERC:2</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='WSP-1L'>
+			<roles>recon</roles>
+			<availability>CC:1-</availability>
 		</model>
 		<model name='WSP-1D'>
 			<roles>recon</roles>
@@ -16723,41 +16746,13 @@
 			<roles>recon</roles>
 			<availability>CC:2-,MOC:2-,FVC:3-,FWL:2-,RCM:2-,Periphery:3-</availability>
 		</model>
-		<model name='WSP-8T'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,ROS:2,IS:3,TC:6</availability>
-		</model>
 		<model name='WSP-3L'>
 			<roles>recon</roles>
 			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
 		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
-		</model>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:5,CC:4,DA:4,TC:4</availability>
-		</model>
 		<model name='WSP-3A'>
 			<roles>recon</roles>
 			<availability>RA.OA:4,RA:8</availability>
-		</model>
-		<model name='WSP-1S'>
-			<roles>recon</roles>
-			<availability>FVC:4,LA:5,FS:4,MERC:2</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-1L'>
-			<roles>recon</roles>
-			<availability>CC:1-</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Watchman' unitType='Mek'>
@@ -16785,46 +16780,46 @@
 		<model name='WTH-3'>
 			<availability>FS.CMM:6</availability>
 		</model>
+		<model name='WTH-2A'>
+			<availability>DC:1</availability>
+		</model>
+		<model name='WTH-1'>
+			<roles>fire_support</roles>
+			<availability>Periphery.Deep:8,MERC:1,Periphery:1</availability>
+		</model>
+		<model name='WTH-2'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:6,MH:6,MERC:4,CDP:6,TC:6</availability>
+		</model>
 		<model name='WTH-1H'>
 			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
 		</model>
 		<model name='WTH-K'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WTH-1'>
-			<roles>fire_support</roles>
-			<availability>Periphery.Deep:8,MERC:1,Periphery:1</availability>
-		</model>
-		<model name='WTH-2A'>
-			<availability>DC:1</availability>
-		</model>
-		<model name='WTH-2'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:6,MH:6,MERC:4,CDP:6,TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:5,LA:5,CNC:2-,FWL:5,IS:4,MERC:5,DC:8</availability>
-		<model name='WGT-3SC'>
-			<availability>CC:8,LA:5,FWL:5,IS:5,MERC:5</availability>
-		</model>
-		<model name='WGT-1LAW/SC3'>
-			<availability>ROS:5,DC:6</availability>
+		<model name='WGT-2LAW'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='WGT-4NC &apos;Dezgra&apos;'>
 			<availability>CNC:8</availability>
 		</model>
+		<model name='WGT-1LAW/SC3'>
+			<availability>ROS:5,DC:6</availability>
+		</model>
 		<model name='WGT-2LAWC3'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WGT-2LAW'>
-			<availability>DC:5</availability>
+		<model name='WGT-1LAW/SC'>
+			<availability>LA:5,FWL:5,IS:4,MERC:5,DC:6</availability>
 		</model>
 		<model name='WGT-2SC'>
 			<availability>LA:6,FWL:6,IS:4,MERC:6</availability>
 		</model>
-		<model name='WGT-1LAW/SC'>
-			<availability>LA:5,FWL:5,IS:4,MERC:5,DC:6</availability>
+		<model name='WGT-3SC'>
+			<availability>CC:8,LA:5,FWL:5,IS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Wildkatze' unitType='Aero'>
@@ -16838,11 +16833,11 @@
 	</chassis>
 	<chassis name='Winston Combat Vehicle' unitType='Tank'>
 		<availability>ROS:4,ROS.pm:6</availability>
-		<model name='(LAC)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(LAC)'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -16854,14 +16849,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>CGB.FRR:3,ROS:3,MERC:3,DC:5-</availability>
-		<model name='WFT-C'>
-			<availability>CGB.FRR:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='WFT-2'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:8,DC:5</availability>
 		</model>
 		<model name='WFT-B'>
 			<availability>ROS:6</availability>
@@ -16869,21 +16858,15 @@
 		<model name='WFT-1'>
 			<availability>General:4</availability>
 		</model>
+		<model name='WFT-C'>
+			<availability>CGB.FRR:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:8,DC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,OP:3,MERC.KH:7,DoO:3,DO:3,FS:2,MERC:4,CWIE:5,DTA:3,MERC.WD:5,FVC:2,LA:7,CGB.FRR:5,ROS:5,MH:4,MSC:3,TP:3</availability>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
-		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:6,LA:5,ROS:5,MERC:4,FS:5,CWIE:5</availability>
-		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:2,MERC.WD:1,FVC:2,LA:4,ROS:4,CGB.FRR:6,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-3M'>
-			<availability>DTA:8,OP:8,DoO:8,FWL:8,DO:8,MSC:8,TP:8</availability>
-		</model>
 		<model name='WLF-4WA'>
 			<roles>ew_support</roles>
 			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
@@ -16891,65 +16874,77 @@
 		<model name='WLF-1'>
 			<availability>MERC.KH:2,HL:6,LA:2,ROS:2,Periphery.Deep:6,FS:1,MERC:2,Periphery:8</availability>
 		</model>
-		<model name='WLF-3S'>
-			<availability>LA:4</availability>
+		<model name='WLF-3M'>
+			<availability>DTA:8,OP:8,DoO:8,FWL:8,DO:8,MSC:8,TP:8</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:2,MERC.WD:1,FVC:2,LA:4,ROS:4,CGB.FRR:6,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
 		</model>
 		<model name='WLF-2H'>
 			<availability>LA:4,MERC:2,CWIE:3</availability>
 		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:6,LA:5,ROS:5,MERC:4,FS:5,CWIE:5</availability>
+		</model>
+		<model name='WLF-3S'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,TC:4,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5,CGB:1</availability>
-		<model name='WVR-9K'>
-			<availability>ROS:3,DC:3</availability>
-		</model>
-		<model name='WVR-6R'>
+		<model name='WVR-7M'>
 			<roles>recon</roles>
-			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>FVC:6,LA:5,ROS:4,FS:5,MERC:3</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,MERC:3,DC:6</availability>
-		</model>
-		<model name='WVR-9W2'>
-			<availability>IS:4,DC:6</availability>
+			<availability>CC:4,MOC:4,FWL:5,MH:4,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-9D'>
 			<roles>spotter</roles>
 			<availability>FS:6,MERC:4</availability>
 		</model>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FWL:5,MH:4,MERC:6,DC:4</availability>
+		<model name='WVR-8K'>
+			<availability>CGB.FRR:5,ROS:4,CNC:5,MERC:3,DC:2,CGB:5</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:6</availability>
+		<model name='WVR-9W2'>
+			<availability>IS:4,DC:6</availability>
 		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>CGB.FRR:8,MERC:6,CGB:8,DC:6</availability>
 		</model>
-		<model name='WVR-9M'>
-			<availability>LA:3,ROS:4,FWL:5,MH:3,MERC:3</availability>
+		<model name='WVR-8D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='WVR-6M'>
 			<roles>recon</roles>
 			<availability>Periphery.MW:4-,PIR:4-,Periphery.ME:4-,FWL:2-,MH:4-</availability>
 		</model>
-		<model name='WVR-8K'>
-			<availability>CGB.FRR:5,ROS:4,CNC:5,MERC:3,DC:2,CGB:5</availability>
+		<model name='WVR-8C'>
+			<availability>ROS:4,MERC:3,DC:6</availability>
+		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
+		</model>
+		<model name='WVR-9M'>
+			<availability>LA:3,ROS:4,FWL:5,MH:3,MERC:3</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>FVC:6,LA:5,ROS:4,FS:5,MERC:3</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>ROS:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith' unitType='Mek'>
@@ -16970,7 +16965,7 @@
 	</chassis>
 	<chassis name='Wusun' unitType='Aero' omni='Clan'>
 		<availability>RA.OA:1+,RA:3</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -16979,29 +16974,29 @@
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
 		<availability>CHH:4,CW:4,CLAN:2</availability>
+		<model name='2'>
+			<availability>CW:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CW:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:2,OP:2,PR:2,DoO:2,IS:2,DO:2,FS:7,MERC:5,DC.GHO:3,DTA:2,FVC:2,RF:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
-		<model name='WVE-9N'>
-			<roles>urban</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>DC.GHO:3,CGB.FRR:8,ROS:6,NIOPS:4,FS:8,MERC:8,BAN:2,DC:3</availability>
+		</model>
+		<model name='WVE-9N'>
+			<roles>urban</roles>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -17017,11 +17012,11 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:6,LA:4,ROS:4,Periphery.CM:4,MERC:4,DC:2,Periphery:2,TC:4</availability>
-		<model name='XNT-2O'>
-			<availability>General:2-</availability>
-		</model>
 		<model name='XNT-6O'>
 			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='XNT-2O'>
+			<availability>General:2-</availability>
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:5,MOC:5,LA:5,ROS:5,MERC:5</availability>
@@ -17039,14 +17034,14 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
-		<model name='2'>
-			<availability>CSA:4,CHH:6,CSL:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CSA:4,CHH:6,CSL:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Yao Lien' unitType='Mek'>
@@ -17057,6 +17052,9 @@
 	</chassis>
 	<chassis name='Yasha VTOL' unitType='VTOL'>
 		<availability>CHH:3,CDS:3,CNC:3,IS:3,CWIE:3</availability>
+		<model name='&apos;Spectre&apos;'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Interdictor)'>
 			<roles>ew_support</roles>
 			<availability>General:4</availability>
@@ -17064,17 +17062,11 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='&apos;Spectre&apos;'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>FVC:8,HL:3,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
 		<model name='(RAC)'>
 			<availability>IS:3,FS:5</availability>
-		</model>
-		<model name='(PPC)'>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2,FS:4</availability>
@@ -17086,15 +17078,18 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(PPC)'>
+			<availability>IS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
 		<availability>ROS:4,FWL:4,MH:3,MERC:3</availability>
-		<model name='YMN-10-OR'>
-			<availability>ROS:4,FWL:4,MERC:4</availability>
-		</model>
 		<model name='YMN-6Y'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='YMN-10-OR'>
+			<availability>ROS:4,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ymir' unitType='Mek'>
@@ -17112,18 +17107,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:5</availability>
-		</model>
-		<model name='Y-H10G'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Y-H9G'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='Y-H10G'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Zephyr Hovertank' unitType='Tank'>
@@ -17145,11 +17140,11 @@
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='(Omnidrone) C'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Omnidrone) A'>
 			<roles>spotter</roles>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(Omnidrone) C'>
 			<availability>ROS:4</availability>
 		</model>
 		<model name='(Omnidrone) Prime'>
@@ -17158,13 +17153,13 @@
 	</chassis>
 	<chassis name='Zephyros Infantry Support Vehicle' unitType='Tank'>
 		<availability>CHH:5,CW:2,CGB:2,CWIE:2</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Dual Turret)'>
 			<roles>apc</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
@@ -17175,6 +17170,9 @@
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:3-,ROS:4</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='ZEU-X3'>
 			<availability>LA:3-</availability>
 		</model>
@@ -17184,29 +17182,26 @@
 		<model name='ZEU-9WD'>
 			<availability>General:4</availability>
 		</model>
-		<model name='ZEU-X2'>
-			<availability>LA:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,HL:5,LA:10,CGB.FRR:4,ROS:5,PIR:3,MH:3,FS:4-,MERC:5,CDP:3,TC:3</availability>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
-		<model name='ZEU-6S'>
-			<availability>HL:2,General:1-,Periphery:4</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>FVC:6,LA:8,CGB.FRR:6,PIR:6,MH:4,MERC:6,CDP:6,TC:6</availability>
 		</model>
-		<model name='ZEU-9S2'>
-			<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
+		<model name='ZEU-6T'>
+			<availability>LA:2-</availability>
 		</model>
 		<model name='ZEU-9S-DC'>
 			<availability>LA:2</availability>
 		</model>
-		<model name='ZEU-6T'>
-			<availability>LA:2-</availability>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4</availability>
+		</model>
+		<model name='ZEU-9S2'>
+			<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
+		</model>
+		<model name='ZEU-6S'>
+			<availability>HL:2,General:1-,Periphery:4</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -17229,30 +17224,34 @@
 		<model name='(A)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CCC:10,CW:10,ROS:6,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CLAN:4,CJF:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(ATM)'>
 			<availability>CW:6,ROS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Zugvogel Omni Support Aircraft' unitType='Conventional Fighter'>
 		<availability>LA:4,IS:2,Periphery:2,CGB:2</availability>
+		<model name='Prime'>
+			<roles>cargo</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<roles>support</roles>
 			<availability>General:6</availability>
@@ -17261,24 +17260,20 @@
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>cargo</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>support,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<roles>support</roles>
+		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
 		<model name='F'>
 			<roles>support</roles>
 			<availability>General:5</availability>
-		</model>
-		<model name='D &apos;Raubvogel&apos;'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 </units>

--- a/megamek/data/forcegenerator/3100.xml
+++ b/megamek/data/forcegenerator/3100.xml
@@ -1176,28 +1176,28 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
 		<availability>MOC:1,CC:4,RA.OA:1,LA:2,CLAN:4,IS:2,FWL:4,FS:2,BAN:5,Periphery:1,TC:1,DC:6</availability>
+		<model name='(3088)'>
+			<availability>DC:5</availability>
+		</model>
 		<model name='(2582)'>
 			<roles>assault</roles>
 			<availability>General:2</availability>
-		</model>
-		<model name='(3088)'>
-			<availability>DC:5</availability>
 		</model>
 		<model name='(3055)'>
 			<roles>assault</roles>
@@ -1261,17 +1261,17 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CJF:6</availability>
-		<model name='(Jade Falcon)' mechanized='true'>
-			<availability>CJF:8</availability>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Jade Falcon)' mechanized='true'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Agrotera' unitType='Mek'>
@@ -1310,13 +1310,12 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4</availability>
@@ -1324,17 +1323,15 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>ROS:4,CNC:4,DC:6</availability>
-		<model name='AKU-2X'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,DC:5</availability>
+		<model name='AKU-2XK'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='AKU-1X'>
 			<availability>DC:4</availability>
@@ -1342,17 +1339,20 @@
 		<model name='AKU-2XC'>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='AKU-2XK'>
-			<availability>DC:5</availability>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,DC:5</availability>
+		</model>
+		<model name='AKU-2X'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,CW:4,LA:6,ROS:5,CNC:4,FS:5,CWIE:6,DC:3</availability>
-		<model name='Mk VII'>
-			<availability>LA:4,FS:4</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk VII'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
@@ -1360,11 +1360,11 @@
 		<model name='ALB-3U'>
 			<availability>FWL:8,MERC:8</availability>
 		</model>
-		<model name='ALB-3Ur'>
-			<availability>ROS:4,FWL:4,MERC:4</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,OP:6,FWL:6,MSC:6</availability>
+		</model>
+		<model name='ALB-3Ur'>
+			<availability>ROS:4,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Amazon Battle Armor' unitType='BattleArmor'>
@@ -1378,11 +1378,11 @@
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CHH:5,RD:5,CDS:6,CW:5,CNC:5,CGB:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>RD:6,CGB:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Anat APC' unitType='Tank'>
@@ -1421,6 +1421,9 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>MERC.KH:2,MERC.WD:8,CHH:3,RD:1,LA:3,ROS:4,MERC:3,CWIE:3,BAN:2,CGB:1,RA:3</availability>
+		<model name='C 2'>
+			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
+		</model>
 		<model name='ANH-4A'>
 			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:4,ROS:4,MERC:4,CWIE:5</availability>
 		</model>
@@ -1432,9 +1435,6 @@
 		</model>
 		<model name='ANH-3A'>
 			<availability>MERC.WD:5,CHH:4,LA:6,ROS:6,MERC:6,CWIE:4</availability>
-		</model>
-		<model name='C 2'>
-			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1463,38 +1463,32 @@
 		<model name='ABS-5Y'>
 			<availability>MOC:4,CC:4</availability>
 		</model>
-		<model name='ABS-5Z'>
-			<roles>spotter</roles>
-			<availability>CC:4,MOC:4</availability>
+		<model name='ABS-3R'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ABS-3T'>
 			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
-		<model name='ABS-3R'>
-			<availability>General:4</availability>
+		<model name='ABS-4C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='ABS-5Z'>
+			<roles>spotter</roles>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
 			<availability>FVC:0,General:8</availability>
 		</model>
-		<model name='ABS-4C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>DTA:6,OP:6,RF:6,ROS:4,FWL:4,MSC:6,MERC:4,DA:6</availability>
-		<model name='ANV-5M'>
-			<availability>DTA:4,OP:4,FWL:4,DA:4</availability>
-		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>DTA:5,OP:5,RF:5,MSC:5,DA:5</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>ROS:6,FWL:3,MERC:3</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,MERC:4</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:4,OP:4,FWL:4,DA:4</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
@@ -1503,34 +1497,40 @@
 		<model name='ANV-5Q'>
 			<availability>DTA:4,RF:4,MSC:4</availability>
 		</model>
+		<model name='ANV-3R'>
+			<availability>FWL:4,MERC:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>ROS:6,FWL:3,MERC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Anzu' unitType='Mek'>
 		<availability>DTA:4,OP:4,MSC:6</availability>
+		<model name='ZU-J70'>
+			<availability>MSC:6</availability>
+		</model>
 		<model name='ZU-G60'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='ZU-J70'>
-			<availability>MSC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,Periphery.MW:3,ROS:4,Periphery.ME:3,FWL:8,MH:4,MSC:8,MERC:4,DC:6</availability>
-		<model name='APL-3T'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,DC:3</availability>
-		</model>
 		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>CC:3,FWL:4,MERC:3,DC:3</availability>
 		</model>
-		<model name='APL-2S'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
-			<availability>CC:3,FWL:4,DC:3</availability>
+			<availability>FWL:4,DC:3</availability>
 		</model>
 		<model name='APL-4M'>
 			<roles>fire_support</roles>
 			<availability>MSC:6</availability>
+		</model>
+		<model name='APL-2S'>
+			<roles>fire_support</roles>
+			<availability>CC:3,FWL:4,DC:3</availability>
 		</model>
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
@@ -1556,14 +1556,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,ROS:4,CNC:6,MERC:4,FS:3,DC:3</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1592,90 +1592,81 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,RD:3,LA:6,CGB.FRR:4,FWL:6,Periphery:3,DC:5,CGB:3</availability>
-		<model name='ARC-6W'>
+		<model name='ARC-7L'>
 			<roles>fire_support</roles>
-			<availability>FVC:4,TC:6,Periphery:4</availability>
+			<availability>CC:8,MOC:4</availability>
 		</model>
 		<model name='ARC-9W'>
 			<roles>fire_support</roles>
 			<availability>ROS:6</availability>
 		</model>
-		<model name='ARC-6S'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>RD:4,LA:2,ROS:4,MERC:3,CGB:4</availability>
-		</model>
-		<model name='ARC-8M'>
-			<roles>fire_support</roles>
-			<availability>DTA:5,MOC:3,OP:5,ROS:4,PIR:3,MH:3,MSC:5,MERC:4</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6</availability>
-		</model>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:8,MOC:4</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
+			<availability>CLAN:4,FWL:4,MERC:4,BAN:2</availability>
 		</model>
 		<model name='ARC-9KC'>
 			<roles>fire_support</roles>
 			<availability>DC:5</availability>
 		</model>
-		<model name='ARC-5R'>
+		<model name='ARC-5W'>
 			<roles>fire_support</roles>
-			<availability>RD:6,MERC:3,CGB:6</availability>
+			<availability>MERC.WD:8,LA:2,MERC:2</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>RD:4,LA:2,ROS:4,MERC:3,CGB:4</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
+		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,TC:6,Periphery:4</availability>
 		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='ARC-9M'>
+			<roles>fire_support</roles>
+			<availability>LA:6,ROS:4,FWL:4,MERC:4,DC:4</availability>
+		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='ARC-9M'>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5R'>
 			<roles>fire_support</roles>
-			<availability>LA:6,ROS:4,FWL:4,MERC:4,DC:4</availability>
+			<availability>RD:6,MERC:3,CGB:6</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>CGB.FRR:2-,BAN:2,Periphery:2-</availability>
 		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:2,MERC:2</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,MERC:4,BAN:2</availability>
-		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>CC:2,FVC:4,PIR:5,FWL:4,MERC:2,DC:2,Periphery:4</availability>
 		</model>
+		<model name='ARC-8M'>
+			<roles>fire_support</roles>
+			<availability>DTA:5,MOC:3,OP:5,ROS:4,PIR:3,MH:3,MSC:5,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,LA:5,ROS:4,CNC:2-,MERC:2,CWIE:3-</availability>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1E'>
-			<availability>General:6</availability>
+		<model name='AF1C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
@@ -1684,21 +1675,30 @@
 		<model name='AF1B'>
 			<availability>General:5</availability>
 		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Wolf II' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:4,CWIE:5</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
@@ -1715,11 +1715,11 @@
 		<model name='A'>
 			<availability>General:2</availability>
 		</model>
-		<model name='J'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:4</availability>
+		</model>
+		<model name='J'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -1749,12 +1749,6 @@
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
 		<availability>FS:6</availability>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
@@ -1764,40 +1758,26 @@
 		<model name='AGS-6F'>
 			<availability>General:4</availability>
 		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1807,17 +1787,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1844,16 +1844,16 @@
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
 		<availability>CC:1-,MOC:1-,FVC:1,LA:1,MERC:1-,RCM:2-,DA:2-,CDP:1-,TC:1-,Periphery:1-</availability>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
+		<model name='ASN-99'>
+			<roles>spotter</roles>
+			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:4,FVC:4,Periphery.HR:5,PIR:3,MH:4,RCM:4,DA:4</availability>
 		</model>
-		<model name='ASN-99'>
-			<roles>spotter</roles>
-			<availability>CC:2,MOC:2</availability>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -1882,11 +1882,11 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CHH:8,RD:6,CDS:5,CW:5,ROS:4,CJF:3,RA:5,CGB:6</availability>
-		<model name='(HAG)'>
-			<availability>CHH:8,ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas III' unitType='Mek'>
@@ -1906,69 +1906,57 @@
 		<model name='AS7-Dr'>
 			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>CGB.FRR:4,IS:4,DC:4</availability>
+		<model name='AS7-K4'>
+			<availability>RF:4,LA:4,DC:4</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>MOC:3,RA.OA:4,FVC:4,CNC:5,MERC:4,CDP:3,DC:5,Periphery:4,TC:3</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:6,ROS:4,MERC:3</availability>
+		</model>
+		<model name='AS7-K3'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
+		</model>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:5</availability>
+		</model>
+		<model name='AS7-D-DC'>
+			<availability>MERC:0,DC:1-</availability>
+		</model>
+		<model name='AS7-K2'>
+			<availability>LA:8,CNC:5,IS:5,CLAN.IS:4,Periphery:5,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:4,FS:4,DC:4</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>CGB.FRR:4,IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-RS'>
+			<availability>Periphery:1-</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>MERC:2,DC:2</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
-		</model>
-		<model name='AS7-C'>
-			<availability>MERC:2,DC:2</availability>
-		</model>
 		<model name='AS7-S2'>
 			<availability>LA:1,ROS:3,MERC:3</availability>
 		</model>
-		<model name='AS7-D'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='AS7-RS'>
-			<availability>Periphery:1-</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:6,ROS:4,MERC:3</availability>
-		</model>
-		<model name='AS7-D-DC'>
-			<availability>MERC:0,DC:1-</availability>
-		</model>
-		<model name='AS7-K4'>
-			<availability>RF:4,LA:4,DC:4</availability>
-		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:5</availability>
-		</model>
-		<model name='AS7-K3'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>MOC:3,RA.OA:4,FVC:4,CNC:5,MERC:4,CDP:3,DC:5,Periphery:4,TC:3</availability>
-		</model>
-		<model name='AS7-K2'>
-			<availability>LA:8,CNC:5,IS:5,CLAN.IS:4,Periphery:5,CWIE:5</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(CV)'>
@@ -1979,6 +1967,14 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Gunship)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
@@ -1986,6 +1982,10 @@
 		<model name='(Tanker)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -1997,24 +1997,24 @@
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CW:3,CLAN:2,CNC:3,RA:2,BAN:5,CWIE:3</availability>
+		<model name='A'>
+			<availability>General:6,RA:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:7,RA:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6,RA:7</availability>
-		</model>
 		<model name='D'>
 			<availability>CW:6,CLAN:4,CNC:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
@@ -2025,34 +2025,34 @@
 		<model name='AV1-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='AV1-OH'>
+			<availability>General:4</availability>
+		</model>
 		<model name='AV1-OI'>
 			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OD'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OH'>
-			<availability>General:4</availability>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
 		</model>
-		<model name='AV1-OE'>
-			<availability>General:6</availability>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AV1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
-		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
@@ -2060,31 +2060,31 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:2,RA.OA:2,LA:4,CGB.FRR:2,IS:2,FWL:3,FS:4,TC:2,Periphery:1,DC:3</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:6,CC:5,RA.OA:6,LA:4,ROS:5,IS:4,FWL:8,FS:4,Periphery:8,TC:5,DC:6</availability>
-		<model name='AWS-8Q'>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='AWS-10KM'>
 			<availability>DTA:4,OP:4,ROS:4,FWL:4,MSC:4,DC:6</availability>
+		</model>
+		<model name='AWS-8Q'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:2,PIR:4,FWL:4,IS:2,MH:2,TC:2,Periphery:4</availability>
 		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:2,OP:2,LA:2,ROS:2,FWL:2,MSC:2,FS:2,MERC:2</availability>
-		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:6,FWL:4,IS:6,MH:6,TC:6,Periphery:4</availability>
+		</model>
+		<model name='AWS-9Ma'>
+			<availability>DTA:2,OP:2,LA:2,ROS:2,FWL:2,MSC:2,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
@@ -2107,8 +2107,18 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:1,LA:5,ROS:4,FS:1</availability>
+		<model name='AXM-6T'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='AXM-3S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='AXM-4D'>
 			<availability>FS:6</availability>
+		</model>
+		<model name='AXM-2N'>
+			<roles>fire_support</roles>
+			<availability>LA:1</availability>
 		</model>
 		<model name='AXM-1N'>
 			<availability>FVC:2,LA:2,MERC:2,FS:2</availability>
@@ -2116,19 +2126,13 @@
 		<model name='AXM-3Sr'>
 			<availability>LA:6,ROS:4,FS:6,MERC:4</availability>
 		</model>
-		<model name='AXM-6T'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='AXM-3S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-2N'>
-			<roles>fire_support</roles>
-			<availability>LA:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CJF:5,RA:5</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>RA:6</availability>
+		</model>
 		<model name='3 &apos;Devil&apos;'>
 			<availability>RA:8</availability>
 		</model>
@@ -2136,14 +2140,30 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>RA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:4,CW:5,LA:3,ROS:4</availability>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:6,General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2155,38 +2175,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>CLAN:6,General:4</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CLAN:5,General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,LA:3,MERC:3</availability>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
@@ -2202,7 +2198,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
@@ -2210,15 +2206,13 @@
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>RA.OA:7,IS:7,CLAN.IS:7</availability>
-		<model name='(Hybrid)'>
-			<availability>CLAN:3,IS:3</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
@@ -2226,24 +2220,30 @@
 		<model name='(Standard)'>
 			<availability>CLAN:8,IS:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Hybrid)'>
+			<availability>CLAN:3,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -2251,33 +2251,41 @@
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:4,DTA:4,LA:4,ROS:4,FWL:4,MERC:8,FS:4,DA:4,Periphery:4</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:2</availability>
+		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
 		<model name='BNDR-01B'>
 			<availability>General:4,MERC:8</availability>
 		</model>
-		<model name='BNDR-01Ar'>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:2,CLAN:1</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
@@ -2287,16 +2295,8 @@
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -2309,9 +2309,13 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:3,MERC:5</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -2321,9 +2325,9 @@
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:6</availability>
+			<availability>General:3</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
@@ -2333,39 +2337,41 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:5-,RA.OA:5-,FVC:2-,RF:2-,LA:3-,FWL:1-,MH:5-,MSC:1-,MERC:2-,Periphery:7-,TC:5-</availability>
-		<model name='BNC-3MC'>
-			<availability>MOC:2-</availability>
-		</model>
-		<model name='BNC-3S'>
-			<availability>RA.OA:1-,CDP:1-,TC:1-,Periphery:1-</availability>
-		</model>
-		<model name='BNC-6S'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BNC-3Mr'>
 			<availability>MOC:6,FWL:6,CDP:6,TC:6</availability>
 		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:2-</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:1</availability>
+		</model>
 		<model name='BNC-9S2'>
 			<availability>RF:2,LA:3</availability>
+		</model>
+		<model name='BNC-9S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1-,FVC:1-,FWL:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>RF:1-,MSC:1-</availability>
@@ -2373,20 +2379,14 @@
 		<model name='BNC-3E'>
 			<availability>MERC:1-,Periphery:2-</availability>
 		</model>
-		<model name='BNC-7S'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6</availability>
+		<model name='BNC-3S'>
+			<availability>RA.OA:1-,CDP:1-,TC:1-,Periphery:1-</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:3,MH:4,MERC:5</availability>
 		</model>
-		<model name='BNC-9S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1-,FVC:1-,FWL:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
+		<model name='BNC-6S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bardiche Heavy Strike Tank' unitType='Tank'>
@@ -2401,21 +2401,21 @@
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,ROS:4,MERC:4</availability>
-		<model name='BGS-2T'>
-			<availability>LA:4,ROS:4,MERC:4</availability>
-		</model>
-		<model name='BGS-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BGS-1T'>
 			<availability>General:3</availability>
+		</model>
+		<model name='BGS-3T'>
+			<availability>LA:3,ROS:3,MERC:3</availability>
+		</model>
+		<model name='BGS-2T'>
+			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
 		<model name='BGS-4T'>
 			<availability>LA:7</availability>
 		</model>
-		<model name='BGS-3T'>
-			<availability>LA:3,ROS:3,MERC:3</availability>
+		<model name='BGS-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Barouche Military Transport' unitType='Tank'>
@@ -2427,21 +2427,21 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>ROS:3+,CNC:5,CLAN:3,IS:3+,RA:6,BAN:5</availability>
-		<model name='D'>
-			<availability>CNC:3,CLAN:2,RA:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CNC:8,General:7,RA:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='D'>
+			<availability>CNC:3,CLAN:2,RA:6</availability>
 		</model>
 		<model name='A'>
 			<availability>RD:8,General:7,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
@@ -2450,25 +2450,25 @@
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CJF:6</availability>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='H'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:5</availability>
-		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
-		<model name='H'>
+		<model name='F'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -2501,20 +2501,32 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:5,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:5,FWL:8,CJF:2,DC:5</availability>
-		<model name='BLR-4L'>
-			<availability>CC:6</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>CC:4,FVC:4,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:3,MH:5,MERC:4,Periphery:2</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:3,ROS:4,MERC:4</availability>
+		<model name='BLR-1Gb'>
+			<availability>CC:4,OP:4,CLAN:8,MSC:4,FS:4,MERC:4,BAN:2,DC:4</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>MSC:2</availability>
 		</model>
+		<model name='BLR-1D'>
+			<availability>FVC:2-</availability>
+		</model>
+		<model name='BLR-6X'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='BLR-4S'>
+			<availability>LA:3,ROS:4,MERC:4</availability>
+		</model>
 		<model name='BLR-10S'>
 			<availability>LA:6,ROS:4,FS:4</availability>
+		</model>
+		<model name='BLR-3S'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>BAN:8,Periphery:2-</availability>
 		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:6,ROS:4,FS:4</availability>
@@ -2526,33 +2538,21 @@
 			<roles>spotter</roles>
 			<availability>DTA:5,OP:5,ROS:4,DA:5,MERC:4</availability>
 		</model>
-		<model name='BLR-K4'>
-			<availability>RD:4,ROS:4,CGB.FRR:5,DC:6</availability>
-		</model>
-		<model name='BLR-6X'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BLR-3S'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>BAN:8,Periphery:2-</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:4,OP:4,CLAN:8,MSC:4,FS:4,MERC:4,BAN:2,DC:4</availability>
-		</model>
-		<model name='BLR-1D'>
-			<availability>FVC:2-</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
-		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:8,OP:8,MSC:8</availability>
+		</model>
+		<model name='BLR-K4'>
+			<availability>RD:4,ROS:4,CGB.FRR:5,DC:6</availability>
 		</model>
 		<model name='BLR-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-3M'>
+			<availability>CC:4,FVC:4,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:3,MH:5,MERC:4,Periphery:2</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='BLR-K3'>
 			<roles>spotter</roles>
@@ -2568,16 +2568,9 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CHH:5,RD:5,CDS:5,CW:6,CNC:5,CJF:6,CGB:5,CWIE:3</availability>
-		<model name='D'>
-			<availability>CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CNC:9,General:8</availability>
-		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,General:5,CJF:6</availability>
@@ -2585,65 +2578,72 @@
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>CW:5,CLAN:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
 		<availability>ROS:6</availability>
-		<model name='(Sealed)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>ROS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>RD:6,ROS:4,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:5,RA:3</availability>
-		<model name='(Standard)'>
-			<availability>RA:3</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:7</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:2,IS:2,MERC:2,FS:2,Periphery:2,RA.OA:2,CDS:3,LA:2,CGB.FRR:2,PIR:2,CNC:3,FWL:2,DC:3</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:6,IS:6,DC:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>FVC:4,CDS:4,General:8</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Kurita)'>
-			<availability>CLAN:6,IS:6,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>FVC:4,CDS:4,General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth II Heavy Tank' unitType='Tank'>
 		<availability>CC:5,MOC:4,LA:3,ROS:5,FWL:4,MH:3,MERC:3,TC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2655,11 +2655,11 @@
 	</chassis>
 	<chassis name='Bellona Hover Tank' unitType='Tank'>
 		<availability>CHH:6</availability>
-		<model name='(Laser)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Beowulf IIC' unitType='Mek'>
@@ -2671,28 +2671,28 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>RD:6,ROS:6,CNC:4,CGB:6</availability>
-		<model name='BEO-14'>
-			<roles>recon</roles>
-			<availability>ROS:6</availability>
-		</model>
 		<model name='BEO-12'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BEO-14'>
+			<roles>recon</roles>
+			<availability>ROS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>RF:5,LA:7,ROS:4,FS:3,MERC:3</availability>
+		<model name='BRZ-A3'>
+			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
+		</model>
 		<model name='BRZ-D4'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:1</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>RF:4,LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='BRZ-A3'>
-			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2717,109 +2717,109 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CHH:1,RD:1,CW:1,ROS:4+,CJF:1,RA:2,BAN:2,CWIE:2,CGB:1</availability>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
 		<model name='B'>
 			<availability>RD:4,CW:6,CNC:7,General:6,CJF:8,CGB:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2</availability>
+		<model name='C'>
+			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>RD:2,CDS:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CWIE:2,CGB:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,CW:3,General:5,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,General:2</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:7,CW:5,General:6,CJF:8,CGB:7</availability>
 		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='A'>
 			<availability>RD:8,CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CDS:5,CW:5,CLAN:4,General:2</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:5,LA:6,IS:5,FS:5,MERC:5,DC:8</availability>
-		<model name='BHKU-OC'>
+		<model name='BHKU-OX'>
+			<availability>FS:2,DC:2</availability>
+		</model>
+		<model name='BHKU-OE'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BHKU-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='BHKU-OX'>
-			<availability>FS:2,DC:2</availability>
-		</model>
 		<model name='BHKU-OR'>
 			<availability>General:3+,DC:3+</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OA'>
-			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OF'>
 			<availability>General:4</availability>
 		</model>
+		<model name='BHKU-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
 		<availability>CHH:8,CDS:6,CNC:6,IS:5,MERC:6,CWIE:6</availability>
-		<model name='3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CDS:3,FWL:6,MSC:6,CGB:5,MOC:3,CC:3,OP:6,IS:4,MERC:4,RA:3,Periphery:3,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3,DC:4</availability>
-		<model name='BL-12-KNT'>
-			<availability>ROS:5,FS:5</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,FWL:6,MERC.SI:3,DC:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>DTA:6,OP:6,LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,BAN:2,DC:6</availability>
 		</model>
-		<model name='BLK-NT-4D'>
-			<availability>CDS:2,CW:2,ROS:2,CNC:3,FS:3,MERC:2,CWIE:3</availability>
-		</model>
-		<model name='BLK-NT-3B'>
-			<availability>LA:4,ROS:4,FWL:4,FS:5,MERC:4</availability>
+		<model name='BL-9-KNT'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='BLK-NT-2Y'>
 			<availability>FVC:4,ROS:6,IS:6,FS:6,CDP:4</availability>
 		</model>
+		<model name='BL-6-KNT'>
+			<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,FWL:6,MERC.SI:3,DC:6</availability>
+		</model>
+		<model name='BLK-NT-4D'>
+			<availability>CDS:2,CW:2,ROS:2,CNC:3,FS:3,MERC:2,CWIE:3</availability>
+		</model>
 		<model name='BLK-NT-3A'>
 			<availability>LA:4,ROS:4,FWL:4,FS:6,MERC:4</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>ROS:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='BLK-NT-3B'>
+			<availability>LA:4,ROS:4,FWL:4,FS:5,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -2827,19 +2827,15 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='H'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='X'>
 			<availability>CJF:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
@@ -2847,6 +2843,10 @@
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -2865,39 +2865,45 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:6,MERC:3</availability>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>MOC:2,CC:2-,RA.OA:3,FVC:4,MERC:2,FS:4,TC:2,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:8,MERC:6</availability>
+		<model name='BJ-2r'>
+			<availability>FVC:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>Periphery:2</availability>
 		</model>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
+		</model>
 		<model name='BJ-2'>
 			<availability>FVC:3,LA:4,FS:2,MERC:4</availability>
 		</model>
-		<model name='BJ-2r'>
-			<availability>FVC:4,FS:4,MERC:4</availability>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,FVC:2,ROS:4,FWL:5,IS:1,FS:6,MERC:3,DA:4,DC:6</availability>
-		<model name='BJ2-O'>
-			<availability>General:7</availability>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8</availability>
 		</model>
-		<model name='BJ2-OX'>
-			<availability>General:2</availability>
+		<model name='BJ2-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:6</availability>
@@ -2905,23 +2911,17 @@
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OC'>
+		<model name='BJ2-OD'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8</availability>
+		<model name='BJ2-O'>
+			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		<model name='BJ2-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blade' unitType='Mek'>
@@ -2933,15 +2933,15 @@
 			<roles>fire_support</roles>
 			<availability>ROS:4,FS:8</availability>
 		</model>
-		<model name='BLD-XS'>
-			<availability>ROS:4,FS:4</availability>
+		<model name='BLD-XX'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:2</availability>
 		</model>
 		<model name='BLD-XL'>
 			<availability>ROS:8,FS:8</availability>
 		</model>
-		<model name='BLD-XX'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:2</availability>
+		<model name='BLD-XS'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
@@ -2955,39 +2955,39 @@
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MERC:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Black Blizzard&apos;'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CHH:5</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='G'>
+		<model name='E'>
 			<availability>General:5</availability>
 		</model>
 		<model name='D'>
@@ -2996,28 +2996,28 @@
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CW:9</availability>
-		<model name='2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
 		<availability>DTA:6,OP:6,RF:4,ROS:4,FWL:5,MH:4,MSC:6,MERC:4,RCM:4,DA:6</availability>
-		<model name='B3-HND'>
-			<roles>anti_infantry</roles>
-			<availability>:0,IS:4</availability>
+		<model name='B2-HND'>
+			<availability>RF:0,General:4,RCM:0</availability>
 		</model>
 		<model name='B1-HND'>
 			<availability>:0,General:8</availability>
 		</model>
-		<model name='B2-HND'>
-			<availability>RF:0,General:4,RCM:0</availability>
+		<model name='B3-HND'>
+			<roles>anti_infantry</roles>
+			<availability>:0,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
-		<availability>MOC:6,FS:2,Periphery:4,DC:2,OA.RA:5</availability>
+		<availability>MOC:6,OA.RA:5,FS:2,Periphery:4,DC:2</availability>
 		<model name='MSF-42'>
 			<availability>General:6</availability>
 		</model>
@@ -3031,12 +3031,12 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank (RotS)' unitType='Tank' omni='IS'>
 		<availability>ROS:3</availability>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
@@ -3053,6 +3053,10 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>RA.OA:5,FVC:4,CDS:3,CLAN:1,DC:5,RA:4</availability>
+		<model name='BMB-12D'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:2,FVC:6,ROS:2,CLAN:8,MERC.SI:8,BAN:8</availability>
+		</model>
 		<model name='BMB-05A'>
 			<roles>missile_artillery,fire_support</roles>
 			<availability>RA.OA:8</availability>
@@ -3060,10 +3064,6 @@
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='BMB-12D'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:2,FVC:6,ROS:2,CLAN:8,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -3082,42 +3082,42 @@
 			<roles>missile_artillery</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
 		<availability>MERC:3,TC:6</availability>
-		<model name='BRM-5A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BRM-5B'>
 			<availability>TC:2</availability>
+		</model>
+		<model name='BRM-5A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2</availability>
-		<model name='LDT-5'>
+		<model name='LDT-X3'>
 			<availability>PIR:4</availability>
 		</model>
-		<model name='LDT-X3'>
+		<model name='LDT-X4'>
 			<availability>PIR:4</availability>
 		</model>
 		<model name='LDT-1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='LDT-X4'>
+		<model name='LDT-5'>
 			<availability>PIR:4</availability>
 		</model>
-		<model name='LDT-X1'>
+		<model name='LDT-X2'>
 			<availability>General:4</availability>
 		</model>
-		<model name='LDT-X2'>
+		<model name='LDT-X1'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -3129,16 +3129,19 @@
 	</chassis>
 	<chassis name='Bruin' unitType='Mek'>
 		<availability>RD:5,CGB:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -3150,9 +3153,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:6,MOC:6,RA.OA:5,RD:5,IS:5,FS:5</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3177,13 +3177,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -3195,14 +3195,14 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Cell)'>
+			<availability>LA:8,ROS:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Cell)'>
-			<availability>LA:8,ROS:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3216,14 +3216,14 @@
 	</chassis>
 	<chassis name='Buraq Fast Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4</availability>
-		<model name='(Support)' mechanized='false'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Hunter-Killer)' mechanized='false'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Support)' mechanized='false'>
+			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
@@ -3245,14 +3245,14 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:5,MERC:3</availability>
+		<model name='BSW-S2r'>
+			<availability>General:4</availability>
+		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BSW-S2r'>
-			<availability>General:4</availability>
 		</model>
 		<model name='BSW-X2'>
 			<availability>LA:4,MERC:4</availability>
@@ -3263,11 +3263,11 @@
 	</chassis>
 	<chassis name='Cadaver' unitType='Mek'>
 		<availability>RA.OA:6,IS:2,MERC:3,TC:6,RA:5,Periphery:2</availability>
-		<model name='CVR-A1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CVR-T1'>
 			<availability>RA.OA:6,TC:4,RA:6</availability>
+		</model>
+		<model name='CVR-A1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Caerleon' unitType='Small Craft'>
@@ -3279,17 +3279,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>FVC:5,LA:3,FS:4,MERC:3</availability>
-		<model name='CES-3R'>
-			<availability>FVC:8,FS:2,MERC:2</availability>
-		</model>
-		<model name='CES-4S'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='CES-4R'>
 			<availability>FS:6</availability>
 		</model>
 		<model name='CES-3S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='CES-3R'>
+			<availability>FVC:8,FS:2,MERC:2</availability>
+		</model>
+		<model name='CES-4S'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Calliope' unitType='Mek'>
@@ -3317,22 +3317,22 @@
 	</chassis>
 	<chassis name='Cardinal Transport' unitType='VTOL'>
 		<availability>CDS:5,LA:4,ROS:4,MERC:4,CJF:5,DC:4</availability>
-		<model name='(RAF)'>
-			<roles>apc</roles>
-			<availability>ROS:8,MERC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>ROS:6,General:8</availability>
 		</model>
+		<model name='(RAF)'>
+			<roles>apc</roles>
+			<availability>ROS:8,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Carnivore Assault Tank' unitType='Tank'>
 		<availability>CC:4,CHH:4,CW:6,LA:4,FS:4,MERC:4,CJF:5,CWIE:4,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>CW:8,CJF:4</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CW:6,CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CW:8,CJF:4</availability>
 		</model>
 		<model name='(Second Line)'>
 			<availability>CW:4-,General:8,CJF:4-</availability>
@@ -3340,13 +3340,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CHH:1,RD:2,CDS:3,CW:1,CNC:5,CJF:1,RA:3,CGB:2</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>RD:4,CDS:8,CNC:8,CJF:4,CGB:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3371,11 +3371,17 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:5,MOC:4,FVC:4,Periphery.CM:2,Periphery.HR:1,Periphery.ME:1,MH:1,FS:3,MERC:4,CDP:4,TC:4</availability>
-		<model name='CTF-1X'>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:4,MH:4,FS:2,MERC:4</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='CTF-3LL'>
+			<availability>CC:5,MOC:5,MERC:3,TC:5</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FVC:4,FS:4,MERC:3</availability>
@@ -3383,42 +3389,44 @@
 		<model name='CTF-4L'>
 			<availability>CC:6,MOC:5</availability>
 		</model>
-		<model name='CTF-5D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:5,MOC:5,MERC:3,TC:5</availability>
+		<model name='CTF-1X'>
+			<availability>Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:4,OP:3,FWL:2,MH:3,MERC:1,DA:4,RCM:3,Periphery:2,TC:2,DC:6</availability>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
+		</model>
 		<model name='CPLT-K4'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>BAN:2,Periphery:2-</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:2,MOC:3,FWL:3,MERC:3,CDP:3,TC:3,DC:4</availability>
 		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>BAN:2,Periphery:2-</availability>
-		</model>
 		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
@@ -3432,14 +3440,6 @@
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:3,MOC:3,MERC:3,CDP:3,TC:3</availability>
-		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
@@ -3448,12 +3448,6 @@
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CNC:5,RA:5,DC:3+</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
@@ -3463,10 +3457,6 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -3474,26 +3464,46 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
+		<model name='(Infiltrator)'>
+			<roles>apc</roles>
+			<availability>FS:5</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
@@ -3502,16 +3512,6 @@
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Infiltrator)'>
-			<roles>apc</roles>
-			<availability>FS:5</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cave Lion' unitType='Mek'>
@@ -3531,22 +3531,22 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CNC:6,RA:5</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,CNC:8</availability>
-		</model>
 		<model name='3'>
 			<availability>RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8,CNC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
@@ -3564,69 +3564,69 @@
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:2</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='CNT-1A'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:2,OP:2,Periphery.OS:4,FS:7,MERC:2,CDP:4,Periphery:2,DTA:2,FVC:8,LA:4,Periphery.HR:4,ROS:4,FWL:2,MH:6,MSC:2</availability>
-		<model name='CN9-D3'>
-			<availability>FVC:2,ROS:2,FS:2,MERC:2,CDP:3</availability>
-		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:3</availability>
-		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:3,Periphery:4</availability>
-		</model>
-		<model name='CN9-H'>
-			<availability>MH:4-</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:4,MERC:4,Periphery:4</availability>
-		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
+		<model name='CN9-D'>
+			<availability>FVC:4,MERC:4,Periphery:4</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:3</availability>
+		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:3,ROS:3,FWL:3,FS:3,MERC:3,CDP:3</availability>
 		</model>
-		<model name='CN9-Da'>
-			<availability>OP:4,FVC:4,ROS:2,FWL:2,MSC:4,MERC:2,FS:2,Periphery:4</availability>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='CN9-H'>
+			<availability>MH:4-</availability>
 		</model>
 		<model name='CN9-D4D'>
 			<availability>DTA:3,OP:3,ROS:3,MSC:3,FS:3,MERC:3</availability>
 		</model>
+		<model name='CN9-Ar'>
+			<availability>IS:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FVC:2,ROS:2,FS:2,MERC:2,CDP:3</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-Da'>
+			<availability>OP:4,FVC:4,ROS:2,FWL:2,MSC:4,MERC:2,FS:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek' omni='IS'>
 		<availability>LA:4,ROS:4,FS:5,MERC:4</availability>
-		<model name='CN11-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CN11-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='CN11-OD'>
+		<model name='CN11-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='CN11-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='CN11-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='CN11-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='CN11-OD'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -3635,11 +3635,11 @@
 		<model name='MR-5M'>
 			<availability>CC:4,MOC:4,ROS:5,FWL:6</availability>
 		</model>
-		<model name='MR-V3'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='MR-V2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MR-V3'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3659,15 +3659,15 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>RD:5,CW:5,CLAN:6,CJF:5,CGB:5</availability>
-		<model name='4'>
-			<roles>spotter</roles>
-			<availability>RA:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<roles>spotter</roles>
+			<availability>RA:4</availability>
 		</model>
 		<model name='3'>
 			<availability>RA:5</availability>
@@ -3675,11 +3675,11 @@
 	</chassis>
 	<chassis name='Chalchiuhtotolin Support Tank' unitType='Tank'>
 		<availability>CW:4,CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
@@ -3691,33 +3691,33 @@
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
+		<model name='Mk. XV'>
+			<availability>FS.PMM:6,ROS:4,FS.CMM:6,FS.DMM:6,FS:5,FS.CrMM:6</availability>
+		</model>
 		<model name='XIVs'>
 			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
 		</model>
 		<model name='XII'>
 			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
-		<model name='Mk. XV'>
-			<availability>FS.PMM:6,ROS:4,FS.CMM:6,FS.DMM:6,FS:5,FS.CrMM:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,TC:5,Periphery:4,DC:4</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:1-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
-		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:4,IS:3,FS:4,Periphery:3</availability>
+		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:1-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
@@ -3725,12 +3725,12 @@
 		<model name='CHP-3N'>
 			<availability>ROS:6</availability>
 		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4,CGB:4</availability>
+		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CHH:1,RD:1,LA:3,MERC.SI:4,MERC:3,BAN:2,CGB:1</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4,CGB:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,RD:6,CLAN:8,CGB:6</availability>
@@ -3738,10 +3738,6 @@
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>RD:2,ROS:4,IS:3,MERC:2,BAN:4,Periphery:2,CGB:2</availability>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
@@ -3750,22 +3746,36 @@
 			<roles>missile_artillery</roles>
 			<availability>RD:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='(ERML)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(CASE)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(ERML)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>MOC:1-,RA.OA:2-,FVC:1,RD:3-,LA:1-,ROS:2-,TC:1-,Periphery:1,DC:4-,CGB:3-</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,RA.OA:10,FVC:5,PIR:5,MH:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
 		<model name='CGR-3K'>
 			<availability>MERC:2-,DC:3-</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>FVC:2-,Periphery:2-</availability>
+		<model name='CGR-3Kr'>
+			<availability>CC:3,RD:4,ROS:4,MERC:4,DC:4,CGB:4</availability>
+		</model>
+		<model name='CGR-C'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>RA.OA:2-,FVC:2-,Periphery:2-</availability>
@@ -3773,71 +3783,61 @@
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,RA.OA:10,FVC:5,PIR:5,MH:5,Periphery:4</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-C'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>CC:3,RD:4,ROS:4,MERC:4,DC:4,CGB:4</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:2,OP:10,MERC:3,FS:3,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
-		<model name='F-11'>
-			<availability>CC:4,MOC:4,OP:8,MERC:6,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
-		</model>
-		<model name='F-14-S'>
-			<availability>DTA:8,OP:8,RF:8,FWL:8,MH:4,MSC:8,MERC:5,RCM:8,DA:8</availability>
-		</model>
-		<model name='OF-17A-R'>
-			<roles>recon</roles>
-			<availability>ROS:4,MSC:6</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:1-,DTA:1-,OP:1-,RF:1-,FWL:1-,MSC:1-,MERC:1-,DA:1-,RCM:1-,Periphery:1-</availability>
+		<model name='F-13'>
+			<availability>DTA:4,CC:4,OP:4,ROS:4,FWL:4,MSC:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,DTA:2,OP:2,FVC:2,RF:2,FWL:2,MSC:2,MERC:2,DA:2,RCM:2,Periphery:2</availability>
 		</model>
-		<model name='F-13'>
-			<availability>DTA:4,CC:4,OP:4,ROS:4,FWL:4,MSC:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>FVC:2,Periphery:2</availability>
 		</model>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:1-,DTA:1-,OP:1-,RF:1-,FWL:1-,MSC:1-,MERC:1-,DA:1-,RCM:1-,Periphery:1-</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:4,MOC:4,OP:8,MERC:6,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
+		</model>
+		<model name='OF-17A-R'>
+			<roles>recon</roles>
+			<availability>ROS:4,MSC:6</availability>
+		</model>
+		<model name='F-14-S'>
+			<availability>DTA:8,OP:8,RF:8,FWL:8,MH:4,MSC:8,MERC:5,RCM:8,DA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>DTA:3,CDS:4,LA:3,ROS:5,CNC:5,FS:3,RCM:3,DC:3</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:6,CDS:6,LA:6,ROS:6,FS:6,RCM:6,DC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3857,23 +3857,23 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6,CGB:3</availability>
-		<model name='CHP-W7T'>
-			<availability>TC:8</availability>
-		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,BAN:3,Periphery:2-</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
 		</model>
-		<model name='CHP-W8'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2,BAN:2</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,BAN:3,Periphery:2-</availability>
+		<model name='CHP-W7T'>
+			<availability>TC:8</availability>
+		</model>
+		<model name='CHP-W8'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='CHP-W7'>
+			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
@@ -3887,13 +3887,6 @@
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:2,RF:4,FWL:4,MSC:4,MERC:2,CDP:2,Periphery:2</availability>
-		<model name='CDA-3P'>
-			<availability>RF:8,FWL:8,MSC:8</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:4,MOC:4,FWL:2,MERC:4</availability>
-		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
 			<availability>CC:6,CGB.FRR:6,FWL:4,MERC:6</availability>
@@ -3902,9 +3895,16 @@
 			<roles>recon</roles>
 			<availability>FWL:8,IS:6,MERC:6,Periphery:4</availability>
 		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:4,MOC:4,FWL:2,MERC:4</availability>
+		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:2,IS:4</availability>
+		</model>
+		<model name='CDA-3P'>
+			<availability>RF:8,FWL:8,MSC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cizin Hover Tank' unitType='Tank'>
@@ -3938,20 +3938,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -3971,14 +3971,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -3986,29 +3983,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -4019,8 +4019,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -4028,18 +4031,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -4048,15 +4057,6 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -4077,14 +4077,14 @@
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -4092,8 +4092,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -4105,13 +4105,13 @@
 	</chassis>
 	<chassis name='Claymore' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='Interceptor'>
-			<roles>assault</roles>
-			<availability>LA:3</availability>
-		</model>
 		<model name='V3'>
 			<roles>assault</roles>
 			<availability>LA:4,ROS:8,FS:4</availability>
+		</model>
+		<model name='Interceptor'>
+			<roles>assault</roles>
+			<availability>LA:3</availability>
 		</model>
 		<model name='(3054)'>
 			<roles>assault</roles>
@@ -4129,47 +4129,47 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:2,MOC:2,FS:2,MERC:2,CDP:2,TC:2,Periphery:3,FVC:2,RF:2,LA:2,ROS:2,DA:2,RCM:1</availability>
-		<model name='CLNT-2-3UL'>
-			<availability>CC:8,MOC:4,TC:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
-		</model>
-		<model name='CLNT-5U'>
-			<roles>spotter</roles>
-			<availability>LA:8,General:6,MERC:8</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:2,General:6</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
 		</model>
+		<model name='CLNT-5U'>
+			<roles>spotter</roles>
+			<availability>LA:8,General:6,MERC:8</availability>
+		</model>
+		<model name='CLNT-2-3UL'>
+			<availability>CC:8,MOC:4,TC:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>MOC:4,IS:4</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
+			<availability>MOC:2,IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>MOC:2,IS:2</availability>
+			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra' unitType='Mek'>
 		<availability>LA:6,ROS:4,MH:4,MERC:3</availability>
-		<model name='CBR-03'>
-			<roles>fire_support</roles>
-			<availability>LA:8,General:5</availability>
-		</model>
 		<model name='CBR-02'>
 			<roles>fire_support</roles>
 			<availability>IS:4</availability>
+		</model>
+		<model name='CBR-03'>
+			<roles>fire_support</roles>
+			<availability>LA:8,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
@@ -4194,53 +4194,53 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
-		<model name='COM-1A'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>FVC:2-,LA:1-,Periphery:2-</availability>
+			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
 		</model>
-		<model name='COM-7B'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>LA:7,ROS:8</availability>
+			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
 		</model>
 		<model name='COM-2Dr'>
 			<roles>recon</roles>
 			<availability>LA:5,MERC:5,Periphery:5</availability>
 		</model>
-		<model name='COM-7S'>
+		<model name='COM-7B'>
 			<roles>recon</roles>
-			<availability>LA:8,MERC:8</availability>
+			<availability>LA:7,ROS:8</availability>
 		</model>
 		<model name='COM-8S'>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='COM-5S'>
+		<model name='COM-1A'>
 			<roles>recon</roles>
-			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
+			<availability>FVC:2-,LA:1-,Periphery:2-</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
 			<availability>Periphery:2-</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,FVC:2,LA:4,ROS:3,IS:2,FWL:2,FS:3,TC:2,DC:2,Periphery:2</availability>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:8,FWL:6,MERC:6</availability>
+		<model name='(Standard)'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='(Upgrade) (Laser)'>
 			<availability>LA:6,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>Periphery:2-</availability>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:8,FWL:6,MERC:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:2,IS:2</availability>
@@ -4248,11 +4248,11 @@
 	</chassis>
 	<chassis name='Condor Multi-Purpose Tank' unitType='Tank'>
 		<availability>ROS:5</availability>
-		<model name='(Reactive)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Reactive)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -4282,24 +4282,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CLAN:4,BAN:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CHH:1,MERC.WD:1,CW:1,CJF:2,RA:1</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -4321,36 +4321,36 @@
 	</chassis>
 	<chassis name='Constable Pacification Suit' unitType='BattleArmor'>
 		<availability>RD:3,CGB:3</availability>
-		<model name='(LMG)' mechanized='true'>
+		<model name='(SRM)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(ECM)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)' mechanized='true'>
+		<model name='(LMG)' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Sensors)' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Sensors)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corax' unitType='Aero'>
@@ -4367,17 +4367,17 @@
 		<model name='CRX-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='CRX-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='CRX-OR'>
-			<availability>RA.OA:4,CLAN:8</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='CRX-OD'>
+			<availability>General:5</availability>
+		</model>
 		<model name='CRX-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='CRX-OR'>
+			<availability>RA.OA:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
@@ -4388,8 +4388,14 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
-		<model name='CSR-V18'>
-			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
+		</model>
+		<model name='CSR-12D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>ROS:4,CLAN:6,FS:4,MERC:4,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>FVC:1,Periphery:1</availability>
@@ -4397,14 +4403,8 @@
 		<model name='CSR-V12'>
 			<availability>BAN:4,Periphery:2-</availability>
 		</model>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>ROS:4,CLAN:6,FS:4,MERC:4,BAN:2</availability>
-		</model>
-		<model name='CSR-12D'>
-			<availability>FS:8</availability>
+		<model name='CSR-V18'>
+			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -4428,9 +4428,6 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='XR'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='G'>
 			<availability>CHH:6,General:4</availability>
 		</model>
@@ -4440,47 +4437,50 @@
 		<model name='X'>
 			<availability>CJF:4</availability>
 		</model>
+		<model name='XR'>
+			<availability>CJF:8</availability>
+		</model>
 		<model name='X 3'>
 			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
 		<availability>CW:4,CJF:5,CWIE:4</availability>
-		<model name='H'>
-			<availability>General:5</availability>
-		</model>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>CW:3,CJF:3,CWIE:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<availability>CW:3,CJF:3,CWIE:3</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
 		</model>
+		<model name='H'>
+			<availability>General:5</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -4489,12 +4489,12 @@
 			<roles>raider</roles>
 			<availability>ROS:8,CLAN:4,FWL:8,MERC:8,BAN:2,DC:6</availability>
 		</model>
+		<model name='CRB-C'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CRB-27'>
 			<roles>raider</roles>
 			<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
-		</model>
-		<model name='CRB-C'>
-			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Hawk' unitType='Mek'>
@@ -4502,42 +4502,45 @@
 		<model name='(Standard)'>
 			<availability>ROS:8,CLAN.IS:8,MSC:8,FS:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CC:8,CDS:4,CNC:4,MERC:8,DC:8</availability>
+		<model name='4'>
+			<availability>CDS:6,ROS:6,MERC:4,CJF:6</availability>
 		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:6,ROS:6,MERC:4,CJF:6</availability>
+		<model name='2'>
+			<availability>CC:8,CDS:4,CNC:4,MERC:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,RA:4</availability>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CHH:5,RD:5,CDS:3,CW:5,ROS:4,CLAN:4,CJF:3,RA:3,CWIE:5,CGB:5</availability>
-		<model name='CRK-5003-3'>
-			<availability>ROS:8</availability>
+		<model name='CRK-5004-1'>
+			<availability>ROS:6</availability>
+		</model>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='CRK-5005-1'>
 			<availability>ROS:8</availability>
@@ -4545,20 +4548,17 @@
 		<model name='CRK-5003-1'>
 			<availability>ROS:4,CLAN:6,BAN:8</availability>
 		</model>
-		<model name='CRK-5004-1'>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='CRK-5003-3'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
 		<availability>DTA:4,OP:4,RF:4,Periphery.MW:4,ROS:3,Periphery.ME:4,FWL:4,MSC:4,MERC:4,DA:4,RCM:4,Periphery:4</availability>
-		<model name='CNS-5M'>
-			<availability>PIR:4,IS:8</availability>
-		</model>
 		<model name='CNS-3M'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CNS-5M'>
+			<availability>PIR:4,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
@@ -4569,28 +4569,28 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CDS:2,CNC:2,RA:5,CWIE:2</availability>
-		<model name='D'>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
 			<availability>General:4</availability>
 		</model>
 		<model name='U'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
-		<model name='C'>
+		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
+		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4600,58 +4600,58 @@
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>MOC:4,IS:4,DC:8</availability>
 		</model>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CLAN:5,IS:6,Periphery:5</availability>
-		<model name='CRD-4D'>
-			<availability>FVC:8,FS:8</availability>
-		</model>
-		<model name='CRD-2R'>
-			<availability>FVC:4,ROS:5,CLAN:4,FWL:5,IS:4,MERC:5,BAN:2</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>ROS:4,MERC:4</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>MERC:6,DC:8</availability>
-		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:6,MERC:6</availability>
+		<model name='CRD-8S'>
+			<availability>LA:8,FS:4</availability>
 		</model>
 		<model name='CRD-7L'>
 			<availability>CC:8</availability>
 		</model>
-		<model name='CRD-5S'>
-			<availability>LA:4,MERC:4</availability>
-		</model>
 		<model name='CRD-3R'>
 			<availability>BAN:1,Periphery:2-</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:2,MOC:4</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>DTA:5,ROS:4,Periphery.MW:4,Periphery.ME:4,MH:4,MSC:5,MERC:2,RCM:5</availability>
-		</model>
-		<model name='CRD-8S'>
-			<availability>LA:8,FS:4</availability>
 		</model>
 		<model name='CRD-5M'>
 			<availability>CC:2,MOC:4,FWL:8,FS:2,MERC:4,CDP:4,DC:2,TC:4</availability>
 		</model>
+		<model name='CRD-7W'>
+			<availability>DTA:5,ROS:4,Periphery.MW:4,Periphery.ME:4,MH:4,MSC:5,MERC:2,RCM:5</availability>
+		</model>
 		<model name='CRD-4K'>
 			<availability>DC:4</availability>
 		</model>
+		<model name='CRD-4BR'>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:2,MOC:4</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>MERC:6,DC:8</availability>
+		</model>
 		<model name='CRD-8L'>
 			<availability>CC:5</availability>
+		</model>
+		<model name='CRD-2R'>
+			<availability>FVC:4,ROS:5,CLAN:4,FWL:5,IS:4,MERC:5,BAN:2</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:6,MERC:6</availability>
+		</model>
+		<model name='CRD-4D'>
+			<availability>FVC:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cuirass' unitType='Mek'>
@@ -4665,60 +4665,60 @@
 	</chassis>
 	<chassis name='Cutlass' unitType='Aero'>
 		<availability>FS:5</availability>
-		<model name='CUT-01E'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='CUT-01E'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:3,RA.OA:2,MOC:4,RD:4,LA:3,ROS:3,IS:3,FWL:2,FS:3,Periphery:2,TC:2,DC:5</availability>
+		<model name='CP-11-G'>
+			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:5,CDP:4,TC:4,Periphery:2</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
+		</model>
+		<model name='CP-11-B'>
+			<availability>CC:8,MOC:6,IS:4,MERC:8,DC:8</availability>
+		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
 			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,DC:5</availability>
 		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>RD:5,IS:4</availability>
-		</model>
 		<model name='CP-11-H'>
 			<availability>FVC:6,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:6</availability>
-		</model>
-		<model name='CP-10-Z'>
-			<availability>General:2-</availability>
 		</model>
 		<model name='CP-11-C3'>
 			<roles>spotter</roles>
 			<availability>FS:3,DC:3</availability>
 		</model>
-		<model name='CP-11-A'>
-			<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:5,CDP:4,TC:4,Periphery:2</availability>
-		</model>
-		<model name='CP-11-G'>
-			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:1</availability>
 		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
-		<model name='CP-11-B'>
-			<availability>CC:8,MOC:6,IS:4,MERC:8,DC:8</availability>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>RD:5,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:5,MERC.WD:3,ROS:3,CWIE:4</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='4'>
 			<availability>General:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
@@ -4733,6 +4733,10 @@
 			<roles>recon,escort</roles>
 			<availability>CC:4,MERC:4,TC:2,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,escort</roles>
+			<availability>CC:4,ROS:4,General:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -4741,41 +4745,37 @@
 			<roles>recon,escort</roles>
 			<availability>MOC:4,CDP:4,TC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon,escort</roles>
-			<availability>CC:4,ROS:4,General:4,MERC:4,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:6,IS:5</availability>
 		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Multipurpose VTOL' unitType='VTOL'>
 		<availability>LA:6,CLAN:4,IS:5,Periphery:4</availability>
-		<model name='(Gunship)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Gunship)'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='DI Schmitt Tank' unitType='Tank'>
 		<availability>LA:5,ROS:3,MERC:3,FS:3</availability>
-		<model name='(Targetting Computer)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Targetting Computer)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dagger' unitType='Aero'>
@@ -4786,18 +4786,18 @@
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='DARO-1'>
-			<availability>General:6,FS:8</availability>
-		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='DARO-1C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1'>
+			<availability>General:6,FS:8</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1A'>
 			<availability>General:7</availability>
@@ -4805,12 +4805,12 @@
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01r'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DAI-01'>
 			<roles>fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DAI-01r'>
+			<availability>General:4</availability>
 		</model>
 		<model name='DAI-02'>
 			<roles>fire_support</roles>
@@ -4823,13 +4823,13 @@
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
 		<availability>RD:2,DC:3+,CGB:2</availability>
-		<model name='67-K'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='67-K2'>
 			<roles>support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='67-K'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
@@ -4837,49 +4837,49 @@
 		<model name='DMO-4K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='DMO-5K'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
+		<model name='DMO-2K'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='DMO-1K'>
 			<availability>General:8,DC:3</availability>
 		</model>
-		<model name='DMO-2K'>
-			<availability>DC:6</availability>
+		<model name='DMO-5K'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,FS:4+,MERC:4+,BAN:3,CWIE:6,MERC.WD:6,RD:5,CDS:5,CW:6,LA:4+,ROS:4+,CNC:5,CJF:5,CGB:5,DC:4+</availability>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CDS:7,CW:5,General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CHH:2,RD:2,CW:2,CNC:2,CLAN:1,General:2,CJF:2,CGB:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:4,CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CDS:5,CW:5,General:4</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:4,CW:8,CNC:4,General:5,CJF:6,CWIE:7,CGB:4</availability>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='A'>
+			<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -4902,11 +4902,11 @@
 			<roles>marine</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_aircraft</roles>
@@ -4915,24 +4915,21 @@
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>LA:5,ROS:4,MH:4,FS:6,MERC:4</availability>
-		<model name='DRT-3S'>
-			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='DRT-4S'>
-			<availability>LA:2,MH:4,FS:3,MERC:4</availability>
-		</model>
 		<model name='DRT-6T'>
 			<availability>LA:6,ROS:8,FS:6,MERC:6</availability>
+		</model>
+		<model name='DRT-3S'>
+			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:3</availability>
 		</model>
+		<model name='DRT-4S'>
+			<availability>LA:2,MH:4,FS:3,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:3,ROS:3,FS:7,CDP:4</availability>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:1,CDP:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:4,General:5,CDP:3</availability>
@@ -4940,6 +4937,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>FVC:4,General:5,CDP:3</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -4949,13 +4950,18 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:1,CDP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,MERC.WD:2,RD:5,IS:3+,CJF:2,BAN:2,CGB:5</availability>
+		<model name='H'>
+			<availability>RD:5,CDS:5,General:4,CWIE:5,CGB:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:7,RD:6,General:2,CWIE:5,CGB:6</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>RD:2,CDS:5,General:3,CJF:4,CGB:2</availability>
@@ -4963,27 +4969,21 @@
 		<model name='E'>
 			<availability>CDS:3,CW:4,General:2</availability>
 		</model>
+		<model name='K'>
+			<availability>RD:4,General:2,CGB:4</availability>
+		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CHH:8,RD:4,CDS:6,CW:4,CNC:4,General:5,CGB:4</availability>
 		</model>
-		<model name='H'>
-			<availability>RD:5,CDS:5,General:4,CWIE:5,CGB:5</availability>
-		</model>
 		<model name='D'>
 			<availability>CHH:8,RD:8,CDS:4,CW:8,CNC:8,General:6,CWIE:8,CGB:8</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:7,RD:6,General:2,CWIE:5,CGB:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,RD:8,CDS:7,CNC:7,General:6,CWIE:7,CGB:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CHH:6,RD:7,CDS:6,CW:7,General:5,CWIE:7,CGB:7</availability>
-		</model>
-		<model name='K'>
-			<availability>RD:4,General:2,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
@@ -5009,19 +5009,19 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:5,MOC:5,MSC:4</availability>
-		<model name='DFC-OD'>
-			<roles>ground_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='DFC-OB'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='DFC-OD'>
+			<roles>ground_support</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OB'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -5032,11 +5032,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='DFN-3T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='DFN-3S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='DFN-3T'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Deimos' unitType='Mek'>
@@ -5047,24 +5047,24 @@
 	</chassis>
 	<chassis name='Deimos' unitType='Mek' omni='Clan'>
 		<availability>RA:7</availability>
-		<model name='Prime'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='S'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='S'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Delphyne' unitType='ProtoMek'>
@@ -5075,21 +5075,21 @@
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,ROS:8,CNC:5,FWL:8,CJF:2,DC:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,MOC:4,LA:4,CGB.FRR:4,ROS:4,IS:2,FWL:4,FS:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>IS:1,Periphery:2</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,IS:8,FS:8,DC:8,TC:8,CWIE:4</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>FVC:4,DC:8,Periphery:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
 		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>IS:1,Periphery:2</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,MOC:4,LA:4,CGB.FRR:4,ROS:4,IS:2,FWL:4,FS:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>FVC:4,DC:8,Periphery:4</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -5098,15 +5098,15 @@
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
 		<availability>LA:6,ROS:4,MERC:4,CWIE:4</availability>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MML)'>
 			<availability>LA:5,ROS:5,CWIE:5</availability>
 		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:4,CWIE:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -5122,17 +5122,17 @@
 	</chassis>
 	<chassis name='Demon Medium Tank' unitType='Tank'>
 		<availability>ROS:6-</availability>
-		<model name='(Standard)'>
+		<model name='(Armor)'>
 			<roles>urban</roles>
-			<availability>General:8</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Rifle)'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Armor)'>
+		<model name='(Standard)'>
 			<roles>urban</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
@@ -5146,23 +5146,23 @@
 	</chassis>
 	<chassis name='Dervish' unitType='Mek'>
 		<availability>OP:3,FVC:4,LA:2,ROS:3,Periphery.HR:4,FS:4,MERC:2,Periphery.OS:4,Periphery:3,TC:2,DC:2</availability>
-		<model name='DV-1S'>
-			<availability>IS:1-</availability>
-		</model>
 		<model name='DV-8D'>
 			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
 		</model>
-		<model name='DV-6Mr'>
-			<availability>General:1</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+		<model name='DV-6M'>
+			<availability>CLAN:4,Periphery:2-</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
-		<model name='DV-6M'>
-			<availability>CLAN:4,Periphery:2-</availability>
+		<model name='DV-7D'>
+			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='DV-6Mr'>
+			<availability>General:1</availability>
+		</model>
+		<model name='DV-1S'>
+			<availability>IS:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Destrier Siege Vehicle' unitType='Tank'>
@@ -5180,14 +5180,14 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:3,FVC:6,LA:6,ROS:5,FS:6,MERC:3,TC:4</availability>
-		<model name='DVS-1D'>
-			<availability>FVC:8,TC:8</availability>
+		<model name='DVS-3'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='DVS-3'>
-			<availability>LA:4,ROS:4,FS:4</availability>
+		<model name='DVS-1D'>
+			<availability>FVC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -5204,6 +5204,9 @@
 	</chassis>
 	<chassis name='Diomede' unitType='Mek'>
 		<availability>CC:7,MOC:7,LA:7,ROS:7,FWL:7,IS:5,MH:7,MERC:7,Periphery:5</availability>
+		<model name='D-M3D-M'>
+			<availability>General:4</availability>
+		</model>
 		<model name='D-M3D-3 ConstructionMech'>
 			<roles>support</roles>
 			<availability>CC:4,MOC:4,LA:4,ROS:4,FWL:4,MH:4,MERC:4</availability>
@@ -5211,9 +5214,6 @@
 		<model name='D-M3D-4 DemolitionMech'>
 			<roles>support</roles>
 			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,MH:8,MERC:8</availability>
-		</model>
-		<model name='D-M3D-M'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dola' unitType='Mek'>
@@ -5228,17 +5228,17 @@
 	</chassis>
 	<chassis name='Doloire' unitType='Mek' omni='IS'>
 		<availability>ROS:5</availability>
-		<model name='DLR-OB'>
+		<model name='DLR-OC'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='DLR-OD'>
+		<model name='DLR-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='DLR-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='DLR-OC'>
-			<roles>spotter</roles>
+		<model name='DLR-OD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='DLR-O'>
@@ -5247,12 +5247,12 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:6,RD:4,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau II Assault Interceptor' unitType='Dropship'>
@@ -5280,28 +5280,28 @@
 	</chassis>
 	<chassis name='Dragon II' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='DRG-11K'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='DRG-11R'>
 			<roles>missile_artillery</roles>
 			<availability>General:2+</availability>
 		</model>
+		<model name='DRG-11K'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:3,DC:2</availability>
-		<model name='DRG-5N'>
-			<availability>MERC:4,DC:4,Periphery:5</availability>
-		</model>
 		<model name='DRG-7N'>
 			<availability>MERC:8,DC:8</availability>
 		</model>
-		<model name='DRG-5Nr'>
-			<availability>MERC:3,DC:3</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>Periphery:1</availability>
+		</model>
+		<model name='DRG-5N'>
+			<availability>MERC:4,DC:4,Periphery:5</availability>
+		</model>
+		<model name='DRG-5Nr'>
+			<availability>MERC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
@@ -5310,18 +5310,14 @@
 			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:7,RD:7,CDS:8,General:6,CJF:8,RA:7,CWIE:7,CGB:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,General:4,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>RD:5,General:2,CGB:5</availability>
-		</model>
 		<model name='A'>
 			<availability>RD:8,CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:6,CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:6,CDS:9,General:8,CJF:9,CGB:6</availability>
@@ -5329,16 +5325,20 @@
 		<model name='H'>
 			<availability>CNC:5,CLAN:3,General:2</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:6,CDS:6,CW:6,CNC:5,General:4,CJF:6,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CW:5,General:4,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<availability>RD:7,CDS:6,CW:7,General:5,CJF:6,CGB:7</availability>
 		</model>
-		<model name='I'>
-			<availability>General:2</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>RD:5,General:2,CGB:5</availability>
 		</model>
-		<model name='U'>
+		<model name='D'>
+			<availability>CHH:7,RD:7,CDS:8,General:6,CJF:8,RA:7,CWIE:7,CGB:7</availability>
+		</model>
+		<model name='I'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5357,11 +5357,11 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>LA:5,ROS:2,FS:4</availability>
-		<model name='(Streak)'>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5382,58 +5382,58 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='EGL-R6'>
-			<availability>General:3-</availability>
-		</model>
 		<model name='EGL-R6b'>
 			<availability>OP:6,MSC:6,RCM:6</availability>
 		</model>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>General:3-</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,DTA:6,RF:6,FWL:6,MH:4,MSC:7,MERC:4,DA:5</availability>
-		<model name='EGL-3M'>
-			<availability>DTA:5,FWL:5,MSC:5</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
-		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
+		</model>
+		<model name='EGL-3M'>
+			<availability>DTA:5,FWL:5,MSC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Ebony' unitType='Mek'>
 		<availability>MOC:5,CC:4</availability>
-		<model name='MEB-12'>
+		<model name='MEB-10'>
 			<roles>recon</roles>
-			<availability>CC:4</availability>
-		</model>
-		<model name='MEB-11'>
-			<roles>recon</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='MEB-9'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='MEB-10'>
+		<model name='MEB-11'>
 			<roles>recon</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
+		</model>
+		<model name='MEB-12'>
+			<roles>recon</roles>
+			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,Periphery:4-</availability>
+		<model name='EFT-7X'>
+			<availability>IS:8,MH:6</availability>
+		</model>
 		<model name='EFT-4J'>
 			<availability>MERC:1-,Periphery:8</availability>
 		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
-		</model>
-		<model name='EFT-7X'>
-			<availability>IS:8,MH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5444,81 +5444,81 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
+		<model name='EST-OD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='EST-OD'>
-			<availability>General:4</availability>
+		<model name='EST-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Eldingar Hover Sled' unitType='Tank'>
 		<availability>CHH:4,RD:5,LA:3,ROS:3,FS:3,MERC:3,CGB:5,CWIE:4</availability>
-		<model name='(Streak)'>
-			<roles>fire_support</roles>
-			<availability>RD:4,CGB:4</availability>
+		<model name='(Standard)'>
+			<availability>RD:8,CGB.FRR:8,CGB:8</availability>
 		</model>
 		<model name='&apos;HumHov&apos;'>
 			<availability>General:8,CGB:0</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>RD:8,CGB.FRR:8,CGB:8</availability>
+		<model name='(Streak)'>
+			<roles>fire_support</roles>
+			<availability>RD:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,MERC.WD:4,CW:4,CLAN:4,CNC:4+</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [AP Gauss]' mechanized='true'>
 			<availability>CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>RD:2,CW:2,CGB:2,CWIE:2</availability>
-		</model>
-		<model name='(Fire) [MicroPL]' mechanized='true'>
-			<availability>CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='[MicroPL]' mechanized='true'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Space) [MicroPL]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CLAN:2,RA:4</availability>
 		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Fire) [Flamer]' mechanized='true'>
 			<availability>CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [MicroPL]' mechanized='true'>
+			<availability>CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[MicroPL]' mechanized='true'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>RD:2,CW:2,CGB:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5529,23 +5529,23 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:3,TC:4,LA:4,CNC:5,FWL:4,MH:3,DC:4</availability>
-		<model name='EMP-6D'>
-			<availability>ROS:8,FS:8</availability>
-		</model>
 		<model name='EMP-6L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='EMP-8L'>
-			<availability>CC:4</availability>
-		</model>
-		<model name='EMP-6S'>
-			<availability>LA:8</availability>
+		<model name='EMP-7L'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='EMP-7L'>
-			<availability>CC:6</availability>
+		<model name='EMP-6S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='EMP-8L'>
+			<availability>CC:4</availability>
+		</model>
+		<model name='EMP-6D'>
+			<availability>ROS:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
@@ -5554,6 +5554,10 @@
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4,FS:4</availability>
 		</model>
+		<model name='END-6Q'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4</availability>
+		</model>
 		<model name='END-6S'>
 			<roles>urban</roles>
 			<availability>LA:2,MERC:2</availability>
@@ -5561,21 +5565,17 @@
 		<model name='END-6Sr'>
 			<availability>LA:3,ROS:8,MERC:3</availability>
 		</model>
-		<model name='END-6Q'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:5,ROS:4,FS:7,MERC:5</availability>
-		<model name='ENF-6Ma'>
-			<availability>FVC:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-6Ma'>
+			<availability>FVC:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='ENF-6T'>
 			<availability>FS:4</availability>
@@ -5586,20 +5586,20 @@
 		<model name='ENF-7C3BS'>
 			<availability>FS:1</availability>
 		</model>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
+		</model>
 		<model name='ENF-7D'>
 			<availability>FS:4</availability>
-		</model>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>FVC:5,FS:4,MERC:2,CDP:1,TC:1</availability>
-		<model name='ENF-4R'>
-			<availability>FVC:2-,FS:1-,TC:1-</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>FVC:8,FS:8,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>FVC:2-,FS:1-,TC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -5631,14 +5631,6 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:6+,RD:3+,CDS:4+,CW:4+,CNC:3+,CGB:3+,CWIE:4+</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>CHH:8</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
@@ -5647,38 +5639,46 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>CHH:8</availability>
+		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CDS:2,ROS:1,RA:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8,DC:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,RA.OA:2,LA:5,IS:5,FWL:5,FS:2,Periphery:2,TC:3,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:4,FS:6</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>FS:4,MERC:2</availability>
-		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -5711,13 +5711,13 @@
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
 		<availability>MOC:8,CC:4</availability>
-		<model name='EYL-45A'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='EYL-45B'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='EYL-45A'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eyrie' unitType='Mek'>
@@ -5728,27 +5728,27 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:6,MERC:3</availability>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CC:5</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='(Support) [King David]' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -5766,12 +5766,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>ROS:8,MSC:6</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5782,11 +5782,11 @@
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-8R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='FLC-9R'>
 			<availability>General:8</availability>
+		</model>
+		<model name='FLC-8R'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -5798,35 +5798,29 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:2</availability>
-		<model name='(Upgrade)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>cruiser</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Upgrade)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Fennec' unitType='Mek'>
 		<availability>FS:4</availability>
-		<model name='FEC-3C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='FEC-1CM'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='FEC-3C'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SRM]' mechanized='false'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[SL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='&apos;Longshot&apos;' mechanized='false'>
 			<availability>General:4</availability>
@@ -5834,32 +5828,38 @@
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[SRM]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir II Assault Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='(LRM)' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Med. Laser)' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(AI)' mechanized='false'>
 			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(MRR)' mechanized='false'>
@@ -5868,51 +5868,51 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:4,MERC.KH:2+,CHH:2,RD:2,CW:4,CJF:2,CWIE:4,CGB:2</availability>
-		<model name='B'>
-			<availability>RD:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:2,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CDS:6,CW:3,CNC:5,General:4,CWIE:3</availability>
-		</model>
-		<model name='H'>
-			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:6,CDS:7,CW:6,CNC:6,General:4,CJF:6,CGB:6</availability>
 		</model>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		<model name='A'>
+			<availability>CDS:7,CNC:4,General:6,CJF:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:6,CDS:7,CW:6,CNC:4,General:5,CJF:7,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:2,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CDS:6,CW:3,CNC:5,General:4,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fensalir Combat WiGE' unitType='Tank'>
 		<availability>MERC.KH:4,LA:5,CWIE:5</availability>
+		<model name='(Infantry)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(HAG)'>
 			<availability>MERC.KH:8,General:2,CWIE:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>LA:8,General:4</availability>
 		</model>
-		<model name='(Infantry)'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:2,LA:3,ROS:2,Periphery.HR:2,Periphery.MW:2,Periphery.CM:2,FWL:2,FS:3</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='&apos;Fermi&apos;'>
+			<roles>apc</roles>
+			<availability>FS:5</availability>
 		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
@@ -5922,9 +5922,9 @@
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:3</availability>
 		</model>
-		<model name='&apos;Fermi&apos;'>
-			<roles>apc</roles>
-			<availability>FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -5951,63 +5951,15 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(LBX20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(UAC20)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
-		</model>
 		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -6015,9 +5967,57 @@
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(LBX2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LBX10)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
@@ -6026,55 +6026,55 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CNC:3,CJF:7</availability>
-		<model name='Prime'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>RD:6,CW:6,General:8,CWIE:6,CGB:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>RD:6,CW:6,General:8,CWIE:6,CGB:6</availability>
+		</model>
+		<model name='H'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:6,MERC:6,FS:6</availability>
-		</model>
 		<model name='ALM-10D'>
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -6099,27 +6099,23 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:6,IS:5,Periphery.Deep:5,Periphery:7</availability>
-		<model name='FS9-M3'>
-			<roles>spotter</roles>
-			<availability>LA:3,IS:2,TC:2</availability>
+		<model name='FS9-S2'>
+			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4</availability>
 		</model>
 		<model name='FS9-M4'>
 			<availability>OP:4,FVC:3,RF:3,LA:4,ROS:3,MH:3,FS:3,DA:3</availability>
+		</model>
+		<model name='FS9-M2'>
+			<roles>incendiary</roles>
+			<availability>LA:4,IS:3,MH:3,TC:3</availability>
+		</model>
+		<model name='FS9-C'>
+			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:2-,Periphery:2-</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
-		</model>
-		<model name='FS9-C'>
-			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
-		</model>
-		<model name='FS9-S2'>
-			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4</availability>
 		</model>
 		<model name='FS9-P'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -6127,56 +6123,60 @@
 		<model name='FS9-S3'>
 			<availability>LA:6,ROS:5,FWL:3,FS:3,MERC:3</availability>
 		</model>
-		<model name='FS9-M2'>
-			<roles>incendiary</roles>
-			<availability>LA:4,IS:3,MH:3,TC:3</availability>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
 		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
 			<availability>LA:2,General:1,FS:1</availability>
 		</model>
+		<model name='FS9-M3'>
+			<roles>spotter</roles>
+			<availability>LA:3,IS:2,TC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CC:4,FVC:3,LA:5,IS:2,FS:3,MERC:4,DC:7</availability>
-		<model name='FS9-OE'>
+		<model name='FS9-OD'>
 			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OX'>
-			<availability>General:2</availability>
 		</model>
 		<model name='FS9-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='FS9-OH'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='FS9-OD'>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:3,DC:3</availability>
+		</model>
+		<model name='FS9-OB'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OG'>
 			<availability>General:6</availability>
 		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='FS9-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:3,DC:3</availability>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek'>
@@ -6190,18 +6190,18 @@
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='C'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
@@ -6209,51 +6209,51 @@
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>DC.GHO:5,CHH:1,RD:2,CDS:1,LA:4,ROS:3,CLAN:1,FWL:4,MSC:5,CJF:2,CGB:1,DC:4</availability>
-		<model name='FLS-9M'>
-			<availability>FWL:6,MSC:8</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,LA:8,ROS:6,CLAN:8,MERC.SI:5,MSC:6,BAN:8</availability>
+		</model>
+		<model name='FLS-9M'>
+			<availability>FWL:6,MSC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:8,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:4,CLAN.IS:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>IS:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>IS:4,BAN:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,DA:3,RCM:3</availability>
+		<model name='FLE-19'>
+			<roles>urban</roles>
+			<availability>MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,RCM:4-,DA:4-,Periphery:6-,TC:4-</availability>
+		</model>
 		<model name='FLE-20'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='FLE-17'>
 			<availability>CC:5,RF:8,ROS:8,FWL:8,MERC:8,RCM:8,DA:8,Periphery:6</availability>
-		</model>
-		<model name='FLE-19'>
-			<roles>urban</roles>
-			<availability>MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,RCM:4-,DA:4-,Periphery:6-,TC:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6264,20 +6264,18 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
@@ -6288,33 +6286,35 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='(2613)'>
-			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3058)'>
 			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
 			<availability>LA:8,FS:8</availability>
 		</model>
+		<model name='(2613)'>
+			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fortune Wheeled Assault Vehicle' unitType='Tank'>
 		<availability>RF:4,LA:6,ROS:4</availability>
-		<model name='(Thunderbolt)'>
-			<availability>RF:4,LA:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>LA:6,ROS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Thunderbolt)'>
+			<availability>RF:4,LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Armored Car' unitType='Tank'>
@@ -6322,14 +6322,14 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Interdictor)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(VSP)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Interdictor)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -6371,13 +6371,13 @@
 			<roles>spotter</roles>
 			<availability>LA:5,FS:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
@@ -6386,14 +6386,14 @@
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='CX-17'>
-			<availability>ROS:4</availability>
+		<model name='(Royal)'>
+			<availability>ROS:4,CLAN:4,BAN:2</availability>
 		</model>
 		<model name='(C3S)'>
 			<availability>ROS:5,FS:5</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>ROS:4,CLAN:4,BAN:2</availability>
+		<model name='CX-17'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -6413,29 +6413,29 @@
 	</chassis>
 	<chassis name='Fusilier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:3,MERC:3</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>FS:4</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fwltur' unitType='Mek'>
 		<availability>IS:5,MERC:4,Periphery:4</availability>
-		<model name='FWL-3R SalvageMech'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='FWL-3V SalvageMech'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='FWL-3R SalvageMech'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='GD Infiltrator Suit' unitType='BattleArmor'>
 		<availability>MERC.KH:4,RF:3,LA:4,ROS:3,MERC:3</availability>
-		<model name='(Mines)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>General:6</availability>
+		<model name='(Remote Sensors)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
@@ -6444,9 +6444,9 @@
 		<model name='(Firedrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Remote Sensors)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:5</availability>
+		<model name='(Mines)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Sensors)' mechanized='true'>
 			<roles>recon</roles>
@@ -6455,10 +6455,6 @@
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
 		<availability>TC:4</availability>
-		<model name='(TDF)'>
-			<roles>recon</roles>
-			<availability>TC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
@@ -6466,14 +6462,18 @@
 		<model name='(ERSL)'>
 			<availability>TC:4</availability>
 		</model>
+		<model name='(TDF)'>
+			<roles>recon</roles>
+			<availability>TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CW:3,ROS:2,RA:3</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:6,ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6484,22 +6484,15 @@
 	</chassis>
 	<chassis name='Gallant' unitType='Mek'>
 		<availability>MOC:4,LA:5,ROS:5,CNC:4,IS:4,FS:5,MERC:4,CDP:4,CWIE:4,TC:4</availability>
-		<model name='GLT-8-0'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
-		</model>
 		<model name='GLT-7-0'>
 			<availability>General:8,FS:4</availability>
+		</model>
+		<model name='GLT-8-0'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:1,LA:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
-		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
-		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3</availability>
 		</model>
@@ -6507,30 +6500,40 @@
 			<roles>recon</roles>
 			<availability>MOC:5,RA.OA:3,RD:5,LA:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,CGB:5,Periphery:4</availability>
 		</model>
+		<model name='GAL-200'>
+			<availability>MOC:1,LA:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
+		</model>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>MERC.WD:5,ROS:4,MH:4,MERC:4,CWIE:5</availability>
-		<model name='GAL-2GLS'>
-			<availability>IS:4-,Periphery:4-</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
 		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2,ROS:2,MERC:2</availability>
 		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		<model name='GAL-2GLS'>
+			<availability>IS:4-,Periphery:4-</availability>
 		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8-,CWIE:8</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:4,FS:6,MERC:4,CDP:4,TC:4</availability>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A2'>
 			<availability>FS:5</availability>
 		</model>
@@ -6539,9 +6542,6 @@
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
-		</model>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Garrot Superheavy Transport' unitType='VTOL'>
@@ -6560,16 +6560,16 @@
 	</chassis>
 	<chassis name='Gauntlet' unitType='Mek' omni='IS'>
 		<availability>LA:5</availability>
-		<model name='GTL-1O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GTL-1OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='GTL-1OB'>
-			<availability>General:7</availability>
+		<model name='GTL-1O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='GTL-1OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='GTL-1OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -6589,52 +6589,52 @@
 		<model name='GST-50'>
 			<availability>DTA:6,OP:6,MSC:6</availability>
 		</model>
-		<model name='GST-11'>
-			<availability>General:4</availability>
-		</model>
 		<model name='GST-10'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GST-11'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Giggins APC' unitType='Tank'>
 		<availability>ROS:6</availability>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>RD:8,CDS:4,ROS:4+,CNC:5,CLAN:4,CJF:3,BAN:4,CGB:8</availability>
-		<model name='Prime'>
-			<availability>RD:8,CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
-		</model>
-		<model name='D'>
-			<availability>RD:4,CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='C'>
 			<availability>CNC:7,General:5,CJF:7</availability>
 		</model>
+		<model name='K'>
+			<availability>CHH:6,RD:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,CW:7,General:8,CJF:9,CWIE:7,CGB:8</availability>
+		</model>
 		<model name='A'>
 			<availability>RD:7,CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
-		</model>
-		<model name='P'>
-			<availability>CHH:6,RD:6,CDS:5,CW:5,CLAN:4,General:3,CJF:5,CWIE:5,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='B'>
-			<availability>RD:4,General:7,CGB:4</availability>
 		</model>
 		<model name='E'>
 			<availability>RD:5,CDS:5,CW:5,CLAN:4,General:3,CGB:5</availability>
 		</model>
-		<model name='K'>
-			<availability>CHH:6,RD:6,CDS:5,CW:5,General:3,CLAN:4,CJF:5,CWIE:5,CGB:6</availability>
+		<model name='D'>
+			<availability>RD:4,CDS:2,CW:3,CNC:3,General:2,CJF:2,CWIE:3,CGB:4</availability>
+		</model>
+		<model name='P'>
+			<availability>CHH:6,RD:6,CDS:5,CW:5,CLAN:4,General:3,CJF:5,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:4,General:7,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator Battle Armor' unitType='BattleArmor'>
@@ -6645,31 +6645,31 @@
 	</chassis>
 	<chassis name='Gladiator' unitType='Mek'>
 		<availability>MOC:1-,FVC:2-,LA:3,MH:3,MERC:4,Periphery:1-,TC:1-</availability>
-		<model name='GLD-5R'>
-			<availability>LA:8,General:8,MH:8,MERC:8</availability>
-		</model>
 		<model name='GLD-1R'>
 			<availability>MH:2-,DA:2-,Periphery:2-</availability>
+		</model>
+		<model name='GLD-5R'>
+			<availability>LA:8,General:8,MH:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladius Medium Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:4,Periphery.CM:3,Periphery.ME:3,MH:6,CDP:4,TC:5,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk II'>
 			<availability>MH:6,TC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Glaive Medium Tank' unitType='Tank'>
 		<availability>LA:5,ROS:3</availability>
-		<model name='(MFB)'>
-			<roles>support</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MFB)'>
+			<roles>support</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
@@ -6677,6 +6677,10 @@
 		<model name='(Light Gauss)'>
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
 		</model>
 		<model name='(3090 Upgrade)'>
 			<roles>fire_support</roles>
@@ -6686,27 +6690,23 @@
 			<roles>missile_artillery</roles>
 			<availability>FS:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6728,45 +6728,49 @@
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:6,RD:7,CGB:7</availability>
-		<model name='(Fast Assault)' mechanized='false'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>RD:8,CGB:8</availability>
 		</model>
-		<model name='(Rock Golem)' mechanized='false'>
-			<availability>CHH:8</availability>
+		<model name='(Fast Assault)' mechanized='false'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
 			<roles>urban,anti_infantry</roles>
 			<availability>RD:4,CGB:4</availability>
 		</model>
+		<model name='(Rock Golem)' mechanized='false'>
+			<availability>CHH:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:3,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-3L'>
+		<model name='GOL-4S'>
 			<roles>fire_support</roles>
-			<availability>CC:6,MOC:6</availability>
+			<availability>LA:6</availability>
 		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:5,FWL:6,MH:5,MERC:6,CDP:5,TC:5</availability>
 		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GOL-6M'>
 			<roles>fire_support</roles>
 			<availability>ROS:5,FWL:6,MERC:4</availability>
+		</model>
+		<model name='GOL-3L'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
 		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>Periphery.HR:6,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,MH:8,Periphery:4</availability>
 		</model>
-		<model name='GOL-4S'>
+		<model name='GOL-1H'>
 			<roles>fire_support</roles>
-			<availability>LA:6</availability>
+			<availability>MERC:1-</availability>
 		</model>
 		<model name='GOL-2H'>
 			<roles>fire_support</roles>
@@ -6775,10 +6779,6 @@
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
-		</model>
-		<model name='GOL-1H'>
-			<roles>fire_support</roles>
-			<availability>MERC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon Carrier' unitType='Dropship'>
@@ -6790,25 +6790,25 @@
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CNC:4,RA:6</availability>
-		<model name='(Standard)'>
-			<availability>CNC:5,RA:5</availability>
-		</model>
 		<model name='3'>
 			<availability>RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CNC:5,RA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk II' unitType='Mek'>
 		<availability>RA:6</availability>
-		<model name='(Standard)'>
-			<availability>RA:8</availability>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>RA:4</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>RA:4</availability>
 		</model>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>RA:4</availability>
+		<model name='(Standard)'>
+			<availability>RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gossamer VTOL' unitType='VTOL'>
@@ -6822,21 +6822,27 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>DTA:7,OP:7,CDS:4,ROS:7,Periphery.MW:5,PIR:5,Periphery.ME:5,CLAN:3,CNC:4,FWL:7,MSC:7,MERC:4</availability>
-		<model name='GTHA-600'>
-			<availability>DTA:8,OP:8,ROS:8,MSC:8</availability>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,CNC:4,FWL:4,MERC:4,BAN:2,Periphery:4</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='GTHA-400'>
 			<availability>PIR:2-,FWL:2-,MH:2-,MERC:2-</availability>
+		</model>
+		<model name='GTHA-600'>
+			<availability>DTA:8,OP:8,ROS:8,MSC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>RD:5,ROS:5,CNC:5,MERC:4,DC:6,CGB:5</availability>
+		<model name='DRG-7KC'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='DRG-5K'>
+			<availability>RD:8,ROS:6,CNC:8,MERC:6,DC:2,CGB:8</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>ROS:4,DC:4</availability>
 		</model>
@@ -6844,50 +6850,44 @@
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:6</availability>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='DRG-7K'>
 			<availability>ROS:6,MERC:4,DC:3</availability>
 		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-5K'>
-			<availability>RD:8,ROS:6,CNC:8,MERC:6,DC:2,CGB:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>CC:5,MOC:5,OP:7,FS:5,MERC:5,DTA:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,MSC:7,DA:7,RCM:7,DC:5</availability>
-		<model name='T-IT-N10M'>
-			<availability>ROS:4,FWL:4,MERC:4,Periphery:4</availability>
+		<model name='T-IT-N13M'>
+			<availability>DTA:6,OP:6,RF:6,ROS:6,MSC:6,DA:6,RCM:6,MERC:6</availability>
 		</model>
 		<model name='T-IT-N11M'>
 			<availability>DTA:8,CC:8,MOC:8,ROS:8,MSC:8,MERC:4,FS:8,DC:8</availability>
 		</model>
-		<model name='T-IT-N13M'>
-			<availability>DTA:6,OP:6,RF:6,ROS:6,MSC:6,DA:6,RCM:6,MERC:6</availability>
+		<model name='T-IT-N10M'>
+			<availability>ROS:4,FWL:4,MERC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>MOC:6,IS:3,Periphery.Deep:4,MERC:7,Periphery:6,DC:4,TC:6</availability>
-		<model name='GHR-5J'>
-			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
-		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='GHR-5H'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='GHR-C'>
-			<availability>IS:2,DC:2</availability>
+		<model name='GHR-5J'>
+			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='GHR-6K'>
 			<availability>ROS:4,MERC:2,FS:2,DC:4</availability>
 		</model>
+		<model name='GHR-5H'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='GHR-7P'>
 			<availability>LA:8,MERC:4</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gravedigger' unitType='Mek'>
@@ -6920,14 +6920,14 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Strike Armor' unitType='BattleArmor'>
@@ -6945,20 +6945,29 @@
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
 		<availability>CHH:5,RD:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CHH:8,RD:8,CGB:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:8,RD:8,CGB:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:4</availability>
+		<model name='[Heavy Flamer]' mechanized='false'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='[MagShot]' mechanized='false'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:4</availability>
@@ -6967,17 +6976,8 @@
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MagShot]' mechanized='false'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Heavy Flamer]' mechanized='false'>
-			<availability>FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
@@ -6985,8 +6985,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
 		</model>
 		<model name='H'>
 			<availability>CHH:8,CLAN:5,IS:3</availability>
@@ -6997,23 +7003,26 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:4</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>MERC.WD:5,CDS:6,CW:2,LA:3,CNC:7,IS:3,CJF:2,CWIE:4,DC:4</availability>
+		<model name='4'>
+			<availability>CDS:6,CNC:8,IS:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:8,CNC:5,IS:8</availability>
+		</model>
+		<model name='2'>
+			<availability>MERC.WD:8,CNC:2</availability>
+		</model>
 		<model name='6'>
 			<availability>ROS:4,CNC:6,DC:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:6,CNC:8,IS:6</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CNC:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CNC:6</availability>
@@ -7024,26 +7033,20 @@
 		<model name='5'>
 			<availability>CDS:4,CNC:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CNC:4</availability>
-		</model>
-		<model name='2'>
-			<availability>MERC.WD:8,CNC:2</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:8,CNC:5,IS:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,RA.OA:1,RD:4,LA:7,ROS:5,CNC:2,IS:6,MERC:7,TC:5,Periphery:4,DC:7</availability>
+		<model name='GRF-2N'>
+			<availability>CC:4,MOC:4,OP:4,CLAN:6,MH:4,MSC:4,FS:4,MERC:4,RCM:4,BAN:4,DC:4</availability>
+		</model>
+		<model name='GRF-1A'>
+			<availability>LA:1-,MERC:1-,TC:2-</availability>
+		</model>
+		<model name='GRF-5M'>
+			<availability>DTA:6,OP:6,ROS:5,MSC:6,MERC:5</availability>
+		</model>
 		<model name='GRF-3M'>
 			<availability>DTA:5,MOC:4,OP:5,RF:6,LA:4,FWL:4,IS:4,MH:4,MSC:5,RCM:6,DA:6,DC:1</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:8,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='GRF-4N'>
-			<availability>TC:5</availability>
 		</model>
 		<model name='GRF-6S2'>
 			<availability>LA:3,FS:3,DC:3</availability>
@@ -7051,82 +7054,75 @@
 		<model name='GRF-4R'>
 			<availability>CC:4,RD:5,ROS:6,CNC:4,FWL:4,FS:4,DC:4,CGB:5</availability>
 		</model>
-		<model name='GRF-2N'>
-			<availability>CC:4,MOC:4,OP:4,CLAN:6,MH:4,MSC:4,FS:4,MERC:4,RCM:4,BAN:4,DC:4</availability>
-		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,OP:6,ROS:5,MSC:6,MERC:5</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>BAN:2,Periphery:2-</availability>
-		</model>
-		<model name='GRF-1A'>
-			<availability>LA:1-,MERC:1-,TC:2-</availability>
+		<model name='GRF-1DS'>
+			<availability>FVC:5,LA:2,CGB.FRR:2,ROS:3,MERC:2,DC:2</availability>
 		</model>
 		<model name='GRF-5K'>
 			<availability>CNC:8,DC:8</availability>
 		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:5,LA:2,CGB.FRR:2,ROS:3,MERC:2,DC:2</availability>
+		<model name='GRF-4N'>
+			<availability>TC:5</availability>
 		</model>
 		<model name='GRF-5L'>
 			<availability>CC:6</availability>
 		</model>
+		<model name='GRF-1N'>
+			<availability>BAN:2,Periphery:2-</availability>
+		</model>
+		<model name='GRF-6S'>
+			<availability>LA:8,FS:4,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>ROS:6,MERC:5,DC:5</availability>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>MERC:4</availability>
+		</model>
 		<model name='GRM-R-PR30'>
 			<availability>ROS:4,MERC:3</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>ROS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
 		<availability>CHH:2,RD:6,CLAN:1,RA:2,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>RD:8,CGB:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:2,FVC:1,RF:3,ROS:3,FWL:2,MERC:2,RCM:3,TC:2,Periphery:1</availability>
-		<model name='D'>
-			<availability>CC:3,MOC:3,RF:2,MERC:2,RCM:2</availability>
-		</model>
-		<model name='B'>
-			<availability>Periphery:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
+		</model>
+		<model name='B'>
+			<availability>Periphery:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CC:3,MOC:3,RF:2,MERC:2,RCM:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:4,CHH:2-,CW:4,LA:4,ROS:4,CNC:2-,CWIE:4</availability>
-		<model name='2'>
-			<availability>CW:4,IS:8,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>ROS:4,CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CW:4,IS:8,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:4,CHH:1,ROS:5,FWL:4,MSC:5,FS:4,MERC:2,RA:1,Periphery:1</availability>
-		<model name='GLT-3N'>
-			<roles>raider</roles>
-			<availability>ROS:6,CLAN:8,MERC.SI:8,BAN:8</availability>
-		</model>
 		<model name='GLT-6WB3'>
 			<roles>raider</roles>
 			<availability>ROS:3,MSC:6,MERC:3</availability>
@@ -7142,6 +7138,10 @@
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:3,MERC:4</availability>
+		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>ROS:6,CLAN:8,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gulltoppr OmniMonitor' unitType='Tank' omni='IS'>
@@ -7159,10 +7159,6 @@
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
 		<availability>FVC:5,LA:8,IS:5,MH:4,FS:5,DC:7</availability>
-		<model name='GUN-2ERDr'>
-			<roles>spotter</roles>
-			<availability>FS:4,DC:4</availability>
-		</model>
 		<model name='GUN-2ERD'>
 			<roles>spotter</roles>
 			<availability>LA:6,General:4,FS:6,DC:6</availability>
@@ -7170,15 +7166,19 @@
 		<model name='GUN-1ERD'>
 			<availability>General:8</availability>
 		</model>
+		<model name='GUN-2ERDr'>
+			<roles>spotter</roles>
+			<availability>FS:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
 		<availability>LA:6,ROS:4,FS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gurzil Support Tank' unitType='Tank'>
@@ -7211,30 +7211,30 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,LA:4,CNC:5,IS:4,DC:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CNC:6,DC:4+</availability>
-		</model>
 		<model name='HKO-1C'>
 			<roles>fire_support</roles>
 			<availability>LA:5,DC:5</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CNC:6,DC:4+</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>RA.OA:5,CHH:7,LA:3,ROS:4,CLAN:5,FS:3,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
-		</model>
 		<model name='(AAA)'>
 			<roles>fire_support</roles>
 			<availability>RA.OA:8,RD:4,CDS:4,RA:8,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hadur Fast Support Vehicle' unitType='Tank'>
@@ -7275,23 +7275,23 @@
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>ROS:3,FS:5,MERC:3</availability>
-		<model name='HMH-6E'>
-			<availability>General:6,MERC:6</availability>
+		<model name='HMH-6D'>
+			<availability>ROS:6,General:6</availability>
 		</model>
 		<model name='HMH-5D'>
 			<availability>General:2,MERC:4</availability>
 		</model>
-		<model name='HMH-6D'>
-			<availability>ROS:6,General:6</availability>
+		<model name='HMH-6E'>
+			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>ROS:6,CLAN:2,CNC:3</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:4</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:4</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
@@ -7299,30 +7299,30 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,RD:3,CDS:4,ROS:3+,CNC:5,CJF:4,CGB:3</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='E'>
-			<roles>anti_infantry</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<roles>anti_infantry</roles>
+			<availability>General:3</availability>
+		</model>
 		<model name='D'>
 			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>CNC:9,General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -7347,9 +7347,6 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:4,CC:4,OP:6,MERC:4,DTA:6,FWL.pm:6,RF:6,LA:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
-		<model name='(Thunderbolt)'>
-			<availability>DTA:5,CC:4,MOC:4,OP:5,RF:5,MH:4,MSC:5,DA:5,RCM:5,MERC:4</availability>
-		</model>
 		<model name='(MML)'>
 			<availability>MOC:4,DTA:6,CC:4,OP:6,RF:6,LA:4,MSC:6,RCM:6,DA:6,MERC:4</availability>
 		</model>
@@ -7357,16 +7354,19 @@
 			<deployedWith>Galleon</deployedWith>
 			<availability>FWL:1</availability>
 		</model>
+		<model name='(Thunderbolt)'>
+			<availability>DTA:5,CC:4,MOC:4,OP:5,RF:5,MH:4,MSC:5,DA:5,RCM:5,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Harpy' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
 		<model name='(Standard)'>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='4'>
+		<model name='2'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='2'>
+		<model name='4'>
 			<availability>CHH:8</availability>
 		</model>
 	</chassis>
@@ -7382,11 +7382,11 @@
 		<model name='HTM-28T'>
 			<availability>ROS:4,DC:2</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>MERC:4,DC:4</availability>
-		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:6,DC:6</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Kaeru' unitType='Mek'>
@@ -7406,46 +7406,46 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,Periphery:2,DTA:5,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,MSC:5,DC:4</availability>
-		<model name='HCT-7R'>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='HCT-5DD'>
-			<availability>ROS:6,FS:8,MERC:6,CDP:4</availability>
+		<model name='HCT-6S'>
+			<availability>LA:8,MERC:6</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>ROS:1,FS:1,MERC:1,CDP:2</availability>
 		</model>
-		<model name='HCT-6D'>
-			<availability>ROS:4,FS:2,MERC:6</availability>
-		</model>
 		<model name='HCT-6M'>
 			<availability>DTA:8,ROS:4,FWL:8,MSC:8,MERC:4</availability>
 		</model>
-		<model name='HCT-7S'>
-			<availability>LA:8,ROS:5,FS:5,MERC:5</availability>
+		<model name='HCT-7R'>
+			<availability>ROS:6</availability>
 		</model>
 		<model name='HCT-5S'>
 			<availability>FVC:4,LA:3,CGB.FRR:4,FS:3,MERC:4,DC:2,Periphery:4</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>DC:8</availability>
+		<model name='HCT-5DD'>
+			<availability>ROS:6,FS:8,MERC:6,CDP:4</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:8,ROS:5,FS:5,MERC:5</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:2-,LA:1-,TC.PL:2-,MERC:1-,Periphery:2-</availability>
 		</model>
-		<model name='HCT-6S'>
-			<availability>LA:8,MERC:6</availability>
+		<model name='HCT-6D'>
+			<availability>ROS:4,FS:2,MERC:6</availability>
+		</model>
+		<model name='HCT-5K'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Commando' mechanized='false'>
 			<roles>urban</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk II Battle Armor' unitType='BattleArmor'>
@@ -7457,24 +7457,24 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:6</availability>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OB'>
-			<availability>General:7</availability>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='HA1-OC'>
+		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OD'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OC'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Havoc' unitType='Mek'>
@@ -7497,16 +7497,16 @@
 	</chassis>
 	<chassis name='Hawk Moth II Gunship' unitType='VTOL'>
 		<availability>IS:3</availability>
-		<model name='(MML)'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
+		<model name='(Sniper)'>
+			<roles>artillery</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Sniper)'>
-			<roles>artillery</roles>
-			<availability>General:2</availability>
+		<model name='(MML)'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='HawkWolf' unitType='Mek'>
@@ -7535,25 +7535,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,TC:6,Periphery:5</availability>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7600,8 +7600,8 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
@@ -7609,14 +7609,14 @@
 		<model name='Meteor-U'>
 			<availability>ROS:2,FS:3,MERC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,TC:1</availability>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
 		</model>
 		<model name='Meteor-G'>
 			<availability>General:3,FWL:4</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7627,10 +7627,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:4,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
@@ -7638,6 +7634,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7646,6 +7646,18 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:4,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(WoB)'>
+			<roles>apc,support</roles>
+			<availability>ROS:2</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
@@ -7654,21 +7666,16 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(WoB)'>
-			<roles>apc,support</roles>
-			<availability>ROS:2</availability>
-		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:4,LA:4+,CNC:4,RA:4,CWIE:5</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -7676,38 +7683,31 @@
 		<model name='Prime'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
 		<availability>CC:4,MOC:4,IS:4,MERC:4</availability>
-		<model name='HEP-4H'>
-			<roles>artillery</roles>
-			<availability>General:8,MERC:8</availability>
-		</model>
 		<model name='HEP-1H'>
 			<roles>artillery</roles>
 			<availability>CC:1-,MOC:1-,MERC:1-</availability>
 		</model>
+		<model name='HEP-4H'>
+			<roles>artillery</roles>
+			<availability>General:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
 		<availability>CC:5,MOC:5,FS:3,MERC:3,DC:3,TC:5</availability>
-		<model name='HEL-3D'>
-			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		<model name='HEL-4A'>
+			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
 		<model name='HEL-C'>
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='HEL-4A'>
-			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
+		<model name='HEL-3D'>
+			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -7718,11 +7718,11 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
-		<model name='HCT-213'>
-			<availability>General:2</availability>
-		</model>
 		<model name='HCT-313'>
 			<availability>RA.OA:8,FVC:8,CDP:8,RA:8</availability>
+		</model>
+		<model name='HCT-213'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellfire' unitType='Mek'>
@@ -7733,8 +7733,8 @@
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>CHH:3,CDS:2,ROS:2,CNC:6,CJF:3</availability>
-		<model name='2'>
-			<availability>CDS:6,CNC:8,CWIE:8,DC:6</availability>
+		<model name='5'>
+			<availability>ROS:5,CNC:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:6</availability>
@@ -7742,15 +7742,27 @@
 		<model name='4'>
 			<availability>CNC:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:6,CNC:8,CWIE:8,DC:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CHH:5,CJF:5</availability>
-		</model>
-		<model name='5'>
-			<availability>ROS:5,CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CNC:5,CJF:2</availability>
+		<model name='B'>
+			<availability>General:7,CJF:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7,CJF:3</availability>
+		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -7759,54 +7771,42 @@
 			<roles>fire_support</roles>
 			<availability>General:6,CJF:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7,CJF:3</availability>
-		</model>
 		<model name='F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7,CJF:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
+		<model name='HSN-9F'>
+			<roles>fire_support</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='HSN-10SR'>
 			<roles>spotter</roles>
 			<availability>FS:5</availability>
 		</model>
-		<model name='HSN-7D'>
-			<roles>fire_support</roles>
-			<availability>FS:8,MERC:8</availability>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-9F'>
+		<model name='HSN-7D'>
 			<roles>fire_support</roles>
-			<availability>FS:4</availability>
+			<availability>FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellstar' unitType='Mek'>
 		<availability>CC:3,CHH:6,MERC.WD:4,MERC.KH:4,LA:4,ROS:4,FS:3,CWIE:6,DC:4</availability>
+		<model name='2'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hephaestus Jump Tank' unitType='Tank'>
@@ -7822,6 +7822,18 @@
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4+</availability>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>recon,apc,fire_support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -7829,18 +7841,6 @@
 		<model name='Prime'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon,apc,fire_support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -7865,13 +7865,13 @@
 			<roles>recon</roles>
 			<availability>ROS:3-,FWL:2-,MERC:3-</availability>
 		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>OP:4,FWL:4,MSC:4</availability>
+		</model>
 		<model name='HER-6D'>
 			<roles>recon</roles>
 			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-5Sr'>
-			<roles>recon</roles>
-			<availability>MOC:4,IS:4,MH:4</availability>
 		</model>
 		<model name='HER-5SA'>
 			<roles>training</roles>
@@ -7885,9 +7885,9 @@
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:6,FS:6,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>OP:4,FWL:4,MSC:4</availability>
+			<availability>MOC:4,IS:4,MH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
@@ -7896,34 +7896,34 @@
 			<roles>recon,spotter</roles>
 			<availability>FWL:1</availability>
 		</model>
-		<model name='HER-4K'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>OP:6,MSC:6,MERC:6,DC:8</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:2</availability>
+			<availability>CLAN:6,BAN:8</availability>
 		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:2</availability>
 		</model>
-		<model name='HER-1S'>
+		<model name='HER-4K'>
 			<roles>recon</roles>
-			<availability>CLAN:6,BAN:8</availability>
+			<availability>OP:6,MSC:6,MERC:6,DC:8</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>OP:4,FWL:3,MSC:4</availability>
 		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,CGB.FRR:1,CNC:2,IS:2-,Periphery.Deep:4,MERC:5,Periphery:6,CWIE:2</availability>
-		<model name='(SRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:4-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:1,Periphery:1</availability>
@@ -7956,29 +7956,29 @@
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CHH:6,RD:6,CDS:4,CW:6,LA:3,ROS:4,CNC:6,CJF:6,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CDS:4,CW:4,CNC:4,IS:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CW:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8,RD:8,CW:4,ROS:4,CJF:8,CGB:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:4,CW:4,CNC:4,IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:5,MOC:4,LA:6,CLAN:4,IS:4,FWL:4,MH:4,MERC:4,FS:4,CJF:5,DC:4</availability>
-		<model name='HGN-732b'>
-			<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
-		</model>
 		<model name='HGN-734'>
 			<availability>LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='HGN-738'>
-			<availability>LA:8,ROS:8</availability>
+		<model name='HGN-732b'>
+			<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+		</model>
+		<model name='HGN-738'>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hippogriff' unitType='ProtoMek'>
@@ -7989,7 +7989,7 @@
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:5</availability>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -7997,7 +7997,7 @@
 			<roles>recon,apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8035,11 +8035,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F5'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BZK-F7'>
 			<availability>General:6</availability>
+		</model>
+		<model name='BZK-F5'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -8053,15 +8053,15 @@
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+		<model name='HNT-182'>
+			<availability>FVC:3,FS.PMM:3,FS.CMM:3,FS.DMM:3,FS.CrMM:3</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:1-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='HNT-182'>
-			<availability>FVC:3,FS.PMM:3,FS.CMM:3,FS.DMM:3,FS.CrMM:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hound' unitType='Mek'>
@@ -8085,13 +8085,13 @@
 	</chassis>
 	<chassis name='Huitzilopochtli Assault Tank &apos;Huey&apos;' unitType='Tank'>
 		<availability>ROS:4,CLAN:5</availability>
-		<model name='(AAA)'>
-			<roles>missile_artillery,anti_aircraft</roles>
-			<availability>CHH:4,RD:5,RA:6,CGB:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>missile_artillery,anti_aircraft</roles>
+			<availability>CHH:4,RD:5,RA:6,CGB:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Humming Bird VTOL' unitType='VTOL'>
@@ -8103,33 +8103,39 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>MERC.WD:4,RD:5,CDS:7,CW:5,CJF:5,CGB:5,CWIE:4,RA:5</availability>
-		<model name='3'>
-			<availability>RA:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:7,RA:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,RA:3</availability>
 		</model>
+		<model name='3'>
+			<availability>RA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:1,CC:1,RA.OA:1,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,FS:2,Periphery:3,TC:1,DC:1</availability>
-		<model name='HBK-6S'>
-			<availability>LA:8,ROS:6,MERC:6</availability>
-		</model>
-		<model name='HBK-5P'>
-			<availability>ROS:6,FWL:8,MERC:4</availability>
-		</model>
-		<model name='HBK-7R'>
-			<roles>spotter</roles>
-			<availability>ROS:6</availability>
-		</model>
 		<model name='HBK-5SS'>
 			<availability>LA:8</availability>
 		</model>
 		<model name='HBK-4G'>
 			<availability>Periphery:2-</availability>
+		</model>
+		<model name='HBK-6S'>
+			<availability>LA:8,ROS:6,MERC:6</availability>
+		</model>
+		<model name='HBK-7R'>
+			<roles>spotter</roles>
+			<availability>ROS:6</availability>
+		</model>
+		<model name='HBK-5P'>
+			<availability>ROS:6,FWL:8,MERC:4</availability>
+		</model>
+		<model name='HBK-5H'>
+			<availability>FVC:3,MH:6,Periphery:4</availability>
+		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:3,CC:3,FWL:4,MERC:3,CDP:3,TC:3</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>Periphery:2-</availability>
@@ -8139,12 +8145,6 @@
 		</model>
 		<model name='HBK-6N'>
 			<availability>ROS:3,FWL:2,MH:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='HBK-5H'>
-			<availability>FVC:3,MH:6,Periphery:4</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:3,CC:3,FWL:4,MERC:3,CDP:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -8158,29 +8158,35 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:3,CC:5,RA.OA:4,LA:6,ROS:2,IS:4,FWL:3,MERC:4,FS:4,Periphery:4,TC:4,DC:2</availability>
-		<model name='&apos;Assault Hunter&apos;'>
-			<availability>LA:1,FS:1</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:2-</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:4</availability>
-		</model>
-		<model name='(Amphibious)'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
 			<availability>RF:6,LA:8,ROS:6,FS:6,RCM:6,MERC:6,DA:6</availability>
 		</model>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='(Amphibious)'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='&apos;Assault Hunter&apos;'>
+			<availability>LA:1,FS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,MERC:2,TC:6</availability>
+		<model name='HUR-WO-R4O'>
+			<availability>CC:8,MOC:8,FWL:5,MERC:6,TC:5</availability>
+		</model>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:4,MOC:4,FWL:5</availability>
 		</model>
@@ -8188,42 +8194,36 @@
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4O'>
-			<availability>CC:8,MOC:8,FWL:5,MERC:6,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,CNC:4,MERC:4,FS:4,CGB:5,DC:4</availability>
-		<model name='HSCL-1-OD'>
-			<availability>General:4</availability>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:3+</availability>
 		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HSCL-1-OA'>
+		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OB'>
+		<model name='HSCL-1-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>LA:1,ROS:2,CLAN:3,MERC:1</availability>
-		<model name='HSR-400-D'>
-			<availability>LA:8,ROS:8,MERC:8</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6,MERC.SI:4,BAN:8</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -8235,25 +8235,25 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CLAN:6,RA:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Algar)'>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8,CLAN:5,CJF:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
 		<availability>CHH:5</availability>
-		<model name='(Standard)'>
+		<model name='2'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='2'>
+		<model name='(Standard)'>
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
@@ -8266,11 +8266,8 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:2,MOC:8,LA:1,ROS:4,IS:8,FWL:3,MH:8,TC:8</availability>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -8278,8 +8275,11 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -8307,11 +8307,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='IMP-4E'>
 			<availability>MERC.WD:6,MERC.KH:8</availability>
+		</model>
+		<model name='IMP-3E'>
+			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -8336,23 +8336,23 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5</availability>
-		<model name='(BA)'>
-			<availability>CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(BA)'>
+			<availability>CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4,TC:3</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
+		<model name='&apos;Puma&apos;' mechanized='true'>
+			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
 		</model>
-		<model name='&apos;Puma&apos;' mechanized='true'>
-			<availability>FS:8,TC:8</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Marine)' mechanized='true'>
 			<roles>marine</roles>
@@ -8361,21 +8361,21 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>CC:4,LA:4,ROS:5,FWL:4,FS:4,DC:4</availability>
-		<model name='(SCC)'>
-			<roles>assault</roles>
-			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
-		</model>
 		<model name='(3115)'>
-			<roles>assault</roles>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='(Sub-Capital)'>
 			<roles>assault</roles>
 			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>assault</roles>
 			<availability>CC:8,ROS:5,FWL:8</availability>
+		</model>
+		<model name='(SCC)'>
+			<roles>assault</roles>
+			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
+		</model>
+		<model name='(Sub-Capital)'>
+			<roles>assault</roles>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -8391,29 +8391,29 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,CLAN:9,IS:7,Periphery.Deep:6,FS:9,BAN:6,Periphery:8,TC:8,RA.OA:8,LA:9,PIR:5,FWL:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ironhold Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CJF:5</availability>
-		<model name='(Fire)' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Tank)' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='(Fire)' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Isegrim Assault DropShip' unitType='Dropship'>
@@ -8454,15 +8454,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -8479,38 +8479,38 @@
 	</chassis>
 	<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
 		<availability>DC.LV:1-,DC.GR:1-,TC:1-</availability>
-		<model name='(TAG)'>
-			<roles>recon,spotter</roles>
-			<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<roles>recon,raider</roles>
+			<availability>General:7,Periphery:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>recon,raider</roles>
 			<availability>FVC:3,IS:4,TC:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Kurita)'>
 			<roles>recon,raider</roles>
-			<availability>General:7,Periphery:4</availability>
+			<availability>DC:8,TC:4</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>recon,raider</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Kurita)'>
-			<roles>recon,raider</roles>
-			<availability>DC:8,TC:4</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>recon,raider</roles>
 			<availability>General:4,Periphery:5</availability>
 		</model>
+		<model name='(TAG)'>
+			<roles>recon,spotter</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
 		<availability>RD:3,IS:4,TC:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<availability>TC:4</availability>
-		</model>
 		<model name='(3082 Upgrade)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
@@ -8530,13 +8530,13 @@
 	</chassis>
 	<chassis name='JI2A1 Attack APC' unitType='Tank'>
 		<availability>FVC:5,ROS:4,FS:5,MERC:4</availability>
-		<model name='(MML)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MML)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jabberwocky ConstructionMech' unitType='Mek'>
@@ -8577,27 +8577,27 @@
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CW:2,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CW:5,General:2,RA:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CW:4,CLAN:2,RA:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CW:4,CLAN:2,RA:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CW:2,General:1</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8611,35 +8611,16 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>MOC:4,RA.OA:4,FVC:4,LA:4,MERC:4,FS:4,CDP:4,DC:4,TC:4</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='JM7-C3BS'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>Periphery:4</availability>
 		</model>
-		<model name='JM6-DGr'>
-			<roles>anti_aircraft</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:3,DC:2</availability>
+		<model name='JM6-DG'>
+			<availability>General:1</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:5,FS:3,MERC:6</availability>
-		</model>
-		<model name='JM7-F'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:1</availability>
 		</model>
 		<model name='JM6-DDa'>
 			<roles>anti_aircraft</roles>
@@ -8649,27 +8630,42 @@
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,PIR:2,MH:6,Periphery:2</availability>
 		</model>
+		<model name='JM7-F'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:4,FS:4</availability>
+		</model>
+		<model name='JM6-DGr'>
+			<roles>anti_aircraft</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:3,DC:2</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM7-G'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>MOC:4,RA.OA:4,FVC:4,LA:4,MERC:4,FS:4,CDP:4,DC:4,TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Jaguar' unitType='Mek'>
 		<availability>LA:3,ROS:3,CWIE:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:3,FVC:7,Periphery.HR:4,ROS:4,FS:7,MERC:4,Periphery.OS:6,Periphery:3,TC:3</availability>
-		<model name='JVN-11D'>
+		<model name='JVN-10P'>
 			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:2,MERC:6,CDP:6,TC:6</availability>
 		</model>
 		<model name='JVN-11F'>
 			<roles>recon</roles>
@@ -8679,12 +8675,16 @@
 			<roles>recon</roles>
 			<availability>IS:1-,Periphery:2-</availability>
 		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+		</model>
 		<model name='JVN-11P'>
 			<availability>FVC:4</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11D'>
 			<roles>recon</roles>
-			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:2,MERC:6,CDP:6,TC:6</availability>
+			<availability>ROS:6,FS:6</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -8693,14 +8693,14 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>RD:9,CW:8,CLAN:6,CWIE:7,CGB:9</availability>
-		<model name='B'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -8711,67 +8711,59 @@
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
+		<model name='B'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CDS:6,CW:6,ROS:4,CNC:8,DC:3</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>CNC:6</availability>
 		</model>
-		<model name='3'>
+		<model name='(Standard)'>
+			<availability>CW:3,CNC:3</availability>
+		</model>
+		<model name='2'>
 			<availability>CNC:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:8,CNC:8,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CW:3,CNC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:5,FS.DMM:5,MERC:4,Periphery.OS:5,FS:4,RA:4,DC:8,Periphery:3</availability>
-		<model name='JR7-K'>
+		<model name='JR7-C4'>
 			<roles>raider</roles>
-			<availability>MOC:2,RA.OA:2,MERC:2,RA:2,DC:2,TC:2</availability>
-		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>ROS:4,DC:8</availability>
-		</model>
-		<model name='JR7-C3'>
-			<roles>raider</roles>
-			<availability>ROS:5,MERC:5,DC:6</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='JR7-C3'>
+			<roles>raider</roles>
+			<availability>ROS:5,MERC:5,DC:6</availability>
+		</model>
+		<model name='JR7-K'>
+			<roles>raider</roles>
+			<availability>MOC:2,RA.OA:2,MERC:2,RA:2,DC:2,TC:2</availability>
+		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
 			<availability>MERC:4,FS:4,DC:4</availability>
 		</model>
-		<model name='JR7-C4'>
+		<model name='JR7-C2'>
 			<roles>raider</roles>
-			<availability>DC:4</availability>
+			<availability>ROS:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:6,TC:4</availability>
-		<model name='JI-50 (Q-Vehicle)'>
-			<roles>support</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='JI-50'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='JI-50 (ML)'>
+		<model name='JI-50 (Hoist)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8779,21 +8771,29 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='JI-50 (Hoist)'>
+		<model name='JI-50'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Q-Vehicle)'>
+			<roles>support</roles>
+			<availability>TC:2</availability>
+		</model>
+		<model name='JI-50 (ML)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:6,MOC:5,TC:4</availability>
-		<model name='JN-G8A'>
-			<availability>General:8</availability>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
+		<model name='JN-G8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Joust Medium Tank' unitType='Tank'>
@@ -8815,11 +8815,11 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
@@ -8831,8 +8831,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -8852,32 +8852,31 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CJF:5</availability>
 		</model>
+		<model name='3'>
+			<availability>CJF:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>ROS:4,DC:6</availability>
-		<model name='KBO-7B'>
+		<model name='KBO-7A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='KBO-7A'>
+		<model name='KBO-7B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+		<model name='C' mechanized='true'>
+			<availability>DC:3</availability>
 		</model>
-		<model name='(DEST)' mechanized='true'>
+		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
@@ -8885,28 +8884,29 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C' mechanized='true'>
-			<availability>DC:3</availability>
+		<model name='[MG]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
+		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='(Space)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='(Vibro-Claw)' mechanized='true'>
+		<model name='[ECM]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
+			<availability>MERC:2,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -8927,6 +8927,13 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Salvage Arm]' mechanized='false'>
+			<roles>support</roles>
+			<availability>DC.NSR:4,DC.SL:4,General:5</availability>
+		</model>
 		<model name='[Industrial Drill]' mechanized='false'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -8934,23 +8941,16 @@
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Salvage Arm]' mechanized='false'>
-			<roles>support</roles>
-			<availability>DC.NSR:4,DC.SL:4,General:5</availability>
-		</model>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>RD:7,CGB:6</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
@@ -8972,22 +8972,22 @@
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>cargo</roles>
-			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
-		</model>
 		<model name='(AC)'>
 			<availability>MH:4,MERC:4</availability>
 		</model>
-		<model name='(BA)'>
-			<roles>apc</roles>
-			<availability>FWL:5,IS:6</availability>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
 		</model>
 		<model name='(Heavy Stealth)'>
 			<availability>PIR:4</availability>
 		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
+		<model name='(3055 Upgrade)'>
+			<roles>cargo</roles>
+			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='(BA)'>
+			<roles>apc</roles>
+			<availability>FWL:5,IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
@@ -8995,12 +8995,12 @@
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:8,DC:8</availability>
 		</model>
+		<model name='CRK-5003-C'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='CRK-5003-CM'>
 			<roles>spotter</roles>
 			<availability>DC:7</availability>
-		</model>
-		<model name='CRK-5003-C'>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kelswa Assault Tank' unitType='Tank'>
@@ -9015,21 +9015,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='King Crab' unitType='Mek'>
@@ -9037,8 +9037,17 @@
 		<model name='KGC-001'>
 			<availability>LA:3,IS:4,MH:6</availability>
 		</model>
+		<model name='KGC-000b'>
+			<availability>ROS:6,CLAN:4,BAN:2,DC:6</availability>
+		</model>
+		<model name='KGC-007'>
+			<availability>LA:6,ROS:8,FS:8,MERC:8</availability>
+		</model>
 		<model name='KGC-008B'>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='KGC-000'>
+			<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
 		</model>
 		<model name='KGC-005r'>
 			<availability>ROS:4,MERC:4</availability>
@@ -9046,41 +9055,32 @@
 		<model name='KGC-009'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='KGC-000b'>
-			<availability>ROS:6,CLAN:4,BAN:2,DC:6</availability>
-		</model>
-		<model name='KGC-000'>
-			<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
-		</model>
-		<model name='KGC-007'>
-			<availability>LA:6,ROS:8,FS:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>RD:6,CDS:3,ROS:3+,CNC:3,RA:3,CGB:6</availability>
 		<model name='C'>
 			<availability>RD:3,General:5,CGB:3</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:5,General:6,CGB:5</availability>
-		</model>
 		<model name='E'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
+		<model name='D'>
+			<availability>RD:5,General:6,CGB:5</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kinnol MBT' unitType='Tank'>
@@ -9088,20 +9088,20 @@
 		<model name='(PPC)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(RAC)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>DC.GHO:5,ROS:6,MERC:3,FS:1,DC:3</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:5</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:2,DC.SL:4,ROS:3,CLAN:6,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-K'>
 			<availability>DC:8</availability>
@@ -9109,29 +9109,29 @@
 		<model name='KTO-20'>
 			<availability>MERC:4,DC:2</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:5</availability>
+		<model name='KTO-19b'>
+			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:5,CGB:6</availability>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -9174,21 +9174,21 @@
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
 		<availability>RD:3-,CGB:3-</availability>
-		<model name='(GB) [SL/Flamer]' mechanized='true'>
+		<model name='(GB) [GL/Flamer]' mechanized='true'>
 			<availability>RD:6,CGB:6</availability>
 		</model>
-		<model name='(GB) [GL]' mechanized='true'>
-			<availability>RD:4,CGB:4</availability>
-		</model>
-		<model name='(GB) [GL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
+		<model name='(GB) [SL/Flamer]' mechanized='true'>
 			<availability>RD:6,CGB:6</availability>
 		</model>
 		<model name='(GB) [SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>RD:8,CGB:8</availability>
 		</model>
-		<model name='(GB) [GL/Flamer]' mechanized='true'>
+		<model name='(GB) [GL]' mechanized='true'>
+			<availability>RD:4,CGB:4</availability>
+		</model>
+		<model name='(GB) [GL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
 			<availability>RD:6,CGB:6</availability>
 		</model>
 	</chassis>
@@ -9205,6 +9205,9 @@
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>RD:7,ROS:4,RA:6,CGB:7</availability>
+		<model name='5'>
+			<availability>RD:4,CGB:4</availability>
+		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
 			<availability>RA:5</availability>
@@ -9214,9 +9217,6 @@
 		</model>
 		<model name='4'>
 			<availability>RD:4,ROS:4,CGB:4</availability>
-		</model>
-		<model name='5'>
-			<availability>RD:4,CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
@@ -9228,9 +9228,6 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='KIM-2'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>General:8,DC:3</availability>
@@ -9239,14 +9236,14 @@
 			<roles>spotter</roles>
 			<availability>DC:1</availability>
 		</model>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>OP:6,ROS:5,FWL:4,MERC:4</availability>
-		<model name='(AI Mk IIr)' mechanized='false'>
-			<availability>OP:4,MERC:3</availability>
-		</model>
-		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='(AI Mk II)' mechanized='false'>
+			<availability>OP:5,MERC:4</availability>
 		</model>
 		<model name='(Mortar)' mechanized='false'>
 			<availability>OP:4,MERC:3</availability>
@@ -9255,8 +9252,11 @@
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(AI Mk II)' mechanized='false'>
-			<availability>OP:5,MERC:4</availability>
+		<model name='(AI Mk IIr)' mechanized='false'>
+			<availability>OP:4,MERC:3</availability>
+		</model>
+		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Koroshiya' unitType='Aero'>
@@ -9267,48 +9267,52 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,DTA:3,ROS:3,MERC:4</availability>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
-			<availability>MERC:5</availability>
-		</model>
 		<model name='KSC-4I'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='KSC-4L'>
 			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='KSC-5I'>
 			<availability>DTA:8,ROS:8,MERC:8</availability>
 		</model>
+		<model name='KSC-5MC'>
+			<availability>MOC:8,CC:8,MERC:4</availability>
+		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:5</availability>
+		</model>
+		<model name='KSC-4L'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
 		<model name='KSC-6L'>
 			<roles>artillery</roles>
 			<availability>CC:4,MOC:4</availability>
 		</model>
-		<model name='KSC-5MC'>
-			<availability>MOC:8,CC:8,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,MERC.WD:4,CDS:4,CW:4,IS:4+,CJF:3,BAN:5,RA:4</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CNC:3,General:2</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>RD:8,CDS:3,CW:7,General:4,CGB:8</availability>
 		</model>
-		<model name='D'>
-			<roles>recon</roles>
-			<availability>RD:2,CDS:5,CW:7,CNC:2,General:3,CJF:2,CWIE:7,CGB:2</availability>
-		</model>
-		<model name='E'>
-			<roles>recon</roles>
+		<model name='F'>
+			<roles>recon,spotter</roles>
 			<availability>CLAN:5,IS:3</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>RD:6,CDS:9,CNC:6,General:8,CGB:6</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>RD:4,CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CLAN:5,IS:3</availability>
 		</model>
 		<model name='G'>
 			<roles>recon,anti_infantry</roles>
@@ -9318,22 +9322,18 @@
 			<roles>recon</roles>
 			<availability>RD:5,CDS:6,CW:6,General:5,CWIE:5,CGB:5</availability>
 		</model>
-		<model name='P'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CLAN:2,IS:2</availability>
+			<availability>RD:2,CDS:5,CW:7,CNC:2,General:3,CJF:2,CWIE:7,CGB:2</availability>
 		</model>
-		<model name='Prime'>
+		<model name='E'>
 			<roles>recon</roles>
-			<availability>RD:6,CDS:9,CNC:6,General:8,CGB:6</availability>
-		</model>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CNC:3,General:2</availability>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Koshi' unitType='Mek'>
 		<availability>CLAN:5,IS:4</availability>
-		<model name='(Standard) 2'>
+		<model name='(Standard) 3'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9341,7 +9341,7 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard) 3'>
+		<model name='(Standard) 2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9377,12 +9377,12 @@
 	</chassis>
 	<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
 		<availability>CHH:6,RD:6,CDS:2,CW:4,CNC:2,CJF:4,RA:6,CGB:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(IFV) &apos;Turhan II&apos;'>
 			<roles>apc</roles>
 			<availability>CHH:8,CJF:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kuan Ti' unitType='Dropship'>
@@ -9394,11 +9394,11 @@
 	</chassis>
 	<chassis name='Kuma' unitType='Mek'>
 		<availability>RD:4,CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
@@ -9453,33 +9453,33 @@
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>CC:4,MOC:4,OP:6,FS:3,MERC:4,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
-		<model name='LX-2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LX-2A'>
 			<availability>DTA:5,OP:5,RF:5,LA:5,ROS:5,FWL:5,MSC:5,RCM:5,MERC:5,DA:5</availability>
 		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
+		<model name='LX-2'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:8,MOC:6,FS:4,TC:4</availability>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3B'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:6</availability>
-		</model>
 		<model name='LHU-4E'>
 			<availability>CC:6</availability>
 		</model>
 		<model name='LHU-3L'>
 			<availability>CC:6,MOC:8,FS:8</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-3B'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -9491,56 +9491,56 @@
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>ROS:4,FS:8,MERC:4</availability>
-		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
+		<model name='LGN-2K'>
+			<roles>raider</roles>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='LGN-2F'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
 		</model>
-		<model name='LGN-2K'>
-			<roles>raider</roles>
-			<availability>ROS:4</availability>
+		<model name='LGN-2XU'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-2XA'>
 			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leonidas Battle Armor' unitType='BattleArmor'>
 		<availability>CC:3,MOC:3,OP:5,MERC:3</availability>
-		<model name='(MG)' mechanized='true'>
+		<model name='(Sensor)' mechanized='true'>
+			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(David)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(FireDrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<roles>recon</roles>
+		<model name='(FireDrake)' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>RA.OA:8,IS:7,Periphery.Deep:5,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>CC:8,DTA:8,OP:8,RF:8,LA:8,ROS:8,General:3,FWL:8,MSC:8,FS:8,RCM:8,DA:8</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:5-</availability>
+		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>CC:8,DTA:8,OP:8,RF:8,LA:8,ROS:8,General:3,FWL:8,MSC:8,FS:8,RCM:8,DA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
@@ -9590,27 +9590,27 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
-		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:4,FWL:8,IS:4</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:3</availability>
+		<model name='Owl'>
+			<availability>LA:1,ROS:1,MERC:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:1,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1,ROS:1,MERC:1</availability>
+		<model name='Comet'>
+			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:2,LA:2</availability>
 		</model>
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
+		</model>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:4,FWL:8,IS:4</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -9621,9 +9621,6 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CLAN:3,CJF:4</availability>
-		<model name='(ERSL)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
@@ -9631,29 +9628,32 @@
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,Periphery:4,TC:4,DC:5</availability>
-		<model name='LTN-G15b'>
-			<availability>CC:5,MOC:5,CLAN:3,IS:4,MERC:4</availability>
-		</model>
-		<model name='LTN-G16L'>
-			<availability>CC:6,MOC:6,RF:4,MSC:4,MERC:4,DA:6</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:3-</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='LTN-G16S'>
-			<availability>LA:6</availability>
+		<model name='LTN-G15b'>
+			<availability>CC:5,MOC:5,CLAN:3,IS:4,MERC:4</availability>
 		</model>
 		<model name='LTN-G16D'>
 			<availability>ROS:6,FS:6,MERC:4</availability>
 		</model>
+		<model name='LTN-G16L'>
+			<availability>CC:6,MOC:6,RF:4,MSC:4,MERC:4,DA:6</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='LTN-G16O'>
 			<availability>RA.OA:6,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G16S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
@@ -9661,11 +9661,14 @@
 		<model name='B'>
 			<availability>RD:6,CDS:4,General:5,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:7,CW:6,General:5,CWIE:6,CGB:7</availability>
+		<model name='A'>
+			<availability>RD:6,CW:6,General:7,CWIE:6,CGB:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3</availability>
+		<model name='H'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:4,RD:5,CW:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
@@ -9673,26 +9676,23 @@
 		<model name='Prime'>
 			<availability>RD:9,CDS:7,General:8,CWIE:9,CGB:9</availability>
 		</model>
-		<model name='A'>
-			<availability>RD:6,CW:6,General:7,CWIE:6,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3</availability>
 		</model>
-		<model name='C'>
-			<availability>CHH:4,RD:5,CW:4,CNC:3,General:3,CJF:2,CWIE:5,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,General:3</availability>
+		<model name='D'>
+			<availability>RD:7,CW:6,General:5,CWIE:6,CGB:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lineholder' unitType='Mek'>
 		<availability>CC:4,ROS:4,FWL:4,IS:3,FS:5,TC:6,Periphery:4</availability>
-		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
-			<availability>ROS:6,FS:7,MERC:6,CDP:4</availability>
-		</model>
 		<model name='KW1-LH3'>
 			<availability>General:2,FS:3</availability>
 		</model>
 		<model name='KW1-LH2'>
 			<availability>General:4,FS:2</availability>
+		</model>
+		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
+			<availability>ROS:6,FS:7,MERC:6,CDP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -9722,95 +9722,95 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CHH:6,RD:6,CW:7,ROS:3,CJF:6,DC:3,CGB:6</availability>
-		<model name='(Standard)'>
-			<availability>CW:2</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:5,CW:5,LA:6,CJF:6</availability>
-		</model>
 		<model name='6'>
 			<availability>RD:6,CW:6,CGB:6</availability>
-		</model>
-		<model name='5'>
-			<availability>CHH:4,RD:4,CW:4,ROS:4,CGB:4</availability>
 		</model>
 		<model name='9'>
 			<availability>CJF:5</availability>
 		</model>
-		<model name='7'>
-			<availability>CHH:5,ROS:2</availability>
+		<model name='(Standard)'>
+			<availability>CW:2</availability>
 		</model>
 		<model name='8'>
 			<availability>RD:6,ROS:5,CGB:6,DC:5</availability>
 		</model>
+		<model name='7'>
+			<availability>CHH:5,ROS:2</availability>
+		</model>
+		<model name='4'>
+			<availability>CHH:5,CW:5,LA:6,CJF:6</availability>
+		</model>
 		<model name='2'>
 			<availability>CJF:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CHH:4,RD:4,CW:4,ROS:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CLAN:2-,IS:6,Periphery:4</availability>
-		<model name='LCT-3M'>
+		<model name='LCT-6M'>
 			<roles>recon</roles>
-			<availability>MOC:2,DTA:6,OP:6,RF:5,FWL:4,IS:2,MSC:5,MERC:5,RCM:5,DA:5</availability>
+			<availability>ROS:2,FWL:4,MSC:5,MERC:3</availability>
+		</model>
+		<model name='LCT-5M2'>
+			<availability>ROS:4,MSC:4</availability>
 		</model>
 		<model name='LCT-5T'>
 			<roles>recon,anti_infantry</roles>
 			<availability>MOC:4,CC:4,FVC:5,TC:6</availability>
 		</model>
-		<model name='LCT-5M2'>
-			<availability>ROS:4,MSC:4</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:3,ROS:4,PIR:4,FWL:3,FS:2,MERC:2</availability>
-		</model>
-		<model name='LCT-6M'>
-			<roles>recon</roles>
-			<availability>ROS:2,FWL:4,MSC:5,MERC:3</availability>
-		</model>
-		<model name='LCT-5W2'>
-			<roles>recon,spotter</roles>
-			<availability>LA:5,ROS:6,CLAN:4,IS:4,FS:5,DC:5</availability>
+		<model name='LCT-5M3'>
+			<availability>ROS:5,MSC:5</availability>
 		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:4,CLAN:6,FWL:4,MERC:4,BAN:2</availability>
 		</model>
-		<model name='LCT-5V'>
+		<model name='LCT-5M'>
 			<roles>recon</roles>
-			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
-		</model>
-		<model name='LCT-1V'>
-			<roles>recon</roles>
-			<availability>LA:1-,General:1-,FS:1-</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
-		<model name='LCT-3S'>
-			<roles>recon</roles>
-			<availability>LA:8,MERC:6</availability>
-		</model>
-		<model name='LCT-1S'>
-			<roles>recon</roles>
-			<availability>LA:2-,MERC:2-</availability>
-		</model>
-		<model name='LCT-5M3'>
-			<availability>ROS:5,MSC:5</availability>
+			<availability>FVC:3,ROS:4,PIR:4,FWL:3,FS:2,MERC:2</availability>
 		</model>
 		<model name='LCT-1V2'>
 			<roles>recon</roles>
 			<availability>PIR:4,MH:4,MERC:3</availability>
 		</model>
+		<model name='LCT-5W2'>
+			<roles>recon,spotter</roles>
+			<availability>LA:5,ROS:6,CLAN:4,IS:4,FS:5,DC:5</availability>
+		</model>
+		<model name='LCT-1V'>
+			<roles>recon</roles>
+			<availability>LA:1-,General:1-,FS:1-</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='LCT-3S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:6</availability>
+		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:2,DTA:6,OP:6,RF:5,FWL:4,IS:2,MSC:5,MERC:5,RCM:5,DA:5</availability>
+		</model>
+		<model name='LCT-1S'>
+			<roles>recon</roles>
+			<availability>LA:2-,MERC:2-</availability>
+		</model>
+		<model name='LCT-3D'>
+			<roles>recon</roles>
+			<availability>FVC:8,FS:8,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CW:3,BAN:4,CWIE:3</availability>
-		<model name='A'>
-			<availability>RD:5,General:7,CGB:5</availability>
+		<model name='E'>
+			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:8,General:8,CJF:9,CGB:8</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>RD:5,CDS:5,General:4,CWIE:5,CGB:5</availability>
@@ -9821,28 +9821,28 @@
 		<model name='B'>
 			<availability>CHH:6,RD:3,CDS:6,CW:4,General:5,CJF:7,CWIE:4,CGB:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CHH:6,RD:5,CW:5,General:4,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
+		<model name='A'>
+			<availability>RD:5,General:7,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,General:8,CJF:9,CGB:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Loki Mk II (Hel)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,RD:4,CDS:4,CW:4,CJF:5,RA:4</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -9858,51 +9858,51 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,IS:6,FS:5,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7,DC:6,CGB:4</availability>
-		<model name='LGB-14C2'>
+		<model name='LGB-7V'>
 			<roles>fire_support</roles>
-			<availability>IS:5</availability>
+			<availability>MOC:2,FVC:4,FWL:2,IS:2,Periphery:4</availability>
 		</model>
 		<model name='LGB-8V'>
 			<roles>missile_artillery,fire_support</roles>
 			<availability>RD:4,LA:4,FWL:4,IS:4,FS:6,MERC:4,CGB:4</availability>
 		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
-		</model>
-		<model name='LGB-13NAIS'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGB-12R'>
 			<roles>fire_support</roles>
 			<availability>DTA:4,LA:4,ROS:8,FS:4,DC:4</availability>
-		</model>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:2,FVC:4,FWL:2,IS:2,Periphery:4</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CDP:4,TC:4</availability>
 		</model>
+		<model name='LGB-13NAIS'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:5,OP:6,ROS:6,MSC:6,FS:6,MERC:6,DA:6,RCM:6,DC:6</availability>
 		</model>
+		<model name='LGB-14C2'>
+			<roles>fire_support</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:8,OP:8,RF:8,FWL:8,MH:6,MSC:8,RCM:8,DA:8</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>FWL:6</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -9916,38 +9916,38 @@
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
-		<model name='LCF-R16K'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>Periphery.R:4,FVC:2,LA:5,Periphery.MW:3,Periphery:2</availability>
-		<model name='LCF-R15'>
-			<availability>FVC:2-,LA:1-,MERC:2-,Periphery:2-</availability>
-		</model>
 		<model name='LCF-R16'>
 			<availability>LA:8,MH:4,MERC:6</availability>
+		</model>
+		<model name='LCF-R15'>
+			<availability>FVC:2-,LA:1-,MERC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM5/M'>
-			<availability>LA:1-</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='LM5/M'>
+			<availability>LA:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -9988,13 +9988,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3</availability>
-		<model name='(Standard)'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='M1'>
 			<roles>escort</roles>
 			<availability>FWL:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -10039,8 +10039,11 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:3+,MERC.WD:4,CDS:2,CW:4,ROS:3+,CLAN:1,MERC:2+,CJF:2,BAN:1,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>RD:7,CDS:8,CNC:7,General:8,CJF:8,CGB:7</availability>
+		<model name='B'>
+			<availability>CHH:7,RD:4,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,RD:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5,CGB:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -10050,31 +10053,29 @@
 			<roles>spotter</roles>
 			<availability>CHH:4,CW:5,CNC:4,CLAN:5,General:5,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CW:5,CNC:3,General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>RD:2,CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CNC:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CW:5,CNC:3,General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>RD:8,CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CHH:7,RD:4,CDS:7,CW:5,General:6,CJF:7,CWIE:5,CGB:4</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CHH:5,RD:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5,CGB:5</availability>
+		<model name='Prime'>
+			<availability>RD:7,CDS:8,CNC:7,General:8,CJF:8,CGB:7</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:2,CW:7,General:5,CJF:6,CWIE:7,CGB:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat III' unitType='Mek'>
 		<availability>CDS:5,LA:5,ROS:5,CNC:4,IS:4,CWIE:4,DC:5</availability>
-		<model name='2'>
+		<model name='4'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)'>
@@ -10085,8 +10086,7 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>fire_support</roles>
+		<model name='2'>
 			<availability>General:6</availability>
 		</model>
 		<model name='3'>
@@ -10099,8 +10099,14 @@
 		<model name='Enhanced'>
 			<availability>CGB.FRR:6,CLAN:6,CNC:4,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CDS:4</availability>
+		</model>
+		<model name='4'>
+			<availability>General:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CDS:4,CW:4,LA:4,CNC:4,IS:4,FS:4,DC:4,CWIE:4</availability>
@@ -10108,42 +10114,36 @@
 		<model name='5'>
 			<availability>General:4</availability>
 		</model>
-		<model name='4'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
 		<availability>LA:6,IS:4,FS:4,MERC:4,DC:6</availability>
-		<model name='MTR-6E'>
-			<roles>recon,spotter</roles>
-			<availability>DC:1</availability>
+		<model name='MTR-5K'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='MTR-5K'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='MTR-6E'>
+			<roles>recon,spotter</roles>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>CC:4,MOC:4,OP:8,Periphery.MM:4,MERC:4,DTA:8,RF:8,LA:4,ROS:4,Periphery.CM:4,Periphery.ME:4,FWL:8,MH:4,MSC:8,RCM:8,DA:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>MOC:4,IS:4</availability>
+		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
 		<model name='(C3)'>
 			<availability>IS:4</availability>
-		</model>
-		<model name='(XL)'>
-			<availability>MOC:4,IS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mammoth' unitType='Dropship'>
@@ -10162,9 +10162,6 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,MERC.WD:5,CDS:5,CW:5,CJF:5,BAN:4,CWIE:5</availability>
-		<model name='E'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:3</availability>
 		</model>
@@ -10175,17 +10172,20 @@
 		<model name='G'>
 			<availability>General:2</availability>
 		</model>
+		<model name='E'>
+			<availability>CLAN:6,General:3</availability>
+		</model>
 		<model name='Prime'>
 			<availability>RD:6,CDS:7,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='C'>
-			<availability>RD:7,CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
+		<model name='A'>
+			<availability>RD:9,CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:4,CDS:4,CNC:6,General:5,CJF:2,CGB:4</availability>
 		</model>
-		<model name='A'>
-			<availability>RD:9,CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
+		<model name='C'>
+			<availability>RD:7,CDS:7,CW:7,CNC:7,General:6,CJF:5,CWIE:7,CGB:7</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:5,CDS:3,CW:5,CNC:5,General:4,CGB:5</availability>
@@ -10193,14 +10193,14 @@
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
 		<availability>MERC.KH:4,RF:4,LA:4,ROS:4,MERC:4,CWIE:6</availability>
+		<model name='MNL-4S'>
+			<availability>General:5</availability>
+		</model>
 		<model name='MNL-3L'>
 			<availability>MERC.KH:6,ROS:4,CWIE:6</availability>
 		</model>
 		<model name='MNL-3W'>
 			<availability>ROS:2,CWIE:4</availability>
-		</model>
-		<model name='MNL-4S'>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -10217,28 +10217,40 @@
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
+		<model name='E'>
+			<availability>General:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:4,CC:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,CWIE:5,RA.OA:5,LA:5,ROS:5,FWL:4,DC:6</availability>
+		<model name='(LB-X)'>
+			<availability>LA:8,ROS:8,FS:8</availability>
+		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,RF:8,LA:8,ROS:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:1-,Periphery:2</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -10246,18 +10258,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:5,MOC:5,DTA:5,LA:5,ROS:6,FS:6,MERC:5,DC:6</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>LA:8,ROS:8,FS:8</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,RF:8,LA:8,ROS:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:1-,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore II Heavy Tank' unitType='Tank'>
@@ -10277,37 +10277,37 @@
 	</chassis>
 	<chassis name='Marauder Battle Armor' unitType='BattleArmor'>
 		<availability>MH:4,MERC:2,TC:3</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>MERC:8,TC:8</availability>
-		</model>
 		<model name='(MH)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>MH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>MERC:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>MERC.WD:6,RD:6,CW:5,CNC:5,CJF:6,RA:5,CWIE:5,CGB:6</availability>
-		<model name='3'>
-			<availability>RD:5,CJF:5,CGB:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CW:6,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:8,RD:3,CJF:3,CGB:3</availability>
-		</model>
-		<model name='2'>
-			<availability>RD:3,CJF:3,CGB:3</availability>
 		</model>
 		<model name='5'>
 			<availability>CJF:3,CWIE:6</availability>
 		</model>
-		<model name='4'>
-			<availability>RD:4,CNC:6,RA:4,CGB:4</availability>
+		<model name='6'>
+			<availability>CW:6,CJF:4</availability>
+		</model>
+		<model name='3'>
+			<availability>RD:5,CJF:5,CGB:5</availability>
 		</model>
 		<model name='7'>
 			<availability>RD:5,CGB:5</availability>
+		</model>
+		<model name='2'>
+			<availability>RD:3,CJF:3,CGB:3</availability>
+		</model>
+		<model name='4'>
+			<availability>RD:4,CNC:6,RA:4,CGB:4</availability>
 		</model>
 		<model name='8'>
 			<availability>RD:3,CJF:3,CGB:3</availability>
@@ -10315,8 +10315,8 @@
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,MOC:4,MERC.WD:6,LA:3,ROS:6,PIR:4,FWL:6,MH:4,FS:6,MERC:6,TC:4,DC:6</availability>
-		<model name='MAD-4H'>
-			<availability>PIR:5,MH:5,TC:5</availability>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:6</availability>
 		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
@@ -10324,14 +10324,8 @@
 		<model name='MAD-6M'>
 			<availability>ROS:4,FWL:6,MERC:6</availability>
 		</model>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:6</availability>
-		</model>
 		<model name='MAD-4L'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>LA:8,ROS:6,CNC:8,FS:5,MERC:8</availability>
@@ -10339,99 +10333,105 @@
 		<model name='MAD-4K'>
 			<availability>DC:8</availability>
 		</model>
+		<model name='MAD-4H'>
+			<availability>PIR:5,MH:5,TC:5</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,RA.OA:2,MOC:2,RD:3,LA:5,FWL:3,FS:6,TC:3,Periphery:2,DC:2,CGB:3</availability>
-		<model name='MAD-5T'>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:8,OP:8,MSC:8,MERC:3,DA:8</availability>
+		</model>
+		<model name='MAD-3D'>
+			<availability>FVC:1-,MH:2-</availability>
+		</model>
+		<model name='MAD-9D'>
 			<availability>FS:4</availability>
-		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:4,FS:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4,CGB:4</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>OP:6,RF:6,ROS:4,MERC:4,DA:6,DC:4</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>FVC:3,LA:4,FS:2,MERC:3</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>DTA:8,OP:8,MSC:8,MERC:3,DA:8</availability>
-		</model>
-		<model name='MAD-3M'>
-			<availability>MOC:1-,Periphery.MW:1-,PIR:1-,Periphery.ME:1-,MH:1-</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:4,FS:2,MERC:2,DC:4</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>MOC:4,ROS:4,FWL:6,MERC:4</availability>
 		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3D'>
-			<availability>FVC:1-,MH:2-</availability>
+		<model name='MAD-6L'>
+			<availability>CC:6,MOC:4</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>Periphery:2-,TC:2-</availability>
 		</model>
-		<model name='MAD-5L'>
-			<availability>CC:6,MOC:5</availability>
+		<model name='MAD-9S'>
+			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4,CGB:4</availability>
 		</model>
 		<model name='MAD-2R'>
 			<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
 		</model>
-		<model name='MAD-9D'>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
+		</model>
+		<model name='MAD-3M'>
+			<availability>MOC:1-,Periphery.MW:1-,PIR:1-,Periphery.ME:1-,MH:1-</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:6,MOC:5</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>FVC:3,LA:4,FS:2,MERC:3</availability>
+		</model>
+		<model name='MAD-9W2'>
+			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
+		</model>
+		<model name='MAD-7D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='MAD-5T'>
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
 		<availability>CHH:4,LA:6,IS:4</availability>
-		<model name='(Light PPC)'>
-			<roles>artillery</roles>
-			<availability>LA:8,IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CHH:8,BAN:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>artillery</roles>
+			<availability>LA:8,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Marksman MBT' unitType='Tank'>
 		<availability>ROS:7,IS:5</availability>
-		<model name='M1J'>
-			<availability>General:4</availability>
+		<model name='M1'>
+			<availability>ROS:2,ROS.pm:8,General:8</availability>
 		</model>
 		<model name='M1A'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='M1'>
-			<availability>ROS:2,ROS.pm:8,General:8</availability>
+		<model name='M1J'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>LA:4,ROS:5,CLAN:7</availability>
-		<model name='(HAG)'>
-			<availability>CHH:5,RD:4,CDS:4,ROS:4,CGB:4</availability>
-		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CJF:2</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CHH:4,RD:3,ROS:4,CGB:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ATM)'>
+			<availability>General:5,CJF:2</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:5,RD:4,CDS:4,ROS:4,CGB:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -10442,11 +10442,11 @@
 	</chassis>
 	<chassis name='Marshal' unitType='Mek'>
 		<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
-		<model name='MHL-6MC'>
-			<availability>MOC:5,CC:4</availability>
-		</model>
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:5,CC:4</availability>
 		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
@@ -10454,36 +10454,36 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3,IS:2,FS:3,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:1,RD:4,CDS:4,CW:2,CNC:2,MERC:3+,CJF:3,RA:2,BAN:3,CGB:4</availability>
-		<model name='Prime'>
-			<availability>RD:8,CDS:9,General:8,CGB:8</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>RD:6,CDS:5,CW:6,General:4,CGB:6</availability>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:8,General:5</availability>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>RD:5,CDS:8,General:5,CGB:5</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:6,CDS:5,CW:6,General:4,CGB:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,CDS:9,General:8,CGB:8</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:8,General:5</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:5,CDS:5,General:4,CGB:5</availability>
@@ -10491,11 +10491,11 @@
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
@@ -10503,21 +10503,21 @@
 		<model name='MAL-1R'>
 			<availability>CGB.FRR:8,MERC:6</availability>
 		</model>
-		<model name='MAL-1K'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='MAL-C'>
 			<availability>DC:2</availability>
 		</model>
 		<model name='MAL-3R'>
 			<availability>DC:4</availability>
 		</model>
+		<model name='MAL-1K'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:3,CLAN:1,MH:4,TC:6</availability>
-		<model name='(BA)'>
+		<model name='(Fusion)'>
 			<roles>apc</roles>
-			<availability>TC:6</availability>
+			<availability>TC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -10527,9 +10527,9 @@
 			<roles>apc</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Fusion)'>
+		<model name='(BA)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -10549,28 +10549,28 @@
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Company Command)'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Mk II Transport' unitType='Tank'>
 		<availability>LA:4,ROS:6,MERC:4</availability>
-		<model name='(Standard)'>
+		<model name='(ECM)'>
 			<roles>apc</roles>
-			<availability>LA:8,ROS:8</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Infantry Support) &apos;Shiloh&apos;'>
 			<roles>apc</roles>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>General:4</availability>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -10594,12 +10594,12 @@
 			<roles>interceptor</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<roles>interceptor</roles>
 			<availability>FVC:1,MERC:1,Periphery:1,DC:1</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -10614,8 +10614,11 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -10624,11 +10627,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -10636,35 +10636,35 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -10677,11 +10677,11 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -10716,11 +10716,11 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5</availability>
-		<model name='MS1-OD'>
-			<roles>recon</roles>
-			<availability>General:7</availability>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -10728,21 +10728,21 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='MS1-OC'>
+			<roles>recon</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='MS1-OU'>
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='MS1-OA'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
@@ -10798,14 +10798,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>RA.OA:8,MERC:6,RA:5,Periphery:4</availability>
-		<model name='MLN-1C'>
-			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
-		</model>
 		<model name='MLN-1A'>
 			<availability>General:2-</availability>
 		</model>
 		<model name='MLN-1B'>
 			<availability>RA.OA:8,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='MLN-1C'>
+			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -10814,6 +10814,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,ROS:6</availability>
+		</model>
+		<model name='(Gauss) &apos;Sandblaster&apos;'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
@@ -10825,25 +10830,20 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Gauss) &apos;Sandblaster&apos;'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CHH:8,RA:3</availability>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='P2'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='XP'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='P2'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -10869,34 +10869,34 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		<model name='MLR-BX'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='MLR-B2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MLR-BX'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,DC:5+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -10919,15 +10919,15 @@
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
 		<availability>DTA:4,CC:5,MOC:5,OP:4,RF:4,DA:7,RCM:4,MERC:4</availability>
-		<model name='M2'>
-			<availability>General:6</availability>
-		</model>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
 			<availability>FWL:2,DA:4</availability>
+		</model>
+		<model name='M2'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>
@@ -10982,9 +10982,6 @@
 		<model name='(2776)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
 		<availability>ROS:4</availability>
@@ -10994,20 +10991,20 @@
 	</chassis>
 	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:5,LA:7,CWIE:5</availability>
-		<model name='MR-1S'>
-			<availability>General:8</availability>
-		</model>
-		<model name='MR-1SA'>
-			<roles>interceptor,ground_support</roles>
+		<model name='MR-1SB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MR-1SD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='MR-1SB'>
-			<availability>General:7</availability>
+		<model name='MR-1S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='MR-1SC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SA'>
+			<roles>interceptor,ground_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -11024,6 +11021,14 @@
 	</chassis>
 	<chassis name='Morrigan' unitType='Mek'>
 		<availability>CDS:3,ROS:3,CNC:5,DC:4</availability>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<roles>specops</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='5'>
 			<roles>recon</roles>
 			<availability>CNC:4,DC:4</availability>
@@ -11032,17 +11037,9 @@
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='3'>
-			<roles>specops</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='2'>
 			<roles>recon</roles>
 			<availability>CLAN:4,IS:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
@@ -11087,33 +11084,33 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:7,Periphery:9</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mountaineer' unitType='Infantry'>
@@ -11139,29 +11136,29 @@
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='(Armor)'>
+		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
-			<availability>FS:4</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(3080 Upgrade)'>
+		<model name='(Armor)'>
 			<roles>spotter</roles>
-			<availability>General:7</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
-		<model name='Type 2'>
-			<availability>CC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>ROS:5,FS:4,MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='NL-45 Gunboat' unitType='Small Craft'>
@@ -11184,21 +11181,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CHH:4,MERC.WD:4,RD:3,CDS:4,CW:4,General:2,CGB:3</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
+			<availability>CHH:3,RD:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:3,RD:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CHH:3,MERC.WD:4,RD:3,CDS:4,CW:4,General:2,CWIE:4,CGB:3</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:6,CDS:6,CW:6,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Nagasawa' unitType='Dropship'>
@@ -11210,17 +11207,17 @@
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>ROS:4,MERC:4,DC:6</availability>
-		<model name='NG-C3A'>
-			<roles>fire_support,spotter</roles>
-			<availability>DC:8</availability>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+		<model name='NG-C3A'>
+			<roles>fire_support,spotter</roles>
+			<availability>DC:8</availability>
 		</model>
 		<model name='NG-C3B'>
 			<roles>spotter</roles>
@@ -11267,11 +11264,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -11283,11 +11280,17 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:5,IS:3</availability>
@@ -11295,28 +11298,22 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='F'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>RA.OA:3,FVC:2,RD:4,CW:4,LA:5,ROS:4,CLAN:1,MERC:3,CGB:4</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Wolf' unitType='Mek'>
@@ -11337,6 +11334,9 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>ROS:6</availability>
@@ -11345,29 +11345,26 @@
 			<roles>apc</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>OP:5,Periphery.R:2,RF:5,LA:8,ROS:6,FS:7,MERC:6</availability>
-		<model name='NGS-4T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-4S'>
 			<availability>:0,OP:4,RF:4,LA:4,ROS:4,General:8,Periphery.Deep:6,FS:4,MERC:4,Periphery:8</availability>
 		</model>
-		<model name='NGS-5T'>
-			<availability>OP:5,RF:5,LA:4,ROS:5,FS:4,MERC:4</availability>
+		<model name='NGS-4T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6T'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
+		<model name='NGS-5T'>
+			<availability>OP:5,RF:5,LA:4,ROS:5,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6S'>
 			<availability>LA:8,ROS:6,MERC:4</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -11375,11 +11372,11 @@
 		<model name='NSR-9FC'>
 			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
-		<model name='NSR-9SS'>
-			<availability>LA:4,MERC:2,FS:4</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9SS'>
+			<availability>LA:4,MERC:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nike Air Defense Platform' unitType='Tank'>
@@ -11393,11 +11390,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-4'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='NJT-3'>
 			<availability>General:2</availability>
+		</model>
+		<model name='NJT-4'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -11420,31 +11417,40 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>RD:4,DC.LV:8,DC.SL:2,LA:3,ROS:5,MERC:3,DC:8,CGB:4</availability>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
-		</model>
-		<model name='NDA-2KC'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
+		<model name='NDA-2KO'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
+		<model name='NDA-2KC'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
+		</model>
 		<model name='NDA-1K'>
 			<availability>RD:4,CGB.FRR:4,ROS:6,MERC:4,DC:4,CGB:4</availability>
 		</model>
-		<model name='NDA-2KO'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>ROS:3+,CNC:8</availability>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
+		</model>
+		<model name='N'>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -11453,18 +11459,9 @@
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,ROS:4,CNC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -11476,6 +11473,15 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>RD:3,CDS:6,ROS:4+,CNC:9,CLAN:3,CWIE:4</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -11484,36 +11490,24 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-	</chassis>
-	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
-		<availability>RA.OA:3,RA:4-</availability>
-		<model name='2 &apos;Numantia&apos;'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
 		<availability>RA.OA:6,RA:8-</availability>
+		<model name='2 &apos;Numantia&apos;'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
@@ -11521,10 +11515,6 @@
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>DTA:4,RD:4,LA:4,ROS:6,MERC:4,FS:4,DC:5,CGB:4</availability>
-		<model name='NX-80C'>
-			<roles>recon</roles>
-			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
-		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -11537,46 +11527,50 @@
 			<roles>recon</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='NX-80C'>
+			<roles>recon</roles>
+			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='OBK-M12'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>DC:2</availability>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
+		<model name='OBK-M12'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ocelot' unitType='Mek'>
 		<availability>RD:4,CDS:4,ROS:3,CNC:6,DC:3,CGB:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CNC:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CNC:3,DC:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CNC:4</availability>
 		</model>
+		<model name='4'>
+			<availability>CNC:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
 		<availability>ROS:4,CLAN:5,CJF:4</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8,ROS:8,CLAN:8</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>recon,spotter</roles>
 			<availability>RD:4,CGB:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8,ROS:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Odyssey Jumpship' unitType='Jumpship'>
@@ -11615,39 +11609,39 @@
 	</chassis>
 	<chassis name='Oni' unitType='Aero'>
 		<availability>CNC:4,DC:6</availability>
-		<model name='ON-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ON-2'>
 			<availability>DC:5</availability>
+		</model>
+		<model name='ON-1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,Periphery:3,TC:3,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:5,Periphery.ME:6,FWL:6,MH:3,DC:2</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:5,CNC:8,IS:5</availability>
+		<model name='HEAT'>
+			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
+		<model name='(Fusion)'>
+			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:6,IS:6</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:8,MOC:6,IS:6,FWL:8</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1</availability>
+		<model name='(MML)'>
+			<availability>MOC:6,IS:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:2-,Periphery:4</availability>
 		</model>
-		<model name='HEAT'>
-			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:5,CNC:8,IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Oo-Suzumebachi' unitType='Small Craft'>
@@ -11659,16 +11653,16 @@
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
@@ -11680,33 +11674,33 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:1,CC:2,CW:2,Periphery.MW:3,CLAN:1,Periphery.ME:3,FWL:5,FS:2,Periphery:3,TC:1,DC:3,CWIE:2</availability>
-		<model name='ON1-MD'>
-			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MSC:4,MERC:2,FS:2</availability>
-		</model>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
-		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2,MOC:2,OP:4,ROS:4,FWL:4,MSC:4,DA:4,MERC:2,RCM:4,DC:2</availability>
-		</model>
-		<model name='ON2-M'>
-			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>FS:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
-		</model>
-		<model name='ON1-M-DC'>
-			<availability>IS:5,DC:8</availability>
-		</model>
 		<model name='ON3-M'>
 			<roles>spotter</roles>
 			<availability>CC:5,FWL:6,MERC:5</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
+		</model>
+		<model name='ON1-MC'>
+			<availability>FS:2,MERC:2,DC:4</availability>
+		</model>
+		<model name='ON1-MB'>
+			<availability>CC:2,MOC:2,OP:4,ROS:4,FWL:4,MSC:4,DA:4,MERC:2,RCM:4,DC:2</availability>
+		</model>
 		<model name='ON1-K'>
 			<availability>CLAN:2-,Periphery:2-</availability>
+		</model>
+		<model name='ON1-M'>
+			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,DC:6</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MSC:4,MERC:2,FS:2</availability>
+		</model>
+		<model name='ON2-M'>
+			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3</availability>
+		</model>
+		<model name='ON1-M-DC'>
+			<availability>IS:5,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -11727,14 +11721,14 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,ROS:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='OSR-5D'>
 			<availability>FS:6</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
@@ -11748,6 +11742,15 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,LA:4,ROS:4,IS:4,TC:4,DC:5,Periphery:2</availability>
+		<model name='OSR-3C'>
+			<availability>FVC:1-,Periphery:1-</availability>
+		</model>
+		<model name='OSR-4K'>
+			<availability>ROS:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='OSR-5C'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>Periphery:2-</availability>
@@ -11755,15 +11758,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2,Periphery:3</availability>
-		</model>
-		<model name='OSR-5C'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='OSR-4K'>
-			<availability>ROS:4,MERC:4,DC:6</availability>
-		</model>
-		<model name='OSR-3C'>
-			<availability>FVC:1-,Periphery:1-</availability>
 		</model>
 		<model name='OSR-2D'>
 			<availability>ROS:6,IS:4,Periphery:4</availability>
@@ -11777,14 +11771,11 @@
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>RD:3,RA:2,CGB:3</availability>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
@@ -11792,12 +11783,15 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,OP:4,FVC:1,RF:4,LA:2,ROS:3,FWL:2,FS:2,MERC:3,DC:3</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='OTT-7K'>
+			<roles>recon,spotter</roles>
+			<availability>FVC:8,IS:8,DC:8</availability>
 		</model>
 		<model name='OTT-11J'>
 			<roles>recon,spotter</roles>
@@ -11807,9 +11801,9 @@
 			<roles>recon,spotter</roles>
 			<availability>CC:4,OP:5,RF:5,LA:8,ROS:5,MERC:5,FS:4,DC:4</availability>
 		</model>
-		<model name='OTT-7K'>
-			<roles>recon,spotter</roles>
-			<availability>FVC:8,IS:8,DC:8</availability>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -11817,23 +11811,8 @@
 		<model name='OTL-7M'>
 			<availability>DTA:8,OP:8,ROS:6,FWL:6,MSC:8,MERC:4</availability>
 		</model>
-		<model name='OTL-5D'>
-			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:2,Periphery:4</availability>
-		</model>
 		<model name='OTL-9M'>
 			<availability>ROS:4,FWL:5</availability>
-		</model>
-		<model name='OTL-6D'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:6,ROS:6,MERC:5</availability>
-		</model>
-		<model name='OTL-5M'>
-			<availability>FWL:3,MERC:4</availability>
-		</model>
-		<model name='OTL-8M'>
-			<availability>DTA:8,RF:8,MSC:6,MERC:3</availability>
 		</model>
 		<model name='OTL-8D'>
 			<availability>FS:8</availability>
@@ -11841,25 +11820,40 @@
 		<model name='OTL-4D'>
 			<availability>Periphery:1-</availability>
 		</model>
+		<model name='OTL-6D'>
+			<availability>FS:4</availability>
+		</model>
+		<model name='OTL-5M'>
+			<availability>FWL:3,MERC:4</availability>
+		</model>
+		<model name='OTL-8M'>
+			<availability>DTA:8,RF:8,MSC:6,MERC:3</availability>
+		</model>
+		<model name='OTL-9R'>
+			<availability>DTA:6,ROS:6,MERC:5</availability>
+		</model>
+		<model name='OTL-5D'>
+			<availability>FVC:4,Periphery.HR:4,PIR:4,FS:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
 		<availability>MOC:2-,RF:6</availability>
-		<model name='OWR-2M'>
-			<availability>General:8,FWL:1-</availability>
-		</model>
 		<model name='OWR-3M'>
 			<availability>RF:8</availability>
+		</model>
+		<model name='OWR-2M'>
+			<availability>General:8,FWL:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CHH:8,CW:4</availability>
-		<model name='(3063)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(3070)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(3063)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
@@ -11875,41 +11869,37 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
-		<model name='A3A'>
-			<availability>LA:2,ROS:2,FS:2</availability>
-		</model>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:2,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:8,IS:4,FS:8</availability>
+		</model>
+		<model name='A3A'>
+			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 		<model name='A3'>
 			<roles>assault</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:2,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,FWL:4,FS:4,MERC:4,DC:6</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='OW-1C'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -11917,13 +11907,17 @@
 			<roles>recon,spotter</roles>
 			<availability>General:2,CLAN:6</availability>
 		</model>
-		<model name='OW-1A'>
+		<model name='OW-1E'>
 			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='OW-1F'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='PAB-28 Sniper Suit' unitType='BattleArmor'>
@@ -11941,17 +11935,17 @@
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CWIE:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CDS:4,CWIE:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CDS:5,CWIE:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CWIE:4</availability>
@@ -11959,16 +11953,12 @@
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CDS:5,CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:2-,CC:2-,IS:3-,FS:4-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,CGB.FRR:2-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery:5</availability>
@@ -11977,13 +11967,17 @@
 			<roles>recon,raider</roles>
 			<availability>CC:1,CGB.FRR:2,PIR:2,General:1,FWL:1,MERC:1,FS:2,Periphery:3,DC:1</availability>
 		</model>
-		<model name='&apos;Gespenst&apos;'>
-			<roles>recon,specops</roles>
-			<availability>LA:2</availability>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
 			<availability>FWL.pm:4,RF.pm:4,MSC.pm:4,DA:3-,RCM.pm:4</availability>
+		</model>
+		<model name='&apos;Gespenst&apos;'>
+			<roles>recon,specops</roles>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Heavy Artillery Tank' unitType='Tank'>
@@ -11995,17 +11989,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:4</availability>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>OP:3,LA:3,ROS:3,FS:3,DC:3</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>OP:3,LA:3,ROS:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paladin Defense System' unitType='Tank'>
@@ -12038,6 +12032,30 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:4,RD:5,ROS:3,FS.DMM:4,MERC:3,Periphery.OS:5,RA:4,Periphery:2,DC:7,CGB:5</availability>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
+		</model>
+		<model name='PNT-12A'>
+			<roles>fire_support</roles>
+			<availability>ROS:2,DC:2</availability>
+		</model>
+		<model name='PNT-12K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3,CGB:3</availability>
+		</model>
+		<model name='PNT-10K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:2,RD:2,ROS:2,FS.DMM:2,MERC:2,RA:2,DC:2,TC:2,CGB:2</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
+		</model>
+		<model name='PNT-12K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
+		</model>
 		<model name='PNT-12KC'>
 			<roles>raider</roles>
 			<availability>DC:4</availability>
@@ -12046,56 +12064,28 @@
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
-		</model>
-		<model name='PNT-10K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:2,RD:2,ROS:2,FS.DMM:2,MERC:2,RA:2,DC:2,TC:2,CGB:2</availability>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='PNT-13K'>
 			<roles>fire_support</roles>
 			<availability>RD:4,DC:6,CGB:4</availability>
 		</model>
-		<model name='PNT-12A'>
-			<roles>fire_support</roles>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='PNT-9R'>
-			<roles>fire_support</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='PNT-12K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='PNT-12K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3,CGB:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
 		<availability>FWL:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MFB)'>
 			<roles>support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Parash' unitType='Mek'>
 		<availability>CHH:8</availability>
-		<model name='3'>
-			<roles>recon,spotter</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
@@ -12103,6 +12093,10 @@
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<roles>recon,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Partisan AA Vehicle' unitType='Tank'>
@@ -12114,20 +12108,20 @@
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,LA:7,CNC:5,IS:5,FS:8,DC:6,Periphery:5,CWIE:5</availability>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:5,FS:5</availability>
-		</model>
 		<model name='(Quad RAC)'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:5,FS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:5,Periphery:5</availability>
 		</model>
-		<model name='(Company Command)'>
+		<model name='(Lance Command)'>
 			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:2,FS:2</availability>
+			<availability>ROS:5,FS:5</availability>
 		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
@@ -12136,31 +12130,31 @@
 		<model name='(Cell)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>ROS:2,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
 		<availability>MOC:2,CC:1,RA.OA:2,LA:2,IS:2,FWL:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
-		<model name='(AC2)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:1-,Periphery:2-</availability>
-		</model>
-		<model name='(C3)'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:2-</availability>
 		</model>
+		<model name='(AC2)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:1-,Periphery:2-</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>Periphery:2-</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -12202,20 +12196,20 @@
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
 		<availability>FVC:5,RF:5,LA:5,ROS:5,FS:4,CWIE:5</availability>
-		<model name='(Standard)'>
-			<availability>Periphery:2</availability>
-		</model>
 		<model name='(Ultra)'>
 			<availability>LA:8,General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Peacekeeper' unitType='Mek'>
 		<availability>ROS:5,DC:5</availability>
-		<model name='PKP-2K'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='PKP-1B'>
 			<availability>General:4</availability>
+		</model>
+		<model name='PKP-2K'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='PKP-1A'>
 			<availability>General:8</availability>
@@ -12227,14 +12221,6 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:8</availability>
 		</model>
-		<model name='X-Pulse'>
-			<roles>recon</roles>
-			<availability>DC.AL:8,General:4,DC:5</availability>
-		</model>
-		<model name='(3058 Upgrade)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,FS:8,DC:7</availability>
-		</model>
 		<model name='(MRM)'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
@@ -12242,6 +12228,14 @@
 		<model name='(Sealed)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
+		</model>
+		<model name='X-Pulse'>
+			<roles>recon</roles>
+			<availability>DC.AL:8,General:4,DC:5</availability>
+		</model>
+		<model name='(3058 Upgrade)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,FS:8,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Pendragon' unitType='Mek'>
@@ -12253,20 +12247,20 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='PTR-6T'>
-			<availability>FS.DBG:8,FS:4</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-6T'>
+			<availability>FS.DBG:8,FS:4</availability>
+		</model>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Penthesilea' unitType='Mek'>
@@ -12274,11 +12268,11 @@
 		<model name='PEN-2MAF'>
 			<availability>General:4</availability>
 		</model>
-		<model name='PEN-3H'>
-			<availability>MOC:4</availability>
-		</model>
 		<model name='PEN-2H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PEN-3H'>
+			<availability>MOC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
@@ -12299,31 +12293,31 @@
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,OP:6,ROS:4,FWL:4,MSC:6</availability>
-		<model name='P1E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='P1D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1'>
-			<availability>General:8</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='P1B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1W'>
 			<availability>General:2</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -12337,70 +12331,70 @@
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,FWL:5,IS:4,FS:4,MERC:4,DC:4</availability>
+		<model name='(Prototype)'>
+			<availability>OP:1,LA:2</availability>
+		</model>
 		<model name='(Production)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Prototype)'>
-			<availability>OP:1,LA:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CHH:7,CW:8,CJF:7,RA:6,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>RD:9,General:8,CGB:9</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>RD:6,CDS:4,CNC:6,General:5,CGB:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>RD:4,General:5,CGB:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:4,General:5,CGB:4</availability>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>RD:9,General:8,CGB:9</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>RD:7,General:6,CGB:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3</availability>
-		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:6,CDS:4,CNC:6,General:5,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CC:3,DTA:3,CDS:5,RF:3,LA:3,ROS:4,CLAN:3,MSC:3,MERC:3,FS:3,RA:5,DC:3</availability>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>DTA:4,CDS:8,RF:4,LA:4,ROS:4,MSC:4,FS:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:2,CNC:2,IS:3,DC:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='6'>
-			<availability>RD:6,CDS:8,CGB:6</availability>
 		</model>
 		<model name='7'>
 			<availability>RD:8,CDS:6,General:5,CGB:8,DC:6</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:6</availability>
+		<model name='4'>
+			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='3'>
+			<availability>DTA:4,CDS:8,RF:4,LA:4,ROS:4,MSC:4,FS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='6'>
+			<availability>RD:6,CDS:8,CGB:6</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CDS:1,CNC:1,RA:4</availability>
+		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk L' unitType='Mek'>
@@ -12414,15 +12408,14 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>RD:4,IS:7,FWL:8,Periphery:6,CGB:4</availability>
-		<model name='PXH-6D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CC:4,OP:4,CLAN:3,FWL:4,MSC:5,MERC:4,DA:4,RCM:4</availability>
+		<model name='PXH-7K'>
+			<availability>OP:4,DC:4</availability>
 		</model>
 		<model name='PXH-7S'>
 			<availability>RF:4,LA:8,ROS:4,MERC:6</availability>
+		</model>
+		<model name='PXH-4W'>
+			<availability>MOC:5,TC:5</availability>
 		</model>
 		<model name='PXH-4L'>
 			<availability>CC:8,MOC:4,MH:4,DA:4,TC:4</availability>
@@ -12431,44 +12424,45 @@
 			<roles>recon</roles>
 			<availability>FVC:1-,PIR:2-,MERC:1-</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,FS:6,MERC:4</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>BAN:6,Periphery:1-</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>RD:4,ROS:2,CGB:4,DC:2</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
 		<model name='PXH-5L'>
 			<availability>CC:5,MOC:4</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>DTA:8,OP:8,RF:8,FWL:8,IS:4,MSC:8,RCM:8,DA:8</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>RD:6,DC:8,CGB:6</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:5,FWL:4,MSC:6,BAN:1</availability>
 		</model>
+		<model name='PXH-6D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>RD:6,DC:8,CGB:6</availability>
+		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='PXH-7K'>
-			<availability>OP:4,DC:4</availability>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>DTA:8,OP:8,RF:8,FWL:8,IS:4,MSC:8,RCM:8,DA:8</availability>
 		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:5,TC:5</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,FS:6,MERC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>RD:4,ROS:2,CGB:4,DC:2</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>BAN:6,Periphery:1-</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CC:4,OP:4,CLAN:3,FWL:4,MSC:5,MERC:4,DA:4,RCM:4</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix' unitType='Mek'>
@@ -12482,17 +12476,17 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>RA.OA:1-,CC:3,CHH:3,MERC.WD:3,CDS:4,CLAN:3,CNC:3,MH:2-,CWIE:4,Periphery:2-</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>CC:8,MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>Periphery:2</availability>
 		</model>
 		<model name='(RAC) &apos;Assault Pike&apos;'>
 			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
 		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
+		<model name='(Standard)'>
+			<availability>Periphery:2</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -12500,6 +12494,9 @@
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,MOC:3,MERC.WD:4,MERC.KH:4,ROS:4,CNC:6,MERC:4</availability>
+		<model name='PLG-5Z'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
@@ -12510,19 +12507,16 @@
 		<model name='PLG-3Z'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PLG-5Z'>
-			<availability>CC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,ROS:5,FS:7,MERC:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -12545,9 +12539,6 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:6,CDS:5,RA:3,CWIE:3</availability>
-		<model name='2'>
-			<availability>CHH:8,CDS:8</availability>
-		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4</availability>
@@ -12557,6 +12548,9 @@
 		</model>
 		<model name='3'>
 			<availability>CDS:6,RA:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:8,CDS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -12574,9 +12568,6 @@
 	</chassis>
 	<chassis name='Plainsman Medium Hovertank' unitType='Tank'>
 		<availability>MERC.WD:3,RD:3,LA:5,FWL:4,IS:3,TC:8,Periphery:3,CGB:3</availability>
-		<model name='(Sealed)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>IS:6,TC:6,Periphery:4</availability>
 		</model>
@@ -12586,6 +12577,9 @@
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:4,Periphery:4</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
@@ -12630,67 +12624,67 @@
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
 		<availability>CC:7,MOC:5,DA:5</availability>
-		<model name='(Stealth)'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='(Gauss)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CC:5,MOC:5</availability>
+		<model name='(Stealth)'>
+			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>MOC:6,CC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CC:5,MOC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Poignard' unitType='Aero'>
 		<availability>DTA:5,ROS:5,FWL:5,MSC:6,RCM:5,MERC:4</availability>
-		<model name='PGD-R3'>
-			<roles>ground_support</roles>
+		<model name='PGD-L3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='PGD-Y3'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PGD-L3'>
+		<model name='PGD-R3'>
+			<roles>ground_support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CDS:5,RA:5,CWIE:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CW:8,CNC:4,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>RD:8,CDS:6,General:8,CJF:7,CGB:8</availability>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>RD:3,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:3</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>RD:8,CDS:6,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:3</availability>
+		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='H'>
-			<availability>RD:3,CDS:5,CW:5,CLAN:4,General:3,CGB:3</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
@@ -12714,23 +12708,23 @@
 	</chassis>
 	<chassis name='Prefect' unitType='Mek'>
 		<availability>ROS:3</availability>
+		<model name='PRF-3R'>
+			<availability>General:4</availability>
+		</model>
 		<model name='PRF-2R'>
 			<availability>General:4</availability>
 		</model>
 		<model name='PRF-1R'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PRF-3R'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Quad)'>
 			<availability>CHH:6+</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -12741,40 +12735,47 @@
 		</model>
 	</chassis>
 	<chassis name='Protector Combat Support Fighter' unitType='Conventional Fighter'>
-		<availability>MOC:5,FS:2,Periphery:4,DC:2,OA.RA:5</availability>
+		<availability>MOC:5,OA.RA:5,FS:2,Periphery:4,DC:2</availability>
 		<model name='ASF-23'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(RAF)'>
-			<roles>apc</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>Periphery:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4,Periphery:4</availability>
 		</model>
-		<model name='(Security)'>
-			<roles>apc</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Sealed)'>
 			<roles>support</roles>
 			<availability>RD:4,IS:4,Periphery:4,CGB:4,RA:4</availability>
 		</model>
+		<model name='(Security)'>
+			<roles>apc</roles>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(RAF)'>
+			<roles>apc</roles>
+			<availability>ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8,CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:6,MERC:3+,RA:6,BAN:5,CWIE:7,MERC.WD:5,RD:5,CDS:7,CW:7,ROS:4+,CNC:7,CJF:4,CGB:5</availability>
+		<model name='H'>
+			<availability>CHH:6,CW:6,CLAN:4,General:3,CJF:6</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
 		<model name='D'>
 			<availability>RD:3,CDS:5,CW:5,General:4,CGB:3</availability>
 		</model>
@@ -12782,25 +12783,18 @@
 			<roles>fire_support</roles>
 			<availability>CHH:6,RD:3,CDS:7,CW:6,CNC:4,General:5,CJF:6,CGB:3</availability>
 		</model>
+		<model name='B'>
+			<availability>RD:4,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>RD:5,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:4,CDS:5,CW:6,General:3,CJF:4,CGB:4</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CHH:6,RD:8,CDS:6,CW:6,CNC:7,General:8,CJF:7,CGB:8</availability>
 		</model>
-		<model name='H'>
-			<availability>CHH:6,CW:6,CLAN:4,General:3,CJF:6</availability>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -12817,15 +12811,15 @@
 	</chassis>
 	<chassis name='Purifier Adaptive Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:5</availability>
-		<model name='[Laser] (RAF)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[PPC] (RAF)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[TAG] (RAF)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='[PPC] (RAF)' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (RAF)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
@@ -12852,31 +12846,31 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:4,CC:5,OP:6,IS:3,FS:5,CDP:3,Periphery:3,TC:2,DTA:6,RA.OA:3,FVC:3,RD:5,RF:6,LA:3,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4,CGB:5</availability>
-		<model name='QKD-8K'>
-			<availability>RD:5,ROS:5,MERC:4,DC:8,CGB:5</availability>
+		<model name='QKD-5K'>
+			<availability>MERC:5,DC:4</availability>
 		</model>
 		<model name='QKD-8P'>
 			<roles>spotter</roles>
 			<availability>ROS:5</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>MERC:5,DC:4</availability>
-		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:6,FWL:8</availability>
-		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:8,IS:8,MH:8,TC:8,Periphery:4</availability>
-		</model>
 		<model name='QKD-9M'>
 			<roles>spotter</roles>
 			<availability>CC:4,MOC:4,ROS:2,DA:4,FS:2</availability>
 		</model>
-		<model name='QKD-4G'>
-			<availability>MOC:2-,Periphery:2-,TC:2-</availability>
+		<model name='QKD-8K'>
+			<availability>RD:5,ROS:5,MERC:4,DC:8,CGB:5</availability>
 		</model>
 		<model name='QKD-C'>
 			<availability>MERC:6,DC:8</availability>
+		</model>
+		<model name='QKD-4G'>
+			<availability>MOC:2-,Periphery:2-,TC:2-</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:8,IS:8,MH:8,TC:8,Periphery:4</availability>
+		</model>
+		<model name='QKD-5Mr'>
+			<availability>General:6,FWL:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Quirinus Battle Armor' unitType='BattleArmor'>
@@ -12920,24 +12914,24 @@
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:6</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden II Battle Armor' unitType='BattleArmor'>
@@ -12951,8 +12945,8 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:3,ROS:3,FS:4,MERC:3</availability>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='MDG-1Ar'>
 			<availability>ROS:8,FS:4,MERC:4</availability>
@@ -12960,23 +12954,19 @@
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>FVC:6,LA:4,ROS:5,ROS.pm:7,FWL:4,MH:6,MERC:6,FS:5,CDP:6,DC:4</availability>
-		<model name='VV1'>
+		<model name='VV1 (MG)'>
 			<roles>urban</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VV1 (Interdictor)'>
 			<roles>urban</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='VV2'>
 			<roles>urban</roles>
@@ -12986,17 +12976,21 @@
 			<roles>urban</roles>
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
+		<model name='VV1'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:6,ROS:4,CLAN:2</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='RPR-100'>
+			<availability>General:2</availability>
 		</model>
 		<model name='RPR-300S'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>General:2</availability>
+		<model name='RPR-100b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='RPR-300'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -13004,11 +12998,11 @@
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
 		<availability>ROS:4</availability>
-		<model name='RPT-5X'>
+		<model name='RPT-2X'>
 			<roles>specops</roles>
-			<availability>General:4</availability>
+			<availability>General:5</availability>
 		</model>
-		<model name='RPT-2X2'>
+		<model name='RPT-5X'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
@@ -13016,28 +13010,40 @@
 			<roles>specops</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='RPT-2X2'>
+			<roles>specops</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='RPT-3X'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='RPT-2X'>
-			<roles>specops</roles>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>FS:4,DC:6</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='RTX1-OU'>
-			<availability>General:2</availability>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
@@ -13046,32 +13052,20 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
 		<availability>Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,TC:6,Periphery:4</availability>
-		<model name='(LRM)' mechanized='false'>
-			<availability>General:4,MH:0</availability>
-		</model>
 		<model name='(MH)' mechanized='false'>
 			<availability>MH:8</availability>
 		</model>
-		<model name='(LRM) [MH]' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8,MH:0</availability>
+		</model>
+		<model name='(LRM)' mechanized='false'>
+			<availability>General:4,MH:0</availability>
+		</model>
+		<model name='(LRM) [MH]' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Raven II' unitType='Mek'>
@@ -13083,40 +13077,40 @@
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:6,MOC:2,FWL:2,MERC:5,DA:3,TC:2</availability>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:2,MOC:2,MERC:2,DC:2,TC:2</availability>
-		</model>
 		<model name='RVN-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:2,MOC:3,FWL:3,MERC:3,TC:3</availability>
 		</model>
-		<model name='RVN-4L'>
+		<model name='RVN-4Lr'>
 			<roles>spotter</roles>
-			<availability>CC:5,MOC:5,DA:6,TC:5</availability>
+			<availability>CC:6,MOC:4</availability>
 		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
 		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:2,MOC:2,MERC:2,DC:2,TC:2</availability>
+		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:5,MOC:5,DA:6,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>OP:4,RF:4,LA:6,ROS:4,MH:4,MERC:4,FS:4,DA:4</availability>
-		<model name='RZK-9S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RZK-10T'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='RZK-10S'>
-			<availability>LA:5</availability>
+		<model name='RZK-9S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10S'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Recon Infantry' unitType='Infantry'>
@@ -13150,96 +13144,106 @@
 		<model name='(Stealth)'>
 			<availability>CC:8</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,RA.OA:7,LA:7,ROS:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,Periphery:10,TC:7,DC:6</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CHH:1,CW:1,General:8,CNC:1</availability>
 		</model>
-		<model name='(ML)'>
+		<model name='(MG)'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(ML)'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:1,OP:8,FS:2,MERC:1,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8,DC:2</availability>
+		<model name='F-700a'>
+			<availability>CC:7,MOC:5,DTA:6,OP:6,RF:6,ROS:8,FWL:7,MSC:6,FS:5,MERC:7,DA:6,RCM:6</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>FVC:3-,Periphery:3-</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:8,MOC:5,DTA:8,OP:8,RF:8,ROS:8,FWL:8,MSC:8,MERC:8,RCM:8,DA:8</availability>
 		</model>
-		<model name='F-100'>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
-		<model name='F-700a'>
-			<availability>CC:7,MOC:5,DTA:6,OP:6,RF:6,ROS:8,FWL:7,MSC:6,FS:5,MERC:7,DA:6,RCM:6</availability>
-		</model>
 		<model name='F-700b'>
 			<availability>MOC:5,CC:5,DTA:8,OP:8,ROS:6,FWL:8,MSC:8,MERC:8,DC:8</availability>
+		</model>
+		<model name='F-100'>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CHH:5,RD:5,CDS:5,CNC:5,IS:3,RA:5,CGB:5</availability>
-		<model name='2'>
-			<availability>CNC:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:4,CDS:5</availability>
-		</model>
 		<model name='8'>
 			<availability>CC:4,OP:4,RD:6,CDS:4,LA:4,IS:4,MSC:4,FS:4,MERC:4,DC:4,CGB:6</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:4,ROS:4,MERC:4,FS:4</availability>
-		</model>
-		<model name='7'>
-			<availability>ROS:4,CNC:8,DC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:2,CNC:2,RA:2</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,IS:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:2,CNC:2,RA:2</availability>
+		</model>
+		<model name='7'>
+			<availability>ROS:4,CNC:8,DC:6</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:4,CDS:5</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:4,ROS:4,MERC:4,FS:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CNC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:4,ROS:6,IS:4,FWL:7,FS:8,CJF:6,Periphery:3</availability>
+		<model name='RFL-7M'>
+			<availability>DTA:8,MOC:4,OP:8,RF:8,FWL:8,IS:4,MSC:8,DA:8,RCM:8,CDP:4,DC:5,TC:4</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='RFL-5D'>
+			<availability>FVC:4,LA:2,FS:3,MERC:3</availability>
+		</model>
+		<model name='RFL-3Cr'>
+			<availability>FS:2</availability>
+		</model>
 		<model name='RFL-1N'>
 			<roles>fire_support</roles>
 			<availability>CC:1-,MOC:2-,OP:1-,PIR:2-,MH:2-,FS:1-,DA:1-,RCM:1-</availability>
 		</model>
-		<model name='RFL-7M'>
-			<availability>DTA:8,MOC:4,OP:8,RF:8,FWL:8,IS:4,MSC:8,DA:8,RCM:8,CDP:4,DC:5,TC:4</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:4,LA:2,FS:3,MERC:3</availability>
+		<model name='C 2'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='RFL-8D'>
 			<availability>FS:3</availability>
@@ -13250,56 +13254,46 @@
 		<model name='RFL-8X'>
 			<availability>ROS:4,MERC:4</availability>
 		</model>
+		<model name='RFL-6X'>
+			<availability>FVC:1,FS:1,MERC:1</availability>
+		</model>
 		<model name='RFL-7X'>
 			<roles>fire_support</roles>
 			<availability>ROS:5,MERC:5</availability>
 		</model>
-		<model name='C 2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='RFL-5M'>
 			<availability>CC:2,MOC:2,Periphery.MW:3,Periphery.ME:3,FWL:3,MH:3,MERC:2,DC:2</availability>
-		</model>
-		<model name='RFL-3Cr'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RFL-6X'>
-			<availability>FVC:1,FS:1,MERC:1</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,FVC:4,LA:5,ROS:6,CLAN:2,FS:5,DC:5</availability>
-		<model name='(SPL)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>FVC:4,IS:4</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
-		<model name='(ERML)'>
+		<model name='(Royal)'>
 			<roles>apc</roles>
-			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
+			<availability>CHH:8,CLAN:6</availability>
 		</model>
 		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>CNC:4,FS:4,DC:5</availability>
 		</model>
-		<model name='(Infantry)'>
+		<model name='(ERML)'>
 			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>CHH:8,CLAN:6</availability>
+			<availability>LA:5,ROS:4,FS:4</availability>
+		</model>
+		<model name='(SPL)'>
+			<roles>apc</roles>
+			<availability>FVC:4,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Roadrunner (Emerald Harrier)' unitType='Mek'>
@@ -13311,26 +13305,26 @@
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CHH:4,CNC:7,RA:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CNC:4,RA:6</availability>
 		</model>
 		<model name='4'>
 			<availability>RA:6</availability>
 		</model>
-		<model name='2'>
-			<availability>RA:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>RD:6-,CGB:6-</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Hybrid)' mechanized='true'>
 			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
@@ -13339,18 +13333,18 @@
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>RA.OA:5,FVC:4,RF:4,LA:5,ROS:4,FS:3,MERC:2,CWIE:6,TC:6</availability>
+		<model name='(Gauss)'>
+			<availability>FRR:0,General:8</availability>
+		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>FRR:0,General:8</availability>
+		<model name='(Standard)'>
+			<availability>RF:0,ROS:0,General:2-,TC:0,CWIE:0</availability>
 		</model>
 		<model name='(Howitzer) Production'>
 			<roles>artillery,fire_support</roles>
 			<availability>LA:4,CWIE:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>RF:0,ROS:0,General:2-,TC:0,CWIE:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Rondel' unitType='Aero'>
@@ -13384,16 +13378,16 @@
 			<roles>urban</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='(Firedrake)' mechanized='false'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>LA:4</availability>
 		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>LA:8</availability>
+		</model>
+		<model name='(Firedrake)' mechanized='false'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -13406,47 +13400,47 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:5,CDS:4,CLAN:4,MERC:3+,CJF:4,RA:5,BAN:5,CWIE:5,DC:4+</availability>
-		<model name='G'>
-			<availability>CHH:5,General:3</availability>
+		<model name='D'>
+			<availability>RD:3,CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:3,CDS:8,CW:5,General:6,CJF:4,CWIE:5,CGB:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:3,General:2</availability>
+		<model name='A'>
+			<availability>RD:3,CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
 		</model>
-		<model name='I'>
+		<model name='H'>
 			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,CDS:5,CW:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 		</model>
-		<model name='A'>
-			<availability>RD:3,CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
+		<model name='F'>
+			<availability>General:3,CJF:5</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:3,CDS:8,CW:3,CNC:6,General:5,CJF:4,CGB:3</availability>
+		<model name='I'>
+			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CDS:6,CNC:4,General:5,CJF:4,RA:6,CWIE:6</availability>
 		</model>
-		<model name='F'>
-			<availability>General:3,CJF:5</availability>
-		</model>
 		<model name='C'>
 			<availability>RD:6,General:5,RA:6,CWIE:5,CGB:6</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ryoken II' unitType='Mek'>
 		<availability>CHH:4,RD:5,CDS:4,ROS:3,IS:2,CGB:5</availability>
-		<model name='2'>
-			<availability>RD:6,ROS:6,CGB:6</availability>
+		<model name='3'>
+			<availability>CHH:8,RD:4,ROS:4,CGB:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>RD:8,CDS:8,IS:8,CGB:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CHH:8,RD:4,ROS:4,CGB:4</availability>
+		<model name='2'>
+			<availability>RD:6,ROS:6,CGB:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
@@ -13487,13 +13481,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,DC:6,Periphery:6</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,DC:8,Periphery:4</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -13510,33 +13504,27 @@
 		<model name='SB-29'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='SB-31D'>
-			<roles>escort</roles>
-			<availability>DC:6</availability>
+		<model name='SB-28'>
+			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:6</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
+		<model name='SB-31D'>
+			<roles>escort</roles>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
+		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='X'>
-			<availability>General:1,CJF:3,RA:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -13545,14 +13533,20 @@
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='X'>
+			<availability>General:1,CJF:3,RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
 		<availability>FVC:4,ROS:4,FS:6,MERC:4</availability>
-		<model name='SGT-10X'>
-			<availability>ROS:6,FS:6,MERC:6</availability>
-		</model>
 		<model name='SGT-8R'>
 			<availability>FVC:8,FS:5</availability>
+		</model>
+		<model name='SGT-10X'>
+			<availability>ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SGT-9D'>
 			<roles>spotter</roles>
@@ -13570,8 +13564,8 @@
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>RD:4,CDS:4,CW:4,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
-		<model name='S-7'>
-			<availability>ROS:6,CNC:6,DC:6</availability>
+		<model name='S-4C'>
+			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
 		<model name='S-8'>
 			<availability>ROS:8,DC:8</availability>
@@ -13579,48 +13573,40 @@
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
 		</model>
-		<model name='S-4C'>
-			<availability>ROS:4,CLAN:8,DC:4</availability>
+		<model name='S-7'>
+			<availability>ROS:6,CNC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:4,Periphery.DD:2,LA:4,DC.AL:8,IS:4,FWL:4,MERC:4,Periphery.OS:2,FS:3,CJF:4,DC:7</availability>
-		<model name='(Ultra)'>
-			<availability>IS:8,DC:8</availability>
-		</model>
-		<model name='(Clan Cargo)'>
-			<availability>CLAN:8</availability>
+		<model name='(LB-X)'>
+			<availability>IS:6,DC:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:2-,Periphery:2-</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>IS:6,DC:8</availability>
+		<model name='(Clan Cargo)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Ultra)'>
+			<availability>IS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>anti_infantry</roles>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='(Laser)' mechanized='true'>
 			<availability>CW:6,RA:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>anti_infantry</roles>
+			<availability>CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:7,ROS:4,FS:5,MERC:5</availability>
-		<model name='PPR-6T'>
-			<roles>fire_support</roles>
-			<availability>LA:6,MERC:4,FS:4</availability>
-		</model>
-		<model name='PPR-5S'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='PPR-7T'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
@@ -13629,13 +13615,21 @@
 			<roles>fire_support</roles>
 			<availability>LA:5,MERC:3,FS:3</availability>
 		</model>
-		<model name='PPR-6S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,FS:2,MERC:2</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='PPR-6T'>
+			<roles>fire_support</roles>
+			<availability>LA:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='PPR-5S'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='PPR-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -13662,11 +13656,11 @@
 		<model name='SRTH-1OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SRTH-1O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SRTH-1OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SRTH-1O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarissa SecurityMech' unitType='Mek'>
@@ -13691,42 +13685,42 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CNC:3,RA:4</availability>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CNC:4,RA:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CNC:4,RA:4</availability>
+		</model>
 		<model name='XP'>
 			<availability>CNC:8</availability>
-		</model>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CW:5</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='W'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>CHH:3,CW:3</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='J'>
 			<availability>CHH:4,CW:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='W'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>CHH:3,CW:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
@@ -13748,77 +13742,77 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MASH)'>
-			<roles>apc,support</roles>
-			<availability>General:4</availability>
+		<model name='(HQ)'>
+			<roles>apc,support,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(HQ)'>
-			<roles>apc,support,spotter</roles>
-			<availability>General:2</availability>
+		<model name='(MASH)'>
+			<roles>apc,support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scapha Hovertank' unitType='Tank' omni='IS'>
 		<availability>ROS:5+</availability>
-		<model name='(J)'>
-			<availability>General:7</availability>
+		<model name='(Primary)'>
+			<availability>General:8</availability>
 		</model>
-		<model name='(B)'>
+		<model name='(H)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(G)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Primary)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(E)'>
-			<roles>artillery</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(C)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(H)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(D)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(A)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(F)'>
-			<roles>spotter</roles>
+		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(I)'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='(C)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(D)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(J)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(E)'>
+			<roles>artillery</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(F)'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(A)'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>RF:5,LA:3,ROS:5,FS:6,MERC:4,DA:5</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>RF:5,LA:6,ROS:4,FS:2,MERC:5,DA:5</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>RF:5,LA:6,ROS:4,FS:2,MERC:5,DA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Scarecrow' unitType='Mek'>
 		<availability>FS:3</availability>
-		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
-			<availability>General:4</availability>
-		</model>
 		<model name='UCU-F4'>
 			<roles>anti_infantry</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schildkrote Line Tank' unitType='Tank'>
@@ -13832,6 +13826,10 @@
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,OP:4,RD:4,ROS:5,FWL:4,FS:4,MERC:4,DC:4,CGB:4</availability>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -13839,6 +13837,10 @@
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support,spotter</roles>
@@ -13848,14 +13850,6 @@
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
@@ -13863,10 +13857,6 @@
 	</chassis>
 	<chassis name='Schrack' unitType='Aero' omni='IS'>
 		<availability>ROS:5</availability>
-		<model name='SCK-OA'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='SCK-OB'>
 			<availability>General:7</availability>
 		</model>
@@ -13874,9 +13864,17 @@
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCK-OA'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>RA.OA:1,RD:3,CNC:3,Periphery:2,RA:3</availability>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:5</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -13884,10 +13882,6 @@
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>RD:8,CNC:8,IS:6,RA:8</availability>
@@ -13914,11 +13908,8 @@
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:5,FS:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(MRM)'>
-			<availability>IS:5,DC:5,Periphery:4</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:6,MOC:5,LA:6,ROS:6,FWL:6,IS:5,MH:5,FS:6,MERC:6,CDP:5,DC:6,TC:5</availability>
+		<model name='(LRM)'>
+			<availability>General:1-</availability>
 		</model>
 		<model name='(Minesweeper)'>
 			<roles>minesweeper</roles>
@@ -13927,14 +13918,17 @@
 		<model name='(Standard)'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='(ML)'>
-			<availability>General:1-</availability>
+		<model name='(LAC)'>
+			<availability>CC:6,MOC:5,LA:6,ROS:6,FWL:6,IS:5,MH:5,FS:6,MERC:6,CDP:5,DC:6,TC:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(ML)'>
 			<availability>General:1-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>IS:5,DC:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -13942,18 +13936,18 @@
 		<model name='SCP-1N'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='SCP-10M'>
-			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,DC:6</availability>
-		</model>
-		<model name='SCP-12S'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
 		<model name='SCP-1O'>
 			<availability>IS:2,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='SCP-12S'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
+		</model>
+		<model name='SCP-10M'>
+			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,DC:6</availability>
 		</model>
 		<model name='SCP-1TB'>
 			<availability>ROS:4,MERC:4</availability>
@@ -13983,14 +13977,14 @@
 	</chassis>
 	<chassis name='Scylla' unitType='Mek'>
 		<availability>CHH:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
@@ -13998,23 +13992,23 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
 		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Fox Amphibious Armor' unitType='BattleArmor'>
@@ -14025,6 +14019,9 @@
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
+		</model>
 		<model name='(SRM6)'>
 			<availability>General:2</availability>
 		</model>
@@ -14033,9 +14030,6 @@
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:2</availability>
-		</model>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SeaBuster Strike Fighter' unitType='Conventional Fighter'>
@@ -14091,30 +14085,30 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2,CGB:2</availability>
-		<model name='SYD-21'>
+		<model name='SYD-Z2'>
 			<roles>interceptor</roles>
-			<availability>FVC:1-,MERC.KH:1-,LA:1-,MERC:1-,Periphery:1-</availability>
-		</model>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>Periphery:3-</availability>
-		</model>
-		<model name='SYD-Z4'>
-			<availability>CC:8,FVC:4,LA:6,ROS:4,MERC:5,FS:4,Periphery:4</availability>
+			<availability>Periphery:1-</availability>
 		</model>
 		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
 			<availability>RD:6,LA:8,ROS:4,FS:8,MERC:6,CGB:6</availability>
 		</model>
-		<model name='SYD-Z2'>
+		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
-			<availability>Periphery:1-</availability>
-		</model>
-		<model name='SYD-Z2B'>
-			<availability>RA.OA:4,LA:4,ROS:4,PIR:3,FS:4,MERC:4,RA:4</availability>
+			<availability>Periphery:3-</availability>
 		</model>
 		<model name='SYD-Z3A'>
 			<availability>RD:3,LA:6,ROS:3,MERC:3,FS:3,CGB:3</availability>
+		</model>
+		<model name='SYD-Z4'>
+			<availability>CC:8,FVC:4,LA:6,ROS:4,MERC:5,FS:4,Periphery:4</availability>
+		</model>
+		<model name='SYD-21'>
+			<roles>interceptor</roles>
+			<availability>FVC:1-,MERC.KH:1-,LA:1-,MERC:1-,Periphery:1-</availability>
+		</model>
+		<model name='SYD-Z2B'>
+			<availability>RA.OA:4,LA:4,ROS:4,PIR:3,FS:4,MERC:4,RA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
@@ -14123,27 +14117,27 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='SYU-4B'>
+		<model name='SYU-6B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SYU-6B'>
+		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat II' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>General:7</availability>
-		</model>
 		<model name='4'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='3'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
+		</model>
+		<model name='3'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
@@ -14155,43 +14149,43 @@
 			<roles>recon</roles>
 			<availability>CW:3,General:6,RA:8</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8,RA:3</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='J'>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CW:3,General:6,RA:3</availability>
 		</model>
+		<model name='J'>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8,RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>OP:3,CHH:4,IS:3,FS:3,CWIE:4,RA:4,DTA:3,RA.OA:3,RD:4,CDS:4,RF:3,LA:3,ROS:4,CNC:4,FWL:3,MSC:3,RCM:3,DA:3,DC:3,CGB:4</availability>
+		<model name='8'>
+			<availability>CDS:4,LA:6,CNC:6,IS:4,CWIE:6</availability>
+		</model>
 		<model name='2'>
 			<availability>RD:2,CGB:2</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:5,CNC:5,IS:6</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:8</availability>
 		</model>
 		<model name='7'>
 			<availability>RA.OA:8,RA:8</availability>
 		</model>
-		<model name='5'>
-			<availability>RD:4,CDS:8,LA:8,FWL:8,IS:8,FS:8,MERC:8,DC:8,CGB:4</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:5,IS:6,RA:6</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:4,LA:6,CNC:6,IS:4,CWIE:6</availability>
+		<model name='3'>
+			<availability>CDS:5,CNC:5,IS:6</availability>
+		</model>
+		<model name='5'>
+			<availability>RD:4,CDS:8,LA:8,FWL:8,IS:8,FS:8,MERC:8,DC:8,CGB:4</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
@@ -14199,47 +14193,47 @@
 		<model name='SHD-2D2'>
 			<availability>FVC:5,FS:4</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,ROS:4,CLAN:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
+		<model name='SHD-1R'>
+			<availability>CC:1-,MOC:2-,FWL:1-,MH:2-,MERC:1-</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:1-,Periphery:2-</availability>
 		</model>
-		<model name='SHD-9D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='SHD-5M'>
-			<availability>CC:6,Periphery.MW:4,Periphery.ME:4,FWL:4,MERC:6,Periphery:4,DC:6</availability>
-		</model>
-		<model name='SHD-3K'>
-			<availability>RD:4,DC:8,CGB:4</availability>
-		</model>
-		<model name='SHD-5D'>
-			<availability>LA:4,ROS:4,FS:8,MERC:6</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,DTA:8,OP:8,FVC:3,ROS:4,MSC:8,MERC:4,RCM:8,CDP:3,TC:3</availability>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,ROS:4,CLAN:4,MSC:4,MERC:4,DA:4,BAN:2</availability>
 		</model>
 		<model name='SHD-12C'>
 			<availability>RD:8,ROS:5,CGB:8,DC:4</availability>
 		</model>
-		<model name='SHD-1R'>
-			<availability>CC:1-,MOC:2-,FWL:1-,MH:2-,MERC:1-</availability>
+		<model name='SHD-5M'>
+			<availability>CC:6,Periphery.MW:4,Periphery.ME:4,FWL:4,MERC:6,Periphery:4,DC:6</availability>
 		</model>
 		<model name='SHD-8L'>
 			<availability>CC:8</availability>
 		</model>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,DTA:8,OP:8,FVC:3,ROS:4,MSC:8,MERC:4,RCM:8,CDP:3,TC:3</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:4,ROS:4,FS:8,MERC:6</availability>
+		</model>
+		<model name='SHD-3K'>
+			<availability>RD:4,DC:8,CGB:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
 		<availability>RD:5,CDS:5,CW:5,ROS:4,CLAN:3,CGB:5</availability>
+		<model name='(Flamer)'>
+			<availability>CDS:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Interdictor)'>
 			<availability>CHH:4,RD:6,CDS:4,CW:4,ROS:8,CNC:4,CJF:4,RA:4,CGB:6,CWIE:4</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CDS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shandra Advanced Scout Vehicle' unitType='Tank'>
@@ -14258,20 +14252,20 @@
 		<model name='[MRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[Interdictor]' mechanized='false'>
+			<availability>General:4</availability>
+		</model>
 		<model name='[Pop-Up Mine]' mechanized='false'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Interdictor]' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='[David Light Gauss]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shen Yi' unitType='Mek'>
@@ -14305,11 +14299,11 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,CGB.FRR:7,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
-		<model name='SL-17'>
-			<availability>ROS:0,Periphery:2-</availability>
-		</model>
 		<model name='SL-18'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
+		</model>
+		<model name='SL-17'>
+			<availability>ROS:0,Periphery:2-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>RD:2,CGB.FRR:2,RA:2</availability>
@@ -14323,11 +14317,14 @@
 	</chassis>
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>DTA:6,OP:6,RF:6,ROS:4,FWL:6,MSC:6,RCM:6,DA:6</availability>
-		<model name='SHV-OB'>
+		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
+		</model>
+		<model name='SHV-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -14335,33 +14332,30 @@
 		<model name='SHV-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SHV-OA'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shockwave' unitType='Mek'>
 		<availability>CC:4,DTA:5,OP:5,ROS:4,FWL:4,MSC:5,FS:3,RCM:4,DC:3</availability>
-		<model name='SKW-4G'>
-			<availability>General:2</availability>
-		</model>
 		<model name='SKW-2F'>
 			<availability>General:8</availability>
 		</model>
 		<model name='SKW-6H'>
 			<availability>General:4</availability>
 		</model>
+		<model name='SKW-4G'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CHH:3,RD:4,CDS:4,CW:3,ROS:3,CNC:5,CGB:4,CWIE:3,DC:3</availability>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:6,DC:6</availability>
+		</model>
 		<model name='(Streak)'>
 			<availability>CDS:4,CW:6,ROS:4,CNC:6,CJF:6,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -14409,15 +14403,27 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverback Coastal Cutter' unitType='Naval'>
+		<availability>LA:7</availability>
+		<model name='(Standard)'>
+			<availability>LA:7</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Simurgh' unitType='Aero' omni='IS'>
 		<availability>ROS:5</availability>
-		<model name='SMG-O'>
-			<roles>assault</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SMG-OA'>
 			<roles>assault</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='SMG-O'>
+			<roles>assault</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='SMG-OB'>
 			<roles>assault</roles>
@@ -14426,14 +14432,14 @@
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,OP:5,ROS:3,MSC:5,MERC:3</availability>
-		<model name='SRC-6C'>
-			<availability>DTA:6,OP:6,ROS:6,MSC:6</availability>
-		</model>
 		<model name='SRC-5C'>
 			<availability>DTA:5,OP:5,ROS:5,MSC:5</availability>
 		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-6C'>
+			<availability>DTA:6,OP:6,ROS:6,MSC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Skadi Swift Attack VTOL' unitType='VTOL'>
@@ -14457,9 +14463,9 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:2,Periphery.DD:3,IS:1,MERC:1,Periphery.OS:3,FS:1,RA.OA:1,FVC:1,LA:1,CGB.FRR:3-,ROS:2-,FWL:2,DC:4</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:4,IS.pm:4</availability>
+			<availability>General:3-</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -14469,9 +14475,9 @@
 			<roles>recon</roles>
 			<availability>FVC:3,IS.pm:3</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:3-</availability>
+			<availability>FVC:4,IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
@@ -14479,23 +14485,23 @@
 		<model name='SL-15R'>
 			<availability>RA.OA:6,RD:6,CGB.FRR:8,ROS:6,FS:6,MERC:6,CDP:4,RA:6,DC:8,TC:4,CGB:6</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>ROS:0,FS:0,Periphery:2-</availability>
-		</model>
 		<model name='SL-15K'>
 			<availability>RD:4,ROS:4,MERC:4,DC:4,CGB:4</availability>
+		</model>
+		<model name='SL-15'>
+			<availability>ROS:0,FS:0,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		<model name='(Huntsman)' mechanized='false'>
-			<availability>LA:4,MERC:4,FS:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>LA:1</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Huntsman)' mechanized='false'>
+			<availability>LA:4,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Snake' unitType='Mek'>
@@ -14526,11 +14532,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CNC:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sokar Urban Combat Unit' unitType='Tank'>
@@ -14557,11 +14563,11 @@
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
 		<availability>RD:3,CDS:6+,CGB:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sortek Assault Craft' unitType='Tank'>
@@ -14584,18 +14590,14 @@
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Spad' unitType='Aero'>
 		<availability>RA.OA:1,ROS:4,RA:1</availability>
-		<model name='SPD-504'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='SPD-503'>
 			<availability>ROS:6,BAN:2</availability>
@@ -14603,15 +14605,15 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+		<model name='SPR-6D'>
+			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
+		</model>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
 			<availability>FVC:1-,FS:1-,MERC:1-,CDP:1-,TC:1-</availability>
 		</model>
 		<model name='SPR-7D'>
 			<availability>ROS:5,FS:5,MERC:5</availability>
-		</model>
-		<model name='SPR-6D'>
-			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 		</model>
 		<model name='SPR-DH'>
 			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:3-</availability>
@@ -14639,11 +14641,11 @@
 	</chassis>
 	<chassis name='Spectre Stealth Battle Armor' unitType='BattleArmor'>
 		<availability>FVC:6,MERC:4,CDP:6,RA:4</availability>
-		<model name='(RA)' mechanized='true'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(RA)' mechanized='true'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sphinx' unitType='Mek'>
@@ -14666,41 +14668,41 @@
 		<model name='SDR-5V'>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='SDR-7Kr'>
+			<availability>ROS:2,MERC:2,DC:2</availability>
+		</model>
+		<model name='SDR-10K'>
+			<availability>ROS:3</availability>
+		</model>
+		<model name='SDR-7K'>
+			<availability>ROS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='SDR-7M'>
 			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,DC:6</availability>
 		</model>
-		<model name='SDR-7K2'>
-			<availability>ROS:3,MERC:3,DC:4</availability>
+		<model name='SDR-7KC'>
+			<availability>ROS:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:4,FWL:4,FS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='SDR-8K'>
 			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='SDR-8R'>
-			<availability>ROS:5,MERC:4</availability>
-		</model>
-		<model name='SDR-7Kr'>
-			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
 		<model name='SDR-8Xr'>
 			<availability>ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='SDR-7K2'>
+			<availability>ROS:3,MERC:3,DC:4</availability>
+		</model>
+		<model name='SDR-8R'>
+			<availability>ROS:5,MERC:4</availability>
 		</model>
 		<model name='SDR-8M'>
 			<availability>MOC:4,CC:4,FWL:8,MH:4,MERC:2</availability>
 		</model>
 		<model name='SDR-8X'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='SDR-10K'>
-			<availability>ROS:3</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:4,FWL:4,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='SDR-7K'>
-			<availability>ROS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='SDR-7KC'>
-			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Spindrift Aquatic SecurityMech' unitType='Mek'>
@@ -14711,34 +14713,34 @@
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
 		<availability>CJF:5-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>MOC:5,FVC:5,LA:7,ROS:7,IS:6,MH:3,FS:7,DC:7</availability>
-		<model name='(Interdictor)'>
-			<roles>spotter</roles>
-			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,DC:4</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>IS:4,DC:6</availability>
+		</model>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Interdictor)'>
+			<roles>spotter</roles>
+			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,DC:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -14749,17 +14751,20 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:4,CC:2,CLAN:2,IS:5,Periphery.Deep:8,FS:4,Periphery:10,TC:6,RA.OA:6,LA:5,ROS:3,FWL:6,DC:2</availability>
-		<model name='STK-3H'>
-			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		<model name='STK-8S'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-7D'>
-			<availability>ROS:4,FS:4,MERC:4</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:3,DC:6,TC:3</availability>
 		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
+		<model name='STK-4P'>
+			<availability>MERC:1,Periphery:1</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='STK-7D'>
+			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>Periphery:2-</availability>
@@ -14767,20 +14772,17 @@
 		<model name='STK-3Fb'>
 			<availability>CC:3,MOC:3,OP:3,RF:3,CLAN:8,FWL:3,MERC:3,DA:3,RCM:3,BAN:2</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:3,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-6M'>
 			<availability>CC:5,MOC:5,OP:6,RF:6,ROS:6,FWL:6,MERC:6,DA:5,RCM:6</availability>
 		</model>
-		<model name='STK-4P'>
-			<availability>MERC:1,Periphery:1</availability>
-		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CJF:3,TC:4</availability>
-		</model>
-		<model name='STK-8S'>
-			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stalking Spider II' unitType='Mek'>
@@ -14807,12 +14809,12 @@
 			<roles>raider</roles>
 			<availability>MOC:4,CC:3,OP:3,LA:4,ROS:3,FS:3,MERC:4</availability>
 		</model>
+		<model name='STY-3Dr'>
+			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
+		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
@@ -14821,32 +14823,32 @@
 			<roles>recon,spotter</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='STH-3S'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='STH-1D'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-2D'>
 			<roles>recon</roles>
 			<availability>FS:6,MERC:4</availability>
 		</model>
+		<model name='STH-3S'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='STH-2D1'>
+			<roles>recon</roles>
+			<availability>FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:5,LA:6,MERC:2</availability>
+		<model name='STM-OB'>
+			<availability>General:7</availability>
+		</model>
 		<model name='STM-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='STM-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='STM-OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -14855,14 +14857,14 @@
 		<model name='STO-4C'>
 			<availability>LA:4,MERC:5</availability>
 		</model>
-		<model name='STO-6S'>
-			<availability>LA:5</availability>
+		<model name='STO-4B'>
+			<availability>General:4</availability>
 		</model>
 		<model name='STO-4A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='STO-4B'>
-			<availability>General:4</availability>
+		<model name='STO-6S'>
+			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger IIC' unitType='Mek'>
@@ -14877,49 +14879,52 @@
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,RD:1-,IS:7,MERC:7,Periphery:6,DC:4,CGB:1-</availability>
-		<model name='STG-5R'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FVC:4,PIR:4,MERC:4,CDP:4,TC:4,Periphery:4</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>BAN:8,Periphery:2-</availability>
-		</model>
-		<model name='STG-6L'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:4,DA:4</availability>
-		</model>
-		<model name='STG-7S'>
-			<roles>recon</roles>
-			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 		<model name='STG-5G'>
 			<roles>recon</roles>
 			<availability>CC:5,OP:4,FVC:4,ROS:4,MH:4,RCM:4,DA:4,FS:4,CDP:5,TC:5</availability>
 		</model>
+		<model name='STG-6S'>
+			<roles>recon</roles>
+			<availability>LA:8,ROS:5,MERC:8,FS:4</availability>
+		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CC:4,OP:6,CLAN:8,FWL:5,MSC:6,RCM:6,DA:6,MERC:4,BAN:2</availability>
+		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='STG-6L'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:4,DA:4</availability>
+		</model>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
 			<availability>RD:3,LA:2,ROS:5,IS:5,MERC:6,DC:2,Periphery:5,CGB:3</availability>
 		</model>
-		<model name='STG-6S'>
+		<model name='STG-5R'>
 			<roles>recon</roles>
-			<availability>LA:8,ROS:5,MERC:8,FS:4</availability>
+			<availability>CC:4,MOC:4,FVC:4,PIR:4,MERC:4,CDP:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='STG-7S'>
+			<roles>recon</roles>
+			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:3,CC:4,OP:6,IS:2,MERC:4,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
+		<model name='F-95'>
+			<availability>CC:5,DTA:6,OP:6,RF:6,LA:5,ROS:5,FWL:8,MSC:6,MERC:5,RCM:6,DA:6</availability>
+		</model>
 		<model name='F-94'>
 			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,IS:4,MH:4</availability>
 		</model>
@@ -14929,35 +14934,32 @@
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
 		</model>
-		<model name='F-95'>
-			<availability>CC:5,DTA:6,OP:6,RF:6,LA:5,ROS:5,FWL:8,MSC:6,MERC:5,RCM:6,DA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>RD:3,CGB:3</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>:0,CLAN:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='F'>
+		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>:0,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -14984,47 +14986,51 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>CC:5,MOC:5,LA:5,ROS:6,FWL:5,FS:6,MERC:5,DA:5,DC:7</availability>
-		<model name='SR1-OA'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='SR1-OD'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
+		<model name='SR1-OG'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SR1-OR'>
 			<availability>CLAN:6,General:3</availability>
 		</model>
-		<model name='SR1-OG'>
-			<availability>General:4</availability>
-		</model>
 		<model name='SR1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OF'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,IS:2,FS:5,MERC:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,CNC:4,FWL:1,DC:1,CGB:4</availability>
+		<model name='(Narc)'>
+			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:2-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>FVC:2-,IS:1-</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,CDS:6,LA:6,ROS:6,CNC:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2</availability>
@@ -15035,30 +15041,26 @@
 		<model name='(SRM)'>
 			<availability>FVC:2-,IS:1-</availability>
 		</model>
-		<model name='(Narc)'>
-			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(3061 Upgrade)'>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:2-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,CDS:6,LA:6,ROS:6,CNC:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:3,MOC:3</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Strix Stealth VTOL' unitType='VTOL'>
@@ -15085,12 +15087,12 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:2,CDS:2,RF:3,LA:3,ROS:3,CNC:2,FS:2,CWIE:2</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Heavy Gauss)'>
 			<availability>RF:5,LA:6,CNC:6,CWIE:6</availability>
@@ -15098,13 +15100,13 @@
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,IS:3,Periphery:3</availability>
-		<model name='(Standard)'>
-			<roles>recon,fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
@@ -15112,14 +15114,14 @@
 		<model name='E'>
 			<availability>RD:5,CW:5,CLAN:2,CGB:5</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<availability>RD:6,General:2,CGB:6</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:6,CW:6,General:2,CGB:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:6,General:2,CJF:6,CGB:6</availability>
@@ -15130,21 +15132,21 @@
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
 		<availability>CDS:3,CW:5,ROS:3,FS:4,MERC:2</availability>
-		<model name='(Standard)'>
-			<availability>CDS:4,CW:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CDS:8,ROS:8,MERC:8,FS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CDS:4,CW:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,ROS:5,FS:5,MERC:4,DC:7</availability>
+		<model name='SD1-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='SD1-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='SD1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='SD1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
@@ -15171,11 +15173,11 @@
 		<model name='3'>
 			<availability>ROS:6,CNC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='4'>
 			<availability>ROS:5,CNC:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Suzaku' unitType='Aero'>
@@ -15201,28 +15203,28 @@
 	</chassis>
 	<chassis name='Svartalfa Ultra ProtoMech' unitType='ProtoMek'>
 		<availability>CHH:4+</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM Variant)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swallow Attack WIGE' unitType='Tank'>
 		<availability>RF:4,LA:5,ROS:4,FWL:4,FS:4,MERC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<availability>LA:4,MERC:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:1,MOC:1,DA:1,CDP:1,TC:1</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -15234,37 +15236,37 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:2</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>ROS:5,CLAN:4</availability>
-		<model name='C'>
-			<availability>CLAN:8,RA:9</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>ROS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:8,RA:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:2,RA:4</availability>
-		<model name='(Standard)' mechanized='true'>
+		<model name='(Upgrade)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Enhanced)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>RA:6</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
@@ -15298,11 +15300,11 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:5,MERC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(RL)'>
 			<availability>MOC:4</availability>
@@ -15319,36 +15321,36 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,DTA:6,OP:6,ROS:4,FWL:6,MSC:6,MERC:4,DC:6</availability>
-		<model name='ZPH-5A'>
-			<roles>recon</roles>
-			<availability>ROS:4,DC:4</availability>
-		</model>
-		<model name='ZPH-3A'>
-			<roles>recon</roles>
-			<availability>DTA:8,OP:8,ROS:5,FWL:8,MSC:8,MERC:4,DC:4</availability>
-		</model>
 		<model name='ZPH-2A'>
 			<roles>recon</roles>
 			<availability>MOC:5,CC:4,ROS:4,FWL:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:3,MOC:3,ROS:3,FWL:3,MERC:3,DC:3</availability>
 		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:8,OP:8,ROS:6,MSC:8,MERC:6,DC:8</availability>
 		</model>
+		<model name='ZPH-5A'>
+			<roles>recon</roles>
+			<availability>ROS:4,DC:4</availability>
+		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:3,MOC:3,ROS:3,FWL:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='ZPH-3A'>
+			<roles>recon</roles>
+			<availability>DTA:8,OP:8,ROS:5,FWL:8,MSC:8,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Targe' unitType='Mek'>
 		<availability>ROS:4,MERC:2</availability>
-		<model name='TRG-1N'>
-			<roles>recon</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='TRG-2N'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='TRG-1N'>
+			<roles>recon</roles>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='TRG-3M'>
 			<roles>recon</roles>
@@ -15357,23 +15359,23 @@
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,DC:6</availability>
+		<model name='MIK-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='MIK-OF'>
 			<availability>General:4</availability>
@@ -15388,8 +15390,8 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>DTA:8,OP:8,RF:8,ROS:5,Periphery.MW:4,Periphery.ME:4,FWL:8,MH:4,MSC:8,MERC:4</availability>
-		<model name='TMP-3G'>
-			<availability>ROS:2,FWL:2,MERC:2</availability>
+		<model name='TMP-3M'>
+			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>RF:4,ROS:4,MSC:4,MERC:4</availability>
@@ -15397,8 +15399,8 @@
 		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
 			<availability>DTA:6,OP:6,ROS:6,MSC:6,MERC:4</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		<model name='TMP-3G'>
+			<availability>ROS:2,FWL:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar III' unitType='Mek' omni='IS'>
@@ -15406,17 +15408,17 @@
 		<model name='TLR2-OC'>
 			<availability>General:7</availability>
 		</model>
+		<model name='TLR2-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='TLR2-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TLR2-OA'>
+		<model name='TLR2-OD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='TLR2-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='TLR2-OD'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
@@ -15424,42 +15426,45 @@
 		<model name='TLR1-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OH'>
-			<availability>General:5</availability>
-		</model>
 		<model name='TLR1-OB'>
 			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OG'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OI'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OE'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
+		<model name='TLR1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OF'>
 			<roles>spotter</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OI'>
-			<availability>General:5</availability>
+		<model name='TLR1-OG'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OU'>
-			<availability>General:2</availability>
+		<model name='TLR1-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Tenshi' unitType='Mek' omni='IS'>
 		<availability>DC.GHO:5,DC:4</availability>
+		<model name='TN-10-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='TN-10-OB'>
 			<availability>General:7</availability>
 		</model>
@@ -15468,9 +15473,6 @@
 		</model>
 		<model name='TN-10-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='TN-10-OA'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Teppo Artillery Vehicle' unitType='Tank'>
@@ -15486,36 +15488,36 @@
 			<roles>recon,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
 		</model>
-		<model name='TSN-C3M'>
+		<model name='TSN-1Cr'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='TSN-1Cr'>
+		<model name='TSN-C3M'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CW:1,CJF:1,RA:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
 		<availability>LA:6,ROS:4,MH:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='TNS-4T'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='TNS-6S'>
 			<availability>LA:6,IS:4</availability>
+		</model>
+		<model name='TNS-4T'>
+			<availability>IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thang-Ta APC' unitType='Tank'>
@@ -15534,43 +15536,43 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:1,CLAN:1,RA:1,BAN:3,CWIE:2,MERC.WD:2,RD:1,CDS:1,CW:1,ROS:3+,CNC:2,CJF:4,CGB:1</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>RD:3,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
+		<model name='H'>
+			<availability>CLAN:4,General:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CHH:4,RD:4,CDS:4,CW:6,CNC:4,General:2,CJF:5,CWIE:5,CGB:4</availability>
 		</model>
-		<model name='HH'>
-			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:2,CJF:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,General:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:8,RD:4,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
+		<model name='D'>
+			<availability>RD:8,CW:8,CNC:6,General:5,CWIE:6,CGB:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CW:5,CLAN:4,General:3,CWIE:5</availability>
+		<model name='A'>
+			<availability>CHH:8,RD:4,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>RD:3,CDS:4,CW:4,CNC:5,General:6,CJF:7,CWIE:5,CGB:3</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>RD:6,CDS:9,CW:6,General:8,CJF:9,CGB:6</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:8,CW:8,CNC:6,General:5,CWIE:6,CGB:8</availability>
+		<model name='HH'>
+			<availability>CHH:6,CDS:4,CW:5,CLAN:2,General:2,CJF:5</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>RD:6,CW:6,General:5,CJF:6,CGB:6</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CW:5,CLAN:4,General:3,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -15586,9 +15588,6 @@
 	</chassis>
 	<chassis name='Thor II (Grand Summoner)' unitType='Mek' omni='Clan'>
 		<availability>RD:5,CDS:5,CW:5,ROS:3,MERC:2,CJF:7,CGB:5</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -15599,55 +15598,58 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>ROS:5</availability>
-		<model name='THE-N1'>
+		<model name='THE-N2'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='THE-N2'>
+		<model name='THE-N1'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,RA:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3,FS:4,MERC:3,Periphery:3,TC:5</availability>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>FVC:2-,Periphery:2-</availability>
+		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:4,MERC:4</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:3,FVC:2,FWL:2,FS:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>MOC:4,CHH:2,CLAN:3,IS:4,CWIE:4,DC.GHO:4,RA.OA:4,RD:4,CDS:2,CW:4,RF:5,Periphery.MW:3,ROS:5,PIR:3,CNC:2,Periphery.ME:3,FWL:4,MH:4,MSC:5,DA:5,CJF:4,CGB:4</availability>
-		<model name='THG-11Eb'>
-			<availability>ROS:6,CLAN:4,FWL:6,MSC:6,MERC:6,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>MOC:8,CLAN:6,IS:8,FS:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
 		</model>
-		<model name='THG-12K'>
-			<availability>ROS:5,DC:8</availability>
+		<model name='THG-11Eb'>
+			<availability>ROS:6,CLAN:4,FWL:6,MSC:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>MOC:2-,RF:2-,PIR:2-,MH:2-,MSC:2-,MERC:2-,DA:2-,Periphery:4</availability>
+		</model>
+		<model name='THG-12K'>
+			<availability>ROS:5,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -15667,25 +15669,22 @@
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
 		<availability>LA:5,ROS:6,DC:4</availability>
-		<model name='TFT-L8'>
-			<availability>LA:8</availability>
+		<model name='TFT-A9'>
+			<availability>ROS:8,General:4</availability>
 		</model>
 		<model name='TFT-F11'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='TFT-A9'>
-			<availability>ROS:8,General:4</availability>
 		</model>
 		<model name='TFT-C3'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='TFT-L8'>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,ROS:6,MERC:4</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -15695,6 +15694,9 @@
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -15711,30 +15713,30 @@
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,RF:5,MERC:4,DA:5,TC:4</availability>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-C4'>
-			<availability>CC:4,MOC:4,CC.LCC:6</availability>
-		</model>
 		<model name='THR-1L'>
 			<availability>General:5</availability>
+		</model>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='THR-C4'>
+			<availability>CC:4,MOC:4,CC.LCC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:8</availability>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Upgrade](ER Laser)' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 		<model name='[Pulse Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -15742,7 +15744,7 @@
 		<model name='(Upgrade)[LBX]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[AP Gauss]' mechanized='true'>
+		<model name='[ER Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -15754,23 +15756,23 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,CGB.FRR:4,IS:4,FWL:4,FS:5,Periphery:5,TC:5,DC:4</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CC:5,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
-		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:2-</availability>
-		</model>
-		<model name='TRB-D36b'>
-			<roles>ground_support</roles>
-			<availability>CLAN:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='TRB-D56'>
 			<availability>LA:8,ROS:4,MERC:4</availability>
 		</model>
 		<model name='TRB-D50'>
 			<availability>TC:7</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CC:5,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
+		</model>
+		<model name='TRB-D36b'>
+			<roles>ground_support</roles>
+			<availability>CLAN:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbolt IIC' unitType='Mek'>
@@ -15781,29 +15783,20 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:5,LA:6,ROS:5,MH:4,FS:5,MERC:6,Periphery:3,TC:4,DC:4</availability>
-		<model name='TDR-9NAIS'>
-			<availability>FS:1</availability>
-		</model>
-		<model name='TDR-5Sb'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='TDR-9M'>
-			<availability>MOC:3,DTA:5,CC:3,OP:5,PIR:3,FWL:2,MH:3,MSC:5,DA:5,MERC:4</availability>
-		</model>
-		<model name='TDR-9S'>
-			<availability>FVC:4,LA:4,FS:2,MERC:3</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>CC:1-,MOC:2-,LA:1-,MERC:1-,TC:2-</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
 		</model>
 		<model name='TDR-60-RLA'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='TDR-9S'>
+			<availability>FVC:4,LA:4,FS:2,MERC:3</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2</availability>
 		</model>
 		<model name='TDR-9T'>
 			<availability>TC:5</availability>
@@ -15811,26 +15804,35 @@
 		<model name='TDR-5S'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='TDR-10S'>
-			<availability>LA:5,MERC:5</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
-		</model>
-		<model name='TDR-10M'>
-			<availability>CC:4,ROS:6,FWL:5,MERC:4</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CC:4,MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:4,MH:4,MERC:4</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2</availability>
+		<model name='TDR-9M'>
+			<availability>MOC:3,DTA:5,CC:3,OP:5,PIR:3,FWL:2,MH:3,MSC:5,DA:5,MERC:4</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>TC:6</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>FS:4,MERC:4</availability>
 		</model>
+		<model name='TDR-10M'>
+			<availability>CC:4,ROS:6,FWL:5,MERC:4</availability>
+		</model>
+		<model name='TDR-10S'>
+			<availability>LA:5,MERC:5</availability>
+		</model>
 		<model name='TDR-17S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
+		</model>
+		<model name='TDR-9NAIS'>
+			<availability>FS:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
@@ -15838,15 +15840,15 @@
 		<model name='TSG-9J'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TSG-9H'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='TSG-9DDC'>
+			<availability>CC:6,CC.WHO:8</availability>
 		</model>
 		<model name='TSG-9C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
-		<model name='TSG-9DDC'>
-			<availability>CC:6,CC.WHO:8</availability>
+		<model name='TSG-9H'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat II' unitType='Dropship'>
@@ -15893,6 +15895,10 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CLAN:4,RA:5</availability>
+		<model name='(2647)'>
+			<roles>asf_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Monitor)'>
 			<roles>assault</roles>
 			<availability>RA:8</availability>
@@ -15901,56 +15907,52 @@
 			<roles>asf_carrier</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2647)'>
-			<roles>asf_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Titan' unitType='Mek'>
 		<availability>ROS:4,MERC:3,FS:4</availability>
-		<model name='TI-1Ar'>
-			<availability>General:4</availability>
-		</model>
 		<model name='TI-1Aj'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TI-1Ar'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,ROS:5,CNC:6,DC:8</availability>
-		<model name='(C3)'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='TKG-150'>
-			<availability>DC:1-</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>DC:3-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>CDS:8,ROS:6,CNC:8,DC:6</availability>
+		<model name='(C3)'>
+			<availability>ROS:5,DC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>ROS:8,DC:8</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>CDS:8,ROS:6,CNC:8,DC:6</availability>
 		</model>
 		<model name='(MRM)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='TKG-150'>
+			<availability>DC:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Tomahawk II' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,CW:5</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>urban</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>urban</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -15959,15 +15961,15 @@
 		<model name='CH'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>ROS:8</availability>
+		<model name='THK-63'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
 		</model>
-		<model name='THK-63'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
+		<model name='THK-63CS'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
@@ -15978,10 +15980,10 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -15994,23 +15996,23 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>FWL:1,MH:1</availability>
-		<model name='G13 [Grenade Launcher]' mechanized='true'>
-			<availability>MH:4</availability>
-		</model>
-		<model name='G13 [Machine Gun]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 		<model name='G12' mechanized='true'>
 			<roles>specops</roles>
 			<availability>FWL:8</availability>
 		</model>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>MH:4</availability>
+		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Machine Gun]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 	</chassis>
@@ -16026,10 +16028,10 @@
 		<model name='(C3)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(aSRM)' mechanized='false'>
+		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)' mechanized='false'>
+		<model name='(aSRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)' mechanized='false'>
@@ -16038,13 +16040,13 @@
 	</chassis>
 	<chassis name='Trajan Assault Infantry Fighting Vehicle' unitType='Tank'>
 		<availability>ROS:6</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>apc</roles>
 			<availability>ROS:3</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -16055,36 +16057,33 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,RCM:3,TC:5</availability>
-		<model name='TR-16'>
-			<availability>CC:7,MOC:5,RF:8,MERC:5,RCM:8,TC:5</availability>
-		</model>
-		<model name='TR-13'>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='TR-13A'>
 			<availability>CC:8,MOC:7,General:5</availability>
 		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='TR-16'>
+			<availability>CC:7,MOC:5,RF:8,MERC:5,RCM:8,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
-		<model name='TR-10'>
-			<availability>MOC:2,General:6,TC:2</availability>
-		</model>
 		<model name='TR-12'>
 			<availability>CC:6,MOC:6</availability>
 		</model>
 		<model name='TR-13G'>
 			<roles>ground_support,assault</roles>
 			<availability>CC:6</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>MOC:2,General:6,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Transportable Field Repair Unit' unitType='Tank'>
@@ -16096,50 +16095,50 @@
 	</chassis>
 	<chassis name='Trebaruna' unitType='Mek'>
 		<availability>CC:5,DTA:4,OP:4,LA:5,ROS:5,MSC:4,MERC:4,DA:4</availability>
-		<model name='TR-XJ'>
-			<availability>DTA:8,OP:8,MSC:8,MERC:4</availability>
-		</model>
 		<model name='TR-XB'>
 			<availability>CC:4,DTA:4,ROS:8,MSC:4,MERC:4</availability>
-		</model>
-		<model name='TR-XL'>
-			<availability>CC:8</availability>
 		</model>
 		<model name='TR-XH'>
 			<availability>CC:4,DTA:4,LA:8,MSC:4,DA:8</availability>
 		</model>
+		<model name='TR-XJ'>
+			<availability>DTA:8,OP:8,MSC:8,MERC:4</availability>
+		</model>
+		<model name='TR-XL'>
+			<availability>CC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>RF:6,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,Periphery:3,TC:4,DC:4</availability>
-		<model name='TBT-7M'>
+		<model name='TBT-5N'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:4,MH:4,FS:4,MERC:4,TC:2,DC:4</availability>
-		</model>
-		<model name='TBT-9K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='TBT-K7R'>
-			<availability>ROS:3</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>ROS:6,MSC:6,MERC:5</availability>
+			<availability>MOC:4-,Periphery:4-</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>RF:4,ROS:5,MSC:4,MERC:4</availability>
 		</model>
-		<model name='TBT-XK7'>
+		<model name='TBT-K7R'>
+			<availability>ROS:3</availability>
+		</model>
+		<model name='TBT-7M'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>CC:4,FWL:4,MH:4,FS:4,MERC:4,TC:2,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>ROS:6,MSC:6,MERC:5</availability>
 		</model>
 		<model name='TBT-9R'>
 			<availability>RF:5</availability>
 		</model>
-		<model name='TBT-5N'>
+		<model name='TBT-9K'>
 			<roles>fire_support</roles>
-			<availability>MOC:4-,Periphery:4-</availability>
+			<availability>DC:8</availability>
+		</model>
+		<model name='TBT-XK7'>
+			<roles>fire_support</roles>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -16153,17 +16152,8 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CC:8,MOC:8,MH:4,TC:8</availability>
-		<model name='(Theseus RL)[LRR]' mechanized='true'>
-			<availability>MOC:6</availability>
-		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='(Asterion)[PPC]' mechanized='true'>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
-			<availability>MOC:6</availability>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Asterion)[MRR]' mechanized='true'>
 			<availability>MH:3,TC:3</availability>
@@ -16171,11 +16161,20 @@
 		<model name='(Ying Long)(Plasma)' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
+		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
+			<availability>MOC:6</availability>
+		</model>
 		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
+		<model name='(Theseus RL)[LRR]' mechanized='true'>
+			<availability>MOC:6</availability>
+		</model>
+		<model name='(Asterion)[PPC]' mechanized='true'>
+			<availability>MH:3,TC:3</availability>
+		</model>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trireme Infantry Transport' unitType='VTOL'>
@@ -16202,14 +16201,14 @@
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
+		<model name='CMT-3T'>
+			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
+		</model>
 		<model name='CMT-4U'>
 			<availability>General:5</availability>
 		</model>
 		<model name='CMT-6T'>
 			<availability>MOC:5,CC:5,MERC:4,DA:4</availability>
-		</model>
-		<model name='CMT-3T'>
-			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Trojan' unitType='Dropship'>
@@ -16228,10 +16227,10 @@
 	</chassis>
 	<chassis name='Tsunami' unitType='Mek'>
 		<availability>MERC:3</availability>
-		<model name='TS-P1D'>
+		<model name='TS-P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TS-P1'>
+		<model name='TS-P1D'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -16248,17 +16247,17 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CW:6+,ROS:3,CWIE:3</availability>
-		<model name='4'>
-			<availability>General:8</availability>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
 		</model>
 		<model name='3'>
 			<availability>CW:3,ROS:2</availability>
 		</model>
+		<model name='4'>
+			<availability>General:8</availability>
+		</model>
 		<model name='5'>
 			<availability>CW:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
@@ -16273,24 +16272,24 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>RD:6,General:2,CGB:6</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>RD:4,CLAN:2,CGB:4</availability>
 		</model>
+		<model name='D'>
+			<availability>RD:6,General:2,CGB:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
@@ -16298,11 +16297,21 @@
 		<model name='A'>
 			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
+		<model name='Prime'>
+			<availability>CHH:8,CW:8,CNC:8,CJF:8</availability>
+		</model>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:7,CW:7,CNC:7,CJF:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:4,CW:4,CNC:4,CJF:4</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:9,CW:9,General:7,CGB:9</availability>
@@ -16310,19 +16319,13 @@
 		<model name='H'>
 			<availability>CHH:5,CW:6,CNC:5,CJF:5</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CHH:8,CW:8,CNC:8,CJF:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:6,CNC:6,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,ROS:3,FS:6,MERC:3</availability>
+		<model name='(RAC)'>
+			<roles>urban</roles>
+			<availability>General:4,FS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
@@ -16330,10 +16333,6 @@
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>urban</roles>
-			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -16345,57 +16344,30 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,RD:5,CDS:4,ROS:3,CGB:5,DC:2</availability>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='3'>
 			<roles>assault</roles>
 			<availability>RD:4,CHH:8,CGB:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CHH:2,MERC.WD:1,CW:2,MERC:2+,CJF:4,RA:4,CWIE:2</availability>
-		<model name='B'>
-			<availability>RD:5,CDS:8,CW:6,General:7,CWIE:6,CGB:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,IS:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:4,CW:4,General:2,CWIE:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>RD:2,CW:6,General:2,CWIE:6,CGB:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CHH:6,RD:4,CDS:6,CW:6,General:5,CJF:6,CWIE:6,CGB:4</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>General:5,RA:6</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>RD:1,CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
-		</model>
-		<model name='Prime'>
-			<availability>RD:8,CDS:9,General:8,CJF:9,CGB:8</availability>
-		</model>
 		<model name='F'>
 			<availability>CHH:6,RD:5,CDS:4,CW:4,CLAN:3,IS:1,CJF:4,CGB:5</availability>
 		</model>
@@ -16403,8 +16375,35 @@
 			<roles>fire_support</roles>
 			<availability>CHH:5,RD:2,CDS:4,CW:2,CNC:3,General:4,CWIE:2,CGB:2</availability>
 		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>RD:2,CW:6,General:2,CWIE:6,CGB:2</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:4,CW:4,General:2,CWIE:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CHH:6,RD:4,CDS:6,CW:6,General:5,CJF:6,CWIE:6,CGB:4</availability>
+		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>General:5,RA:6</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:5,CDS:8,CW:6,General:7,CWIE:6,CGB:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,CDS:9,General:8,CJF:9,CGB:8</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>RD:1,CDS:2,CW:4,CNC:2,General:1,CJF:2,CWIE:4,CGB:1</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,IS:2</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
@@ -16436,24 +16435,24 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:4</availability>
-		<model name='(3065)'>
-			<roles>troop_carrier</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(3071)'>
 			<roles>troop_carrier</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='(3065)'>
+			<roles>troop_carrier</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:2,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:8,IS:7,FS:8</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:2,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='UrbanMech IIC' unitType='Mek'>
@@ -16469,6 +16468,10 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,Periphery:4-,TC:3-,DC:5-</availability>
+		<model name='UM-R80'>
+			<roles>urban,spotter</roles>
+			<availability>CC:6,MOC:6,IS:5,FWL:5,MERC:5,Periphery:5</availability>
+		</model>
 		<model name='UM-R69'>
 			<roles>urban</roles>
 			<availability>FWL:6,IS:6,Periphery:6</availability>
@@ -16481,30 +16484,26 @@
 			<roles>urban</roles>
 			<availability>Periphery:1</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:6,IS:4,Periphery:4</availability>
-		</model>
-		<model name='UM-R80'>
-			<roles>urban,spotter</roles>
-			<availability>CC:6,MOC:6,IS:5,FWL:5,MERC:5,Periphery:5</availability>
-		</model>
 		<model name='UM-R93'>
 			<roles>urban</roles>
 			<availability>CC:3</availability>
 		</model>
-		<model name='UM-R63'>
+		<model name='UM-R60'>
 			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>CC:4,MOC:4,FS.CMM:6,MSC:4,FS:4</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R63'>
 			<roles>urban</roles>
-			<availability>Periphery:2-</availability>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:6,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursa' unitType='Mek'>
@@ -16524,23 +16523,23 @@
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
 		<availability>CHH:4,RD:7,ROS:4,CGB:7</availability>
-		<model name='(Standard)'>
+		<model name='3'>
+			<roles>anti_infantry,specops</roles>
 			<deployedWith>IS</deployedWith>
-			<availability>General:8</availability>
+			<availability>RD:1,CGB:2</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>RD:1,CGB:1</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>RD:1,CGB:1</availability>
-		</model>
-		<model name='3'>
-			<roles>anti_infantry,specops</roles>
+		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
-			<availability>RD:1,CGB:2</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -16558,8 +16557,8 @@
 	</chassis>
 	<chassis name='Valiant' unitType='Mek'>
 		<availability>LA:6,IS:5,FS:6,MERC:5,CDP:5,DC:6</availability>
-		<model name='V4-LNT-J3'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
+		<model name='V4-LNT-K7'>
+			<availability>General:8</availability>
 		</model>
 		<model name='VLT-3E'>
 			<availability>ROS:6</availability>
@@ -16567,35 +16566,31 @@
 		<model name='VLN-3T'>
 			<availability>LA:2,General:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='V4-LNT-K7'>
-			<availability>General:8</availability>
+		<model name='V4-LNT-J3'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:2,ROS:4,FS:9,MERC:4,CDP:4,TC:4</availability>
-		<model name='VLK-QD4'>
+		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
-			<availability>ROS:6,FS:6</availability>
+			<availability>LA:6,ROS:4,MERC:4</availability>
+		</model>
+		<model name='VLK-QD'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,LA:4,ROS:5,FS:4,MERC:6</availability>
 		</model>
 		<model name='VLK-QD2'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:4,FS:4</availability>
 		</model>
-		<model name='VLK-QS5'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:6,ROS:4,MERC:4</availability>
-		</model>
-		<model name='VLK-QA'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:2-,CDP:2-</availability>
-		</model>
 		<model name='VLK-QD8'>
 			<roles>recon,fire_support</roles>
 			<availability>FS:4,MERC:3</availability>
 		</model>
-		<model name='VLK-QD'>
+		<model name='VLK-QA'>
 			<roles>recon,fire_support</roles>
-			<availability>FVC:4,LA:4,ROS:5,FS:4,MERC:6</availability>
+			<availability>FVC:2-,CDP:2-</availability>
 		</model>
 		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
@@ -16609,6 +16604,10 @@
 			<roles>recon,fire_support</roles>
 			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='VLK-QD4'>
+			<roles>recon,fire_support</roles>
+			<availability>ROS:6,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
 		<availability>FS:2</availability>
@@ -16619,27 +16618,27 @@
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CW:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CHH:6,CW:4,CLAN:2,CJF:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>General:5,RA:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>General:5,RA:6</availability>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -16651,17 +16650,11 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CHH:4,CW:3,IS:10,CJF:3,Periphery:10</availability>
-		<model name='V-G7X'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='V7'>
-			<availability>LA:4,ROS:4,FS:4,MERC:6</availability>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:4,FS:6</availability>
 		</model>
 		<model name='V9'>
 			<availability>LA:4,CLAN:8</availability>
@@ -16669,11 +16662,17 @@
 		<model name='(LB-X)'>
 			<availability>CC:5,MOC:5,DTA:5,RF:5,DA:5,RCM:5,CDP:5,TC:5</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>IS:4,FS:6</availability>
+		</model>
 		<model name='(Light Gauss)'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
+		<model name='V-G7X'>
+			<availability>LA:1</availability>
+		</model>
+		<model name='V7'>
+			<availability>LA:4,ROS:4,FS:4,MERC:6</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>CC:6,LA:4,FWL:6,IS:4,FS:4,MERC:5,DC:4,Periphery:4</availability>
@@ -16681,6 +16680,10 @@
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,Periphery:1,TC:1,DC:4</availability>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:4,CC:4</availability>
 		</model>
@@ -16688,79 +16691,75 @@
 			<roles>asf_carrier</roles>
 			<availability>IS:4,FS:8</availability>
 		</model>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
 		<availability>ROS:4,MERC:3,RCM:4,DC:8</availability>
+		<model name='SDR-9KC'>
+			<availability>ROS:6,FWL:6,MERC:6,RCM:6,DC:6</availability>
+		</model>
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
-		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,RCM:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,RCM:5,DC:5</availability>
 		</model>
-		<model name='SDR-9KC'>
-			<availability>ROS:6,FWL:6,MERC:6,RCM:6,DC:6</availability>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,RCM:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:3,LA:3,ROS:3,CWIE:2</availability>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:2,CC:5,RA.OA:2,LA:3,Periphery.HR:2,FWL:2,FS:7,Periphery.OS:2,Periphery:3,TC:2,DC:4</availability>
-		<model name='VTR-C'>
-			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
-		</model>
-		<model name='VTR-10S'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='VTR-9B'>
 			<availability>Periphery:2-</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='VTR-9D'>
-			<availability>FVC:1,CDP:1</availability>
-		</model>
-		<model name='VTR-9A1'>
-			<availability>FVC:1,Periphery:1</availability>
-		</model>
-		<model name='VTR-10D'>
-			<availability>ROS:5,FS:6,MERC:2</availability>
-		</model>
-		<model name='VTR-11D'>
-			<roles>urban</roles>
-			<availability>ROS:2,FS:2,MERC:1</availability>
-		</model>
-		<model name='VTR-Cr'>
-			<availability>FS:1,DC:2</availability>
-		</model>
-		<model name='VTR-10L'>
-			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 		<model name='VTR-9K'>
 			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,DC:8,TC:4,Periphery:4</availability>
 		</model>
 		<model name='VTR-9Ka'>
 			<availability>CC:3,FVC:3,ROS:3,FS:4,MERC:4,DC:3,Periphery:3</availability>
+		</model>
+		<model name='VTR-Cr'>
+			<availability>FS:1,DC:2</availability>
+		</model>
+		<model name='VTR-10S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='VTR-C'>
+			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
+		</model>
+		<model name='VTR-11D'>
+			<roles>urban</roles>
+			<availability>ROS:2,FS:2,MERC:1</availability>
+		</model>
+		<model name='VTR-9A1'>
+			<availability>FVC:1,Periphery:1</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='VTR-10D'>
+			<availability>ROS:5,FS:6,MERC:2</availability>
+		</model>
+		<model name='VTR-9D'>
+			<availability>FVC:1,CDP:1</availability>
+		</model>
+		<model name='VTR-10L'>
+			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vidar Heavy Defense Tank' unitType='Tank'>
@@ -16778,12 +16777,12 @@
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>RD:7,ROS:6,MERC:5,CGB:7</availability>
+		<model name='VKG-2G'>
+			<availability>RD:6,ROS:6,MERC:6,CGB:6</availability>
+		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-2G'>
-			<availability>RD:6,ROS:6,MERC:6,CGB:6</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
@@ -16803,20 +16802,20 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,PIR:4,MERC:4,TC:6</availability>
+		<model name='VND-5L'>
+			<availability>CC:2,MOC:1,MERC:1</availability>
+		</model>
 		<model name='VND-4L'>
 			<availability>CC:8,MOC:6</availability>
-		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:6,MOC:6,PIR:3,MERC:6,TC:6</availability>
 		</model>
 		<model name='VND-3L'>
 			<availability>CC:3,MOC:2,General:2,TC:2</availability>
 		</model>
-		<model name='VND-5L'>
-			<availability>CC:2,MOC:1,MERC:1</availability>
-		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
+		</model>
+		<model name='VND-3Lr'>
+			<availability>CC:6,MOC:6,PIR:3,MERC:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Violator' unitType='Mek'>
@@ -16839,23 +16838,23 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:2,CJF:6,RA:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CJF:6,RA:6</availability>
+		</model>
 		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
@@ -16863,27 +16862,27 @@
 		<model name='(Standard)'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='5'>
+		<model name='4'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:5,DC:6+</availability>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Nova Cat)' mechanized='true'>
-			<availability>CNC:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='(Nova Cat)' mechanized='true'>
+			<availability>CNC:8</availability>
+		</model>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
@@ -16897,18 +16896,14 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>PIR:2,FS:1,DC:2</availability>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
-		</model>
 		<model name='VNL-K75N'>
 			<availability>LA:8,CGB.FRR:6,FWL:8,FS:8,DC:8</availability>
+		</model>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -16922,9 +16917,17 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>MOC:4,RD:4,LA:4,FWL:4,IS:2,Periphery:4,CGB:4,TC:4</availability>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>OP:6,DA:6,RCM:6</availability>
+		</model>
 		<model name='VL-2T'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:2-,General:2-,FS:1-</availability>
+		</model>
+		<model name='VL-5T'>
+			<roles>anti_infantry</roles>
+			<availability>MOC:2,FVC:2,PIR:2,IS:2,FS:1-,Periphery:2,TC:2</availability>
 		</model>
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
@@ -16934,26 +16937,27 @@
 			<roles>anti_infantry</roles>
 			<availability>FVC:6,RD:6,LA:6,ROS:6,MH:4,FS:6,MERC:6,CGB:6</availability>
 		</model>
-		<model name='VL-5T'>
-			<roles>anti_infantry</roles>
-			<availability>MOC:2,FVC:2,PIR:2,IS:2,FS:1-,Periphery:2,TC:2</availability>
-		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:4,LA:8,MH:5,FS:4,MERC:5</availability>
 		</model>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>OP:6,DA:6,RCM:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,MERC.WD:4,RD:5,ROS:4+,CLAN:4,MERC:2+,CJF:4,BAN:5,CGB:5,CWIE:4,DC:3+</availability>
+		<model name='B'>
+			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>RD:4,CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,CNC:7,General:8,CJF:7,CGB:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:5,RD:3,CDS:7,CNC:7,General:5,CGB:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:5,CDS:5,General:4,RA:5,CGB:5</availability>
@@ -16964,37 +16968,28 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='B'>
-			<availability>CDS:7,CW:7,General:6,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:5,RD:3,CDS:7,CNC:7,General:5,CGB:3</availability>
-		</model>
-		<model name='E'>
-			<availability>CHH:5,CDS:3,CW:4,General:2,CJF:4</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CNC:5,CLAN:4,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulture Mk III (Mad Dog Mk III)' unitType='Mek' omni='Clan'>
 		<availability>RD:5,ROS:4,RA:5</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Prime)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='War Dog' unitType='Mek'>
@@ -17008,109 +17003,109 @@
 	</chassis>
 	<chassis name='Warg Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CW:4</availability>
-		<model name='(Reactive)' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(Reactive)' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>MOC:3,CLAN:7,IS:3,TC:3</availability>
+		<model name='9'>
+			<availability>CDS:5</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:5,IS:4</availability>
+		</model>
+		<model name='10'>
+			<availability>MOC:3,CLAN:3,IS:3,TC:3</availability>
+		</model>
+		<model name='8'>
+			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
+		</model>
 		<model name='6'>
 			<availability>RD:6,RA:6,CGB:6</availability>
+		</model>
+		<model name='7'>
+			<availability>RA:6</availability>
+		</model>
+		<model name='4'>
+			<availability>CC:4,CHH:5,RD:5,CDS:6,LA:4,ROS:4,CNC:5,FS:4,RA:5,CWIE:5,CGB:5,DC:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,DC:4</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>IS:3</availability>
 		</model>
-		<model name='9'>
-			<availability>CDS:5</availability>
-		</model>
-		<model name='3'>
-			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,DC:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:5,IS:4</availability>
-		</model>
-		<model name='8'>
-			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
-		</model>
-		<model name='7'>
-			<availability>RA:6</availability>
-		</model>
 		<model name='11'>
 			<availability>MOC:3,CLAN:3,IS:3,TC:3</availability>
-		</model>
-		<model name='10'>
-			<availability>MOC:3,CLAN:3,IS:3,TC:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CC:4,CHH:5,RD:5,CDS:6,LA:4,ROS:4,CNC:5,FS:4,RA:5,CWIE:5,CGB:5,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>LA:7,IS:7,FWL:7,TC:8,Periphery:5</availability>
-		<model name='WHM-6R'>
-			<availability>BAN:8,Periphery:2-</availability>
+		<model name='WHM-9S'>
+			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
 		</model>
-		<model name='WHM-10T'>
-			<availability>FS:4,TC:8</availability>
+		<model name='WHM-8M'>
+			<availability>RF:6,FWL:4</availability>
 		</model>
 		<model name='WHM-7K'>
 			<roles>spotter</roles>
 			<availability>DC:5</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:8,MERC:4</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='WHM-8M'>
-			<availability>RF:6,FWL:4</availability>
-		</model>
-		<model name='WHM-11T'>
-			<availability>MOC:4,TC:5</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='WHD-10CT'>
-			<availability>CC:4,OP:4,LA:4,ROS:4</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
-		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:2,PIR:4,IS:2,MH:4,FS:2,MERC:3,CDP:4,TC:4</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:4,LA:4,FS:3,MERC:4</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CC:3,FVC:3,ROS:4,FWL:5,MERC:2,Periphery:3</availability>
-		</model>
-		<model name='WHM-9S'>
-			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
-		</model>
-		<model name='WHM-8D2'>
-			<availability>FS:5</availability>
+		<model name='WHM-6R'>
+			<availability>BAN:8,Periphery:2-</availability>
 		</model>
 		<model name='WHM-4L'>
 			<availability>CC:6,MOC:4</availability>
 		</model>
+		<model name='WHM-11T'>
+			<availability>MOC:4,TC:5</availability>
+		</model>
+		<model name='WHM-8K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='WHD-10CT'>
+			<availability>CC:4,OP:4,LA:4,ROS:4</availability>
+		</model>
+		<model name='WHM-8D2'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='WHM-5L'>
+			<availability>CC:6</availability>
+		</model>
 		<model name='WHM-6D'>
 			<availability>FVC:1-</availability>
+		</model>
+		<model name='WHM-7M'>
+			<availability>CC:3,FVC:3,ROS:4,FWL:5,MERC:2,Periphery:3</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:4,LA:4,FS:3,MERC:4</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:8,MERC:4</availability>
+		</model>
+		<model name='WHM-10T'>
+			<availability>FS:4,TC:8</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:6,ROS:4,FS:6</availability>
-		<model name='BLR-2G'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BLR-2D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BLR-2G'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:6</availability>
@@ -17128,11 +17123,11 @@
 		<model name='H-8'>
 			<availability>RD:8,LA:4,FS.CH:8,ROS:6,IS:4,FWL:4,FS:6,RA:8</availability>
 		</model>
-		<model name='H-9'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='H-9'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Stealth Helicopter' unitType='VTOL'>
@@ -17144,6 +17139,30 @@
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>IS:8,Periphery:6,RA:4</availability>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
+		</model>
+		<model name='WSP-3W'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='WSP-8T'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,ROS:2,IS:4,TC:8</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WSP-1S'>
+			<roles>recon</roles>
+			<availability>FVC:3,LA:4,FS:2,MERC:2</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
+		</model>
 		<model name='WSP-1D'>
 			<roles>recon</roles>
 			<availability>FVC:1-</availability>
@@ -17152,10 +17171,6 @@
 			<roles>recon</roles>
 			<availability>CC:1-,MOC:2-,FVC:2-,FWL:1-,RCM:1-,Periphery:2-</availability>
 		</model>
-		<model name='WSP-8T'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,ROS:2,IS:4,TC:8</availability>
-		</model>
 		<model name='WSP-3L'>
 			<roles>recon</roles>
 			<availability>CC:4,MOC:3,PIR:3,DA:3,TC:3</availability>
@@ -17163,29 +17178,9 @@
 		<model name='WSP-3P'>
 			<availability>FVC:5,Periphery:5</availability>
 		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,CGB.FRR:4,ROS:5,FS:4,MERC:4</availability>
-		</model>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
-		</model>
 		<model name='WSP-3A'>
 			<roles>recon</roles>
 			<availability>RA.OA:6,RA:8</availability>
-		</model>
-		<model name='WSP-1S'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:4,FS:2,MERC:2</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,DC:6</availability>
 		</model>
 		<model name='WSP-3K'>
 			<availability>DC:4</availability>
@@ -17216,46 +17211,46 @@
 		<model name='WTH-3'>
 			<availability>FS.CMM:7</availability>
 		</model>
+		<model name='WTH-2A'>
+			<availability>DC:1</availability>
+		</model>
+		<model name='WTH-1'>
+			<roles>fire_support</roles>
+			<availability>MERC:1,Periphery:1</availability>
+		</model>
+		<model name='WTH-2'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:6,MH:6,MERC:6,CDP:6,TC:6</availability>
+		</model>
 		<model name='WTH-1H'>
 			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
 		</model>
 		<model name='WTH-K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='WTH-1'>
-			<roles>fire_support</roles>
-			<availability>MERC:1,Periphery:1</availability>
-		</model>
-		<model name='WTH-2A'>
-			<availability>DC:1</availability>
-		</model>
-		<model name='WTH-2'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:6,MH:6,MERC:6,CDP:6,TC:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:6,LA:5,CNC:2-,FWL:5,IS:4,MERC:5,DC:8</availability>
-		<model name='WGT-3SC'>
-			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6</availability>
-		</model>
-		<model name='WGT-1LAW/SC3'>
-			<availability>ROS:5,DC:6</availability>
+		<model name='WGT-2LAW'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='WGT-4NC &apos;Dezgra&apos;'>
 			<availability>CNC:8</availability>
 		</model>
+		<model name='WGT-1LAW/SC3'>
+			<availability>ROS:5,DC:6</availability>
+		</model>
 		<model name='WGT-2LAWC3'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WGT-2LAW'>
-			<availability>DC:6</availability>
+		<model name='WGT-1LAW/SC'>
+			<availability>LA:4,FWL:4,IS:4,MERC:4,DC:5</availability>
 		</model>
 		<model name='WGT-2SC'>
 			<availability>LA:6,FWL:6,IS:4,MERC:6</availability>
 		</model>
-		<model name='WGT-1LAW/SC'>
-			<availability>LA:4,FWL:4,IS:4,MERC:4,DC:5</availability>
+		<model name='WGT-3SC'>
+			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wildkatze' unitType='Aero'>
@@ -17269,8 +17264,8 @@
 	</chassis>
 	<chassis name='Winston Combat Vehicle' unitType='Tank'>
 		<availability>ROS:5,ROS.pm:8</availability>
-		<model name='(LAC)'>
-			<availability>General:5</availability>
+		<model name='(Standard)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(TSEMP)'>
 			<availability>General:4</availability>
@@ -17279,8 +17274,8 @@
 			<roles>fire_support,spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:7</availability>
+		<model name='(LAC)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -17292,14 +17287,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>CGB.FRR:3,ROS:2,MERC:2,DC:5-</availability>
-		<model name='WFT-C'>
-			<availability>CGB.FRR:4,MERC:4,DC:4</availability>
-		</model>
 		<model name='WFT-2'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:8,DC:6</availability>
 		</model>
 		<model name='WFT-B'>
 			<availability>ROS:6</availability>
@@ -17307,21 +17296,15 @@
 		<model name='WFT-1'>
 			<availability>General:4</availability>
 		</model>
+		<model name='WFT-C'>
+			<availability>CGB.FRR:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:8,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,OP:3,MERC.KH:7,MERC:4,FS:2,CWIE:5,DTA:3,MERC.WD:5,FVC:2,LA:7,ROS:5,MH:4,MSC:3</availability>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
-		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
-		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-3M'>
-			<availability>DTA:8,OP:8,FWL:8,MSC:8</availability>
-		</model>
 		<model name='WLF-4WA'>
 			<roles>ew_support</roles>
 			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
@@ -17329,65 +17312,77 @@
 		<model name='WLF-1'>
 			<availability>LA:1,ROS:1,Periphery.Deep:6,MERC:1,Periphery:8</availability>
 		</model>
-		<model name='WLF-3S'>
-			<availability>LA:4</availability>
+		<model name='WLF-3M'>
+			<availability>DTA:8,OP:8,FWL:8,MSC:8</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
 		</model>
 		<model name='WLF-2H'>
 			<availability>LA:6,MERC:3,CWIE:4</availability>
 		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
+		</model>
+		<model name='WLF-3S'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,RD:2,LA:5,CNC:2,IS:5,FWL:8,MH:4,FS:6,DC:5,Periphery:4,CGB:2,TC:4</availability>
-		<model name='WVR-9K'>
-			<availability>ROS:3,DC:4</availability>
-		</model>
-		<model name='WVR-6R'>
+		<model name='WVR-7M'>
 			<roles>recon</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>FVC:5,LA:4,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,MERC:4,DC:7</availability>
-		</model>
-		<model name='WVR-9W2'>
-			<availability>IS:4,DC:8</availability>
+			<availability>CC:4,MOC:5,FWL:4,MH:5,MERC:6,DC:4</availability>
 		</model>
 		<model name='WVR-9D'>
 			<roles>spotter</roles>
 			<availability>FS:6,MERC:4</availability>
 		</model>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:5,FWL:4,MH:5,MERC:6,DC:4</availability>
+		<model name='WVR-8K'>
+			<availability>RD:5,ROS:4,CNC:4,MERC:3,CGB:5</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:6</availability>
+		<model name='WVR-9W2'>
+			<availability>IS:4,DC:8</availability>
 		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>RD:8,MERC:6,CGB:8,DC:6</availability>
 		</model>
-		<model name='WVR-9M'>
-			<availability>LA:4,ROS:4,FWL:6,MH:4,MERC:4</availability>
+		<model name='WVR-8D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='WVR-6M'>
 			<roles>recon</roles>
 			<availability>Periphery.MW:3-,PIR:3-,Periphery.ME:3-,MH:3-</availability>
 		</model>
-		<model name='WVR-8K'>
-			<availability>RD:5,ROS:4,CNC:4,MERC:3,CGB:5</availability>
+		<model name='WVR-8C'>
+			<availability>ROS:4,MERC:4,DC:7</availability>
+		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='WVR-9M'>
+			<availability>LA:4,ROS:4,FWL:6,MH:4,MERC:4</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>FVC:5,LA:4,ROS:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>ROS:3,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith Battle Armor' unitType='BattleArmor'>
@@ -17418,10 +17413,7 @@
 	</chassis>
 	<chassis name='Wusun' unitType='Aero' omni='Clan'>
 		<availability>RA.OA:1+,RA:4</availability>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -17430,29 +17422,32 @@
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
 		<availability>CHH:4,CW:4</availability>
+		<model name='2'>
+			<availability>CW:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CW:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:1,OP:1,IS:1,FS:7,MERC:5,DC.GHO:2,DTA:1,FVC:2,RF:1,CGB.FRR:5,ROS:5,MSC:1,RCM:1,DA:2,DC:6</availability>
-		<model name='WVE-9N'>
-			<roles>urban</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
+		</model>
+		<model name='WVE-9N'>
+			<roles>urban</roles>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -17468,11 +17463,11 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:6,LA:4,ROS:4,Periphery.CM:4,MERC:4,Periphery:2,TC:4</availability>
-		<model name='XNT-2O'>
-			<availability>General:1-</availability>
-		</model>
 		<model name='XNT-6O'>
 			<availability>CC:5,MOC:5</availability>
+		</model>
+		<model name='XNT-2O'>
+			<availability>General:1-</availability>
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:6,MOC:6,LA:6,ROS:6,MERC:6</availability>
@@ -17490,25 +17485,25 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
-		<model name='2'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CHH:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Xiphos Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:3,OP:3,MSC:4</availability>
-		<model name='(B)' mechanized='false'>
+		<model name='(C)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(A)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C)' mechanized='false'>
+		<model name='(B)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -17520,6 +17515,9 @@
 	</chassis>
 	<chassis name='Yasha VTOL' unitType='VTOL'>
 		<availability>CHH:4,CDS:4,CNC:4,IS:4,CWIE:4</availability>
+		<model name='&apos;Spectre&apos;'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Interdictor)'>
 			<roles>ew_support</roles>
 			<availability>General:4</availability>
@@ -17527,17 +17525,11 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='&apos;Spectre&apos;'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>FVC:8,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
 		<model name='(RAC)'>
 			<availability>IS:3,FS:5</availability>
-		</model>
-		<model name='(PPC)'>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2,FS:4</availability>
@@ -17549,15 +17541,18 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(PPC)'>
+			<availability>IS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
 		<availability>ROS:4,FWL:4,MH:3,MERC:3</availability>
-		<model name='YMN-10-OR'>
-			<availability>ROS:4,FWL:4,MERC:4</availability>
-		</model>
 		<model name='YMN-6Y'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='YMN-10-OR'>
+			<availability>ROS:4,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ymir' unitType='Mek'>
@@ -17575,18 +17570,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='Y-H10G'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Y-H9G'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='Y-H10G'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Yun' unitType='Aero'>
@@ -17622,11 +17617,11 @@
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='(Omnidrone) C'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Omnidrone) A'>
 			<roles>spotter</roles>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(Omnidrone) C'>
 			<availability>ROS:4</availability>
 		</model>
 		<model name='(Omnidrone) Prime'>
@@ -17635,13 +17630,13 @@
 	</chassis>
 	<chassis name='Zephyros Infantry Support Vehicle' unitType='Tank'>
 		<availability>CHH:7,RD:3,CW:3,CGB:3,CWIE:3</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Dual Turret)'>
 			<roles>apc</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
@@ -17652,8 +17647,8 @@
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:3,ROS:4</availability>
-		<model name='ZEU-X4'>
-			<availability>LA:8</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:5-</availability>
 		</model>
 		<model name='ZEU-X3'>
 			<availability>LA:2-</availability>
@@ -17664,26 +17659,26 @@
 		<model name='ZEU-9WD'>
 			<availability>General:4</availability>
 		</model>
-		<model name='ZEU-X2'>
-			<availability>LA:5-</availability>
+		<model name='ZEU-X4'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,ROS:5,PIR:3,MH:3,FS:2-,MERC:5,CDP:3,TC:3</availability>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
-		<model name='ZEU-6S'>
-			<availability>Periphery:2</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>FVC:6,LA:8,PIR:6,MH:6,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,ROS:4,FS:7,MERC:4</availability>
 		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
+		<model name='ZEU-6S'>
+			<availability>Periphery:2</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -17713,39 +17708,43 @@
 		<model name='(A)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CW:10,ROS:6,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CLAN:4,CJF:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(ATM)'>
 			<availability>CW:6,ROS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Zou Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>DC:3</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:6-</availability>
-		</model>
 		<model name='(C3)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Zugvogel Omni Support Aircraft' unitType='Conventional Fighter'>
 		<availability>RD:2,LA:4,IS:2,Periphery:2,CGB:2</availability>
+		<model name='Prime'>
+			<roles>cargo</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<roles>support</roles>
 			<availability>General:6</availability>
@@ -17754,23 +17753,19 @@
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>cargo</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>support,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<roles>support</roles>
+		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
 		<model name='F'>
 			<roles>support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/3135.xml
+++ b/megamek/data/forcegenerator/3135.xml
@@ -1345,28 +1345,28 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
 		<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,CP:4,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,FWL:4,DC:6</availability>
+		<model name='(3088)'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='(2582)'>
 			<roles>assault</roles>
 			<availability>General:2</availability>
-		</model>
-		<model name='(3088)'>
-			<availability>DC:6</availability>
 		</model>
 		<model name='(3055)'>
 			<roles>assault</roles>
@@ -1430,17 +1430,17 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CJF:6</availability>
-		<model name='(Jade Falcon)' mechanized='true'>
-			<availability>CJF:8</availability>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Jade Falcon)' mechanized='true'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Agrotera' unitType='Mek'>
@@ -1479,13 +1479,12 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4</availability>
@@ -1493,17 +1492,15 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>ROS:4,CNC:4,CP:4,DC:6</availability>
-		<model name='AKU-2X'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CNC:5,CP:5,DC:5</availability>
+		<model name='AKU-2XK'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='AKU-1X'>
 			<availability>DC:4</availability>
@@ -1511,17 +1508,20 @@
 		<model name='AKU-2XC'>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='AKU-2XK'>
-			<availability>DC:6</availability>
+		<model name='AKU-1XJ'>
+			<availability>CNC:5,CP:5,DC:5</availability>
+		</model>
+		<model name='AKU-2X'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CWE:4,CDS:4,CW:4,LA:6,ROS:5,CNC:4,FS:5,CP:4,CWIE:6,DC:3</availability>
-		<model name='Mk VII'>
-			<availability>LA:4,FS:4</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk VII'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
@@ -1529,11 +1529,11 @@
 		<model name='ALB-3U'>
 			<availability>FWL:8,MERC:8,CP:8</availability>
 		</model>
-		<model name='ALB-3Ur'>
-			<availability>ROS:4,FWL:4,MERC:4,CP:4</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>DTA:6,OP:6,FWL:6,MSC:6,CP:6</availability>
+		</model>
+		<model name='ALB-3Ur'>
+			<availability>ROS:4,FWL:4,MERC:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Amazon Battle Armor' unitType='BattleArmor'>
@@ -1547,11 +1547,11 @@
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CW:5,CNC:5,CP:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>RD:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Anat APC' unitType='Tank'>
@@ -1590,6 +1590,9 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>MERC.KH:2,MERC.WD:8,CHH:3,LA:2,ROS:3,MERC:3,CWIE:2,BAN:2,RA:3</availability>
+		<model name='C 2'>
+			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
+		</model>
 		<model name='ANH-4A'>
 			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:5,ROS:5,MERC:5,CWIE:5</availability>
 		</model>
@@ -1601,9 +1604,6 @@
 		</model>
 		<model name='ANH-3A'>
 			<availability>MERC.WD:5,CHH:4,LA:6,ROS:6,MERC:6,CWIE:4</availability>
-		</model>
-		<model name='C 2'>
-			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1632,38 +1632,32 @@
 		<model name='ABS-5Y'>
 			<availability>MOC:5,CC:5</availability>
 		</model>
-		<model name='ABS-5Z'>
-			<roles>spotter</roles>
-			<availability>CC:5,MOC:5</availability>
+		<model name='ABS-3R'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ABS-3T'>
 			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
-		<model name='ABS-3R'>
-			<availability>General:4</availability>
+		<model name='ABS-4C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='ABS-5Z'>
+			<roles>spotter</roles>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
 			<availability>FVC:0,General:8</availability>
 		</model>
-		<model name='ABS-4C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>DTA:6,OP:6,RF:6,ROS:4,FWL:5,MSC:6,MERC:4,DA:6,CP:5</availability>
-		<model name='ANV-5M'>
-			<availability>DTA:4,OP:4,FWL:4,DA:4,CP:4</availability>
-		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>DTA:5,OP:5,RF:5,FWL:3,MSC:5,DA:5,CP:3</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>ROS:6,FWL:3,MERC:3,CP:3</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,MERC:4,CP:4</availability>
+		<model name='ANV-5M'>
+			<availability>DTA:4,OP:4,FWL:4,DA:4,CP:4</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
@@ -1672,34 +1666,40 @@
 		<model name='ANV-5Q'>
 			<availability>DTA:4,RF:4,FWL:2,MSC:4,CP:2</availability>
 		</model>
+		<model name='ANV-3R'>
+			<availability>FWL:4,MERC:4,CP:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>ROS:6,FWL:3,MERC:3,CP:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Anzu' unitType='Mek'>
 		<availability>DTA:6,OP:6,FWL:6:3139,MSC:7,CP:6</availability>
+		<model name='ZU-J70'>
+			<availability>FWL:4,MSC:6,CP:4</availability>
+		</model>
 		<model name='ZU-G60'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='ZU-J70'>
-			<availability>FWL:4,MSC:6,CP:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,Periphery.MW:3,ROS:4,Periphery.ME:3,FWL:8,MH:4,MSC:8,MERC:4,CP:8,DC:6</availability>
-		<model name='APL-3T'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,CP:4,DC:3</availability>
-		</model>
 		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>CC:3,FWL:4,MERC:3,CP:4,DC:3</availability>
 		</model>
-		<model name='APL-2S'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
-			<availability>CC:3,FWL:4,CP:4,DC:3</availability>
+			<availability>FWL:4,CP:4,DC:3</availability>
 		</model>
 		<model name='APL-4M'>
 			<roles>fire_support</roles>
 			<availability>FWL:2:3139,MSC:6,CP:2</availability>
+		</model>
+		<model name='APL-2S'>
+			<roles>fire_support</roles>
+			<availability>CC:3,FWL:4,CP:4,DC:3</availability>
 		</model>
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
@@ -1725,14 +1725,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,ROS:4,CNC:6,MERC:4,FS:3,CP:4,DC:3</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1761,90 +1761,81 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,RD:4,LA:6,FWL:6,CP:6,Periphery:3,DC:5</availability>
-		<model name='ARC-6W'>
+		<model name='ARC-7L'>
 			<roles>fire_support</roles>
-			<availability>FVC:4,TC:6,Periphery:4</availability>
+			<availability>CC:8,MOC:4</availability>
 		</model>
 		<model name='ARC-9W'>
 			<roles>fire_support</roles>
 			<availability>ROS:6</availability>
 		</model>
-		<model name='ARC-6S'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>RD:4,LA:2,ROS:4,MERC:2</availability>
-		</model>
-		<model name='ARC-8M'>
-			<roles>fire_support</roles>
-			<availability>DTA:5,MOC:3,OP:5,ROS:4,PIR:3,FWL:3,MH:3,MSC:5,MERC:4,CP:3</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6</availability>
-		</model>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:8,MOC:4</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
+			<availability>CLAN:4,FWL:4,MERC:4,CP:4,BAN:2</availability>
 		</model>
 		<model name='ARC-9KC'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='ARC-5R'>
+		<model name='ARC-5W'>
 			<roles>fire_support</roles>
-			<availability>RD:6,MERC:3</availability>
+			<availability>MERC.WD:8,LA:1,MERC:1</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>RD:4,LA:2,ROS:4,MERC:2</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
+		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,TC:6,Periphery:4</availability>
 		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='ARC-9M'>
+			<roles>fire_support</roles>
+			<availability>LA:6,ROS:4,FWL:4,MERC:4,CP:4,DC:4</availability>
+		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='ARC-9M'>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5R'>
 			<roles>fire_support</roles>
-			<availability>LA:6,ROS:4,FWL:4,MERC:4,CP:4,DC:4</availability>
+			<availability>RD:6,MERC:3</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>BAN:2,Periphery:2-</availability>
 		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,LA:1,MERC:1</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,MERC:4,CP:4,BAN:2</availability>
-		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>FVC:4,PIR:5,FWL:3,CP:3,Periphery:4</availability>
 		</model>
+		<model name='ARC-8M'>
+			<roles>fire_support</roles>
+			<availability>DTA:5,MOC:3,OP:5,ROS:4,PIR:3,FWL:3,MH:3,MSC:5,MERC:4,CP:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,LA:5,ROS:4,CNC:2-,MERC:2,CP:2-,CWIE:3-</availability>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1E'>
-			<availability>General:6</availability>
+		<model name='AF1C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
@@ -1853,21 +1844,30 @@
 		<model name='AF1B'>
 			<availability>General:5</availability>
 		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Wolf II' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:6,CWIE:7</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
@@ -1884,11 +1884,11 @@
 		<model name='A'>
 			<availability>General:2</availability>
 		</model>
-		<model name='J'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:4</availability>
+		</model>
+		<model name='J'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -1918,11 +1918,11 @@
 	</chassis>
 	<chassis name='Ares' unitType='Mek' omni='IS'>
 		<availability>ROS:2+</availability>
-		<model name='ARS-V1 Zeus'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ARS-V1A Hera'>
 			<availability>General:7</availability>
+		</model>
+		<model name='ARS-V1 Zeus'>
+			<availability>General:8</availability>
 		</model>
 		<model name='ARS-V1B Hades'>
 			<availability>General:7</availability>
@@ -1937,12 +1937,6 @@
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
 		<availability>FS:6</availability>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
@@ -1951,6 +1945,12 @@
 		</model>
 		<model name='AGS-6F'>
 			<availability>General:4</availability>
+		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Arion' unitType='Mek'>
@@ -1961,37 +1961,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -2001,17 +1981,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -2038,16 +2038,16 @@
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
 		<availability>RCM:1-,DA:1-,Periphery:1-</availability>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
+		<model name='ASN-99'>
+			<roles>spotter</roles>
+			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:4,FVC:4,Periphery.HR:5,PIR:3,MH:4,RCM:4,DA:4</availability>
 		</model>
-		<model name='ASN-99'>
-			<roles>spotter</roles>
-			<availability>CC:2,MOC:2</availability>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -2076,11 +2076,11 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CWE:5,CHH:8,RD:6,CDS:5,CW:5,ROS:4,CP:5,CJF:3,RA:5</availability>
-		<model name='(HAG)'>
-			<availability>CHH:8,ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas III' unitType='Mek'>
@@ -2103,63 +2103,51 @@
 		<model name='AS7-Dr'>
 			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>IS:4,DC:4</availability>
+		<model name='AS7-K4'>
+			<availability>RF:4,LA:4,DC:4</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>MOC:3,RA.OA:4,FVC:4,CNC:5,MERC:4,CP:5,CDP:3,DC:4,Periphery:4,TC:3</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:6,ROS:4,MERC:3</availability>
+		</model>
+		<model name='AS7-K3'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
+		</model>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:6</availability>
+		</model>
+		<model name='AS7-K2'>
+			<availability>LA:8,CNC:6,IS:6,CLAN.IS:4,CP:6,Periphery:6,CWIE:6</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:4,FS:4,DC:4</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>MERC:2,DC:2</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
-		</model>
-		<model name='AS7-C'>
-			<availability>MERC:2,DC:2</availability>
-		</model>
 		<model name='AS7-S2'>
 			<availability>LA:1,ROS:3,MERC:3</availability>
 		</model>
-		<model name='AS7-D'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:6,ROS:4,MERC:3</availability>
-		</model>
-		<model name='AS7-K4'>
-			<availability>RF:4,LA:4,DC:4</availability>
-		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:6</availability>
-		</model>
-		<model name='AS7-K3'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>MOC:3,RA.OA:4,FVC:4,CNC:5,MERC:4,CP:5,CDP:3,DC:4,Periphery:4,TC:3</availability>
-		</model>
-		<model name='AS7-K2'>
-			<availability>LA:8,CNC:6,IS:6,CLAN.IS:4,CP:6,Periphery:6,CWIE:6</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(CV)'>
@@ -2170,6 +2158,14 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Gunship)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
@@ -2177,6 +2173,10 @@
 		<model name='(Tanker)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalanche' unitType='Mek' omni='IS'>
@@ -2190,14 +2190,14 @@
 		<model name='AVL-1OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='AVL-1ON'>
+			<availability>General:6</availability>
+		</model>
 		<model name='AVL-1OR'>
 			<availability>General:6,CLAN:8</availability>
 		</model>
 		<model name='AVL-1O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AVL-1ON'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -2209,24 +2209,24 @@
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CWE:3,CW:3,CLAN:2,CNC:3,CP:3,RA:2,BAN:5,CWIE:3</availability>
+		<model name='A'>
+			<availability>General:6,RA:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:7,CP:9,RA:8</availability>
 		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6,CP:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CWE:4,CW:4,CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6,RA:7</availability>
-		</model>
 		<model name='D'>
 			<availability>CWE:6,CW:6,CLAN:4,CNC:6,CP:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
@@ -2234,40 +2234,40 @@
 		<model name='AV1-OG'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OJ'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OI'>
-			<availability>General:3</availability>
-		</model>
-		<model name='AV1-OA'>
-			<availability>General:7</availability>
 		</model>
 		<model name='AV1-OH'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AV1-OE'>
+		<model name='AV1-OI'>
+			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OD'>
 			<availability>General:6</availability>
+		</model>
+		<model name='AV1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AV1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OJ'>
+			<availability>General:4</availability>
 		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
@@ -2275,34 +2275,34 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:2,RA.OA:2,LA:4,IS:2,FWL:3,FS:4,CP:3,TC:2,Periphery:1,DC:3</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:6,CC:5,RA.OA:6,LA:4,ROS:5,IS:4,FWL:8,FS:4,CP:8,Periphery:8,TC:5,DC:6</availability>
-		<model name='AWS-8Q'>
-			<availability>Periphery:2-</availability>
+		<model name='AWS-11R'>
+			<availability>RF:4,MSC:4</availability>
 		</model>
 		<model name='AWS-10KM'>
 			<availability>DTA:4,OP:4,ROS:4,FWL:4,MSC:4,CP:4,DC:6</availability>
 		</model>
+		<model name='AWS-8Q'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:2,PIR:4,FWL:4,IS:2,MH:2,CP:4,TC:2,Periphery:4</availability>
-		</model>
-		<model name='AWS-9Ma'>
-			<availability>DTA:2,OP:2,LA:2,ROS:2,FWL:2,MSC:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:6,FWL:4,IS:6,MH:6,CP:4,TC:6,Periphery:4</availability>
 		</model>
-		<model name='AWS-11R'>
-			<availability>RF:4,MSC:4</availability>
+		<model name='AWS-9Ma'>
+			<availability>DTA:2,OP:2,LA:2,ROS:2,FWL:2,MSC:2,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
@@ -2322,8 +2322,18 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:1,LA:5,ROS:4,FS:1</availability>
+		<model name='AXM-6T'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='AXM-3S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='AXM-4D'>
 			<availability>FS:6</availability>
+		</model>
+		<model name='AXM-2N'>
+			<roles>fire_support</roles>
+			<availability>LA:1</availability>
 		</model>
 		<model name='AXM-1N'>
 			<availability>FVC:2,LA:2,MERC:2,FS:2</availability>
@@ -2331,19 +2341,13 @@
 		<model name='AXM-3Sr'>
 			<availability>LA:6,ROS:4,FS:6,MERC:4</availability>
 		</model>
-		<model name='AXM-6T'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='AXM-3S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-2N'>
-			<roles>fire_support</roles>
-			<availability>LA:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CJF:5,RA:5</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>RA:6</availability>
+		</model>
 		<model name='3 &apos;Devil&apos;'>
 			<availability>RA:8</availability>
 		</model>
@@ -2351,14 +2355,30 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>RA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CWE:6,MERC.WD:5,CW:6,LA:4,ROS:5</availability>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:6,General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2370,38 +2390,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>CLAN:6,General:4</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CLAN:5,General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,LA:2,MERC:3</availability>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
@@ -2417,7 +2413,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
@@ -2425,15 +2421,13 @@
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>RA.OA:7,IS:7,CLAN.IS:7</availability>
-		<model name='(Hybrid)'>
-			<availability>CLAN:3,IS:3</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
@@ -2441,24 +2435,30 @@
 		<model name='(Standard)'>
 			<availability>CLAN:8,IS:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Hybrid)'>
+			<availability>CLAN:3,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -2469,33 +2469,41 @@
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:4,DTA:4,LA:4,ROS:4,FWL:4,MERC:8,FS:4,DA:4,CP:4,Periphery:4</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:2</availability>
+		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
 		<model name='BNDR-01B'>
 			<availability>General:4,MERC:8</availability>
 		</model>
-		<model name='BNDR-01Ar'>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:2,CLAN:1</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
@@ -2505,16 +2513,8 @@
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -2527,9 +2527,13 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,MERC:5</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
 			<availability>General:3</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:1</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -2539,9 +2543,9 @@
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:6</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
@@ -2551,39 +2555,41 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:3</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:1</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:4-,RA.OA:4-,FVC:2-,RF:2-,LA:2-,FWL:1-,MH:4-,MSC:1-,MERC:1-,CP:1-,Periphery:7-,TC:4-</availability>
-		<model name='BNC-3MC'>
-			<availability>MOC:1-</availability>
-		</model>
-		<model name='BNC-3S'>
-			<availability>Periphery:1-</availability>
-		</model>
-		<model name='BNC-6S'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BNC-3Mr'>
 			<availability>MOC:6,FWL:6,CP:6,CDP:6,TC:6</availability>
 		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:1-</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:1</availability>
+		</model>
 		<model name='BNC-9S2'>
 			<availability>RF:3,LA:4</availability>
+		</model>
+		<model name='BNC-9S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1-,FVC:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>RF:1-,MSC:1-</availability>
@@ -2591,20 +2597,14 @@
 		<model name='BNC-3E'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='BNC-7S'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6</availability>
+		<model name='BNC-3S'>
+			<availability>Periphery:1-</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:2,MH:4,MERC:5</availability>
 		</model>
-		<model name='BNC-9S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1-,FVC:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
+		<model name='BNC-6S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bardiche Heavy Strike Tank' unitType='Tank'>
@@ -2619,21 +2619,21 @@
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,ROS:4,MERC:4</availability>
-		<model name='BGS-2T'>
-			<availability>LA:4,ROS:4,MERC:4</availability>
-		</model>
-		<model name='BGS-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BGS-1T'>
 			<availability>General:2</availability>
+		</model>
+		<model name='BGS-3T'>
+			<availability>LA:3,ROS:3,MERC:3</availability>
+		</model>
+		<model name='BGS-2T'>
+			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
 		<model name='BGS-4T'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='BGS-3T'>
-			<availability>LA:3,ROS:3,MERC:3</availability>
+		<model name='BGS-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Barouche Military Transport' unitType='Tank'>
@@ -2645,21 +2645,21 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>ROS:3+,CNC:4,CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
-		<model name='D'>
-			<availability>CNC:3,CLAN:2,CP:3,RA:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CNC:8,General:7,CP:8,RA:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='D'>
+			<availability>CNC:3,CLAN:2,CP:3,RA:6</availability>
 		</model>
 		<model name='A'>
 			<availability>RD:8,General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
@@ -2668,25 +2668,25 @@
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CJF:6</availability>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='H'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:5</availability>
-		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
-		<model name='H'>
+		<model name='F'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -2716,20 +2716,29 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
-		<model name='BLR-4L'>
-			<availability>CC:6</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>CC:3,MERC:3,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
-		</model>
-		<model name='BLR-4S'>
-			<availability>LA:3,ROS:4,MERC:4</availability>
+		<model name='BLR-1Gb'>
+			<availability>CC:4,OP:4,CLAN:8,MSC:4,FS:4,MERC:4,BAN:2,DC:4</availability>
 		</model>
 		<model name='BLR-1Gbc'>
 			<availability>MSC:2</availability>
 		</model>
+		<model name='BLR-6X'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='BLR-4S'>
+			<availability>LA:3,ROS:4,MERC:4</availability>
+		</model>
 		<model name='BLR-10S'>
 			<availability>LA:6,ROS:4,FS:4</availability>
+		</model>
+		<model name='BLR-3S'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>BAN:8,Periphery:1-</availability>
 		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:6,ROS:4,FS:4</availability>
@@ -2741,30 +2750,21 @@
 			<roles>spotter</roles>
 			<availability>DTA:5,OP:5,ROS:4,FWL:4:3139,DA:5,MERC:4,CP:4</availability>
 		</model>
-		<model name='BLR-K4'>
-			<availability>RD:4,ROS:4,DC:6</availability>
-		</model>
-		<model name='BLR-6X'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BLR-3S'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>BAN:8,Periphery:1-</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:4,OP:4,CLAN:8,MSC:4,FS:4,MERC:4,BAN:2,DC:4</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
-		</model>
 		<model name='BLR-5M'>
 			<availability>DTA:8,OP:8,FWL:6,MSC:8,CP:6</availability>
+		</model>
+		<model name='BLR-K4'>
+			<availability>RD:4,ROS:4,DC:6</availability>
 		</model>
 		<model name='BLR-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-3M'>
+			<availability>CC:3,MERC:3,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='BLR-K3'>
 			<roles>spotter</roles>
@@ -2780,16 +2780,9 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CWE:6,CHH:5,RD:5,CDS:5,CW:6,CNC:5,CP:5,CJF:6,CWIE:3</availability>
-		<model name='D'>
-			<availability>CWE:5,CW:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,CNC:9,General:8,CP:9</availability>
-		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,General:5,CJF:6</availability>
@@ -2797,65 +2790,72 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
 		</model>
+		<model name='D'>
+			<availability>CWE:5,CW:5,CLAN:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
 		<availability>ROS:6</availability>
-		<model name='(Sealed)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>ROS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>RD:6,ROS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:5,RA:3</availability>
-		<model name='(Standard)'>
-			<availability>RA:3</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:7</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:1,IS:1,MERC:2,FS:2,CP:2,Periphery:2,RA.OA:2,CDS:2,LA:1,PIR:1,CNC:2,FWL:2,DC:2</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:6,IS:6,DC:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>FVC:4,CDS:4,General:8,CP:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Kurita)'>
-			<availability>CLAN:6,IS:6,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>FVC:4,CDS:4,General:8,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth II Heavy Tank' unitType='Tank'>
 		<availability>CC:6,MOC:5,LA:4,ROS:6,FWL:5,MH:4,MERC:4,CP:5,TC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2867,11 +2867,11 @@
 	</chassis>
 	<chassis name='Bellona Hover Tank' unitType='Tank'>
 		<availability>CHH:6</availability>
-		<model name='(Laser)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Beowulf IIC' unitType='Mek'>
@@ -2883,28 +2883,28 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>RD:6,ROS:6,CNC:4,CP:4</availability>
-		<model name='BEO-14'>
-			<roles>recon</roles>
-			<availability>ROS:6</availability>
-		</model>
 		<model name='BEO-12'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BEO-14'>
+			<roles>recon</roles>
+			<availability>ROS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>RF:5,LA:7,ROS:4,FS:3,MERC:3</availability>
+		<model name='BRZ-A3'>
+			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
+		</model>
 		<model name='BRZ-D4'>
 			<availability>LA:5</availability>
-		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:1</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>RF:4,LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='BRZ-A3'>
-			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2929,122 +2929,122 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CWE:1,CHH:1,RD:1,CW:1,ROS:4+,CJF:1,RA:1,BAN:2,CWIE:1</availability>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
 		<model name='B'>
 			<availability>CWE:6,RD:4,CW:6,CNC:7,General:6,CP:7,CJF:8</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:5,CHH:6,CDS:5,CW:5,CLAN:4,General:2,CP:5</availability>
+		<model name='C'>
+			<availability>CWE:3,CHH:6,CW:3,General:5,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CWE:2,RD:2,CDS:2,CW:2,CNC:2,CLAN:1,General:2,CP:2,CJF:2,CWIE:2</availability>
 		</model>
-		<model name='I'>
-			<availability>General:4</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:3,CHH:6,CW:3,General:5,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CWE:5,RD:7,CW:5,General:6,CJF:8</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
+		<model name='D'>
+			<availability>CWE:3,CHH:6,CW:3,CNC:5,General:4,CP:5,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='T'>
 			<availability>General:4</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CWE:5,RD:7,CW:5,General:6,CJF:8</availability>
+		</model>
 		<model name='A'>
 			<availability>RD:8,CDS:8,CNC:8,General:7,CP:8,CJF:9</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:3,CHH:6,CW:3,CNC:5,General:4,CP:5,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CWE:5,CHH:6,CDS:5,CW:5,CLAN:4,General:2,CP:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='I'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:5,LA:6,IS:5,FS:5,MERC:5,DC:8</availability>
-		<model name='BHKU-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='BHKU-OU'>
-			<roles>marine</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
-		</model>
-		<model name='BHKU-OR'>
-			<availability>General:3+,DC:3+</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OE'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
 		</model>
 		<model name='BHKU-OG'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OU'>
+			<roles>marine</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='BHKU-OR'>
+			<availability>General:3+,DC:3+</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
+		</model>
+		<model name='BHKU-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
 		<availability>CHH:8,CDS:6,CNC:6,IS:5,MERC:6,CP:5,CWIE:6</availability>
-		<model name='3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MSC:6,MOC:4,CC:4,OP:6,IS:4,MERC:4,CP:5,RA:3,Periphery:4,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3,DC:4</availability>
-		<model name='BL-12-KNT'>
-			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>DTA:6,OP:6,LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
 		</model>
-		<model name='BLK-NT-5H'>
-			<availability>FWL:3,FS:4,MERC:3,CP:3,DC:3</availability>
-		</model>
-		<model name='BLK-NT-4D'>
-			<availability>CWE:4,CDS:4,CW:4,ROS:4,CNC:5,FS:4,MERC:3,CP:4,CWIE:5</availability>
-		</model>
-		<model name='BLK-NT-3B'>
-			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:5,MERC:5</availability>
+		<model name='BL-9-KNT'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='BLK-NT-2Y'>
 			<availability>FVC:4,ROS:6,IS:6,FS:6,CDP:4</availability>
 		</model>
+		<model name='BL-6-KNT'>
+			<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+		</model>
+		<model name='BLK-NT-4D'>
+			<availability>CWE:4,CDS:4,CW:4,ROS:4,CNC:5,FS:4,MERC:3,CP:4,CWIE:5</availability>
+		</model>
 		<model name='BLK-NT-3A'>
 			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:6,MERC:5</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>ROS:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:4,FS:4</availability>
+		</model>
+		<model name='BLK-NT-3B'>
+			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:5,MERC:5</availability>
+		</model>
+		<model name='BLK-NT-5H'>
+			<availability>FWL:3,FS:4,MERC:3,CP:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -3052,19 +3052,15 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='H'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='X'>
 			<availability>CJF:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
@@ -3072,6 +3068,10 @@
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -3090,23 +3090,17 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:6,MERC:3</availability>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Wolf Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,CW:4,CWIE:5</availability>
 		<model name='[LBX]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Plasma]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Heavy Flamer]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[ERSPL]' mechanized='true'>
@@ -3115,32 +3109,44 @@
 		<model name='[Heavy Mortar]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[Heavy Flamer]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Plasma]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>MOC:2,RA.OA:3,FVC:4,FS:4,MERC:2,TC:2,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:8,MERC:6</availability>
+		<model name='BJ-2r'>
+			<availability>FVC:5,FS:5,MERC:5</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>Periphery:1</availability>
 		</model>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
+		</model>
 		<model name='BJ-2'>
 			<availability>FVC:3,LA:4,FS:2,MERC:4</availability>
 		</model>
-		<model name='BJ-2r'>
-			<availability>FVC:5,FS:5,MERC:5</availability>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,FVC:2,ROS:4,FWL:5,IS:1,FS:6,MERC:3,DA:4,CP:5,DC:6</availability>
-		<model name='BJ2-O'>
-			<availability>General:7</availability>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8,CP:8</availability>
 		</model>
-		<model name='BJ2-OX'>
-			<availability>General:2</availability>
+		<model name='BJ2-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7,CP:7</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:6</availability>
@@ -3148,23 +3154,17 @@
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OC'>
+		<model name='BJ2-OD'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8,CP:8</availability>
+		<model name='BJ2-O'>
+			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7,CP:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		<model name='BJ2-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blade' unitType='Mek'>
@@ -3176,15 +3176,15 @@
 			<roles>fire_support</roles>
 			<availability>ROS:5,FS:8</availability>
 		</model>
-		<model name='BLD-XS'>
-			<availability>ROS:4,FS:4</availability>
+		<model name='BLD-XX'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:2</availability>
 		</model>
 		<model name='BLD-XL'>
 			<availability>ROS:8,FS:8</availability>
 		</model>
-		<model name='BLD-XX'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:2</availability>
+		<model name='BLD-XS'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
@@ -3198,39 +3198,39 @@
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MERC:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Black Blizzard&apos;'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CHH:5</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='G'>
+		<model name='E'>
 			<availability>General:5</availability>
 		</model>
 		<model name='D'>
@@ -3239,28 +3239,28 @@
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CWE:9,CW:9</availability>
-		<model name='2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
 		<availability>DTA:6,OP:6,RF:5,ROS:4,FWL:5,MH:4,MSC:6,MERC:4,RCM:5,DA:6,CP:5</availability>
-		<model name='B3-HND'>
-			<roles>anti_infantry</roles>
-			<availability>:0,IS:4</availability>
+		<model name='B2-HND'>
+			<availability>RF:0,General:4,RCM:0</availability>
 		</model>
 		<model name='B1-HND'>
 			<availability>:0,General:8</availability>
 		</model>
-		<model name='B2-HND'>
-			<availability>RF:0,General:4,RCM:0</availability>
+		<model name='B3-HND'>
+			<roles>anti_infantry</roles>
+			<availability>:0,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
-		<availability>MOC:6,FS:2,Periphery:4,DC:2,OA.RA:5</availability>
+		<availability>MOC:6,OA.RA:5,FS:2,Periphery:4,DC:2</availability>
 		<model name='MSF-42'>
 			<availability>General:6</availability>
 		</model>
@@ -3274,11 +3274,11 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank (RotS)' unitType='Tank' omni='IS'>
 		<availability>ROS:4</availability>
-		<model name='A'>
-			<roles>spotter</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
@@ -3296,6 +3296,10 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>RA.OA:5,FVC:4,CDS:3,CLAN:1,CP:3,DC:4,RA:4</availability>
+		<model name='BMB-12D'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:2,FVC:6,ROS:2,CLAN:8,MERC.SI:8,BAN:8</availability>
+		</model>
 		<model name='BMB-05A'>
 			<roles>missile_artillery,fire_support</roles>
 			<availability>RA.OA:8</availability>
@@ -3303,10 +3307,6 @@
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='BMB-12D'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:2,FVC:6,ROS:2,CLAN:8,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -3318,7 +3318,11 @@
 	</chassis>
 	<chassis name='Boreas' unitType='Mek' omni='Clan'>
 		<availability>CHH:3</availability>
-		<model name='A'>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='B'>
@@ -3328,11 +3332,7 @@
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -3345,42 +3345,42 @@
 			<roles>missile_artillery</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:2</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
 		<availability>MERC:3,TC:6</availability>
-		<model name='BRM-5A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BRM-5B'>
 			<availability>TC:2</availability>
+		</model>
+		<model name='BRM-5A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2</availability>
-		<model name='LDT-5'>
+		<model name='LDT-X3'>
 			<availability>PIR:4</availability>
 		</model>
-		<model name='LDT-X3'>
+		<model name='LDT-X4'>
 			<availability>PIR:4</availability>
 		</model>
 		<model name='LDT-1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='LDT-X4'>
+		<model name='LDT-5'>
 			<availability>PIR:4</availability>
 		</model>
-		<model name='LDT-X1'>
+		<model name='LDT-X2'>
 			<availability>General:4</availability>
 		</model>
-		<model name='LDT-X2'>
+		<model name='LDT-X1'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -3392,16 +3392,19 @@
 	</chassis>
 	<chassis name='Bruin' unitType='Mek'>
 		<availability>RD:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -3413,9 +3416,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:6,MOC:6,RA.OA:6,RD:6,IS:6,FS:6</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3440,13 +3440,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CP:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -3458,14 +3458,14 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Cell)'>
+			<availability>LA:8,ROS:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Cell)'>
-			<availability>LA:8,ROS:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3479,14 +3479,14 @@
 	</chassis>
 	<chassis name='Buraq Fast Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6</availability>
-		<model name='(Support)' mechanized='false'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Hunter-Killer)' mechanized='false'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Support)' mechanized='false'>
+			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
@@ -3508,14 +3508,14 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:5,MERC:3</availability>
+		<model name='BSW-S2r'>
+			<availability>General:4</availability>
+		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BSW-S2r'>
-			<availability>General:4</availability>
 		</model>
 		<model name='BSW-X2'>
 			<availability>LA:4,MERC:4</availability>
@@ -3526,11 +3526,11 @@
 	</chassis>
 	<chassis name='Cadaver' unitType='Mek'>
 		<availability>RA.OA:7,IS:3,MERC:4,TC:7,RA:6,Periphery:3</availability>
-		<model name='CVR-A1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CVR-T1'>
 			<availability>RA.OA:6,TC:4,RA:6</availability>
+		</model>
+		<model name='CVR-A1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Caerleon' unitType='Small Craft'>
@@ -3542,17 +3542,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>FVC:4,LA:2,FS:3,MERC:2</availability>
-		<model name='CES-3R'>
-			<availability>FVC:8,FS:1,MERC:1</availability>
-		</model>
-		<model name='CES-4S'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='CES-4R'>
 			<availability>FS:6</availability>
 		</model>
 		<model name='CES-3S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='CES-3R'>
+			<availability>FVC:8,FS:1,MERC:1</availability>
+		</model>
+		<model name='CES-4S'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Calliope' unitType='Mek'>
@@ -3580,22 +3580,22 @@
 	</chassis>
 	<chassis name='Cardinal Transport' unitType='VTOL'>
 		<availability>CDS:7,LA:5,ROS:5,MERC:5,CP:7,CJF:6,DC:5</availability>
-		<model name='(RAF)'>
-			<roles>apc</roles>
-			<availability>ROS:8,MERC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>ROS:4,General:8</availability>
 		</model>
+		<model name='(RAF)'>
+			<roles>apc</roles>
+			<availability>ROS:8,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Carnivore Assault Tank' unitType='Tank'>
 		<availability>CC:4,CWE:6,CHH:4,CW:6,LA:4,FS:4,MERC:4,CJF:5,CWIE:4,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>CWE:8,CW:8,CJF:4</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CWE:6,CW:6,CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CWE:8,CW:8,CJF:4</availability>
 		</model>
 		<model name='(Second Line)'>
 			<availability>CWE:4-,CW:4-,General:8,CJF:4-</availability>
@@ -3603,13 +3603,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CWE:1,CHH:1,RD:2,CDS:3,CW:1,CNC:5,CP:4,CJF:1,RA:3</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>RD:4,CDS:8,CNC:8,CP:8,CJF:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3634,11 +3634,17 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,Periphery.ME:1,MH:1,FS:3,MERC:3,CDP:3,TC:3</availability>
-		<model name='CTF-1X'>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:3,MH:4,FS:2,MERC:4</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='CTF-3LL'>
+			<availability>CC:6,MOC:6,MERC:3,TC:6</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FVC:4,FS:4,MERC:3</availability>
@@ -3646,53 +3652,55 @@
 		<model name='CTF-4L'>
 			<availability>CC:6,MOC:6</availability>
 		</model>
-		<model name='CTF-5D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:6,MOC:6,MERC:3,TC:6</availability>
+		<model name='CTF-1X'>
+			<availability>Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult II' unitType='Mek'>
 		<availability>CC:4,MOC:4,DA:4,MERC:2</availability>
-		<model name='CPLT-L7'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='CPLT-L7L'>
 			<roles>fire_support</roles>
 			<availability>General:4,MERC:0</availability>
 		</model>
+		<model name='CPLT-L7'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:4,OP:3,FWL:3,MH:3,MERC:1,CP:2,DA:4,RCM:3,Periphery:2,TC:2,DC:6</availability>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:2,MERC:2,CDP:2,TC:2</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
+		</model>
 		<model name='CPLT-K4'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>BAN:2</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:6,MOC:6,MERC:4,TC:6</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,CDP:3,TC:3,DC:4</availability>
 		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
@@ -3706,14 +3714,6 @@
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:6,MOC:6,MERC:4,TC:6</availability>
-		</model>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:2,MERC:2,CDP:2,TC:2</availability>
-		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
@@ -3722,12 +3722,6 @@
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CNC:5,CP:5,RA:5,DC:3+</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
@@ -3737,10 +3731,6 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -3748,26 +3738,46 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
+		<model name='(Infiltrator)'>
+			<roles>apc</roles>
+			<availability>FS:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
@@ -3776,16 +3786,6 @@
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Infiltrator)'>
-			<roles>apc</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cave Lion' unitType='Mek'>
@@ -3805,15 +3805,11 @@
 	</chassis>
 	<chassis name='Celerity' unitType='Mek' omni='IS'>
 		<availability>ROS:3</availability>
-		<model name='CLR-03-OB'>
-			<roles>specops</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='CLR-03-OC'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='CLR-03-OE'>
+		<model name='CLR-03-OB'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
@@ -3829,6 +3825,10 @@
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='CLR-03-OE'>
+			<roles>specops</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Centaur Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:4</availability>
@@ -3839,22 +3839,22 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CNC:6,CP:6,RA:5</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,CNC:8,CP:8</availability>
-		</model>
 		<model name='3'>
 			<availability>RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8,CNC:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
@@ -3872,69 +3872,69 @@
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:2</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='CNT-1A'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:4,OP:2,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2,DTA:2,FVC:8,LA:3,Periphery.HR:4,ROS:5,FWL:1,MH:6,MSC:2</availability>
-		<model name='CN9-D3'>
-			<availability>FVC:2,ROS:2,FS:2,MERC:2,CDP:3</availability>
-		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:3</availability>
-		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:3,Periphery:4</availability>
-		</model>
-		<model name='CN9-H'>
-			<availability>MH:2-</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:3,MERC:2,Periphery:4</availability>
-		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
+		<model name='CN9-D'>
+			<availability>FVC:3,MERC:2,Periphery:4</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:3</availability>
+		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:3,ROS:3,FWL:3,FS:3,MERC:3,CP:3,CDP:3</availability>
 		</model>
-		<model name='CN9-Da'>
-			<availability>OP:4,FVC:4,ROS:2,FWL:2,MSC:4,MERC:2,FS:2,CP:1,Periphery:4</availability>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='CN9-H'>
+			<availability>MH:2-</availability>
 		</model>
 		<model name='CN9-D4D'>
 			<availability>DTA:3,OP:3,ROS:3,FWL:1,MSC:3,FS:3,MERC:3,CP:1</availability>
 		</model>
+		<model name='CN9-Ar'>
+			<availability>IS:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FVC:2,ROS:2,FS:2,MERC:2,CDP:3</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-Da'>
+			<availability>OP:4,FVC:4,ROS:2,FWL:2,MSC:4,MERC:2,FS:2,CP:1,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek' omni='IS'>
 		<availability>LA:6,ROS:6,FS:7,MERC:5</availability>
-		<model name='CN11-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CN11-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='CN11-OD'>
+		<model name='CN11-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='CN11-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='CN11-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='CN11-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='CN11-OD'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -3943,11 +3943,11 @@
 		<model name='MR-5M'>
 			<availability>CC:4,MOC:4,ROS:5,FWL:6,CP:6</availability>
 		</model>
-		<model name='MR-V3'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='MR-V2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MR-V3'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3967,15 +3967,15 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CWE:5,RD:5,CW:5,CLAN:6,CJF:5</availability>
-		<model name='4'>
-			<roles>spotter</roles>
-			<availability>RA:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<roles>spotter</roles>
+			<availability>RA:4</availability>
 		</model>
 		<model name='3'>
 			<availability>RA:5</availability>
@@ -3983,11 +3983,11 @@
 	</chassis>
 	<chassis name='Chalchiuhtotolin Support Tank' unitType='Tank'>
 		<availability>CWE:4,CW:4,CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
@@ -3999,33 +3999,33 @@
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
+		<model name='Mk. XV'>
+			<availability>FS.PMM:8,ROS:4,FS.CMM:8,FS.DMM:8,FS:6,FS.CrMM:8</availability>
+		</model>
 		<model name='XIVs'>
 			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
 		</model>
 		<model name='XII'>
 			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
-		<model name='Mk. XV'>
-			<availability>FS.PMM:8,ROS:4,FS.CMM:8,FS.DMM:8,FS:6,FS.CrMM:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,CP:5,TC:5,Periphery:4,DC:4</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:1-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
-		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:4,IS:3,FS:4,Periphery:3</availability>
+		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:1-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
@@ -4033,12 +4033,12 @@
 		<model name='CHP-3N'>
 			<availability>ROS:6</availability>
 		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4</availability>
+		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CHH:1,RD:1,LA:2,MERC.SI:4,MERC:2,BAN:2</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,RD:6,CLAN:8</availability>
@@ -4046,10 +4046,6 @@
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>RD:2,ROS:4,IS:3,MERC:2,BAN:4,Periphery:2</availability>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
@@ -4058,22 +4054,36 @@
 			<roles>missile_artillery</roles>
 			<availability>RD:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='(ERML)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(CASE)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(ERML)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>MOC:1-,RA.OA:2-,FVC:1,RD:3-,LA:1-,ROS:2-,TC:1-,Periphery:1,DC:4-</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,RA.OA:10,FVC:5,PIR:5,MH:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
 		<model name='CGR-3K'>
 			<availability>MERC:1-,DC:2-</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>FVC:2-,Periphery:2-</availability>
+		<model name='CGR-3Kr'>
+			<availability>CC:4,RD:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='CGR-C'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>RA.OA:2-,FVC:2-,Periphery:2-</availability>
@@ -4081,71 +4091,61 @@
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,RA.OA:10,FVC:5,PIR:5,MH:5,Periphery:4</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-C'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>CC:4,RD:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:2,OP:10,MERC:3,FS:3,CP:10,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
-		<model name='F-11'>
-			<availability>CC:4,MOC:4,OP:8,MERC:6,CP:8,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
-		</model>
-		<model name='F-14-S'>
-			<availability>DTA:8,OP:8,RF:8,FWL:8,MH:4,MSC:8,MERC:5,RCM:8,DA:8,CP:8</availability>
-		</model>
-		<model name='OF-17A-R'>
-			<roles>recon</roles>
-			<availability>ROS:4,FWL:3:3139,MSC:6,CP:3</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:1-,DTA:1-,OP:1-,RF:1-,FWL:1-,MSC:1-,MERC:1-,DA:1-,RCM:1-,CP:1-,Periphery:1-</availability>
+		<model name='F-13'>
+			<availability>DTA:4,CC:4,OP:4,ROS:4,FWL:4,MSC:4,FS:4,CP:4,MERC:4</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,DTA:2,OP:2,FVC:2,RF:2,FWL:2,MSC:2,MERC:2,DA:2,RCM:2,CP:2,Periphery:2</availability>
 		</model>
-		<model name='F-13'>
-			<availability>DTA:4,CC:4,OP:4,ROS:4,FWL:4,MSC:4,FS:4,CP:4,MERC:4</availability>
-		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>FVC:2,Periphery:2</availability>
 		</model>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:1-,DTA:1-,OP:1-,RF:1-,FWL:1-,MSC:1-,MERC:1-,DA:1-,RCM:1-,CP:1-,Periphery:1-</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:4,MOC:4,OP:8,MERC:6,CP:8,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
+		</model>
+		<model name='OF-17A-R'>
+			<roles>recon</roles>
+			<availability>ROS:4,FWL:3:3139,MSC:6,CP:3</availability>
+		</model>
+		<model name='F-14-S'>
+			<availability>DTA:8,OP:8,RF:8,FWL:8,MH:4,MSC:8,MERC:5,RCM:8,DA:8,CP:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>DTA:3,CDS:4,LA:3,ROS:5,CNC:5,FWL:3:3139,FS:3,CP:4,RCM:3,DC:3</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>DTA:6,CDS:6,LA:6,ROS:6,FWL:4:3139,FS:6,RCM:6,CP:5,DC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -4165,23 +4165,23 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
-		<model name='CHP-W7T'>
-			<availability>TC:8</availability>
-		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,BAN:3,Periphery:2-</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
 		</model>
-		<model name='CHP-W8'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2,BAN:2</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,BAN:3,Periphery:2-</availability>
+		<model name='CHP-W7T'>
+			<availability>TC:8</availability>
+		</model>
+		<model name='CHP-W8'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='CHP-W7'>
+			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
@@ -4195,13 +4195,6 @@
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:1,RF:3,FWL:3,MSC:3,MERC:1,CP:3,CDP:2,Periphery:2</availability>
-		<model name='CDA-3P'>
-			<availability>RF:8,FWL:8,MSC:8,CP:8</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:4,MOC:4,FWL:2,MERC:4,CP:2</availability>
-		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
 			<availability>CC:6,FWL:4,MERC:6,CP:4</availability>
@@ -4210,9 +4203,16 @@
 			<roles>recon</roles>
 			<availability>FWL:8,IS:6,MERC:6,CP:8,Periphery:4</availability>
 		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:4,MOC:4,FWL:2,MERC:4,CP:2</availability>
+		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:2,IS:4,CP:2</availability>
+		</model>
+		<model name='CDA-3P'>
+			<availability>RF:8,FWL:8,MSC:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cizin Hover Tank' unitType='Tank'>
@@ -4246,20 +4246,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -4279,14 +4279,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -4294,29 +4291,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -4327,8 +4327,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -4336,18 +4339,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -4356,15 +4365,6 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -4385,14 +4385,14 @@
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -4400,8 +4400,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -4413,13 +4413,13 @@
 	</chassis>
 	<chassis name='Claymore' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='Interceptor'>
-			<roles>assault</roles>
-			<availability>LA:3</availability>
-		</model>
 		<model name='V3'>
 			<roles>assault</roles>
 			<availability>LA:4,ROS:8,FS:4</availability>
+		</model>
+		<model name='Interceptor'>
+			<roles>assault</roles>
+			<availability>LA:3</availability>
 		</model>
 		<model name='(3054)'>
 			<roles>assault</roles>
@@ -4437,47 +4437,47 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:2,MOC:2,FS:2,MERC:1,CDP:2,TC:2,Periphery:3,FVC:2,RF:2,LA:2,ROS:2,DA:2,RCM:1</availability>
-		<model name='CLNT-2-3UL'>
-			<availability>CC:8,MOC:4,TC:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
-		</model>
-		<model name='CLNT-5U'>
-			<roles>spotter</roles>
-			<availability>LA:8,General:6,MERC:8</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:2,General:6</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
 		</model>
+		<model name='CLNT-5U'>
+			<roles>spotter</roles>
+			<availability>LA:8,General:6,MERC:8</availability>
+		</model>
+		<model name='CLNT-2-3UL'>
+			<availability>CC:8,MOC:4,TC:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>MOC:4,IS:4</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
+			<availability>MOC:2,IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>MOC:2,IS:2</availability>
+			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra' unitType='Mek'>
 		<availability>LA:6,ROS:4,MH:4,MERC:3</availability>
-		<model name='CBR-03'>
-			<roles>fire_support</roles>
-			<availability>LA:8,General:6</availability>
-		</model>
 		<model name='CBR-02'>
 			<roles>fire_support</roles>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CBR-03'>
+			<roles>fire_support</roles>
+			<availability>LA:8,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
@@ -4502,53 +4502,53 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
-		<model name='COM-1A'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>FVC:1-,Periphery:1-</availability>
+			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
 		</model>
-		<model name='COM-7B'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>LA:8,ROS:8</availability>
+			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
 		</model>
 		<model name='COM-2Dr'>
 			<roles>recon</roles>
 			<availability>LA:5,MERC:5,Periphery:5</availability>
 		</model>
-		<model name='COM-7S'>
+		<model name='COM-7B'>
 			<roles>recon</roles>
-			<availability>LA:8,MERC:8</availability>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 		<model name='COM-8S'>
 			<availability>LA:6,MERC:4</availability>
 		</model>
-		<model name='COM-5S'>
+		<model name='COM-1A'>
 			<roles>recon</roles>
-			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
+			<availability>FVC:1-,Periphery:1-</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
 			<availability>Periphery:1-</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,FVC:2,LA:3,ROS:3,IS:2,FWL:2,FS:3,CP:2,TC:2,DC:2,Periphery:2</availability>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:8,FWL:6,MERC:6,CP:6</availability>
+		<model name='(Standard)'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='(Upgrade) (Laser)'>
 			<availability>LA:6,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>Periphery:2-</availability>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:8,FWL:6,MERC:6,CP:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:2,IS:2</availability>
@@ -4559,11 +4559,11 @@
 	</chassis>
 	<chassis name='Condor Multi-Purpose Tank' unitType='Tank'>
 		<availability>ROS:5</availability>
-		<model name='(Reactive)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Reactive)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -4593,24 +4593,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CLAN:4,BAN:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CWE:1,CHH:1,MERC.WD:1,CW:1,CJF:2,RA:1</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -4632,36 +4632,36 @@
 	</chassis>
 	<chassis name='Constable Pacification Suit' unitType='BattleArmor'>
 		<availability>RD:3</availability>
-		<model name='(LMG)' mechanized='true'>
+		<model name='(SRM)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(ECM)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)' mechanized='true'>
+		<model name='(LMG)' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Sensors)' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Sensors)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corax' unitType='Aero'>
@@ -4678,17 +4678,17 @@
 		<model name='CRX-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='CRX-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='CRX-OR'>
-			<availability>RA.OA:4,CLAN:8</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='CRX-OD'>
+			<availability>General:5</availability>
+		</model>
 		<model name='CRX-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='CRX-OR'>
+			<availability>RA.OA:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
@@ -4699,8 +4699,14 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
-		<model name='CSR-V18'>
-			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
+		</model>
+		<model name='CSR-12D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>ROS:4,CLAN:6,FS:4,MERC:4,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>FVC:1,Periphery:1</availability>
@@ -4708,14 +4714,8 @@
 		<model name='CSR-V12'>
 			<availability>BAN:4,Periphery:2-</availability>
 		</model>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>ROS:4,CLAN:6,FS:4,MERC:4,BAN:2</availability>
-		</model>
-		<model name='CSR-12D'>
-			<availability>FS:8</availability>
+		<model name='CSR-V18'>
+			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -4739,9 +4739,6 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='XR'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='G'>
 			<availability>CHH:6,General:4</availability>
 		</model>
@@ -4751,50 +4748,53 @@
 		<model name='X'>
 			<availability>CJF:4</availability>
 		</model>
+		<model name='XR'>
+			<availability>CJF:8</availability>
+		</model>
 		<model name='X 3'>
 			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,CW:4,CJF:5,CWIE:4</availability>
-		<model name='H'>
-			<availability>General:5</availability>
-		</model>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>CWE:3,CW:3,CJF:3,CWIE:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
+		<model name='I'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<availability>CWE:3,CW:3,CJF:3,CWIE:3</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
 		</model>
-		<model name='I'>
+		<model name='H'>
+			<availability>General:5</availability>
+		</model>
+		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -4803,12 +4803,12 @@
 			<roles>raider</roles>
 			<availability>ROS:8,CLAN:4,FWL:8,MERC:8,CP:8,BAN:2,DC:6</availability>
 		</model>
+		<model name='CRB-C'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CRB-27'>
 			<roles>raider</roles>
 			<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
-		</model>
-		<model name='CRB-C'>
-			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Crane Heavy Transport' unitType='VTOL'>
@@ -4823,42 +4823,45 @@
 		<model name='(Standard)'>
 			<availability>ROS:8,FWL:8,CLAN.IS:8,MSC:8,FS:8,CP:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CC:8,CDS:4,CNC:4,MERC:8,CP:4,DC:8</availability>
+		<model name='4'>
+			<availability>CDS:8,ROS:8,MERC:6,CP:8,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:8,ROS:8,MERC:6,CP:8,CJF:8</availability>
+		<model name='2'>
+			<availability>CC:8,CDS:4,CNC:4,MERC:8,CP:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,CP:4,RA:4</availability>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:3,CW:5,ROS:3,CLAN:4,CP:3,CJF:3,RA:3,CWIE:5</availability>
-		<model name='CRK-5003-3'>
-			<availability>ROS:8</availability>
+		<model name='CRK-5004-1'>
+			<availability>ROS:6</availability>
+		</model>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='CRK-5005-1'>
 			<availability>ROS:8</availability>
@@ -4866,20 +4869,17 @@
 		<model name='CRK-5003-1'>
 			<availability>ROS:4,CLAN:6,BAN:8</availability>
 		</model>
-		<model name='CRK-5004-1'>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='CRK-5003-3'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
 		<availability>OP:4,MERC:4,CP:4,Periphery:4,DTA:4,RF:4,Periphery.MW:4,ROS:3,Periphery.ME:4,FWL:4,MSC:4,DA:4,RCM:4</availability>
-		<model name='CNS-5M'>
-			<availability>PIR:4,IS:8</availability>
-		</model>
 		<model name='CNS-3M'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CNS-5M'>
+			<availability>PIR:4,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
@@ -4890,28 +4890,28 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CDS:2,CNC:2,CP:2,RA:5,CWIE:2</availability>
-		<model name='D'>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
 			<availability>General:4</availability>
 		</model>
 		<model name='U'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
-		<model name='C'>
+		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
+		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4921,67 +4921,67 @@
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8,CP:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>MOC:4,IS:4,DC:8</availability>
 		</model>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>CC:8,MOC:8,ROS:6,CNC:8,FWL:8,MERC:8,CP:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CLAN:5,IS:6,Periphery:5</availability>
-		<model name='CRD-4D'>
-			<availability>FVC:8,FS:8</availability>
-		</model>
-		<model name='CRD-2R'>
-			<availability>FVC:4,ROS:5,CLAN:4,FWL:5,IS:4,MERC:5,CP:5,BAN:2</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>ROS:4,MERC:4</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>MERC:6,DC:8</availability>
-		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
+		<model name='CRD-8S'>
+			<availability>LA:8,FS:4</availability>
 		</model>
 		<model name='CRD-7L'>
 			<availability>CC:8</availability>
 		</model>
-		<model name='CRD-5S'>
-			<availability>LA:4,MERC:4</availability>
-		</model>
 		<model name='CRD-3R'>
 			<availability>BAN:1,Periphery:2-</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:2,MOC:4</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>DTA:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:5:3139,MH:4,MSC:5,MERC:2,RCM:5,CP:5</availability>
-		</model>
-		<model name='CRD-8S'>
-			<availability>LA:8,FS:4</availability>
 		</model>
 		<model name='CRD-5M'>
 			<availability>CC:1,MOC:4,FWL:8,FS:1,MERC:4,CP:8,CDP:4,DC:1,TC:4</availability>
 		</model>
+		<model name='CRD-7W'>
+			<availability>DTA:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:5:3139,MH:4,MSC:5,MERC:2,RCM:5,CP:5</availability>
+		</model>
 		<model name='CRD-4K'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>ROS:4,MERC:4</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:2,MOC:4</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>MERC:6,DC:8</availability>
 		</model>
 		<model name='CRD-8L'>
 			<availability>CC:6</availability>
 		</model>
+		<model name='CRD-2R'>
+			<availability>FVC:4,ROS:5,CLAN:4,FWL:5,IS:4,MERC:5,CP:5,BAN:2</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
+		</model>
+		<model name='CRD-4D'>
+			<availability>FVC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cuchulainn Support Armor' unitType='BattleArmor'>
 		<availability>CWE:3:3140,MERC.KH:5,MERC.WD:4,CW:3:3140,LA:3,MERC:4,CWIE:5</availability>
-		<model name='(IS Model)' mechanized='true'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(Clan Model)' mechanized='true'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(IS Model)' mechanized='true'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cuirass' unitType='Mek'>
@@ -4989,69 +4989,69 @@
 		<model name='CDR-1X'>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDR-2X'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CDR-2BC'>
 			<availability>General:6</availability>
+		</model>
+		<model name='CDR-2X'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cutlass' unitType='Aero'>
 		<availability>FS:7</availability>
-		<model name='CUT-01E'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='CUT-01E'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,Periphery:2,TC:2,RA.OA:2,RD:4,LA:3,ROS:3,FWL:2,DC:5</availability>
+		<model name='CP-11-G'>
+			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:4,CP:4,CDP:4,TC:4,Periphery:2</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
+		</model>
+		<model name='CP-11-B'>
+			<availability>CC:8,MOC:6,IS:4,MERC:8,DC:8</availability>
+		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
 			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,CP:3,DC:5</availability>
 		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>RD:5,IS:5</availability>
-		</model>
 		<model name='CP-11-H'>
 			<availability>FVC:6,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:6</availability>
-		</model>
-		<model name='CP-10-Z'>
-			<availability>General:2-</availability>
 		</model>
 		<model name='CP-11-C3'>
 			<roles>spotter</roles>
 			<availability>FS:4,DC:4</availability>
 		</model>
-		<model name='CP-11-A'>
-			<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:4,CP:4,CDP:4,TC:4,Periphery:2</availability>
-		</model>
-		<model name='CP-11-G'>
-			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:1</availability>
 		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
-		<model name='CP-11-B'>
-			<availability>CC:8,MOC:6,IS:4,MERC:8,DC:8</availability>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>RD:5,IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:5,MERC.WD:3,ROS:3,CWIE:4</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='4'>
 			<availability>General:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
@@ -5072,6 +5072,10 @@
 			<roles>recon,escort</roles>
 			<availability>CC:4,MERC:4,TC:2,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,escort</roles>
+			<availability>CC:4,ROS:4,General:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -5080,57 +5084,53 @@
 			<roles>recon,escort</roles>
 			<availability>MOC:4,CDP:4,TC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon,escort</roles>
-			<availability>CC:4,ROS:4,General:4,MERC:4,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:6,IS:5</availability>
 		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Multipurpose VTOL' unitType='VTOL'>
 		<availability>LA:7,CLAN:5,IS:6,Periphery:5</availability>
-		<model name='(Gunship)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Gunship)'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='DI Schmitt Tank' unitType='Tank'>
 		<availability>LA:6,ROS:4,MERC:4,FS:4</availability>
-		<model name='(Targetting Computer)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Targetting Computer)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='DARO-1'>
-			<availability>General:6,FS:8</availability>
-		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='DARO-1C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1'>
+			<availability>General:6,FS:8</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1A'>
 			<availability>General:7</availability>
@@ -5138,11 +5138,11 @@
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01r'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DAI-01'>
 			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='DAI-01r'>
 			<availability>General:4</availability>
 		</model>
 		<model name='DAI-02'>
@@ -5156,13 +5156,13 @@
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
 		<availability>RD:2,DC:3+</availability>
-		<model name='67-K'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='67-K2'>
 			<roles>support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='67-K'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
@@ -5170,52 +5170,52 @@
 		<model name='DMO-4K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='DMO-5K'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
+		<model name='DMO-2K'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='DMO-1K'>
 			<availability>General:8,DC:2</availability>
 		</model>
-		<model name='DMO-2K'>
-			<availability>DC:6</availability>
+		<model name='DMO-5K'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,FS:4+,MERC:4+,CP:5,BAN:3,CWIE:6,CWE:6,MERC.WD:6,RD:5,CDS:5,CW:6,LA:4+,ROS:4+,CNC:5,CJF:5,DC:4+</availability>
-		<model name='E'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:5,CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CWE:5,CDS:7,CW:5,General:8,CP:7,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:5,CW:5,General:7,CJF:8,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CWE:2,CHH:2,RD:2,CW:2,CNC:2,CLAN:1,General:2,CP:2,CJF:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:5,CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:8,RD:4,CW:8,CNC:4,General:5,CP:4,CJF:6,CWIE:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CWE:5,CDS:5,CW:5,General:4,CP:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:8,RD:4,CW:8,CNC:4,General:5,CP:4,CJF:6,CWIE:7</availability>
+		<model name='E'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='A'>
+			<availability>CWE:5,CW:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -5238,11 +5238,11 @@
 			<roles>marine</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_aircraft</roles>
@@ -5251,24 +5251,21 @@
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>LA:5,ROS:4,MH:4,FS:6,MERC:4</availability>
-		<model name='DRT-3S'>
-			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='DRT-4S'>
-			<availability>LA:1,MH:4,MERC:4,FS:2</availability>
-		</model>
 		<model name='DRT-6T'>
 			<availability>LA:6,ROS:8,FS:6,MERC:6</availability>
+		</model>
+		<model name='DRT-3S'>
+			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:3</availability>
 		</model>
+		<model name='DRT-4S'>
+			<availability>LA:1,MH:4,MERC:4,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:3,ROS:3,FS:7,CDP:4</availability>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:1,CDP:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:4,General:5,CDP:3</availability>
@@ -5276,6 +5273,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>FVC:4,General:5,CDP:3</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -5285,13 +5286,18 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:1,CDP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,MERC.WD:2,RD:4,IS:3+,CJF:2,BAN:2</availability>
+		<model name='H'>
+			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:7,RD:6,General:2,CWIE:5</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>RD:2,CDS:5,General:3,CP:5,CJF:4</availability>
@@ -5299,21 +5305,18 @@
 		<model name='E'>
 			<availability>CWE:4,CDS:3,CW:4,General:2,CP:3</availability>
 		</model>
+		<model name='G'>
+			<availability>General:4</availability>
+		</model>
+		<model name='K'>
+			<availability>RD:4,General:2</availability>
+		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CWE:4,CHH:8,RD:4,CDS:6,CW:4,CNC:4,General:5,CP:5</availability>
 		</model>
-		<model name='H'>
-			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<availability>General:4</availability>
-		</model>
 		<model name='D'>
 			<availability>CWE:8,CHH:8,RD:8,CDS:4,CW:8,CNC:8,General:6,CP:6,CWIE:8</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:7,RD:6,General:2,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,RD:8,CDS:7,CNC:7,General:6,CP:7,CWIE:7</availability>
@@ -5321,17 +5324,14 @@
 		<model name='B'>
 			<availability>CWE:7,CHH:6,RD:7,CDS:6,CW:7,General:5,CP:6,CWIE:7</availability>
 		</model>
-		<model name='K'>
-			<availability>RD:4,General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
 		<availability>RD:4,CDS:5,LA:3,ROS:4,CNC:4,IS:3,FS:3,CP:4,RA:4,DC:3</availability>
-		<model name='3'>
-			<availability>MERC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:3</availability>
+		</model>
+		<model name='3'>
+			<availability>MERC:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:8,IS:6</availability>
@@ -5354,19 +5354,19 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2:3139,MSC:4,CP:2</availability>
-		<model name='DFC-OD'>
-			<roles>ground_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='DFC-OB'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='DFC-OD'>
+			<roles>ground_support</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OB'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -5377,11 +5377,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='DFN-3T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='DFN-3S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='DFN-3T'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Deimos' unitType='Mek'>
@@ -5392,46 +5392,46 @@
 	</chassis>
 	<chassis name='Deimos' unitType='Mek' omni='Clan'>
 		<availability>RA:8</availability>
-		<model name='Prime'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='S'>
-			<availability>General:5</availability>
-		</model>
-		<model name='E'>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='S'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CNC:5,FWL:8,CJF:2,DC:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>Periphery:2</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,IS:8,FS:8,CP:8,DC:8,TC:8,CWIE:4</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>FVC:4,DC:8,Periphery:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
 		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>Periphery:2</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>FVC:4,DC:8,Periphery:4</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -5440,15 +5440,15 @@
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
 		<availability>LA:6,ROS:4,MERC:4,CWIE:4</availability>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MML)'>
 			<availability>LA:5,ROS:5,CWIE:5</availability>
 		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:4,CWIE:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -5464,17 +5464,17 @@
 	</chassis>
 	<chassis name='Demon Medium Tank' unitType='Tank'>
 		<availability>ROS:6-</availability>
-		<model name='(Standard)'>
+		<model name='(Armor)'>
 			<roles>urban</roles>
-			<availability>General:8</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Rifle)'>
 			<roles>urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Armor)'>
+		<model name='(Standard)'>
 			<roles>urban</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
@@ -5491,17 +5491,17 @@
 		<model name='DV-8D'>
 			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
 		</model>
-		<model name='DV-6Mr'>
-			<availability>General:1</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+		<model name='DV-6M'>
+			<availability>CLAN:4,Periphery:2-</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
-		<model name='DV-6M'>
-			<availability>CLAN:4,Periphery:2-</availability>
+		<model name='DV-7D'>
+			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='DV-6Mr'>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Destrier Siege Vehicle' unitType='Tank'>
@@ -5519,14 +5519,14 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:3,FVC:6,LA:6,ROS:5,FS:6,MERC:3,TC:4</availability>
-		<model name='DVS-1D'>
-			<availability>FVC:8,TC:8</availability>
+		<model name='DVS-3'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='DVS-3'>
-			<availability>LA:4,ROS:4,FS:4</availability>
+		<model name='DVS-1D'>
+			<availability>FVC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -5543,6 +5543,9 @@
 	</chassis>
 	<chassis name='Diomede' unitType='Mek'>
 		<availability>CC:7,MOC:7,LA:7,ROS:7,FWL:7,IS:5,MH:7,MERC:7,CP:7,Periphery:5</availability>
+		<model name='D-M3D-M'>
+			<availability>General:4</availability>
+		</model>
 		<model name='D-M3D-3 ConstructionMech'>
 			<roles>support</roles>
 			<availability>CC:4,MOC:4,LA:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4</availability>
@@ -5550,9 +5553,6 @@
 		<model name='D-M3D-4 DemolitionMech'>
 			<roles>support</roles>
 			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,MH:8,MERC:8,CP:8</availability>
-		</model>
-		<model name='D-M3D-M'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dola' unitType='Mek'>
@@ -5567,17 +5567,17 @@
 	</chassis>
 	<chassis name='Doloire' unitType='Mek' omni='IS'>
 		<availability>ROS:7,MERC:2</availability>
-		<model name='DLR-OB'>
+		<model name='DLR-OC'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='DLR-OD'>
+		<model name='DLR-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='DLR-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='DLR-OC'>
-			<roles>spotter</roles>
+		<model name='DLR-OD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='DLR-O'>
@@ -5586,12 +5586,12 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:6,RD:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau II Assault Interceptor' unitType='Dropship'>
@@ -5619,28 +5619,28 @@
 	</chassis>
 	<chassis name='Dragon II' unitType='Mek'>
 		<availability>DC:7</availability>
-		<model name='DRG-11K'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='DRG-11R'>
 			<roles>missile_artillery</roles>
 			<availability>General:2+</availability>
 		</model>
+		<model name='DRG-11K'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:3,DC:2</availability>
-		<model name='DRG-5N'>
-			<availability>Periphery.Deep:4,MERC:4,DC:4,Periphery:6</availability>
-		</model>
 		<model name='DRG-7N'>
 			<availability>MERC:8,DC:8</availability>
 		</model>
-		<model name='DRG-5Nr'>
-			<availability>MERC:4,DC:4</availability>
-		</model>
 		<model name='DRG-1N'>
 			<availability>Periphery:1</availability>
+		</model>
+		<model name='DRG-5N'>
+			<availability>Periphery.Deep:4,MERC:4,DC:4,Periphery:6</availability>
+		</model>
+		<model name='DRG-5Nr'>
+			<availability>MERC:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
@@ -5649,18 +5649,14 @@
 			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:7,RD:7,CDS:8,General:6,CP:8,CJF:8,RA:7,CWIE:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CW:5,General:4,CP:5,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>RD:5,General:2</availability>
-		</model>
 		<model name='A'>
 			<availability>RD:8,CDS:8,General:6,CP:8,CJF:8,CWIE:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:6,CDS:6,CW:6,CNC:5,General:4,CP:5,CJF:6,CWIE:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:6,CDS:9,General:8,CP:9,CJF:9</availability>
@@ -5668,16 +5664,20 @@
 		<model name='H'>
 			<availability>CNC:5,CLAN:3,General:2,CP:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:6,RD:6,CDS:6,CW:6,CNC:5,General:4,CP:5,CJF:6,CWIE:6</availability>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CW:5,General:4,CP:5,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CWE:7,RD:7,CDS:6,CW:7,General:5,CP:6,CJF:6</availability>
 		</model>
-		<model name='I'>
-			<availability>General:2</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>RD:5,General:2</availability>
 		</model>
-		<model name='U'>
+		<model name='D'>
+			<availability>CHH:7,RD:7,CDS:8,General:6,CP:8,CJF:8,RA:7,CWIE:7</availability>
+		</model>
+		<model name='I'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5696,11 +5696,11 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>LA:5,ROS:2,FS:4</availability>
-		<model name='(Streak)'>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5728,62 +5728,62 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='EGL-R6'>
-			<availability>General:2-</availability>
-		</model>
 		<model name='EGL-R6b'>
 			<availability>OP:6,FWL:5:3139,MSC:6,RCM:6,CP:5</availability>
 		</model>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>General:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,DTA:6,FWL.MM:7,RF:6,FWL:6,MH:4,FWL.FO:7,MSC:7,MERC:4,DA:5,CP:6</availability>
-		<model name='EGL-3M'>
-			<availability>DTA:5,FWL:5,MSC:5,CP:5</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2,CP:1</availability>
-		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2,CP:1</availability>
+		</model>
+		<model name='EGL-3M'>
+			<availability>DTA:5,FWL:5,MSC:5,CP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Ebony' unitType='Mek'>
 		<availability>MOC:5,CC:4</availability>
-		<model name='MEB-12'>
+		<model name='MEB-10'>
 			<roles>recon</roles>
-			<availability>CC:5</availability>
-		</model>
-		<model name='MEB-11'>
-			<roles>recon</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='MEB-9'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='MEB-10'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='MEB-13'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='MEB-11'>
+			<roles>recon</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='MEB-12'>
+			<roles>recon</roles>
+			<availability>CC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,Periphery:4-</availability>
+		<model name='EFT-7X'>
+			<availability>IS:8,MH:6</availability>
+		</model>
 		<model name='EFT-4J'>
 			<availability>MERC:1-,Periphery:8</availability>
 		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
-		</model>
-		<model name='EFT-7X'>
-			<availability>IS:8,MH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5794,81 +5794,81 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
+		<model name='EST-OD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='EST-OD'>
-			<availability>General:4</availability>
+		<model name='EST-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Eldingar Hover Sled' unitType='Tank'>
 		<availability>CHH:4,RD:5,LA:3,ROS:3,FS:3,MERC:3,CWIE:4</availability>
-		<model name='(Streak)'>
-			<roles>fire_support</roles>
-			<availability>RD:4</availability>
+		<model name='(Standard)'>
+			<availability>RD:8</availability>
 		</model>
 		<model name='&apos;HumHov&apos;'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>RD:8</availability>
+		<model name='(Streak)'>
+			<roles>fire_support</roles>
+			<availability>RD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,CHH:4,MERC.WD:4,CW:4,CLAN:4,CNC:4+,CP:4+</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [AP Gauss]' mechanized='true'>
 			<availability>CWE:2,CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CWE:2,RD:2,CW:2,CWIE:2</availability>
-		</model>
-		<model name='(Fire) [MicroPL]' mechanized='true'>
-			<availability>CWE:2,CHH:2,CW:2,CJF:4</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='[MicroPL]' mechanized='true'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Space) [MicroPL]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CLAN:2,RA:4</availability>
 		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Fire) [Flamer]' mechanized='true'>
 			<availability>CWE:2,CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [MicroPL]' mechanized='true'>
+			<availability>CWE:2,CHH:2,CW:2,CJF:4</availability>
+		</model>
+		<model name='[MicroPL]' mechanized='true'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CWE:2,RD:2,CW:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5879,23 +5879,23 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,LA:4,CNC:5,FWL:4,MH:3,DC:4</availability>
-		<model name='EMP-6D'>
-			<availability>ROS:8,FS:8</availability>
-		</model>
 		<model name='EMP-6L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='EMP-8L'>
-			<availability>CC:5</availability>
-		</model>
-		<model name='EMP-6S'>
-			<availability>LA:8</availability>
+		<model name='EMP-7L'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='EMP-7L'>
-			<availability>CC:6</availability>
+		<model name='EMP-6S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='EMP-8L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='EMP-6D'>
+			<availability>ROS:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
@@ -5904,6 +5904,10 @@
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4,FS:4</availability>
 		</model>
+		<model name='END-6Q'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4</availability>
+		</model>
 		<model name='END-6S'>
 			<roles>urban</roles>
 			<availability>LA:2,MERC:2</availability>
@@ -5911,21 +5915,17 @@
 		<model name='END-6Sr'>
 			<availability>LA:3,ROS:8,MERC:3</availability>
 		</model>
-		<model name='END-6Q'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:5,ROS:4,MERC:5,FS:7</availability>
-		<model name='ENF-6Ma'>
-			<availability>FVC:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-6Ma'>
+			<availability>FVC:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='ENF-6T'>
 			<availability>FS:4</availability>
@@ -5936,20 +5936,20 @@
 		<model name='ENF-7C3BS'>
 			<availability>FS:1</availability>
 		</model>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
+		</model>
 		<model name='ENF-7D'>
 			<availability>FS:5</availability>
-		</model>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
 		<availability>FVC:5,FS:4,MERC:2,CDP:1,TC:1</availability>
-		<model name='ENF-4R'>
-			<availability>FVC:1-</availability>
-		</model>
 		<model name='ENF-5D'>
 			<availability>FVC:8,FS:8,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ENF-4R'>
+			<availability>FVC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Engineering Vehicle' unitType='Tank'>
@@ -5981,14 +5981,6 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CWE:4+,CHH:6+,RD:3+,CDS:4+,CW:4+,CNC:3+,CP:3+,CWIE:4+</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>CHH:8</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
@@ -5997,38 +5989,46 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>CHH:8</availability>
+		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CDS:2,ROS:1,CP:2,RA:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8,DC:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,RA.OA:2,LA:5,IS:5,FWL:5,FS:2,CP:5,Periphery:2,TC:3,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:4,FS:6</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>FS:4,MERC:2</availability>
-		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -6044,11 +6044,11 @@
 	</chassis>
 	<chassis name='Exhumer' unitType='Mek'>
 		<availability>DC.BR:4,MERC:3,DC:2</availability>
-		<model name='EXR-2X'>
-			<availability>General:8</availability>
-		</model>
 		<model name='EXR-3P'>
 			<availability>General:6</availability>
+		</model>
+		<model name='EXR-2X'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -6064,13 +6064,13 @@
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
 		<availability>MOC:8,CC:4</availability>
-		<model name='EYL-45A'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='EYL-45B'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='EYL-45A'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eyrie' unitType='Mek'>
@@ -6081,27 +6081,27 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:5,MERC:4</availability>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CC:5</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='(Support) [King David]' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -6116,12 +6116,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,CP:8</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>ROS:8,FWL:4:3139,MSC:6,CP:4</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -6132,11 +6132,11 @@
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-8R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='FLC-9R'>
 			<availability>General:8</availability>
+		</model>
+		<model name='FLC-8R'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -6148,39 +6148,33 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:2</availability>
-		<model name='(Upgrade)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>cruiser</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Upgrade)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Fennec' unitType='Mek'>
 		<availability>FS:5</availability>
-		<model name='FEC-3C'>
-			<availability>General:4</availability>
+		<model name='FEC-1CM'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='FEC-5CM'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='FEC-1CM'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='FEC-3C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SRM]' mechanized='false'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[SL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='&apos;Longshot&apos;' mechanized='false'>
 			<availability>General:4</availability>
@@ -6188,32 +6182,38 @@
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[SRM]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir II Assault Battle Armor' unitType='BattleArmor'>
 		<availability>LA:5</availability>
-		<model name='(LRM)' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Med. Laser)' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(AI)' mechanized='false'>
 			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(MRR)' mechanized='false'>
@@ -6222,51 +6222,51 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,MERC.WD:4,MERC.KH:2+,CHH:1,RD:1,CW:4,CJF:2,CWIE:4</availability>
-		<model name='B'>
-			<availability>CWE:6,RD:6,CDS:7,CW:6,CNC:4,General:5,CP:5,CJF:7,CWIE:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:2,CP:5,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:3,CDS:6,CW:3,CNC:5,General:4,CP:5,CWIE:3</availability>
-		</model>
-		<model name='H'>
-			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:7,CNC:4,General:6,CP:5,CJF:7</availability>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:6,RD:6,CDS:7,CW:6,CNC:6,General:4,CP:6,CJF:6</availability>
 		</model>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		<model name='A'>
+			<availability>CDS:7,CNC:4,General:6,CP:5,CJF:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:6,CDS:7,CW:6,CNC:4,General:5,CP:5,CJF:7,CWIE:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:2,CP:5,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CWE:3,CDS:6,CW:3,CNC:5,General:4,CP:5,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fensalir Combat WiGE' unitType='Tank'>
 		<availability>MERC.KH:4,LA:6,CWIE:6</availability>
+		<model name='(Infantry)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(HAG)'>
 			<availability>MERC.KH:8,General:2,CWIE:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>LA:8,General:4</availability>
 		</model>
-		<model name='(Infantry)'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>Periphery.R:1,LA:2,ROS:1,Periphery.HR:1,Periphery.MW:1,Periphery.CM:1,FWL:1,FS:2,CP:1</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='&apos;Fermi&apos;'>
+			<roles>apc</roles>
+			<availability>FS:5</availability>
 		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
@@ -6276,9 +6276,9 @@
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:2</availability>
 		</model>
-		<model name='&apos;Fermi&apos;'>
-			<roles>apc</roles>
-			<availability>FS:5</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -6305,63 +6305,15 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(LBX20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(UAC20)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
-		</model>
 		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -6369,9 +6321,57 @@
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(LBX2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LBX10)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
@@ -6380,55 +6380,55 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CNC:3,CP:3,CJF:7</availability>
-		<model name='Prime'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CWE:6,RD:6,CW:6,General:8,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CWE:6,RD:6,CW:6,General:8,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:6,MERC:6,FS:6</availability>
-		</model>
 		<model name='ALM-10D'>
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -6450,27 +6450,23 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:6,IS:5,Periphery.Deep:5,Periphery:7</availability>
-		<model name='FS9-M3'>
-			<roles>spotter</roles>
-			<availability>LA:3,IS:2,TC:2,Periphery:2</availability>
+		<model name='FS9-S2'>
+			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4,CP:3</availability>
 		</model>
 		<model name='FS9-M4'>
 			<availability>OP:4,FVC:3,RF:4,LA:4,ROS:4,IS:4,MH:3,FS:4,DA:4,TC:3</availability>
+		</model>
+		<model name='FS9-M2'>
+			<roles>incendiary</roles>
+			<availability>LA:4,IS:3,MH:3,TC:3,Periphery:3</availability>
+		</model>
+		<model name='FS9-C'>
+			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:1-,Periphery:2-</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
-		</model>
-		<model name='FS9-C'>
-			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
-		</model>
-		<model name='FS9-S2'>
-			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4,CP:3</availability>
 		</model>
 		<model name='FS9-P'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -6478,56 +6474,60 @@
 		<model name='FS9-S3'>
 			<availability>LA:6,ROS:5,FWL:3,FS:3,MERC:3,CP:3</availability>
 		</model>
-		<model name='FS9-M2'>
-			<roles>incendiary</roles>
-			<availability>LA:4,IS:3,MH:3,TC:3,Periphery:3</availability>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
 		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
 			<availability>LA:2,General:1,FS:1</availability>
 		</model>
+		<model name='FS9-M3'>
+			<roles>spotter</roles>
+			<availability>LA:3,IS:2,TC:2,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CC:4,FVC:2,LA:5,IS:2,FS:3,MERC:4,DC:7</availability>
-		<model name='FS9-OE'>
+		<model name='FS9-OD'>
 			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OX'>
-			<availability>General:2</availability>
 		</model>
 		<model name='FS9-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='FS9-OH'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='FS9-OD'>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:3,DC:3</availability>
+		</model>
+		<model name='FS9-OB'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OG'>
 			<availability>General:6</availability>
 		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='FS9-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:3,DC:3</availability>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek'>
@@ -6541,18 +6541,18 @@
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='C'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
@@ -6560,51 +6560,51 @@
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>DC.GHO:5,CHH:1,RD:2,CDS:1,LA:4,ROS:2,CLAN:1,FWL:4,MSC:5,CP:2,CJF:2,DC:4</availability>
-		<model name='FLS-9M'>
-			<availability>FWL:6,MSC:8,CP:6</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,LA:8,ROS:6,CLAN:8,FWL:4:3139,MERC.SI:5,MSC:6,CP:4,BAN:8</availability>
+		</model>
+		<model name='FLS-9M'>
+			<availability>FWL:6,MSC:8,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:8,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:4,CLAN.IS:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>IS:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>IS:4,BAN:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2:3139,DA:3,RCM:3</availability>
+		<model name='FLE-19'>
+			<roles>urban</roles>
+			<availability>MOC:4-,CC:4-,MERC:5-,CP:2-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,RCM:4-,DA:4-</availability>
+		</model>
 		<model name='FLE-20'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='FLE-17'>
 			<availability>CC:4,RF:8,ROS:8,FWL:8,MERC:8,RCM:8,DA:8,CP:8,Periphery:6</availability>
-		</model>
-		<model name='FLE-19'>
-			<roles>urban</roles>
-			<availability>MOC:4-,CC:4-,MERC:5-,CP:2-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,RCM:4-,DA:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6615,20 +6615,18 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
@@ -6639,33 +6637,35 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='(2613)'>
-			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(3058)'>
 			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
 			<availability>LA:8,FS:8</availability>
 		</model>
+		<model name='(2613)'>
+			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Fortune Wheeled Assault Vehicle' unitType='Tank'>
 		<availability>RF:4,LA:6,ROS:4</availability>
-		<model name='(Thunderbolt)'>
-			<availability>RF:4,LA:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>LA:6,ROS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Thunderbolt)'>
+			<availability>RF:4,LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Armored Car' unitType='Tank'>
@@ -6673,14 +6673,14 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Interdictor)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(VSP)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Interdictor)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -6722,36 +6722,36 @@
 			<roles>spotter</roles>
 			<availability>LA:5,FS:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CWE:1,CHH:3,RD:3,CW:1,ROS:5,FS:5,MERC:4,CJF:1</availability>
-		<model name='(Fury IIIm)'>
-			<roles>spotter</roles>
-			<availability>FS:3</availability>
+		<model name='(Fury III)'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='CX-17'>
-			<availability>ROS:4</availability>
+		<model name='(Fury IIIm)'>
+			<roles>spotter</roles>
+			<availability>FS:3</availability>
 		</model>
-		<model name='(Fury III)'>
-			<availability>FS:4</availability>
+		<model name='(Royal)'>
+			<availability>ROS:4,CLAN:4,BAN:2</availability>
 		</model>
 		<model name='(C3S)'>
 			<availability>ROS:5,FS:5</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>ROS:4,CLAN:4,BAN:2</availability>
+		<model name='CX-17'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -6771,29 +6771,29 @@
 	</chassis>
 	<chassis name='Fusilier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,MERC:3</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>FS:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fwltur' unitType='Mek'>
 		<availability>IS:5,MERC:4,Periphery:4</availability>
-		<model name='FWL-3R SalvageMech'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='FWL-3V SalvageMech'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='FWL-3R SalvageMech'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='GD Infiltrator Suit' unitType='BattleArmor'>
 		<availability>MERC.KH:5,RF:4,LA:5,ROS:4,MERC:4</availability>
-		<model name='(Mines)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>General:6</availability>
+		<model name='(Remote Sensors)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
@@ -6802,9 +6802,9 @@
 		<model name='(Firedrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Remote Sensors)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:5</availability>
+		<model name='(Mines)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Sensors)' mechanized='true'>
 			<roles>recon</roles>
@@ -6813,10 +6813,6 @@
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
 		<availability>TC:4</availability>
-		<model name='(TDF)'>
-			<roles>recon</roles>
-			<availability>TC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
@@ -6824,14 +6820,18 @@
 		<model name='(ERSL)'>
 			<availability>TC:4</availability>
 		</model>
+		<model name='(TDF)'>
+			<roles>recon</roles>
+			<availability>TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CWE:2,CW:2,ROS:2,RA:2</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CWE:6,CW:6,ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6842,25 +6842,18 @@
 	</chassis>
 	<chassis name='Gallant' unitType='Mek'>
 		<availability>MOC:4,LA:6,ROS:6,CNC:4,IS:4,FS:6,MERC:4,CP:4,CDP:4,CWIE:4,TC:4</availability>
-		<model name='GLT-8-0'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
-		</model>
 		<model name='GLT-10-0'>
 			<availability>LA:3,ROS:3,FS:5,MERC:3</availability>
 		</model>
 		<model name='GLT-7-0'>
 			<availability>General:8,FS:4</availability>
 		</model>
+		<model name='GLT-8-0'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:1,LA:1,IS:1,DC:1,Periphery:1</availability>
-		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
-		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3,CP:3</availability>
 		</model>
@@ -6868,40 +6861,50 @@
 			<roles>recon</roles>
 			<availability>MOC:5,RA.OA:3,RD:5,LA:5,IS:3,FWL:7,FS:5,MERC:5,CP:7,TC:5,DC:4,Periphery:4</availability>
 		</model>
+		<model name='GAL-200'>
+			<availability>MOC:1,LA:1,IS:1,DC:1,Periphery:1</availability>
+		</model>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>MERC.WD:5,ROS:4,MH:4,MERC:4,CWIE:5</availability>
-		<model name='GAL-2GLS'>
-			<availability>IS:4-,Periphery:4-</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
 		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2,ROS:2,MERC:2</availability>
 		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		<model name='GAL-2GLS'>
+			<availability>IS:4-,Periphery:4-</availability>
 		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8-,CWIE:8</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gambit' unitType='Mek'>
 		<availability>IS:4</availability>
-		<model name='GBT-1G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GBT-1L'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='GBT-1G'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:4,FS:6,MERC:4,CDP:4,TC:4</availability>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A2'>
 			<availability>FS:6</availability>
 		</model>
@@ -6910,9 +6913,6 @@
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
-		</model>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Garrot Superheavy Transport' unitType='VTOL'>
@@ -6931,16 +6931,16 @@
 	</chassis>
 	<chassis name='Gauntlet' unitType='Mek' omni='IS'>
 		<availability>LA:7</availability>
-		<model name='GTL-1O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GTL-1OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='GTL-1OB'>
-			<availability>General:7</availability>
+		<model name='GTL-1O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='GTL-1OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='GTL-1OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -6960,64 +6960,64 @@
 		<model name='GST-50'>
 			<availability>DTA:6,OP:6,FWL:6:3139,MSC:6,CP:6</availability>
 		</model>
-		<model name='GST-11'>
-			<availability>General:4</availability>
-		</model>
 		<model name='GST-90'>
 			<availability>PIR:6,MERC:6</availability>
 		</model>
 		<model name='GST-10'>
 			<availability>General:8</availability>
 		</model>
+		<model name='GST-11'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Giggins APC' unitType='Tank'>
 		<availability>ROS:7</availability>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>RD:8,CDS:4,ROS:4+,CNC:5,CLAN:4,CP:4,CJF:3,BAN:4</availability>
-		<model name='Prime'>
-			<availability>CWE:7,RD:8,CW:7,General:8,CJF:9,CWIE:7</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:3,RD:4,CDS:2,CW:3,CNC:3,General:2,CP:2,CJF:2,CWIE:3</availability>
-		</model>
-		<model name='C'>
-			<availability>CNC:7,General:5,CP:7,CJF:7</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:8,RD:7,CDS:5,CW:8,CNC:5,General:6,CP:5,CJF:5,CWIE:8</availability>
-		</model>
-		<model name='P'>
-			<availability>CWE:5,CHH:6,RD:6,CDS:5,CW:5,CLAN:4,General:3,CP:5,CJF:5,CWIE:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		<model name='C'>
+			<availability>CNC:7,General:5,CP:7,CJF:7</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:4,General:7</availability>
+		<model name='K'>
+			<availability>CWE:5,CHH:6,RD:6,CDS:5,CW:5,General:3,CLAN:4,CP:5,CJF:5,CWIE:5</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:5,RD:5,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
+		<model name='Prime'>
+			<availability>CWE:7,RD:8,CW:7,General:8,CJF:9,CWIE:7</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='K'>
-			<availability>CWE:5,CHH:6,RD:6,CDS:5,CW:5,General:3,CLAN:4,CP:5,CJF:5,CWIE:5</availability>
+		<model name='A'>
+			<availability>CWE:8,RD:7,CDS:5,CW:8,CNC:5,General:6,CP:5,CJF:5,CWIE:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,RD:5,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:3,RD:4,CDS:2,CW:3,CNC:3,General:2,CP:2,CJF:2,CWIE:3</availability>
+		</model>
+		<model name='P'>
+			<availability>CWE:5,CHH:6,RD:6,CDS:5,CW:5,CLAN:4,General:3,CP:5,CJF:5,CWIE:5</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:4,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator Battle Armor' unitType='BattleArmor'>
@@ -7034,22 +7034,22 @@
 	</chassis>
 	<chassis name='Gladius Medium Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:4,Periphery.CM:3,Periphery.ME:3,MH:6,CDP:4,TC:5,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk II'>
 			<availability>MH:6,TC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Glaive Medium Tank' unitType='Tank'>
 		<availability>LA:5,ROS:3</availability>
-		<model name='(MFB)'>
-			<roles>support</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MFB)'>
+			<roles>support</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
@@ -7057,6 +7057,10 @@
 		<model name='(Light Gauss)'>
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
 		</model>
 		<model name='(3090 Upgrade)'>
 			<roles>fire_support</roles>
@@ -7066,27 +7070,23 @@
 			<roles>missile_artillery</roles>
 			<availability>FS:1</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -7108,45 +7108,49 @@
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:6,RD:7</availability>
-		<model name='(Fast Assault)' mechanized='false'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>RD:8</availability>
 		</model>
-		<model name='(Rock Golem)' mechanized='false'>
-			<availability>CHH:8</availability>
+		<model name='(Fast Assault)' mechanized='false'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
 			<roles>urban,anti_infantry</roles>
 			<availability>RD:4</availability>
 		</model>
+		<model name='(Rock Golem)' mechanized='false'>
+			<availability>CHH:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,TC:4,Periphery:3,RA.OA:3,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-3L'>
+		<model name='GOL-4S'>
 			<roles>fire_support</roles>
-			<availability>CC:6,MOC:6</availability>
+			<availability>LA:6</availability>
 		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:6,FWL:5,MH:6,MERC:6,CP:5,CDP:6,TC:6</availability>
 		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GOL-6M'>
 			<roles>fire_support</roles>
 			<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
+		</model>
+		<model name='GOL-3L'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
 		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>Periphery.HR:6,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,MH:8,Periphery:4</availability>
 		</model>
-		<model name='GOL-4S'>
+		<model name='GOL-1H'>
 			<roles>fire_support</roles>
-			<availability>LA:6</availability>
+			<availability>MERC:1-</availability>
 		</model>
 		<model name='GOL-2H'>
 			<roles>fire_support</roles>
@@ -7155,10 +7159,6 @@
 		<model name='GOL-3S'>
 			<roles>fire_support</roles>
 			<availability>LA:6,MERC:4</availability>
-		</model>
-		<model name='GOL-1H'>
-			<roles>fire_support</roles>
-			<availability>MERC:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Gorgon Carrier' unitType='Dropship'>
@@ -7170,28 +7170,28 @@
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CNC:4,CP:4,RA:6</availability>
-		<model name='(Standard)'>
-			<availability>CNC:5,CP:5,RA:5</availability>
-		</model>
 		<model name='3'>
 			<availability>RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CNC:5,CP:5,RA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk II' unitType='Mek'>
 		<availability>ROS:2,RA:7</availability>
-		<model name='(Standard)'>
-			<availability>RA:8</availability>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>RA:4</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>RA:4</availability>
 		</model>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>RA:4</availability>
-		</model>
 		<model name='RISC'>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gossamer VTOL' unitType='VTOL'>
@@ -7205,14 +7205,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>DTA:7,OP:7,CDS:4,ROS:7,CLAN:3,CNC:4,FWL:7,MSC:7,CP:5,MERC:4</availability>
-		<model name='GTHA-600'>
-			<availability>DTA:8,OP:8,ROS:8,FWL:6:3139,MSC:8,CP:6</availability>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:6,CP:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,CNC:4,FWL:4,CP:4,MERC:4,BAN:2,Periphery:4</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:6,CP:6,MERC:6,BAN:2</availability>
+		<model name='GTHA-600'>
+			<availability>DTA:8,OP:8,ROS:8,FWL:6:3139,MSC:8,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotterdammerung' unitType='Mek'>
@@ -7223,6 +7223,15 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>RD:4,ROS:5,CNC:5,MERC:4,CP:5,DC:5</availability>
+		<model name='DRG-10K'>
+			<availability>DC:6</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:7</availability>
+		</model>
+		<model name='DRG-5K'>
+			<availability>RD:8,ROS:6,CNC:8,MERC:6,CP:8,DC:2</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>ROS:4,DC:3</availability>
 		</model>
@@ -7230,53 +7239,44 @@
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:7</availability>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='DRG-7K'>
 			<availability>ROS:6,MERC:4,DC:2</availability>
 		</model>
-		<model name='DRG-10K'>
-			<availability>DC:6</availability>
-		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-5K'>
-			<availability>RD:8,ROS:6,CNC:8,MERC:6,CP:8,DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>CC:4,MOC:4,OP:7,FS:4,MERC:4,CP:7,DTA:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,MSC:7,DA:7,RCM:7,DC:4</availability>
-		<model name='T-IT-N10M'>
-			<availability>ROS:3,FWL:3,MERC:3,CP:3,Periphery:3</availability>
+		<model name='T-IT-N13M'>
+			<availability>DTA:8,OP:8,RF:8,ROS:8,FWL:8:3139,MSC:8,DA:8,RCM:8,MERC:8,CP:8</availability>
 		</model>
 		<model name='T-IT-N11M'>
 			<availability>DTA:8,CC:8,MOC:8,ROS:8,FWL:6:3139,MSC:8,MERC:4,FS:8,CP:6,DC:8</availability>
 		</model>
-		<model name='T-IT-N13M'>
-			<availability>DTA:8,OP:8,RF:8,ROS:8,FWL:8:3139,MSC:8,DA:8,RCM:8,MERC:8,CP:8</availability>
+		<model name='T-IT-N10M'>
+			<availability>ROS:3,FWL:3,MERC:3,CP:3,Periphery:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>MOC:6,IS:3,Periphery.Deep:4,MERC:7,Periphery:6,DC:4,TC:6</availability>
-		<model name='GHR-5J'>
-			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
-		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='GHR-5H'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='GHR-C'>
-			<availability>IS:2,DC:2</availability>
+		<model name='GHR-5J'>
+			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='GHR-6K'>
 			<availability>ROS:4,MERC:2,FS:2,DC:4</availability>
 		</model>
+		<model name='GHR-5H'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='GHR-7P'>
 			<availability>LA:8,MERC:4</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gravedigger' unitType='Mek'>
@@ -7309,14 +7309,14 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Strike Armor' unitType='BattleArmor'>
@@ -7334,61 +7334,61 @@
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
 		<availability>CHH:5,RD:5</availability>
-		<model name='2'>
-			<availability>CHH:8,RD:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:8,RD:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
+		<model name='(Hunter-Killer)[C3/HRR]' mechanized='false'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Hunter-Killer)[C3/HRR]' mechanized='false'>
+		<model name='[Heavy Flamer]' mechanized='false'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Hunter-Killer)[SVSP/Magshot]' mechanized='false'>
 			<availability>FS:4</availability>
 		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
+		<model name='[MagShot]' mechanized='false'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Hunter-Killer)[SVSP/Magshot]' mechanized='false'>
+		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
 			<availability>FS:4</availability>
 		</model>
 		<model name='[TAG]' mechanized='false'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MagShot]' mechanized='false'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Heavy Flamer]' mechanized='false'>
-			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4</availability>
-		<model name='A' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='C' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='A' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D' mechanized='true'>
 			<roles>artillery</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='C' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
@@ -7396,8 +7396,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
 		</model>
 		<model name='H'>
 			<availability>CHH:8,CLAN:5,IS:3</availability>
@@ -7408,23 +7414,26 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:4</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CWE:2,MERC.WD:5,CDS:6,CW:2,LA:3,CNC:7,IS:3,CP:6,CJF:2,CWIE:4,DC:4</availability>
+		<model name='4'>
+			<availability>CDS:6,CNC:8,IS:6,CP:7</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:8,CNC:5,IS:8,CP:6</availability>
+		</model>
+		<model name='2'>
+			<availability>MERC.WD:8,CNC:2</availability>
+		</model>
 		<model name='6'>
 			<availability>ROS:4,CNC:6,CP:6,DC:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:6,CNC:8,IS:6,CP:7</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CNC:4,CP:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CNC:6,CP:6</availability>
@@ -7435,26 +7444,20 @@
 		<model name='5'>
 			<availability>CDS:4,CNC:4,CP:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CNC:4,CP:4</availability>
-		</model>
-		<model name='2'>
-			<availability>MERC.WD:8,CNC:2</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:8,CNC:5,IS:8,CP:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,IS:6,MERC:7,CP:2,TC:5,Periphery:4,RA.OA:1,RD:4,LA:7,ROS:5,CNC:2,DC:7</availability>
+		<model name='GRF-2N'>
+			<availability>CC:4,MOC:4,OP:4,CLAN:6,FS:4,MERC:4,CP:4,BAN:4,FWL:4:3139,MH:4,MSC:4,RCM:4,DC:4</availability>
+		</model>
+		<model name='GRF-1A'>
+			<availability>TC:1-</availability>
+		</model>
+		<model name='GRF-5M'>
+			<availability>DTA:6,OP:6,ROS:5,FWL:5:3139,MSC:6,MERC:5,CP:5</availability>
+		</model>
 		<model name='GRF-3M'>
 			<availability>MOC:4,OP:5,IS:4,CP:4,DTA:5,RF:6,LA:3,FWL:4,MH:4,MSC:5,RCM:6,DA:6,DC:1</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:8,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='GRF-4N'>
-			<availability>TC:6</availability>
 		</model>
 		<model name='GRF-6S2'>
 			<availability>LA:4,FS:3,DC:3</availability>
@@ -7462,82 +7465,75 @@
 		<model name='GRF-4R'>
 			<availability>CC:4,RD:5,ROS:6,CNC:4,FWL:4,FS:4,CP:4,DC:4</availability>
 		</model>
-		<model name='GRF-2N'>
-			<availability>CC:4,MOC:4,OP:4,CLAN:6,FS:4,MERC:4,CP:4,BAN:4,FWL:4:3139,MH:4,MSC:4,RCM:4,DC:4</availability>
-		</model>
-		<model name='GRF-5M'>
-			<availability>DTA:6,OP:6,ROS:5,FWL:5:3139,MSC:6,MERC:5,CP:5</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>BAN:2,Periphery:2-</availability>
-		</model>
-		<model name='GRF-1A'>
-			<availability>TC:1-</availability>
+		<model name='GRF-1DS'>
+			<availability>FVC:4,ROS:3,DC:1</availability>
 		</model>
 		<model name='GRF-5K'>
 			<availability>CNC:8,CP:8,DC:8</availability>
 		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:4,ROS:3,DC:1</availability>
+		<model name='GRF-4N'>
+			<availability>TC:6</availability>
 		</model>
 		<model name='GRF-5L'>
 			<availability>CC:6</availability>
 		</model>
+		<model name='GRF-1N'>
+			<availability>BAN:2,Periphery:2-</availability>
+		</model>
+		<model name='GRF-6S'>
+			<availability>LA:8,FS:4,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>ROS:6,MERC:5,DC:5</availability>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>MERC:4</availability>
+		</model>
 		<model name='GRM-R-PR30'>
 			<availability>ROS:4,MERC:3</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>ROS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
 		<availability>CHH:1,RD:6,CLAN:1,RA:1</availability>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>RD:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:2,FVC:1,RF:3,ROS:3,FWL:2,MERC:2,RCM:3,TC:2,Periphery:1</availability>
-		<model name='D'>
-			<availability>CC:3,MOC:3,RF:2,MERC:2,RCM:2</availability>
-		</model>
-		<model name='B'>
-			<availability>Periphery:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5,RF:3,MERC:3,RCM:3</availability>
+		</model>
+		<model name='B'>
+			<availability>Periphery:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CC:3,MOC:3,RF:2,MERC:2,RCM:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.KH:4,MERC.WD:4,CHH:2-,CW:4,LA:4,ROS:4,CNC:2-,CP:2-,CWIE:4</availability>
-		<model name='2'>
-			<availability>CWE:4,CW:4,IS:8,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>ROS:4,CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CWE:4,CW:4,IS:8,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:4,CHH:1,ROS:5,FWL:4,MSC:5,FS:4,CP:4,MERC:2,RA:1,Periphery:1</availability>
-		<model name='GLT-3N'>
-			<roles>raider</roles>
-			<availability>ROS:6,CLAN:8,MERC.SI:8,BAN:8</availability>
-		</model>
 		<model name='GLT-6WB3'>
 			<roles>raider</roles>
 			<availability>ROS:3,FWL:4:3139,MSC:6,MERC:3,CP:4</availability>
@@ -7553,6 +7549,10 @@
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:2,MERC:4,CP:8</availability>
+		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>ROS:6,CLAN:8,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gulltoppr OmniMonitor' unitType='Tank' omni='IS'>
@@ -7583,16 +7583,16 @@
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
 		<availability>FVC:5,LA:8,IS:5,MH:4,FS:5,DC:7</availability>
-		<model name='GUN-2ERDr'>
-			<roles>spotter</roles>
-			<availability>FS:4,DC:4</availability>
-		</model>
 		<model name='GUN-2ERD'>
 			<roles>spotter</roles>
 			<availability>LA:6,General:4,FS:6,DC:6</availability>
 		</model>
 		<model name='GUN-1ERD'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GUN-2ERDr'>
+			<roles>spotter</roles>
+			<availability>FS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunsmith' unitType='Mek'>
@@ -7603,12 +7603,12 @@
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
 		<availability>LA:6,ROS:4,FS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gurzil Support Tank' unitType='Tank'>
@@ -7641,30 +7641,30 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,LA:4,CNC:5,IS:4,CP:5,DC:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4,CP:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CNC:6,CP:5,DC:4+</availability>
-		</model>
 		<model name='HKO-1C'>
 			<roles>fire_support</roles>
 			<availability>LA:4,DC:4</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CNC:6,CP:5,DC:4+</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:4,CP:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>RA.OA:5,CHH:7,LA:3,ROS:4,CLAN:5,FS:3,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
-		</model>
 		<model name='(AAA)'>
 			<roles>fire_support</roles>
 			<availability>RA.OA:8,RD:4,CDS:4,CP:4,RA:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hadur Fast Support Vehicle' unitType='Tank'>
@@ -7705,23 +7705,23 @@
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>ROS:3,FS:5,MERC:3</availability>
-		<model name='HMH-6E'>
-			<availability>General:6,MERC:6</availability>
+		<model name='HMH-6D'>
+			<availability>ROS:6,General:6</availability>
 		</model>
 		<model name='HMH-5D'>
 			<availability>General:2,MERC:4</availability>
 		</model>
-		<model name='HMH-6D'>
-			<availability>ROS:6,General:6</availability>
+		<model name='HMH-6E'>
+			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>ROS:5,CLAN:2,CNC:3,CP:3</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CNC:4,CP:4</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CNC:4,CP:4</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
@@ -7729,34 +7729,34 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,RD:3,CDS:4,ROS:3+,CNC:5,CP:4,CJF:4</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='E'>
-			<roles>anti_infantry</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='B'>
 			<availability>CNC:7,General:6,CP:7</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>CNC:9,General:8,CP:9</availability>
+		<model name='E'>
+			<roles>anti_infantry</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='F'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>CNC:9,General:8,CP:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -7774,11 +7774,11 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,OP:7,MERC:5,CP:7,DTA:7,FWL.pm:7,RF:7,LA:5,FWL:7,MH:5,MSC:7,DA:7,RCM:7</availability>
-		<model name='(Thunderbolt)'>
-			<availability>DTA:6,CC:6,MOC:6,OP:6,RF:6,FWL:6:3139,MH:6,MSC:6,DA:6,RCM:6,CP:6,MERC:5</availability>
-		</model>
 		<model name='(MML)'>
 			<availability>MOC:6,DTA:8,CC:6,OP:8,RF:8,LA:6,FWL:8:3139,MSC:8,RCM:8,DA:8,MERC:6,CP:8</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>DTA:6,CC:6,MOC:6,OP:6,RF:6,FWL:6:3139,MH:6,MSC:6,DA:6,RCM:6,CP:6,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Harpagos' unitType='Mek'>
@@ -7792,10 +7792,10 @@
 		<model name='(Standard)'>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='4'>
+		<model name='2'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='2'>
+		<model name='4'>
 			<availability>CHH:8</availability>
 		</model>
 	</chassis>
@@ -7811,11 +7811,11 @@
 		<model name='HTM-28T'>
 			<availability>ROS:4,DC:2</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>MERC:3,DC:3</availability>
-		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:6,DC:8</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>MERC:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Godai' unitType='Mek'>
@@ -7848,46 +7848,46 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,CP:4,Periphery:2,DTA:5,Periphery.R:3,FVC:5,LA:6,ROS:5,Periphery.MW:3,FWL:4,MSC:5,DC:4</availability>
-		<model name='HCT-7R'>
-			<availability>ROS:8</availability>
-		</model>
-		<model name='HCT-5DD'>
-			<availability>ROS:6,FS:8,MERC:6,CDP:4</availability>
+		<model name='HCT-6S'>
+			<availability>LA:8,MERC:6</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>CDP:1</availability>
 		</model>
-		<model name='HCT-6D'>
-			<availability>ROS:4,FS:2,MERC:6</availability>
-		</model>
 		<model name='HCT-6M'>
 			<availability>DTA:8,ROS:5,FWL:8,MSC:8,MERC:6,CP:8</availability>
 		</model>
-		<model name='HCT-7S'>
-			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
+		<model name='HCT-7R'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='HCT-5S'>
 			<availability>FVC:3,LA:2,FS:2,MERC:4,DC:2,Periphery:4</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>DC:8</availability>
+		<model name='HCT-5DD'>
+			<availability>ROS:6,FS:8,MERC:6,CDP:4</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:1-,TC.PL:1-,Periphery:1-</availability>
 		</model>
-		<model name='HCT-6S'>
-			<availability>LA:8,MERC:6</availability>
+		<model name='HCT-6D'>
+			<availability>ROS:4,FS:2,MERC:6</availability>
+		</model>
+		<model name='HCT-5K'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Commando' mechanized='false'>
 			<roles>urban</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk II Battle Armor' unitType='BattleArmor'>
@@ -7899,34 +7899,34 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:6</availability>
-		<model name='HA1-OT'>
-			<availability>General:4</availability>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
 		</model>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OB'>
-			<availability>General:7</availability>
+		<model name='HA1-OE'>
+			<availability>General:5</availability>
 		</model>
 		<model name='HA1-OM'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='HA1-OE'>
-			<availability>General:5</availability>
-		</model>
-		<model name='HA1-OC'>
+		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OD'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OT'>
+			<availability>General:4</availability>
+		</model>
 		<model name='HA1-OF'>
 			<availability>General:4</availability>
+		</model>
+		<model name='HA1-OC'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Havoc' unitType='Mek'>
@@ -7949,16 +7949,16 @@
 	</chassis>
 	<chassis name='Hawk Moth II Gunship' unitType='VTOL'>
 		<availability>IS:4</availability>
-		<model name='(MML)'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
+		<model name='(Sniper)'>
+			<roles>artillery</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Sniper)'>
-			<roles>artillery</roles>
-			<availability>General:2</availability>
+		<model name='(MML)'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='HawkWolf' unitType='Mek'>
@@ -7987,25 +7987,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,TC:6,Periphery:5</availability>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -8052,8 +8052,8 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CP:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
@@ -8061,14 +8061,14 @@
 		<model name='Meteor-U'>
 			<availability>ROS:2,FS:3,MERC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CP:4,TC:1</availability>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
 		</model>
 		<model name='Meteor-G'>
 			<availability>General:3,FWL:4,CP:4</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -8079,10 +8079,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:4,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
@@ -8090,6 +8086,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -8098,6 +8098,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:4,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
@@ -8106,17 +8114,16 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:4,LA:4+,CNC:4,CP:4,RA:4,CWIE:5</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -8124,15 +8131,8 @@
 		<model name='Prime'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -8144,14 +8144,14 @@
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
 		<availability>CC:5,MOC:5,FS:3,MERC:3,DC:3,TC:5</availability>
-		<model name='HEL-3D'>
-			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		<model name='HEL-4A'>
+			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
 		<model name='HEL-C'>
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='HEL-4A'>
-			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
+		<model name='HEL-3D'>
+			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -8162,17 +8162,17 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
-		<model name='HCT-213'>
-			<availability>General:2</availability>
-		</model>
 		<model name='HCT-313'>
 			<availability>RA.OA:8,FVC:8,CDP:8,RA:8</availability>
+		</model>
+		<model name='HCT-213'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>CHH:3,CDS:2,ROS:2,CNC:6,CP:4,CJF:3</availability>
-		<model name='2'>
-			<availability>CDS:6,CNC:8,CP:7,CWIE:8,DC:6</availability>
+		<model name='5'>
+			<availability>ROS:5,CNC:5,CP:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CNC:6,CP:6</availability>
@@ -8180,15 +8180,30 @@
 		<model name='4'>
 			<availability>CNC:5,CP:5</availability>
 		</model>
+		<model name='2'>
+			<availability>CDS:6,CNC:8,CP:7,CWIE:8,DC:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CHH:4,CJF:4</availability>
-		</model>
-		<model name='5'>
-			<availability>ROS:5,CNC:5,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CNC:5,CP:5,CJF:2</availability>
+		<model name='B'>
+			<availability>General:7,CJF:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7,CJF:3</availability>
+		</model>
+		<model name='G'>
+			<availability>General:5</availability>
+		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -8197,57 +8212,42 @@
 			<roles>fire_support</roles>
 			<availability>General:6,CJF:3</availability>
 		</model>
-		<model name='G'>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7,CJF:3</availability>
-		</model>
 		<model name='F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7,CJF:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
+		<model name='HSN-9F'>
+			<roles>fire_support</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='HSN-10SR'>
 			<roles>spotter</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='HSN-7D'>
-			<roles>fire_support</roles>
-			<availability>FS:8,MERC:8</availability>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-9F'>
+		<model name='HSN-7D'>
 			<roles>fire_support</roles>
-			<availability>FS:4</availability>
+			<availability>FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellstar' unitType='Mek'>
 		<availability>CC:3,CHH:6,MERC.WD:4,MERC.KH:4,LA:4,ROS:4,FS:3,CWIE:6,DC:4</availability>
+		<model name='2'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hephaestus Jump Tank' unitType='Tank'>
@@ -8263,6 +8263,18 @@
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4+</availability>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>recon,apc,fire_support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -8270,18 +8282,6 @@
 		<model name='Prime'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon,apc,fire_support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -8306,13 +8306,13 @@
 			<roles>recon</roles>
 			<availability>ROS:2-,MERC:2-</availability>
 		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>OP:4,FWL:4,MSC:4,CP:4</availability>
+		</model>
 		<model name='HER-6D'>
 			<roles>recon</roles>
 			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-5Sr'>
-			<roles>recon</roles>
-			<availability>MOC:4,IS:4,MH:4</availability>
 		</model>
 		<model name='HER-5SA'>
 			<roles>training</roles>
@@ -8326,9 +8326,9 @@
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:6,FS:6,CP:8,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>OP:4,FWL:4,MSC:4,CP:4</availability>
+			<availability>MOC:4,IS:4,MH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
@@ -8337,34 +8337,34 @@
 			<roles>recon,spotter</roles>
 			<availability>FWL:1,CP:1</availability>
 		</model>
-		<model name='HER-4K'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>OP:6,FWL:4:3139,MSC:6,MERC:6,CP:4,DC:8</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:1,CP:1</availability>
+			<availability>CLAN:6,BAN:8</availability>
 		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:1,CP:1</availability>
 		</model>
-		<model name='HER-1S'>
+		<model name='HER-4K'>
 			<roles>recon</roles>
-			<availability>CLAN:6,BAN:8</availability>
+			<availability>OP:6,FWL:4:3139,MSC:6,MERC:6,CP:4,DC:8</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>OP:4,FWL:3,MSC:4,CP:3</availability>
 		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:1,CP:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,CNC:2,IS:2-,Periphery.Deep:4,MERC:4,Periphery:6,CWIE:2</availability>
-		<model name='(SRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:3-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:1,Periphery:1</availability>
@@ -8397,29 +8397,29 @@
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CWE:6,CHH:6,RD:6,CDS:4,CW:6,LA:3,ROS:4,CNC:6,CP:5,CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>CWE:4,CDS:4,CW:4,CNC:4,IS:8,CP:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CWE:4,CW:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CWE:4,CHH:8,RD:8,CW:4,ROS:4,CJF:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CWE:4,CDS:4,CW:4,CNC:4,IS:8,CP:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:5,MOC:4,LA:6,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
-		<model name='HGN-732b'>
-			<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
-		</model>
 		<model name='HGN-734'>
 			<availability>LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='HGN-738'>
-			<availability>LA:8,ROS:8</availability>
+		<model name='HGN-732b'>
+			<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+		</model>
+		<model name='HGN-738'>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hippogriff' unitType='ProtoMek'>
@@ -8430,7 +8430,7 @@
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:5</availability>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8438,7 +8438,7 @@
 			<roles>recon,apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8464,11 +8464,11 @@
 	</chassis>
 	<chassis name='Hitotsume Kozo' unitType='Mek'>
 		<availability>DC.GHO:6,DC:4</availability>
-		<model name='HKZ-1P'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HKZ-1F'>
 			<availability>DC.GHO:6,General:4</availability>
+		</model>
+		<model name='HKZ-1P'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander III' unitType='Mek'>
@@ -8485,11 +8485,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F5'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BZK-F7'>
 			<availability>General:6</availability>
+		</model>
+		<model name='BZK-F5'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -8503,18 +8503,18 @@
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+		<model name='HNT-182'>
+			<availability>FVC:4,FS.PMM:4,FS.CMM:4,FS.DMM:4,FS.CrMM:4</availability>
+		</model>
+		<model name='HNT-181'>
+			<availability>FVC:6,FS.PMM:6,FS.CMM:6,FS.DMM:6,FS.CrMM:6</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:1-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:6,MERC:8</availability>
-		</model>
-		<model name='HNT-181'>
-			<availability>FVC:6,FS.PMM:6,FS.CMM:6,FS.DMM:6,FS.CrMM:6</availability>
-		</model>
-		<model name='HNT-182'>
-			<availability>FVC:4,FS.PMM:4,FS.CMM:4,FS.DMM:4,FS.CrMM:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hound' unitType='Mek'>
@@ -8538,13 +8538,13 @@
 	</chassis>
 	<chassis name='Huitzilopochtli Assault Tank &apos;Huey&apos;' unitType='Tank'>
 		<availability>ROS:4,CLAN:5</availability>
-		<model name='(AAA)'>
-			<roles>missile_artillery,anti_aircraft</roles>
-			<availability>CHH:4,RD:5,RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>missile_artillery,anti_aircraft</roles>
+			<availability>CHH:4,RD:5,RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Humming Bird VTOL' unitType='VTOL'>
@@ -8556,37 +8556,39 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.WD:3,RD:4,CDS:7,CW:4,CP:7,CJF:4,CWIE:3,RA:4</availability>
-		<model name='3'>
-			<availability>RA:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:8,CP:8,RA:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,RA:3</availability>
 		</model>
+		<model name='3'>
+			<availability>RA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
-		<model name='HBK-6S'>
-			<availability>LA:8,ROS:6,MERC:6</availability>
-		</model>
-		<model name='HBK-7S'>
-			<roles>spotter</roles>
-			<availability>LA:2</availability>
-		</model>
-		<model name='HBK-5P'>
-			<availability>ROS:6,FWL:8,MERC:4,CP:8</availability>
-		</model>
-		<model name='HBK-7R'>
-			<roles>spotter</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='HBK-5SS'>
 			<availability>LA:8</availability>
 		</model>
 		<model name='HBK-4G'>
 			<availability>Periphery:2-</availability>
+		</model>
+		<model name='HBK-6S'>
+			<availability>LA:8,ROS:6,MERC:6</availability>
+		</model>
+		<model name='HBK-7R'>
+			<roles>spotter</roles>
+			<availability>ROS:8</availability>
+		</model>
+		<model name='HBK-5P'>
+			<availability>ROS:6,FWL:8,MERC:4,CP:8</availability>
+		</model>
+		<model name='HBK-5H'>
+			<availability>FVC:3,MH:6,Periphery:4</availability>
+		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:3,CC:3,FWL:4,MERC:3,CP:4,CDP:3,TC:3</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>Periphery:2-</availability>
@@ -8597,11 +8599,9 @@
 		<model name='HBK-6N'>
 			<availability>ROS:3,FWL:2,MH:4,MERC:3,CP:2,DC:3</availability>
 		</model>
-		<model name='HBK-5H'>
-			<availability>FVC:3,MH:6,Periphery:4</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:3,CC:3,FWL:4,MERC:3,CP:4,CDP:3,TC:3</availability>
+		<model name='HBK-7S'>
+			<roles>spotter</roles>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -8615,29 +8615,35 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:2,CC:4,IS:3,MERC:3,FS:3,CP:2,Periphery:3,TC:3,RA.OA:3,LA:5,ROS:2,FWL:2,DC:2</availability>
-		<model name='&apos;Assault Hunter&apos;'>
-			<availability>LA:1,FS:1</availability>
-		</model>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:1-</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:4</availability>
-		</model>
-		<model name='(Amphibious)'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
 			<availability>RF:6,LA:8,ROS:6,FWL:4:3139,FS:6,RCM:6,MERC:6,DA:6,CP:4</availability>
 		</model>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='(Amphibious)'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='&apos;Assault Hunter&apos;'>
+			<availability>LA:1,FS:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,MERC:2,CP:5,TC:6</availability>
+		<model name='HUR-WO-R4O'>
+			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
+		</model>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:4,MOC:4,FWL:5,CP:5</availability>
 		</model>
@@ -8645,42 +8651,36 @@
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4O'>
-			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,CNC:4,MERC:4,FS:4,CP:4,DC:4</availability>
-		<model name='HSCL-1-OD'>
-			<availability>General:4</availability>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:3+</availability>
 		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HSCL-1-OA'>
+		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OB'>
+		<model name='HSCL-1-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>ROS:2,CLAN:3</availability>
-		<model name='HSR-400-D'>
-			<availability>LA:8,ROS:8,MERC:8</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6,MERC.SI:4,BAN:8</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -8692,25 +8692,25 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CLAN:6,RA:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Algar)'>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8,CLAN:6,CJF:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
 		<availability>CHH:5</availability>
-		<model name='(Standard)'>
+		<model name='2'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='2'>
+		<model name='(Standard)'>
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
@@ -8723,11 +8723,8 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:2,MOC:8,LA:1,ROS:4,IS:8,FWL:3,MH:8,CP:3,TC:8</availability>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -8735,8 +8732,11 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -8761,11 +8761,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='IMP-4E'>
 			<availability>MERC.WD:6,MERC.KH:8</availability>
+		</model>
+		<model name='IMP-3E'>
+			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -8790,23 +8790,23 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5</availability>
-		<model name='(BA)'>
-			<availability>CWE:6,CW:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(BA)'>
+			<availability>CWE:6,CW:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4,TC:3</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
+		<model name='&apos;Puma&apos;' mechanized='true'>
+			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
 		</model>
-		<model name='&apos;Puma&apos;' mechanized='true'>
-			<availability>FS:8,TC:8</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Marine)' mechanized='true'>
 			<roles>marine</roles>
@@ -8815,21 +8815,21 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>CC:4,LA:4,ROS:5,FWL:4,FS:4,CP:4,DC:4</availability>
-		<model name='(SCC)'>
-			<roles>assault</roles>
-			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
-		</model>
 		<model name='(3115)'>
 			<roles>assault</roles>
 			<availability>ROS:5</availability>
 		</model>
-		<model name='(Sub-Capital)'>
-			<roles>assault</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>assault</roles>
 			<availability>CC:8,ROS:4,FWL:8,CP:8</availability>
+		</model>
+		<model name='(SCC)'>
+			<roles>assault</roles>
+			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
+		</model>
+		<model name='(Sub-Capital)'>
+			<roles>assault</roles>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -8845,29 +8845,29 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,CLAN:9,IS:7,Periphery.Deep:6,FS:9,CP:9,BAN:6,Periphery:8,TC:8,RA.OA:8,LA:9,PIR:5,FWL:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ironhold Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CJF:5</availability>
-		<model name='(Fire)' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Tank)' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='(Fire)' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Isegrim Assault DropShip' unitType='Dropship'>
@@ -8908,15 +8908,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -8933,11 +8933,11 @@
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
 		<availability>RD:3,IS:4,TC:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<availability>TC:3</availability>
-		</model>
 		<model name='(3082 Upgrade)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
@@ -8957,17 +8957,13 @@
 	</chassis>
 	<chassis name='JES III Missile Carrier' unitType='Tank'>
 		<availability>IS:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Speed)'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MML)'>
 			<roles>fire_support</roles>
@@ -8977,16 +8973,20 @@
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Speed)'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='JI2A1 Attack APC' unitType='Tank'>
 		<availability>CC:4,FVC:5,ROS:4,FS:6,MERC:4</availability>
-		<model name='(MML)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MML)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jabberwocky ConstructionMech' unitType='Mek'>
@@ -9027,10 +9027,6 @@
 	</chassis>
 	<chassis name='Jackalope' unitType='Mek'>
 		<availability>DTA:4,ROS:5,MERC:3,RCM:4</availability>
-		<model name='JLP-KA'>
-			<roles>recon</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='JLP-BD'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -9043,48 +9039,52 @@
 			<roles>recon</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='JLP-KA'>
+			<roles>recon</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Jade Hawk' unitType='Mek'>
 		<availability>MERC:4,CJF:4</availability>
-		<model name='JHK-04'>
-			<availability>MERC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
+		<model name='JHK-04'>
+			<availability>MERC:4</availability>
 		</model>
 		<model name='JHK-03'>
 			<availability>MERC:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CJF:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CWE:8,CW:8,CLAN:6</availability>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CWE:2,CW:2,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:5,CW:5,General:2,RA:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:4,CW:4,CLAN:2,RA:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CW:4,CLAN:2,RA:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CWE:2,CW:2,General:1</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -9098,35 +9098,16 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>MOC:6,RA.OA:4,FVC:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='JM7-C3BS'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>Periphery:4</availability>
 		</model>
-		<model name='JM6-DGr'>
-			<roles>anti_aircraft</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:1,MERC:2,CDP:3,DC:2</availability>
+		<model name='JM6-DG'>
+			<availability>General:1</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:5,FS:3,MERC:6</availability>
-		</model>
-		<model name='JM7-F'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:1</availability>
 		</model>
 		<model name='JM6-DDa'>
 			<roles>anti_aircraft</roles>
@@ -9136,27 +9117,42 @@
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,PIR:2,MH:6,Periphery:2</availability>
 		</model>
+		<model name='JM7-F'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:4,FS:4</availability>
+		</model>
+		<model name='JM6-DGr'>
+			<roles>anti_aircraft</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:1,MERC:2,CDP:3,DC:2</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM7-G'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>MOC:6,RA.OA:4,FVC:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Jaguar' unitType='Mek'>
 		<availability>LA:4,ROS:4,FS:4,CJF:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:3,FVC:6,Periphery.HR:3,ROS:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3,TC:3</availability>
-		<model name='JVN-11D'>
+		<model name='JVN-10P'>
 			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:2,MERC:6,CDP:6,TC:6</availability>
 		</model>
 		<model name='JVN-11F'>
 			<roles>recon</roles>
@@ -9166,12 +9162,16 @@
 			<roles>recon</roles>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+		</model>
 		<model name='JVN-11P'>
 			<availability>FVC:6</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11D'>
 			<roles>recon</roles>
-			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:2,MERC:6,CDP:6,TC:6</availability>
+			<availability>ROS:6,FS:6</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -9180,14 +9180,14 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CWE:8,RD:9,CW:8,CLAN:6,CWIE:7</availability>
-		<model name='B'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -9195,73 +9195,65 @@
 		<model name='X'>
 			<availability>General:1,CJF:2,RA:2</availability>
 		</model>
-		<model name='C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
+		<model name='C'>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CWE:6,CDS:6,CW:6,ROS:4,CNC:8,CP:7,DC:3</availability>
-		<model name='2'>
+		<model name='3'>
 			<availability>CNC:6,CP:6</availability>
 		</model>
-		<model name='3'>
+		<model name='(Standard)'>
+			<availability>CWE:3,CW:3,CNC:3,CP:3</availability>
+		</model>
+		<model name='2'>
 			<availability>CNC:6,CP:6</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:8,CNC:8,IS:8,CP:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CWE:3,CW:3,CNC:3,CP:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:5,FS.DMM:5,MERC:4,Periphery.OS:5,FS:4,RA:4,DC:8,Periphery:3</availability>
-		<model name='JR7-K'>
+		<model name='JR7-C4'>
 			<roles>raider</roles>
-			<availability>MOC:2,RA.OA:2,MERC:2,RA:2,DC:1,TC:2</availability>
-		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>ROS:4,DC:8</availability>
-		</model>
-		<model name='JR7-C3'>
-			<roles>raider</roles>
-			<availability>ROS:5,MERC:5,DC:6</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='JR7-C3'>
+			<roles>raider</roles>
+			<availability>ROS:5,MERC:5,DC:6</availability>
+		</model>
+		<model name='JR7-K'>
+			<roles>raider</roles>
+			<availability>MOC:2,RA.OA:2,MERC:2,RA:2,DC:1,TC:2</availability>
+		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
 			<availability>MERC:4,FS:4,DC:2</availability>
 		</model>
-		<model name='JR7-C4'>
+		<model name='JR7-C2'>
 			<roles>raider</roles>
-			<availability>DC:4</availability>
+			<availability>ROS:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:6,TC:4</availability>
-		<model name='JI-50 (Q-Vehicle)'>
-			<roles>support</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='JI-50'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='JI-50 (ML)'>
+		<model name='JI-50 (Hoist)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9269,21 +9261,29 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='JI-50 (Hoist)'>
+		<model name='JI-50'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Q-Vehicle)'>
+			<roles>support</roles>
+			<availability>TC:2</availability>
+		</model>
+		<model name='JI-50 (ML)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:6,MOC:5,TC:4</availability>
-		<model name='JN-G8A'>
-			<availability>General:8</availability>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
+		<model name='JN-G8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Joust Medium Tank' unitType='Tank'>
@@ -9305,11 +9305,11 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
@@ -9321,8 +9321,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -9342,32 +9342,31 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CJF:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CJF:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>ROS:4,DC:5</availability>
-		<model name='KBO-7B'>
+		<model name='KBO-7A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='KBO-7A'>
+		<model name='KBO-7B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+		<model name='C' mechanized='true'>
+			<availability>DC:3</availability>
 		</model>
-		<model name='(DEST)' mechanized='true'>
+		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
@@ -9375,28 +9374,29 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C' mechanized='true'>
-			<availability>DC:3</availability>
+		<model name='[MG]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
+		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='(Space)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='(Vibro-Claw)' mechanized='true'>
+		<model name='[ECM]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
+			<availability>MERC:2,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -9417,6 +9417,13 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Salvage Arm]' mechanized='false'>
+			<roles>support</roles>
+			<availability>DC.NSR:2,DC.SL:2,General:4</availability>
+		</model>
 		<model name='[Industrial Drill]' mechanized='false'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -9424,18 +9431,12 @@
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Salvage Arm]' mechanized='false'>
-			<roles>support</roles>
-			<availability>DC.NSR:2,DC.SL:2,General:4</availability>
-		</model>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>RD:8</availability>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -9443,15 +9444,14 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -9466,22 +9466,22 @@
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>cargo</roles>
-			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
-		</model>
 		<model name='(AC)'>
 			<availability>MH:2,MERC:2</availability>
 		</model>
-		<model name='(BA)'>
-			<roles>apc</roles>
-			<availability>FWL:5,IS:6,CP:5</availability>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
 		</model>
 		<model name='(Heavy Stealth)'>
 			<availability>PIR:4</availability>
 		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
+		<model name='(3055 Upgrade)'>
+			<roles>cargo</roles>
+			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='(BA)'>
+			<roles>apc</roles>
+			<availability>FWL:5,IS:6,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
@@ -9489,12 +9489,12 @@
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:8,DC:8</availability>
 		</model>
+		<model name='CRK-5003-C'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='CRK-5003-CM'>
 			<roles>spotter</roles>
 			<availability>DC:7</availability>
-		</model>
-		<model name='CRK-5003-C'>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kelswa Assault Tank' unitType='Tank'>
@@ -9509,21 +9509,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kheper' unitType='Mek'>
@@ -9537,8 +9537,17 @@
 		<model name='KGC-001'>
 			<availability>LA:2,IS:3,MH:6</availability>
 		</model>
+		<model name='KGC-000b'>
+			<availability>ROS:6,CLAN:4,BAN:2,DC:6</availability>
+		</model>
+		<model name='KGC-007'>
+			<availability>LA:4,ROS:8,FS:8,MERC:8</availability>
+		</model>
 		<model name='KGC-008B'>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='KGC-000'>
+			<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
 		</model>
 		<model name='KGC-005r'>
 			<availability>ROS:4,MERC:4</availability>
@@ -9546,41 +9555,32 @@
 		<model name='KGC-009'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='KGC-000b'>
-			<availability>ROS:6,CLAN:4,BAN:2,DC:6</availability>
-		</model>
-		<model name='KGC-000'>
-			<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
-		</model>
-		<model name='KGC-007'>
-			<availability>LA:4,ROS:8,FS:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>RD:6,CDS:3,ROS:3+,CNC:3,CP:2,RA:3</availability>
 		<model name='C'>
 			<availability>RD:3,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:5,General:6</availability>
-		</model>
 		<model name='E'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
+		<model name='D'>
+			<availability>RD:5,General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kinnol MBT' unitType='Tank'>
@@ -9588,20 +9588,20 @@
 		<model name='(PPC)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(RAC)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>DC.GHO:5,ROS:6,MERC:2,DC:2</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:5</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:2,DC.SL:4,ROS:3,CLAN:6,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-K'>
 			<availability>DC:8</availability>
@@ -9609,29 +9609,29 @@
 		<model name='KTO-20'>
 			<availability>MERC:3,DC:2</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:5</availability>
+		<model name='KTO-19b'>
+			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:4</availability>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -9674,21 +9674,21 @@
 	</chassis>
 	<chassis name='Kobold Battle Armor' unitType='BattleArmor'>
 		<availability>RD:2-</availability>
-		<model name='(GB) [SL/Flamer]' mechanized='true'>
+		<model name='(GB) [GL/Flamer]' mechanized='true'>
 			<availability>RD:6</availability>
 		</model>
-		<model name='(GB) [GL]' mechanized='true'>
-			<availability>RD:4</availability>
-		</model>
-		<model name='(GB) [GL/TAG]' mechanized='true'>
-			<roles>spotter</roles>
+		<model name='(GB) [SL/Flamer]' mechanized='true'>
 			<availability>RD:6</availability>
 		</model>
 		<model name='(GB) [SL/TAG]' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>RD:8</availability>
 		</model>
-		<model name='(GB) [GL/Flamer]' mechanized='true'>
+		<model name='(GB) [GL]' mechanized='true'>
+			<availability>RD:4</availability>
+		</model>
+		<model name='(GB) [GL/TAG]' mechanized='true'>
+			<roles>spotter</roles>
 			<availability>RD:6</availability>
 		</model>
 	</chassis>
@@ -9705,6 +9705,9 @@
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>RD:6,ROS:4,RA:5</availability>
+		<model name='5'>
+			<availability>RD:4</availability>
+		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
 			<availability>RA:5</availability>
@@ -9714,9 +9717,6 @@
 		</model>
 		<model name='4'>
 			<availability>RD:4,ROS:4</availability>
-		</model>
-		<model name='5'>
-			<availability>RD:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
@@ -9728,9 +9728,6 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='KIM-2'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>General:8,DC:2</availability>
@@ -9739,14 +9736,14 @@
 			<roles>spotter</roles>
 			<availability>DC:1</availability>
 		</model>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>OP:6,ROS:5,FWL:5,MERC:4,CP:5</availability>
-		<model name='(AI Mk IIr)' mechanized='false'>
-			<availability>OP:4,MERC:3</availability>
-		</model>
-		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='(AI Mk II)' mechanized='false'>
+			<availability>OP:6,MERC:4</availability>
 		</model>
 		<model name='(Mortar)' mechanized='false'>
 			<availability>OP:4,MERC:3</availability>
@@ -9755,8 +9752,11 @@
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(AI Mk II)' mechanized='false'>
-			<availability>OP:6,MERC:4</availability>
+		<model name='(AI Mk IIr)' mechanized='false'>
+			<availability>OP:4,MERC:3</availability>
+		</model>
+		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Koroshiya' unitType='Aero'>
@@ -9767,48 +9767,52 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,DTA:3,ROS:3,MERC:4,CC.TG:6</availability>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
-			<availability>MERC:5</availability>
-		</model>
 		<model name='KSC-4I'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='KSC-4L'>
 			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='KSC-5I'>
 			<availability>DTA:8,ROS:8,MERC:8</availability>
 		</model>
+		<model name='KSC-5MC'>
+			<availability>MOC:8,CC:8,MERC:4</availability>
+		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:5</availability>
+		</model>
+		<model name='KSC-4L'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
 		<model name='KSC-6L'>
 			<roles>artillery</roles>
 			<availability>CC:5,MOC:5</availability>
 		</model>
-		<model name='KSC-5MC'>
-			<availability>MOC:8,CC:8,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,CHH:3,MERC.WD:3,CDS:3,CW:4,IS:4+,CP:3,CJF:2,BAN:4,RA:3</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>CNC:3,General:2,CP:3</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>CWE:7,RD:8,CDS:3,CW:7,General:4,CP:3</availability>
 		</model>
-		<model name='D'>
-			<roles>recon</roles>
-			<availability>CWE:7,RD:2,CDS:5,CW:7,CNC:2,General:3,CP:3,CJF:2,CWIE:7</availability>
-		</model>
-		<model name='E'>
-			<roles>recon</roles>
+		<model name='F'>
+			<roles>recon,spotter</roles>
 			<availability>CLAN:5,IS:3</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>RD:6,CDS:9,CNC:6,General:8,CP:7</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CWE:4,RD:4,CDS:7,CW:4,General:5,CP:7,CWIE:4</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CLAN:5,IS:3</availability>
 		</model>
 		<model name='G'>
 			<roles>recon,anti_infantry</roles>
@@ -9818,22 +9822,18 @@
 			<roles>recon</roles>
 			<availability>CWE:6,RD:5,CDS:6,CW:6,General:5,CP:6,CWIE:5</availability>
 		</model>
-		<model name='P'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CLAN:2,IS:2</availability>
+			<availability>CWE:7,RD:2,CDS:5,CW:7,CNC:2,General:3,CP:3,CJF:2,CWIE:7</availability>
 		</model>
-		<model name='Prime'>
+		<model name='E'>
 			<roles>recon</roles>
-			<availability>RD:6,CDS:9,CNC:6,General:8,CP:7</availability>
-		</model>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>CNC:3,General:2,CP:3</availability>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Koshi' unitType='Mek'>
 		<availability>CLAN:6,IS:5</availability>
-		<model name='(Standard) 2'>
+		<model name='(Standard) 3'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9841,7 +9841,7 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard) 3'>
+		<model name='(Standard) 2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9877,12 +9877,12 @@
 	</chassis>
 	<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
 		<availability>CWE:4,CHH:6,RD:6,CDS:2,CW:4,CNC:2,CP:2,CJF:4,RA:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(IFV) &apos;Turhan II&apos;'>
 			<roles>apc</roles>
 			<availability>CHH:8,CJF:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kuan Ti' unitType='Dropship'>
@@ -9897,11 +9897,11 @@
 		<model name='4'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
@@ -9936,14 +9936,14 @@
 	</chassis>
 	<chassis name='Lament' unitType='Mek'>
 		<availability>ROS:5</availability>
+		<model name='LMT-4RC'>
+			<availability>General:3</availability>
+		</model>
 		<model name='LMT-3C'>
 			<availability>General:5</availability>
 		</model>
 		<model name='LMT-2R'>
 			<availability>General:8</availability>
-		</model>
-		<model name='LMT-4RC'>
-			<availability>General:3</availability>
 		</model>
 		<model name='LMT-3R'>
 			<availability>General:5</availability>
@@ -9965,33 +9965,33 @@
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>CC:4,MOC:4,OP:6,FS:3,MERC:4,CP:6,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
-		<model name='LX-2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LX-2A'>
 			<availability>DTA:5,OP:5,RF:5,LA:5,ROS:5,FWL:5,MSC:5,RCM:5,MERC:5,DA:5,CP:5</availability>
 		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
+		<model name='LX-2'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:8,MOC:6,FS:4,TC:4</availability>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3B'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:6</availability>
-		</model>
 		<model name='LHU-4E'>
 			<availability>CC:6</availability>
 		</model>
 		<model name='LHU-3L'>
 			<availability>CC:6,MOC:8,FS:8</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-3B'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -10003,56 +10003,56 @@
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>ROS:4,FS:8,MERC:4</availability>
-		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
+		<model name='LGN-2K'>
+			<roles>raider</roles>
+			<availability>ROS:5</availability>
 		</model>
 		<model name='LGN-2F'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
 		</model>
-		<model name='LGN-2K'>
-			<roles>raider</roles>
-			<availability>ROS:5</availability>
+		<model name='LGN-2XU'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-2XA'>
 			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leonidas Battle Armor' unitType='BattleArmor'>
 		<availability>CC:4,MOC:4,OP:6,FWL:5:3139,MH:3,MERC:4,CP:5</availability>
-		<model name='(MG)' mechanized='true'>
+		<model name='(Sensor)' mechanized='true'>
+			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(David)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(FireDrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<roles>recon</roles>
+		<model name='(FireDrake)' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>RA.OA:8,IS:7,Periphery.Deep:5,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>CC:8,OP:8,FS:8,CP:8,DTA:8,RF:8,LA:8,ROS:8,General:4,FWL:8,MSC:8,RCM:8,DA:8</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:5-</availability>
+		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>CC:8,OP:8,FS:8,CP:8,DTA:8,RF:8,LA:8,ROS:8,General:4,FWL:8,MSC:8,RCM:8,DA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
@@ -10109,27 +10109,27 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
-		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:4,FWL:8,IS:4,CP:8</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:3</availability>
+		<model name='Owl'>
+			<availability>LA:1,ROS:1,MERC:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:1,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1,ROS:1,MERC:1</availability>
+		<model name='Comet'>
+			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:2,LA:2</availability>
 		</model>
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
+		</model>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:4,FWL:8,IS:4,CP:8</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -10140,9 +10140,6 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CLAN:3,CJF:4</availability>
-		<model name='(ERSL)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
@@ -10150,71 +10147,74 @@
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
-		<model name='LTN-G15b'>
-			<availability>CC:5,MOC:5,CLAN:3,IS:4,MERC:4</availability>
-		</model>
-		<model name='LTN-G16L'>
-			<availability>CC:6,MOC:6,RF:4,FWL:2:3139,MSC:4,MERC:4,DA:6,CP:2</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='LTN-G16S'>
-			<availability>LA:6</availability>
+		<model name='LTN-G15b'>
+			<availability>CC:5,MOC:5,CLAN:3,IS:4,MERC:4</availability>
 		</model>
 		<model name='LTN-G16D'>
 			<availability>ROS:6,FS:6,MERC:4</availability>
 		</model>
+		<model name='LTN-G16L'>
+			<availability>CC:6,MOC:6,RF:4,FWL:2:3139,MSC:4,MERC:4,DA:6,CP:2</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='LTN-G16O'>
 			<availability>RA.OA:6,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G16S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,MERC.KH:4+,CW:5,CJF:4,RA:5,CWIE:6</availability>
-		<model name='B'>
-			<availability>RD:6,CDS:4,General:5,CP:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:6,RD:7,CW:6,General:5,CWIE:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
-		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:9,CDS:7,General:8,CP:7,CWIE:9</availability>
+		<model name='B'>
+			<availability>RD:6,CDS:4,General:5,CP:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CWE:6,RD:6,CW:6,General:7,CWIE:6</availability>
 		</model>
+		<model name='H'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
 		<model name='C'>
 			<availability>CWE:4,CHH:4,RD:5,CW:4,CNC:3,General:3,CP:3,CJF:2,CWIE:5</availability>
 		</model>
-		<model name='H'>
+		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:9,CDS:7,General:8,CP:7,CWIE:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:6,RD:7,CW:6,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lineholder' unitType='Mek'>
 		<availability>CC:4,ROS:4,FWL:4,IS:3,FS:5,CP:4,TC:6,Periphery:4</availability>
-		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
-			<availability>ROS:6,FS:7,MERC:6,CDP:4</availability>
-		</model>
 		<model name='KW1-LH3'>
 			<availability>General:2,FS:3</availability>
 		</model>
 		<model name='KW1-LH2'>
 			<availability>General:4,FS:2</availability>
+		</model>
+		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
+			<availability>ROS:6,FS:7,MERC:6,CDP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -10244,90 +10244,90 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CWE:7,CHH:6,RD:6,CW:7,ROS:3,CJF:6,DC:3</availability>
-		<model name='4'>
-			<availability>CWE:5,CHH:5,CW:5,LA:6,CJF:6</availability>
-		</model>
 		<model name='6'>
 			<availability>CWE:6,RD:6,CW:6</availability>
-		</model>
-		<model name='5'>
-			<availability>CWE:4,CHH:4,RD:4,CW:4,ROS:4</availability>
 		</model>
 		<model name='9'>
 			<availability>CJF:6</availability>
 		</model>
+		<model name='8'>
+			<availability>RD:6,ROS:5,DC:5</availability>
+		</model>
 		<model name='7'>
 			<availability>CHH:6,ROS:2</availability>
 		</model>
-		<model name='8'>
-			<availability>RD:6,ROS:5,DC:5</availability>
+		<model name='4'>
+			<availability>CWE:5,CHH:5,CW:5,LA:6,CJF:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CJF:2</availability>
 		</model>
+		<model name='5'>
+			<availability>CWE:4,CHH:4,RD:4,CW:4,ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CLAN:2-,IS:6,Periphery:3</availability>
-		<model name='LCT-3M'>
+		<model name='LCT-6M'>
 			<roles>recon</roles>
-			<availability>MOC:2,DTA:6,OP:6,RF:5,FWL:4,IS:2,MSC:5,MERC:4,RCM:5,DA:5,CP:4</availability>
+			<availability>ROS:2,FWL:4,MSC:5,MERC:3,CP:4</availability>
+		</model>
+		<model name='LCT-5M2'>
+			<availability>ROS:4,FWL:4:3139,MSC:6,CP:4</availability>
 		</model>
 		<model name='LCT-5T'>
 			<roles>recon,anti_infantry</roles>
 			<availability>MOC:4,CC:4,FVC:5,TC:6</availability>
 		</model>
-		<model name='LCT-5M2'>
-			<availability>ROS:4,FWL:4:3139,MSC:6,CP:4</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:2,ROS:4,PIR:4,FWL:2,CP:2</availability>
-		</model>
-		<model name='LCT-6M'>
-			<roles>recon</roles>
-			<availability>ROS:2,FWL:4,MSC:5,MERC:3,CP:4</availability>
-		</model>
-		<model name='LCT-5W2'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:6,CLAN:4,IS:4,FS:6,DC:6</availability>
+		<model name='LCT-5M3'>
+			<availability>ROS:5,FWL:3:3139,MSC:5,CP:3</availability>
 		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:4,CLAN:6,FWL:4,MERC:4,CP:4,BAN:2</availability>
 		</model>
-		<model name='LCT-5V'>
+		<model name='LCT-5M'>
 			<roles>recon</roles>
-			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
-		<model name='LCT-3S'>
-			<roles>recon</roles>
-			<availability>LA:8,MERC:6</availability>
-		</model>
-		<model name='LCT-5M3'>
-			<availability>ROS:5,FWL:3:3139,MSC:5,CP:3</availability>
+			<availability>FVC:2,ROS:4,PIR:4,FWL:2,CP:2</availability>
 		</model>
 		<model name='LCT-1V2'>
 			<roles>recon</roles>
 			<availability>PIR:4,MH:4,MERC:3</availability>
 		</model>
+		<model name='LCT-5W2'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,ROS:6,CLAN:4,IS:4,FS:6,DC:6</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='LCT-3S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:6</availability>
+		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:2,DTA:6,OP:6,RF:5,FWL:4,IS:2,MSC:5,MERC:4,RCM:5,DA:5,CP:4</availability>
+		</model>
+		<model name='LCT-3D'>
+			<roles>recon</roles>
+			<availability>FVC:8,FS:8,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CWE:3,CHH:4,CW:3,BAN:4,CWIE:3</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
+		<model name='E'>
+			<availability>CWE:5,CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>RD:5,General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>RD:8,General:8,CJF:9</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
+		</model>
+		<model name='G'>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:4,CP:5</availability>
@@ -10335,28 +10335,28 @@
 		<model name='B'>
 			<availability>CWE:4,CHH:6,RD:3,CDS:6,CW:4,General:5,CP:6,CJF:7,CWIE:4</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CHH:6,CW:5,CLAN:4,General:3,CJF:5</availability>
-		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CWE:5,CHH:6,RD:5,CW:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
+		<model name='A'>
+			<availability>RD:5,General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,General:8,CJF:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Loki Mk II (Hel)' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,CHH:6,RD:5,MERC.WD:3,MERC.KH:3,CDS:5,CW:5,CP:5,CJF:6,RA:5</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -10372,51 +10372,51 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,IS:6,FS:5,CP:7,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7,DC:6</availability>
-		<model name='LGB-14C2'>
+		<model name='LGB-7V'>
 			<roles>fire_support</roles>
-			<availability>IS:6</availability>
+			<availability>MOC:2,FVC:4,FWL:2,IS:2,CP:2,Periphery:4</availability>
 		</model>
 		<model name='LGB-8V'>
 			<roles>missile_artillery,fire_support</roles>
 			<availability>RD:4,LA:4,FWL:4,IS:4,FS:6,MERC:4,CP:4</availability>
 		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
-		</model>
-		<model name='LGB-13NAIS'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGB-12R'>
 			<roles>fire_support</roles>
 			<availability>DTA:4,LA:4,ROS:8,FWL:2:3139,FS:4,CP:2,DC:4</availability>
-		</model>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:2,FVC:4,FWL:2,IS:2,CP:2,Periphery:4</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CP:4,CDP:4,TC:4</availability>
 		</model>
+		<model name='LGB-13NAIS'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:5,OP:6,ROS:6,FWL:6:3139,MSC:6,FS:6,MERC:6,DA:6,RCM:6,CP:6,DC:6</availability>
 		</model>
+		<model name='LGB-14C2'>
+			<roles>fire_support</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:8,OP:8,RF:8,FWL:8,MH:6,MSC:8,RCM:8,DA:8,CP:8</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>FWL:6,CP:6</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -10436,20 +10436,20 @@
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>ROS:4,MERC:3,DC:4</availability>
-		<model name='LCF-R16K'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>ROS:5,MERC:3,DC:6</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>Periphery.R:4,FVC:2,LA:4,Periphery.MW:3,Periphery:2</availability>
-		<model name='LCF-R15'>
-			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
-		</model>
 		<model name='LCF-R16'>
 			<availability>LA:8,MH:4,MERC:6</availability>
+		</model>
+		<model name='LCF-R15'>
+			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Luduan Scout Vehicle' unitType='Tank'>
@@ -10461,20 +10461,20 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM5/M'>
-			<availability>LA:1-</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='LM5/M'>
+			<availability>LA:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -10515,13 +10515,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3,CP:3</availability>
-		<model name='(Standard)'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='M1'>
 			<roles>escort</roles>
 			<availability>FWL:6,CP:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -10566,8 +10566,11 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,MERC.KH:3+,MERC.WD:4,CDS:2,CW:4,ROS:3+,CLAN:1,MERC:2+,CP:2,CJF:2,BAN:1,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>RD:7,CDS:8,CNC:7,General:8,CP:7,CJF:8</availability>
+		<model name='B'>
+			<availability>CWE:5,CHH:7,RD:4,CDS:7,CW:5,General:6,CP:7,CJF:7,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CWE:5,CHH:5,RD:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -10577,31 +10580,29 @@
 			<roles>spotter</roles>
 			<availability>CWE:5,CHH:4,CW:5,CNC:4,CLAN:5,General:5,CP:4,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:5,CW:5,CNC:3,General:4,CP:3</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:7,RD:2,CW:7,General:5,CJF:6,CWIE:7</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CNC:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:5,CW:5,CNC:3,General:4,CP:3</availability>
 		</model>
 		<model name='A'>
 			<availability>CWE:7,RD:8,CDS:8,CW:7,General:7,CP:8,CJF:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:5,CHH:7,RD:4,CDS:7,CW:5,General:6,CP:7,CJF:7,CWIE:5</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CWE:5,CHH:5,RD:5,CW:5,CLAN:4,General:3,CJF:6,CWIE:5</availability>
+		<model name='Prime'>
+			<availability>RD:7,CDS:8,CNC:7,General:8,CP:7,CJF:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CWE:7,RD:2,CW:7,General:5,CJF:6,CWIE:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat III' unitType='Mek'>
 		<availability>CDS:6,LA:5,ROS:5,CNC:4,IS:4,CP:5,CWIE:4,DC:5</availability>
-		<model name='2'>
+		<model name='4'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)'>
@@ -10612,8 +10613,7 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>fire_support</roles>
+		<model name='2'>
 			<availability>General:6</availability>
 		</model>
 		<model name='3'>
@@ -10623,13 +10623,19 @@
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,CW:4,LA:4,CNC:6,CLAN:4,IS:4,FS:4,CP:5,CWIE:4,DC:4</availability>
-		<model name='6'>
-			<availability>CDS:4,CP:4</availability>
-		</model>
 		<model name='Enhanced'>
 			<availability>CLAN:6,CNC:4,CP:4,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
+			<availability>CDS:4,CP:4</availability>
+		</model>
+		<model name='4'>
+			<availability>General:6</availability>
+		</model>
+		<model name='6'>
 			<availability>CDS:4,CP:4</availability>
 		</model>
 		<model name='2'>
@@ -10637,12 +10643,6 @@
 		</model>
 		<model name='5'>
 			<availability>General:5</availability>
-		</model>
-		<model name='4'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk IV (Savage Wolf)' unitType='Mek'>
@@ -10656,36 +10656,42 @@
 		<model name='(Prime)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
 		<availability>LA:6,IS:4,FS:4,MERC:4,DC:6</availability>
-		<model name='MTR-6E'>
-			<roles>recon,spotter</roles>
-			<availability>DC:1</availability>
+		<model name='MTR-5K'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='MTR-7K'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='MTR-7K'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='MTR-5K'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='MTR-6E'>
+			<roles>recon,spotter</roles>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>CC:6,MOC:6,OP:6,Periphery.MM:6,MERC:6,CP:8,DTA:8,RF:8,LA:6,ROS:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,MSC:8,RCM:8,DA:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>MOC:4,IS:4</availability>
+		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
@@ -10693,18 +10699,9 @@
 		<model name='(C3)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(XL)'>
-			<availability>MOC:4,IS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Malice' unitType='Mek'>
 		<availability>ROS:4,MERC:3</availability>
-		<model name='MAL-XT'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MAL-XV'>
 			<availability>General:2</availability>
 		</model>
@@ -10714,6 +10711,9 @@
 		</model>
 		<model name='MAL-XP'>
 			<availability>General:6</availability>
+		</model>
+		<model name='MAL-XT'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mammoth' unitType='Dropship'>
@@ -10732,9 +10732,6 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,CHH:2,MERC.WD:4,CDS:4,CW:4,CP:4,CJF:4,BAN:4,CWIE:4</availability>
-		<model name='E'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
@@ -10745,35 +10742,38 @@
 		<model name='G'>
 			<availability>General:2</availability>
 		</model>
-		<model name='T'>
-			<availability>General:4</availability>
+		<model name='E'>
+			<availability>CLAN:6,General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:6,CDS:7,General:8,CP:7,CJF:9</availability>
 		</model>
-		<model name='C'>
-			<availability>CWE:7,RD:7,CDS:7,CW:7,CNC:7,General:6,CP:7,CJF:5,CWIE:7</availability>
+		<model name='A'>
+			<availability>CWE:8,RD:9,CDS:4,CW:8,CNC:8,General:7,CP:6,CJF:9</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:4,CDS:4,CNC:6,General:5,CP:5,CJF:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CWE:8,RD:9,CDS:4,CW:8,CNC:8,General:7,CP:6,CJF:9</availability>
+		<model name='C'>
+			<availability>CWE:7,RD:7,CDS:7,CW:7,CNC:7,General:6,CP:7,CJF:5,CWIE:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:5,RD:5,CDS:3,CW:5,CNC:5,General:4,CP:4</availability>
 		</model>
+		<model name='T'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
 		<availability>MERC.KH:4,RF:4,LA:4,ROS:4,MERC:4,CWIE:6</availability>
+		<model name='MNL-4S'>
+			<availability>General:6</availability>
+		</model>
 		<model name='MNL-3L'>
 			<availability>MERC.KH:6,ROS:4,CWIE:6</availability>
 		</model>
 		<model name='MNL-3W'>
 			<availability>ROS:2,CWIE:4</availability>
-		</model>
-		<model name='MNL-4S'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -10790,28 +10790,40 @@
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>General:6</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
+		<model name='E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:3,CC:3,IS:4,MERC:4,FS:4,CP:3,Periphery:4,TC:4,CWIE:4,RA.OA:4,LA:4,ROS:4,FWL:3,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>LA:8,ROS:8,FS:8</availability>
+		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,RF:8,LA:8,ROS:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:1-,Periphery:2</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -10819,18 +10831,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:6,MOC:6,DTA:6,LA:6,ROS:6,FWL:4:3139,FS:6,MERC:6,CP:4,DC:6</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>LA:8,ROS:8,FS:8</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,RF:8,LA:8,ROS:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:1-,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore II Heavy Tank' unitType='Tank'>
@@ -10850,37 +10850,37 @@
 	</chassis>
 	<chassis name='Marauder Battle Armor' unitType='BattleArmor'>
 		<availability>MH:6,MERC:2,TC:4</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>MERC:8,TC:8</availability>
-		</model>
 		<model name='(MH)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>MH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>MERC:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.WD:6,RD:5,CW:4,CNC:4,CP:4,CJF:5,RA:4,CWIE:4</availability>
-		<model name='3'>
-			<availability>RD:5,CJF:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CWE:6,CW:6,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:8,RD:2,CJF:2</availability>
-		</model>
-		<model name='2'>
-			<availability>RD:3,CJF:3</availability>
 		</model>
 		<model name='5'>
 			<availability>CJF:2,CWIE:6</availability>
 		</model>
-		<model name='4'>
-			<availability>RD:4,CNC:6,CP:6,RA:4</availability>
+		<model name='6'>
+			<availability>CWE:6,CW:6,CJF:4</availability>
+		</model>
+		<model name='3'>
+			<availability>RD:5,CJF:5</availability>
 		</model>
 		<model name='7'>
 			<availability>RD:6</availability>
+		</model>
+		<model name='2'>
+			<availability>RD:3,CJF:3</availability>
+		</model>
+		<model name='4'>
+			<availability>RD:4,CNC:6,CP:6,RA:4</availability>
 		</model>
 		<model name='8'>
 			<availability>RD:2,CJF:2</availability>
@@ -10888,8 +10888,8 @@
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:6,MERC:5,CP:6,TC:4,MERC.WD:6,LA:2,ROS:6,PIR:4,FWL:6,MH:4,DC:6</availability>
-		<model name='MAD-4H'>
-			<availability>PIR:4,MH:4,TC:4</availability>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:6</availability>
 		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
@@ -10897,114 +10897,114 @@
 		<model name='MAD-6M'>
 			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
 		</model>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:6</availability>
-		</model>
 		<model name='MAD-4L'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>LA:6,ROS:6,CNC:8,FS:4,MERC:8,CP:8</availability>
 		</model>
+		<model name='MAD-6S'>
+			<availability>LA:4</availability>
+		</model>
 		<model name='MAD-4K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='MAD-6S'>
-			<availability>LA:4</availability>
+		<model name='MAD-4H'>
+			<availability>PIR:4,MH:4,TC:4</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,RA.OA:2,MOC:2,RD:3,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>DTA:8,OP:8,FWL:8:3139,MSC:8,MERC:3,DA:8,CP:8</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:3,FS:2,MERC:2,DC:4</availability>
+		<model name='MAD-3D'>
+			<availability>MH:1-</availability>
 		</model>
-		<model name='MAD-9S'>
-			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4</availability>
+		<model name='MAD-9D'>
+			<availability>FS:5</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>OP:6,RF:6,ROS:4,FWL:4:3139,MERC:4,DA:6,CP:4,DC:4</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>FVC:2,LA:3,MERC:3</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>DTA:8,OP:8,FWL:8:3139,MSC:8,MERC:3,DA:8,CP:8</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:3,FS:2,MERC:2,DC:4</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>MOC:4,ROS:4,FWL:6,MERC:4,CP:6</availability>
 		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
-		</model>
-		<model name='MAD-3D'>
-			<availability>MH:1-</availability>
+		<model name='MAD-6L'>
+			<availability>CC:6,MOC:4</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>Periphery:2-,TC:2-</availability>
 		</model>
-		<model name='MAD-5L'>
-			<availability>CC:6,MOC:5</availability>
+		<model name='MAD-9S'>
+			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4</availability>
 		</model>
 		<model name='MAD-2R'>
 			<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
 		</model>
-		<model name='MAD-9D'>
-			<availability>FS:5</availability>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:6,MOC:5</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>FVC:2,LA:3,MERC:3</availability>
+		</model>
+		<model name='MAD-9W2'>
+			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
+		</model>
+		<model name='MAD-7D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
 		<availability>CHH:4,LA:6,IS:4</availability>
-		<model name='(Light PPC)'>
-			<roles>artillery</roles>
-			<availability>LA:8,IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CHH:8,BAN:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>artillery</roles>
+			<availability>LA:8,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Marksman MBT' unitType='Tank'>
 		<availability>ROS:8,IS:5</availability>
-		<model name='M1J'>
-			<availability>General:5</availability>
+		<model name='M1'>
+			<availability>ROS:1,ROS.pm:8,General:8</availability>
 		</model>
 		<model name='M1A'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='M1'>
-			<availability>ROS:1,ROS.pm:8,General:8</availability>
+		<model name='M1J'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>LA:4,ROS:5,CLAN:7</availability>
-		<model name='(HAG)'>
-			<availability>CHH:6,RD:4,CDS:4,ROS:4,CP:4</availability>
-		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CJF:2</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CHH:4,RD:3,ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ATM)'>
+			<availability>General:5,CJF:2</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:6,RD:4,CDS:4,ROS:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -11015,14 +11015,14 @@
 	</chassis>
 	<chassis name='Marshal' unitType='Mek'>
 		<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
-		<model name='MHL-6MC'>
-			<availability>MOC:6,CC:4</availability>
-		</model>
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
 		</model>
 		<model name='MHL-3MC'>
 			<availability>MOC:4</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:6,CC:4</availability>
 		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
@@ -11030,36 +11030,36 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3,IS:2,FS:3,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CWE:2,RD:3,CDS:4,CW:2,CNC:2,MERC:3+,CP:3,CJF:3,RA:2,BAN:3</availability>
-		<model name='Prime'>
-			<availability>RD:8,CDS:9,General:8,CP:9</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:6,RD:6,CDS:5,CW:6,General:4,CP:5</availability>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:8,General:5,CP:8</availability>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>RD:5,CDS:8,General:5,CP:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CWE:6,RD:6,CDS:5,CW:6,General:4,CP:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,CDS:9,General:8,CP:9</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:8,General:5,CP:8</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:5,CDS:5,General:4,CP:5</availability>
@@ -11067,11 +11067,11 @@
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
@@ -11079,21 +11079,21 @@
 		<model name='MAL-1R'>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='MAL-1K'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='MAL-C'>
 			<availability>DC:1</availability>
 		</model>
 		<model name='MAL-3R'>
 			<availability>DC:4</availability>
 		</model>
+		<model name='MAL-1K'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:3,CLAN:1,MH:4,TC:6</availability>
-		<model name='(BA)'>
+		<model name='(Fusion)'>
 			<roles>apc</roles>
-			<availability>TC:6</availability>
+			<availability>TC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -11103,9 +11103,9 @@
 			<roles>apc</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Fusion)'>
+		<model name='(BA)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -11125,28 +11125,28 @@
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Company Command)'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Mk II Transport' unitType='Tank'>
 		<availability>LA:5,ROS:6,MERC:4</availability>
-		<model name='(Standard)'>
+		<model name='(ECM)'>
 			<roles>apc</roles>
-			<availability>LA:8,ROS:8</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Infantry Support) &apos;Shiloh&apos;'>
 			<roles>apc</roles>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>General:4</availability>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -11170,12 +11170,12 @@
 			<roles>interceptor</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<roles>interceptor</roles>
 			<availability>FVC:1,MERC:1,Periphery:1,DC:1</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -11190,8 +11190,11 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -11200,11 +11203,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -11212,35 +11212,35 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -11253,11 +11253,11 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -11292,15 +11292,26 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5</availability>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OB'>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='MS1-OC'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -11308,20 +11319,9 @@
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='MS1-OA'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='MS1-OG'>
-			<availability>General:4</availability>
 		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
@@ -11377,14 +11377,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>RA.OA:8,MERC:6,RA:5,Periphery:4</availability>
-		<model name='MLN-1C'>
-			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
-		</model>
 		<model name='MLN-1A'>
 			<availability>General:2-</availability>
 		</model>
 		<model name='MLN-1B'>
 			<availability>RA.OA:8,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='MLN-1C'>
+			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -11393,6 +11393,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,ROS:6</availability>
+		</model>
+		<model name='(Gauss) &apos;Sandblaster&apos;'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
@@ -11404,25 +11409,20 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Gauss) &apos;Sandblaster&apos;'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CHH:8,RA:3</availability>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='P2'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='XP'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='P2'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -11448,34 +11448,34 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		<model name='MLR-BX'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='MLR-B2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MLR-BX'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,CP:5+,DC:5+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -11498,15 +11498,15 @@
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
 		<availability>DTA:4,CC:5,MOC:5,OP:4,RF:4,DA:7,RCM:4,MERC:4</availability>
-		<model name='M2'>
-			<availability>General:6</availability>
-		</model>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
 			<availability>FWL:2,DA:4</availability>
+		</model>
+		<model name='M2'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>
@@ -11561,9 +11561,6 @@
 		<model name='(2776)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
 		<availability>ROS:4</availability>
@@ -11576,20 +11573,20 @@
 		<model name='MR-1SE'>
 			<availability>General:6</availability>
 		</model>
-		<model name='MR-1S'>
-			<availability>General:8</availability>
-		</model>
-		<model name='MR-1SA'>
-			<roles>interceptor,ground_support</roles>
+		<model name='MR-1SB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MR-1SD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='MR-1SB'>
-			<availability>General:7</availability>
+		<model name='MR-1S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='MR-1SC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SA'>
+			<roles>interceptor,ground_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -11606,6 +11603,14 @@
 	</chassis>
 	<chassis name='Morrigan' unitType='Mek'>
 		<availability>CDS:3,ROS:4,CNC:6,CP:4,DC:5</availability>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<roles>specops</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='5'>
 			<roles>recon</roles>
 			<availability>CNC:4,CP:4,DC:4</availability>
@@ -11614,17 +11619,9 @@
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='3'>
-			<roles>specops</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='2'>
 			<roles>recon</roles>
 			<availability>CLAN:4,IS:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
@@ -11669,33 +11666,33 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:7,Periphery:9</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mountaineer' unitType='Infantry'>
@@ -11721,29 +11718,29 @@
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='(Armor)'>
+		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
-			<availability>FS:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(3080 Upgrade)'>
+		<model name='(Armor)'>
 			<roles>spotter</roles>
-			<availability>General:8</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
-		<model name='Type 2'>
-			<availability>CC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>ROS:5,FS:4,MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='NL-45 Gunboat' unitType='Small Craft'>
@@ -11766,21 +11763,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CWE:4,CHH:4,MERC.WD:4,RD:3,CDS:4,CW:4,General:2,CP:4</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CWE:6,CHH:6,CDS:6,CW:6,General:5,CP:6,CWIE:6</availability>
+			<availability>CWE:4,CHH:3,RD:3,CDS:4,CW:4,General:2,CP:4,CWIE:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8,CP:9</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CWE:4,CHH:3,RD:3,CDS:4,CW:4,General:2,CP:4,CWIE:4</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CWE:4,CHH:3,MERC.WD:4,RD:3,CDS:4,CW:4,General:2,CP:4,CWIE:4</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CWE:6,CHH:6,CDS:6,CW:6,General:5,CP:6,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Nagasawa' unitType='Dropship'>
@@ -11792,17 +11789,17 @@
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>ROS:4,MERC:4,DC:6</availability>
-		<model name='NG-C3A'>
-			<roles>fire_support,spotter</roles>
-			<availability>DC:8</availability>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+		<model name='NG-C3A'>
+			<roles>fire_support,spotter</roles>
+			<availability>DC:8</availability>
 		</model>
 		<model name='NG-C3B'>
 			<roles>spotter</roles>
@@ -11849,11 +11846,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -11865,11 +11862,17 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:5,IS:3</availability>
@@ -11877,44 +11880,38 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='F'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>RA.OA:3,CWE:4,FVC:2,RD:4,CW:4,LA:5,ROS:4,CLAN:1,MERC:3</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Night Stalker' unitType='Mek'>
 		<availability>LA:4,ROS:1,FS:4,MERC:4</availability>
-		<model name='NSR-K4'>
-			<availability>General:4</availability>
-		</model>
-		<model name='NSR-KC'>
-			<availability>General:4</availability>
-		</model>
 		<model name='NSR-K3'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='NSR-K1'>
 			<availability>General:6</availability>
+		</model>
+		<model name='NSR-K4'>
+			<availability>General:4</availability>
+		</model>
+		<model name='NSR-KC'>
+			<availability>General:4</availability>
 		</model>
 		<model name='NSR-K7'>
 			<availability>General:2</availability>
@@ -11938,6 +11935,9 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>ROS:6</availability>
@@ -11946,29 +11946,26 @@
 			<roles>apc</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>OP:5,Periphery.R:2,RF:5,LA:8,ROS:6,FWL:3:3139,FS:7,MERC:6,CP:3</availability>
-		<model name='NGS-4T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-4S'>
 			<availability>:0,OP:4,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 		</model>
-		<model name='NGS-5T'>
-			<availability>OP:5,RF:5,LA:4,ROS:5,FWL:5,FS:4,MERC:4,CP:5</availability>
+		<model name='NGS-4T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6T'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
+		<model name='NGS-5T'>
+			<availability>OP:5,RF:5,LA:4,ROS:5,FWL:5,FS:4,MERC:4,CP:5</availability>
 		</model>
 		<model name='NGS-6S'>
 			<availability>LA:8,ROS:6,MERC:4</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -11976,11 +11973,11 @@
 		<model name='NSR-9FC'>
 			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
-		<model name='NSR-9SS'>
-			<availability>LA:4,MERC:2,FS:4</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9SS'>
+			<availability>LA:4,MERC:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nike Air Defense Platform' unitType='Tank'>
@@ -11994,11 +11991,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-4'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='NJT-3'>
 			<availability>General:2</availability>
+		</model>
+		<model name='NJT-4'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -12021,34 +12018,43 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>RD:4,DC.LV:8,DC.SL:2,LA:3,ROS:5,MERC:3,DC:8</availability>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
-		</model>
-		<model name='NDA-2KC'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
+		<model name='NDA-2KO'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
+		<model name='NDA-2KC'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
+		</model>
 		<model name='NDA-1K'>
 			<availability>RD:4,ROS:6,MERC:4,DC:4</availability>
 		</model>
-		<model name='NDA-2KO'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>ROS:3+,CNC:8,CP:8</availability>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
+		</model>
+		<model name='N'>
+			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
+		</model>
 		<model name='F'>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -12057,18 +12063,9 @@
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,ROS:4,CNC:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -12080,6 +12077,18 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>RD:3,CDS:6,ROS:4+,CNC:9,CP:7,CWIE:4</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -12088,42 +12097,27 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='I'>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-	</chassis>
-	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
-		<availability>RA.OA:3,RA:4-</availability>
-		<model name='2 &apos;Numantia&apos;'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
 		<availability>RA.OA:6,RA:8-</availability>
+		<model name='2 &apos;Numantia&apos;'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
@@ -12131,9 +12125,9 @@
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>DTA:4,RD:4,LA:4,ROS:6,MERC:4,FS:4,DC:5</availability>
-		<model name='NX-80C'>
+		<model name='NX-110'>
 			<roles>recon</roles>
-			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
@@ -12143,54 +12137,54 @@
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='NX-110'>
-			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
 		<model name='NX-100'>
 			<roles>recon</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='NX-80C'>
+			<roles>recon</roles>
+			<availability>DTA:3,ROS:3,MERC:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='OBK-M12'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>DC:2</availability>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
+		<model name='OBK-M12'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ocelot' unitType='Mek'>
 		<availability>RD:4,CDS:4,ROS:3,CNC:6,CP:5,DC:3</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CNC:6,CP:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CNC:3,CP:3,DC:3</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CDS:4,CNC:4,CP:4</availability>
 		</model>
+		<model name='4'>
+			<availability>CNC:3,CP:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
 		<availability>ROS:4,CLAN:5,CJF:4</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8,ROS:8,CLAN:8</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>recon,spotter</roles>
 			<availability>RD:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8,ROS:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Odyssey Jumpship' unitType='Jumpship'>
@@ -12226,16 +12220,16 @@
 	</chassis>
 	<chassis name='Onager' unitType='Mek'>
 		<availability>CJF:5</availability>
-		<model name='(Standard)'>
+		<model name='2'>
 			<availability>General:6</availability>
 		</model>
-		<model name='2'>
+		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Oni Battle Armor' unitType='BattleArmor'>
 		<availability>DC.pm:5,DC:2-</availability>
-		<model name='[Narc]' mechanized='true'>
+		<model name='[PPC]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[MRR]' mechanized='true'>
@@ -12244,45 +12238,45 @@
 		<model name='[Bearhunter]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[PPC]' mechanized='true'>
+		<model name='[Narc]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Oni' unitType='Aero'>
 		<availability>CNC:4,CP:4,DC:6</availability>
-		<model name='ON-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ON-2'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='ON-1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:4,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:4,CNC:8,IS:4,CP:8</availability>
+		<model name='HEAT'>
+			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:6,MOC:6,IS:6,FWL:6,CP:6</availability>
+		<model name='(Fusion)'>
+			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1,CP:1</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:6,IS:6</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:6,MOC:6,IS:6,FWL:6,CP:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1,CP:1</availability>
+		<model name='(MML)'>
+			<availability>MOC:6,IS:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:1-,Periphery:4</availability>
 		</model>
-		<model name='HEAT'>
-			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:4,CNC:8,IS:4,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Oo-Suzumebachi' unitType='Small Craft'>
@@ -12294,16 +12288,16 @@
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
@@ -12315,33 +12309,33 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,Periphery:3,TC:1,CWIE:2,CWE:2,CW:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
-		<model name='ON1-MD'>
-			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MSC:4,MERC:2,FS:2,CP:4</availability>
-		</model>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4,CP:6</availability>
-		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2,MOC:2,OP:4,ROS:4,FWL:4,MSC:4,DA:4,MERC:2,RCM:4,CP:4,DC:2</availability>
-		</model>
-		<model name='ON2-M'>
-			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3,CP:4</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>FS:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8,DC:6</availability>
-		</model>
-		<model name='ON1-M-DC'>
-			<availability>IS:5,DC:8</availability>
-		</model>
 		<model name='ON3-M'>
 			<roles>spotter</roles>
 			<availability>CC:6,FWL:6,MERC:5,CP:6</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4,CP:6</availability>
+		</model>
+		<model name='ON1-MC'>
+			<availability>FS:2,MERC:2,DC:4</availability>
+		</model>
+		<model name='ON1-MB'>
+			<availability>CC:2,MOC:2,OP:4,ROS:4,FWL:4,MSC:4,DA:4,MERC:2,RCM:4,CP:4,DC:2</availability>
+		</model>
 		<model name='ON1-K'>
 			<availability>CLAN:2-,Periphery:2-</availability>
+		</model>
+		<model name='ON1-M'>
+			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8,DC:6</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MSC:4,MERC:2,FS:2,CP:4</availability>
+		</model>
+		<model name='ON2-M'>
+			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3,CP:4</availability>
+		</model>
+		<model name='ON1-M-DC'>
+			<availability>IS:5,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -12362,23 +12356,23 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,ROS:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='OSR-5D'>
 			<availability>FS:6</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
 		</model>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
 		<availability>CC:4,LA:4,ROS:7,FS:4,MERC:4,DC:4</availability>
-		<model name='OSP-36'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='OSP-26'>
 			<availability>CC:4,ROS:8</availability>
+		</model>
+		<model name='OSP-36'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='OSP-25'>
 			<availability>General:6</availability>
@@ -12386,6 +12380,12 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,LA:4,ROS:4,IS:4,TC:4,DC:5,Periphery:2</availability>
+		<model name='OSR-4K'>
+			<availability>ROS:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='OSR-5C'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>Periphery:2-</availability>
@@ -12393,12 +12393,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2,Periphery:3</availability>
-		</model>
-		<model name='OSR-5C'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='OSR-4K'>
-			<availability>ROS:4,MERC:4,DC:6</availability>
 		</model>
 		<model name='OSR-2D'>
 			<availability>ROS:6,IS:4,Periphery:4</availability>
@@ -12412,14 +12406,11 @@
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
@@ -12427,12 +12418,15 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,OP:4,FVC:1,RF:4,LA:2,ROS:3,FWL:2,FS:2,MERC:3,CP:2,DC:3</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='OTT-7K'>
+			<roles>recon,spotter</roles>
+			<availability>FVC:8,IS:8,DC:8</availability>
 		</model>
 		<model name='OTT-11J'>
 			<roles>recon,spotter</roles>
@@ -12442,9 +12436,9 @@
 			<roles>recon,spotter</roles>
 			<availability>CC:4,OP:5,RF:5,LA:8,ROS:5,FWL:5,MERC:5,FS:4,CP:5,DC:4</availability>
 		</model>
-		<model name='OTT-7K'>
-			<roles>recon,spotter</roles>
-			<availability>FVC:8,IS:8,DC:8</availability>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -12452,17 +12446,14 @@
 		<model name='OTL-7M'>
 			<availability>DTA:8,OP:8,ROS:6,FWL:6,MSC:8,MERC:4,CP:6</availability>
 		</model>
-		<model name='OTL-5D'>
-			<availability>FVC:3,Periphery.HR:4,PIR:3,FS:2,Periphery:4</availability>
-		</model>
 		<model name='OTL-9M'>
 			<availability>ROS:4,FWL:6,CP:6</availability>
 		</model>
+		<model name='OTL-8D'>
+			<availability>FS:8</availability>
+		</model>
 		<model name='OTL-6D'>
 			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-9R'>
-			<availability>DTA:6,ROS:6,FWL:4:3139,MERC:5,CP:4</availability>
 		</model>
 		<model name='OTL-5M'>
 			<availability>FWL:2,MERC:4,CP:2</availability>
@@ -12470,8 +12461,11 @@
 		<model name='OTL-8M'>
 			<availability>DTA:8,RF:8,FWL:5:3139,MSC:6,MERC:3,CP:5</availability>
 		</model>
-		<model name='OTL-8D'>
-			<availability>FS:8</availability>
+		<model name='OTL-9R'>
+			<availability>DTA:6,ROS:6,FWL:4:3139,MERC:5,CP:4</availability>
+		</model>
+		<model name='OTL-5D'>
+			<availability>FVC:3,Periphery.HR:4,PIR:3,FS:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -12482,13 +12476,13 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CWE:4,CHH:8,CW:4</availability>
-		<model name='(3063)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(3070)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(3063)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
@@ -12504,49 +12498,29 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
-		<model name='A3A'>
-			<availability>LA:2,ROS:2,FS:2</availability>
-		</model>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:2,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:8,IS:6,FS:8</availability>
+		</model>
+		<model name='A3A'>
+			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 		<model name='A3'>
 			<roles>assault</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:2,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,FWL:4,FS:2,MERC:2,CP:4,DC:6</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='OW-1C'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:2,CLAN:6</availability>
-		</model>
-		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -12554,9 +12528,29 @@
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:2,CLAN:6</availability>
+		</model>
+		<model name='OW-1E'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='OW-1F'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='PAB-28 Sniper Suit' unitType='BattleArmor'>
@@ -12580,8 +12574,8 @@
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CDS:4,CP:4,CWIE:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CDS:5,CP:5,CWIE:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CWIE:4</availability>
@@ -12589,16 +12583,12 @@
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CDS:5,CP:5,CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery:5</availability>
@@ -12607,13 +12597,17 @@
 			<roles>recon,raider</roles>
 			<availability>CC:1,PIR:2,General:1,FWL:1,MERC:1,FS:2,CP:1,Periphery:3,DC:1</availability>
 		</model>
-		<model name='&apos;Gespenst&apos;'>
-			<roles>recon,specops</roles>
-			<availability>LA:2</availability>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
 			<availability>FWL.pm:4,RF.pm:4,MSC.pm:4,DA:3-,RCM.pm:4</availability>
+		</model>
+		<model name='&apos;Gespenst&apos;'>
+			<roles>recon,specops</roles>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Anti-Missile Tank' unitType='Tank'>
@@ -12632,17 +12626,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:4</availability>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>OP:3,LA:3,ROS:3,FS:3,DC:3</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>OP:3,LA:3,ROS:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paladin Defense System' unitType='Tank'>
@@ -12675,6 +12669,30 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:4,RD:5,ROS:3,FS.DMM:4,MERC:3,Periphery.OS:5,RA:4,Periphery:2,DC:6</availability>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
+		</model>
+		<model name='PNT-12A'>
+			<roles>fire_support</roles>
+			<availability>ROS:2,DC:2</availability>
+		</model>
+		<model name='PNT-12K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='PNT-10K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:2,RD:2,ROS:2,FS.DMM:2,MERC:2,RA:2,TC:2,DC:2</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
+		</model>
+		<model name='PNT-12K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
+		</model>
 		<model name='PNT-12KC'>
 			<roles>raider</roles>
 			<availability>DC:4</availability>
@@ -12683,56 +12701,28 @@
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
-		</model>
-		<model name='PNT-10K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:2,RD:2,ROS:2,FS.DMM:2,MERC:2,RA:2,TC:2,DC:2</availability>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='PNT-13K'>
 			<roles>fire_support</roles>
 			<availability>RD:4,DC:8</availability>
 		</model>
-		<model name='PNT-12A'>
-			<roles>fire_support</roles>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='PNT-9R'>
-			<roles>fire_support</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='PNT-12K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='PNT-12K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
 		<availability>FWL:2,CP:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MFB)'>
 			<roles>support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Parash' unitType='Mek'>
 		<availability>CHH:8</availability>
-		<model name='3'>
-			<roles>recon,spotter</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
@@ -12740,6 +12730,10 @@
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<roles>recon,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Partisan AA Vehicle' unitType='Tank'>
@@ -12755,20 +12749,20 @@
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,LA:7,CNC:5,IS:5,FS:8,CP:5,DC:6,Periphery:5,CWIE:5</availability>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:5,FS:5</availability>
-		</model>
 		<model name='(Quad RAC)'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:5,FS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:5,Periphery:5</availability>
 		</model>
-		<model name='(Company Command)'>
+		<model name='(Lance Command)'>
 			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:2,FS:2</availability>
+			<availability>ROS:5,FS:5</availability>
 		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
@@ -12777,13 +12771,13 @@
 		<model name='(Cell)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Company Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>ROS:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
@@ -12792,12 +12786,12 @@
 			<roles>anti_aircraft</roles>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -12839,20 +12833,20 @@
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
 		<availability>FVC:5,RF:5,LA:5,ROS:5,FS:4,CWIE:5</availability>
-		<model name='(Standard)'>
-			<availability>Periphery:2</availability>
-		</model>
 		<model name='(Ultra)'>
 			<availability>LA:8,General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Peacekeeper' unitType='Mek'>
 		<availability>ROS:6,DC:6</availability>
-		<model name='PKP-2K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='PKP-1B'>
 			<availability>General:4</availability>
+		</model>
+		<model name='PKP-2K'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='PKP-1A'>
 			<availability>General:8</availability>
@@ -12864,14 +12858,6 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:8</availability>
 		</model>
-		<model name='X-Pulse'>
-			<roles>recon</roles>
-			<availability>DC.AL:8,General:4,DC:5</availability>
-		</model>
-		<model name='(3058 Upgrade)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,FS:8,DC:7</availability>
-		</model>
 		<model name='(MRM)'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
@@ -12879,6 +12865,14 @@
 		<model name='(Sealed)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
+		</model>
+		<model name='X-Pulse'>
+			<roles>recon</roles>
+			<availability>DC.AL:8,General:4,DC:5</availability>
+		</model>
+		<model name='(3058 Upgrade)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,FS:8,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Pendragon' unitType='Mek'>
@@ -12890,20 +12884,20 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='PTR-6T'>
-			<availability>FS.DBG:8,FS:4</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-6T'>
+			<availability>FS.DBG:8,FS:4</availability>
+		</model>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Penthesilea' unitType='Mek'>
@@ -12911,11 +12905,11 @@
 		<model name='PEN-2MAF'>
 			<availability>General:4</availability>
 		</model>
-		<model name='PEN-3H'>
-			<availability>MOC:5,CC:4</availability>
-		</model>
 		<model name='PEN-2H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PEN-3H'>
+			<availability>MOC:5,CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
@@ -12936,31 +12930,31 @@
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>DTA:6,OP:6,ROS:4,FWL:4,MSC:6,CP:4</availability>
-		<model name='P1E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='P1D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1'>
-			<availability>General:8</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='P1B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1W'>
 			<availability>General:2</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -12974,70 +12968,70 @@
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,FWL:5,IS:4,FS:4,MERC:4,CP:5,DC:4</availability>
+		<model name='(Prototype)'>
+			<availability>OP:1,LA:2</availability>
+		</model>
 		<model name='(Production)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Prototype)'>
-			<availability>OP:1,LA:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CWE:8,CHH:7,CW:8,CJF:7,RA:6,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>RD:9,General:8</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>RD:6,CDS:4,CNC:6,General:5,CP:5</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='D'>
+			<availability>RD:4,General:5</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:4,General:5</availability>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>RD:9,General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>RD:7,General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:6,CDS:4,CNC:6,General:5,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CC:3,CLAN:3,CP:5,MERC:3,FS:3,RA:5,DTA:3,CDS:5,RF:3,LA:3,ROS:4,MSC:3,DC:3</availability>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>DTA:4,CDS:8,RF:4,LA:4,ROS:4,MSC:4,FS:4,MERC:4,CP:8,DC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CDS:1,CNC:1,IS:3,CP:1,DC:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,CP:6,DC:4</availability>
-		</model>
-		<model name='6'>
-			<availability>RD:6,CDS:8,CP:8</availability>
 		</model>
 		<model name='7'>
 			<availability>RD:8,CDS:6,General:6,DC:6</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:8,CP:8</availability>
+		<model name='4'>
+			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,CP:6,DC:4</availability>
+		</model>
+		<model name='3'>
+			<availability>DTA:4,CDS:8,RF:4,LA:4,ROS:4,MSC:4,FS:4,MERC:4,CP:8,DC:4</availability>
+		</model>
+		<model name='6'>
+			<availability>RD:6,CDS:8,CP:8</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>RA:3</availability>
+		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk L' unitType='Mek'>
@@ -13051,15 +13045,14 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>RD:4,IS:7,FWL:8,CP:8,Periphery:6</availability>
-		<model name='PXH-6D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CC:4,OP:4,CLAN:3,FWL:4,MSC:5,MERC:4,DA:4,RCM:4,CP:4</availability>
+		<model name='PXH-7K'>
+			<availability>OP:4,DC:4</availability>
 		</model>
 		<model name='PXH-7S'>
 			<availability>RF:4,LA:8,ROS:4,MERC:6</availability>
+		</model>
+		<model name='PXH-4W'>
+			<availability>MOC:6,TC:6</availability>
 		</model>
 		<model name='PXH-4L'>
 			<availability>CC:8,MOC:4,MH:4,DA:4,TC:4</availability>
@@ -13068,44 +13061,45 @@
 			<roles>recon</roles>
 			<availability>PIR:1-</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,FS:6,MERC:4</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>BAN:6,Periphery:1-</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>RD:4,ROS:2,DC:2</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
 		<model name='PXH-5L'>
 			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>DTA:8,OP:8,RF:8,FWL:8,IS:4,MSC:8,RCM:8,DA:8,CP:8</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>RD:6,DC:8</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:5,FWL:4,MSC:6,CP:4,BAN:1</availability>
 		</model>
+		<model name='PXH-6D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>RD:6,DC:8</availability>
+		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:3,MERC:4</availability>
 		</model>
-		<model name='PXH-7K'>
-			<availability>OP:4,DC:4</availability>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>DTA:8,OP:8,RF:8,FWL:8,IS:4,MSC:8,RCM:8,DA:8,CP:8</availability>
 		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:6,TC:6</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,FS:6,MERC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>RD:4,ROS:2,DC:2</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>BAN:6,Periphery:1-</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CC:4,OP:4,CLAN:3,FWL:4,MSC:5,MERC:4,DA:4,RCM:4,CP:4</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Picaroon' unitType='Aero'>
@@ -13116,17 +13110,17 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>RA.OA:1-,CC:3,CHH:3,MERC.WD:3,CDS:4,CLAN:3,CNC:3,MH:1-,CP:3,CWIE:4,Periphery:2-</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>CC:8,MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>Periphery:2</availability>
 		</model>
 		<model name='(RAC) &apos;Assault Pike&apos;'>
 			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
 		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
+		<model name='(Standard)'>
+			<availability>Periphery:2</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -13134,6 +13128,9 @@
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,MOC:3,MERC.WD:4,MERC.KH:4,ROS:4,CNC:6,MERC:4,CP:6</availability>
+		<model name='PLG-5Z'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
@@ -13144,19 +13141,16 @@
 		<model name='PLG-3Z'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PLG-5Z'>
-			<availability>CC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,ROS:5,FS:7,MERC:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -13179,9 +13173,6 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:6,CDS:5,CP:5,RA:3,CWIE:3</availability>
-		<model name='2'>
-			<availability>CHH:8,CDS:8,CP:8</availability>
-		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4,CP:4</availability>
@@ -13191,6 +13182,9 @@
 		</model>
 		<model name='3'>
 			<availability>CDS:6,CP:6,RA:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:8,CDS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -13208,9 +13202,6 @@
 	</chassis>
 	<chassis name='Plainsman Medium Hovertank' unitType='Tank'>
 		<availability>MERC.WD:3,RD:3,LA:5,FWL:4,IS:3,CP:4,TC:8,Periphery:3</availability>
-		<model name='(Sealed)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>IS:6,TC:6,Periphery:4</availability>
 		</model>
@@ -13220,6 +13211,9 @@
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:3,Periphery:3</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
@@ -13264,30 +13258,30 @@
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
 		<availability>CC:7,MOC:5,DA:5</availability>
-		<model name='(Stealth)'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='(Gauss)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Stealth)'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>MOC:8,CC:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Poignard' unitType='Aero'>
 		<availability>DTA:5,ROS:5,FWL:5,MSC:6,RCM:5,MERC:4,CP:5</availability>
-		<model name='PGD-R3'>
-			<roles>ground_support</roles>
+		<model name='PGD-L3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='PGD-Y3'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PGD-L3'>
+		<model name='PGD-R3'>
+			<roles>ground_support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -13299,38 +13293,38 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CDS:5,CP:5,RA:5,CWIE:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CWE:8,CHH:4,CW:8,CNC:4,CP:4,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>RD:8,CDS:6,General:8,CP:6,CJF:7</availability>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CWE:5,RD:3,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>RD:8,CDS:6,General:8,CP:6,CJF:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
+		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CWE:5,RD:3,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
@@ -13354,17 +13348,17 @@
 	</chassis>
 	<chassis name='Prefect' unitType='Mek'>
 		<availability>ROS:4</availability>
-		<model name='PRF-2R'>
-			<availability>General:4</availability>
-		</model>
-		<model name='PRF-1R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='PRF-3R'>
 			<availability>General:5</availability>
 		</model>
+		<model name='PRF-2R'>
+			<availability>General:4</availability>
+		</model>
 		<model name='PRF-1C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='PRF-1R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Prey Seeker' unitType='Mek'>
@@ -13376,11 +13370,11 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Quad)'>
 			<availability>CHH:6+</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -13391,44 +13385,51 @@
 		</model>
 	</chassis>
 	<chassis name='Protector Combat Support Fighter' unitType='Conventional Fighter'>
-		<availability>MOC:5,FS:2,Periphery:4,DC:2,OA.RA:5</availability>
+		<availability>MOC:5,OA.RA:5,FS:2,Periphery:4,DC:2</availability>
 		<model name='ASF-23'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(RAF)'>
-			<roles>apc</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>Periphery:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4,Periphery:4</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>RD:4,IS:4,Periphery:4,RA:4</availability>
+		</model>
 		<model name='(Security)'>
 			<roles>apc</roles>
 			<availability>ROS:5</availability>
+		</model>
+		<model name='(RAF)'>
+			<roles>apc</roles>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='(3140 Upgrade)'>
 			<roles>apc</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='(Sealed)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>RD:4,IS:4,Periphery:4,RA:4</availability>
+			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:6,MERC:3+,CP:7,RA:6,BAN:5,CWIE:7,CWE:7,MERC.WD:4,RD:5,CDS:7,CW:7,ROS:4+,CNC:7,CJF:4</availability>
+		<model name='H'>
+			<availability>CWE:6,CHH:6,CW:6,CLAN:4,General:3,CJF:6</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
 		<model name='D'>
 			<availability>CWE:5,RD:3,CDS:5,CW:5,General:4,CP:5</availability>
 		</model>
@@ -13436,25 +13437,18 @@
 			<roles>fire_support</roles>
 			<availability>CWE:6,CHH:6,RD:3,CDS:7,CW:6,CNC:4,General:5,CP:5,CJF:6</availability>
 		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:4,CDS:5,CW:6,General:3,CP:5,CJF:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CWE:5,RD:5,CDS:8,CW:5,CNC:8,General:7,CP:8,CWIE:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:6,RD:4,CDS:5,CW:6,General:3,CP:5,CJF:4</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CWE:6,CHH:6,RD:8,CDS:6,CW:6,CNC:7,General:8,CP:6,CJF:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CWE:6,CHH:6,CW:6,CLAN:4,General:3,CJF:6</availability>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -13471,15 +13465,15 @@
 	</chassis>
 	<chassis name='Purifier Adaptive Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:5</availability>
-		<model name='[Laser] (RAF)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[PPC] (RAF)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[TAG] (RAF)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='[PPC] (RAF)' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (RAF)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
@@ -13512,31 +13506,31 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:4,CC:5,OP:6,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,DTA:6,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4</availability>
-		<model name='QKD-8K'>
-			<availability>RD:5,ROS:5,MERC:4,DC:8</availability>
+		<model name='QKD-5K'>
+			<availability>MERC:5,DC:4</availability>
 		</model>
 		<model name='QKD-8P'>
 			<roles>spotter</roles>
 			<availability>ROS:6</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>MERC:5,DC:4</availability>
-		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:6,FWL:8,CP:8</availability>
-		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
-		</model>
 		<model name='QKD-9M'>
 			<roles>spotter</roles>
 			<availability>CC:5,MOC:5,ROS:3,DA:5,FS:3</availability>
 		</model>
-		<model name='QKD-4G'>
-			<availability>MOC:2-,Periphery:2-,TC:2-</availability>
+		<model name='QKD-8K'>
+			<availability>RD:5,ROS:5,MERC:4,DC:8</availability>
 		</model>
 		<model name='QKD-C'>
 			<availability>MERC:6,DC:8</availability>
+		</model>
+		<model name='QKD-4G'>
+			<availability>MOC:2-,Periphery:2-,TC:2-</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
+		</model>
+		<model name='QKD-5Mr'>
+			<availability>General:6,FWL:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Quirinus Battle Armor' unitType='BattleArmor'>
@@ -13584,24 +13578,24 @@
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:5</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden II Battle Armor' unitType='BattleArmor'>
@@ -13615,8 +13609,8 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:2,ROS:3,FS:3,MERC:3</availability>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='MDG-1Ar'>
 			<availability>ROS:8,FS:4,MERC:4</availability>
@@ -13624,23 +13618,19 @@
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>FVC:6,LA:4,ROS:5,ROS.pm:7,FWL:4,MH:6,MERC:6,FS:5,CP:4,CDP:6,DC:4</availability>
-		<model name='VV1'>
+		<model name='VV1 (MG)'>
 			<roles>urban</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VV1 (Interdictor)'>
 			<roles>urban</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='VV2'>
 			<roles>urban</roles>
@@ -13650,17 +13640,21 @@
 			<roles>urban</roles>
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
+		<model name='VV1'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:6,ROS:4,CLAN:1</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='RPR-100'>
+			<availability>General:1</availability>
 		</model>
 		<model name='RPR-300S'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>General:1</availability>
+		<model name='RPR-100b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='RPR-300'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -13668,11 +13662,11 @@
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
 		<availability>ROS:4</availability>
-		<model name='RPT-5X'>
+		<model name='RPT-2X'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='RPT-2X2'>
+		<model name='RPT-5X'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
@@ -13680,28 +13674,40 @@
 			<roles>specops</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='RPT-2X2'>
+			<roles>specops</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='RPT-3X'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='RPT-2X'>
-			<roles>specops</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>DC:6</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='RTX1-OU'>
-			<availability>General:2</availability>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
@@ -13710,32 +13716,20 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
 		<availability>Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
-		<model name='(LRM)' mechanized='false'>
-			<availability>General:4,MH:0</availability>
-		</model>
 		<model name='(MH)' mechanized='false'>
 			<availability>MH:8</availability>
 		</model>
-		<model name='(LRM) [MH]' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8,MH:0</availability>
+		</model>
+		<model name='(LRM)' mechanized='false'>
+			<availability>General:4,MH:0</availability>
+		</model>
+		<model name='(LRM) [MH]' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Raven II' unitType='Mek'>
@@ -13747,40 +13741,40 @@
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:5,MOC:2,FWL:2,MERC:4,DA:3,CP:2,TC:2</availability>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:7,MOC:5</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:1,MOC:1,MERC:1,DC:1,TC:1</availability>
-		</model>
 		<model name='RVN-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,TC:3</availability>
 		</model>
-		<model name='RVN-4L'>
+		<model name='RVN-4Lr'>
 			<roles>spotter</roles>
-			<availability>CC:4,MOC:4,DA:6,TC:4</availability>
+			<availability>CC:7,MOC:5</availability>
 		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
 		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:1,MOC:1,MERC:1,DC:1,TC:1</availability>
+		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:4,MOC:4,DA:6,TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>OP:4,RF:4,LA:6,ROS:4,FWL:2:3139,MH:4,MERC:4,FS:4,DA:4,CP:2</availability>
-		<model name='RZK-9S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RZK-10T'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='RZK-10S'>
-			<availability>LA:6</availability>
+		<model name='RZK-9S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Recon Infantry' unitType='Infantry'>
@@ -13814,23 +13808,15 @@
 		<model name='(Stealth)'>
 			<availability>CC:8</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:2</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Revenant' unitType='Mek'>
 		<availability>ROS:2</availability>
-		<model name='UBM-2R3'>
-			<roles>specops</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='UBM-2R2'>
-			<roles>specops</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='UBM-2R'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
@@ -13839,6 +13825,14 @@
 			<roles>specops</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='UBM-2R3'>
+			<roles>specops</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='UBM-2R2'>
+			<roles>specops</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='UBM-2R4'>
 			<roles>spotter,specops</roles>
 			<availability>General:6</availability>
@@ -13846,87 +13840,97 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,RA.OA:7,LA:7,ROS:7,DC:6</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CWE:1,CHH:1,CW:1,General:8,CNC:1,CP:1</availability>
 		</model>
-		<model name='(ML)'>
+		<model name='(MG)'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(ML)'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:1,OP:8,FS:2,CP:8,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8</availability>
+		<model name='F-700a'>
+			<availability>CC:7,MOC:5,OP:6,FS:5,MERC:7,CP:6,DTA:6,RF:6,ROS:8,FWL:6,MSC:6,DA:6,RCM:6</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:8,MOC:5,DTA:8,OP:8,RF:8,ROS:8,FWL:8,MSC:8,MERC:8,RCM:8,DA:8,CP:8</availability>
 		</model>
-		<model name='F-100'>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
-		<model name='F-700a'>
-			<availability>CC:7,MOC:5,OP:6,FS:5,MERC:7,CP:6,DTA:6,RF:6,ROS:8,FWL:6,MSC:6,DA:6,RCM:6</availability>
-		</model>
 		<model name='F-700b'>
 			<availability>MOC:5,CC:5,DTA:8,OP:8,ROS:6,FWL:8,MSC:8,MERC:8,CP:8,DC:8</availability>
+		</model>
+		<model name='F-100'>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CHH:5,RD:5,CDS:5,CNC:5,IS:3,CP:5,RA:5</availability>
-		<model name='2'>
-			<availability>CNC:5,CP:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:4,CDS:6,CP:6</availability>
-		</model>
 		<model name='8'>
 			<availability>CC:4,OP:4,RD:6,CDS:4,LA:4,IS:4,MSC:4,FS:4,MERC:4,CP:4,DC:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:4,ROS:4,MERC:4,FS:4,CP:4</availability>
-		</model>
-		<model name='7'>
-			<availability>ROS:4,CNC:8,CP:8,DC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:1,CNC:1,CP:1,RA:2</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,IS:4,CP:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:1,CNC:1,CP:1,RA:2</availability>
+		</model>
+		<model name='7'>
+			<availability>ROS:4,CNC:8,CP:8,DC:6</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:4,CDS:6,CP:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:4,ROS:4,MERC:4,FS:4,CP:4</availability>
+		</model>
+		<model name='2'>
+			<availability>CNC:5,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:4,ROS:6,IS:4,FWL:7,FS:8,CP:7,CJF:6,Periphery:2</availability>
+		<model name='RFL-7M'>
+			<availability>MOC:4,OP:8,IS:4,CP:8,CDP:4,TC:4,DTA:8,RF:8,FWL:8,MSC:8,DA:8,RCM:8,DC:5</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='RFL-5D'>
+			<availability>FVC:3,LA:2,FS:2,MERC:3</availability>
+		</model>
+		<model name='RFL-3Cr'>
+			<availability>FS:2</availability>
+		</model>
 		<model name='RFL-1N'>
 			<roles>fire_support</roles>
 			<availability>MOC:1-,PIR:1-,MH:1-</availability>
 		</model>
-		<model name='RFL-7M'>
-			<availability>MOC:4,OP:8,IS:4,CP:8,CDP:4,TC:4,DTA:8,RF:8,FWL:8,MSC:8,DA:8,RCM:8,DC:5</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:3,LA:2,FS:2,MERC:3</availability>
+		<model name='C 2'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='RFL-8D'>
 			<availability>FS:2</availability>
@@ -13941,49 +13945,39 @@
 			<roles>fire_support</roles>
 			<availability>ROS:5,MERC:5</availability>
 		</model>
-		<model name='C 2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='RFL-5M'>
 			<availability>CC:1,MOC:1,Periphery.MW:3,Periphery.ME:3,FWL:2,MH:3,MERC:1,CP:2,DC:1</availability>
-		</model>
-		<model name='RFL-3Cr'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,FVC:4,LA:5,ROS:6,CLAN:2,FS:5,DC:5</availability>
-		<model name='(SPL)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>FVC:4,IS:4</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
-		<model name='(ERML)'>
+		<model name='(Royal)'>
 			<roles>apc</roles>
-			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
+			<availability>CHH:8,CLAN:6</availability>
 		</model>
 		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>CNC:4,FS:4,CP:4,DC:5</availability>
 		</model>
-		<model name='(Infantry)'>
+		<model name='(ERML)'>
 			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>CHH:8,CLAN:6</availability>
+			<availability>LA:5,ROS:4,FS:4</availability>
+		</model>
+		<model name='(SPL)'>
+			<roles>apc</roles>
+			<availability>FVC:4,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Roadrunner (Emerald Harrier)' unitType='Mek'>
@@ -13995,27 +13989,27 @@
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CHH:4,CNC:7,CP:7,RA:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CNC:4,CP:4,RA:6</availability>
 		</model>
 		<model name='4'>
 			<availability>RA:6</availability>
 		</model>
-		<model name='2'>
-			<availability>RA:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>RD:6-</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Hybrid)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='true'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
@@ -14023,30 +14017,30 @@
 	</chassis>
 	<chassis name='Rokurokubi' unitType='Mek'>
 		<availability>DC:6</availability>
-		<model name='RK-4T'>
-			<availability>General:4</availability>
-		</model>
 		<model name='RK-4K'>
 			<availability>General:8</availability>
 		</model>
 		<model name='RK-4X'>
 			<availability>General:2</availability>
 		</model>
+		<model name='RK-4T'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>RA.OA:5,FVC:4,RF:4,LA:5,ROS:4,FS:3,MERC:2,CWIE:6,TC:6</availability>
+		<model name='(Gauss)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>General:8</availability>
+		<model name='(Standard)'>
+			<availability>RF:0,ROS:0,General:1-,TC:0,CWIE:0</availability>
 		</model>
 		<model name='(Howitzer) Production'>
 			<roles>artillery,fire_support</roles>
 			<availability>LA:4,CWIE:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>RF:0,ROS:0,General:1-,TC:0,CWIE:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Rondel' unitType='Aero'>
@@ -14077,16 +14071,16 @@
 			<roles>urban</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='(Firedrake)' mechanized='false'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>LA:4</availability>
 		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>LA:8</availability>
+		</model>
+		<model name='(Firedrake)' mechanized='false'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -14099,44 +14093,44 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:5,CDS:4,CLAN:4,MERC:3+,CP:4,CJF:4,RA:5,BAN:5,CWIE:5,DC:4+</availability>
-		<model name='G'>
-			<availability>CHH:5,General:3</availability>
+		<model name='D'>
+			<availability>CWE:3,RD:3,CDS:8,CW:3,CNC:6,General:5,CP:7,CJF:4</availability>
 		</model>
 		<model name='B'>
 			<availability>CWE:5,RD:3,CDS:8,CW:5,General:6,CP:8,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:3,General:2</availability>
+		<model name='A'>
+			<availability>CWE:6,RD:3,CDS:9,CW:6,General:6,CP:9,CJF:5</availability>
 		</model>
-		<model name='I'>
+		<model name='H'>
 			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CWE:8,RD:8,CDS:5,CW:8,CNC:8,General:7,CP:6,CJF:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CWE:6,RD:3,CDS:9,CW:6,General:6,CP:9,CJF:5</availability>
+		<model name='F'>
+			<availability>General:3,CJF:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:3,RD:3,CDS:8,CW:3,CNC:6,General:5,CP:7,CJF:4</availability>
+		<model name='I'>
+			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CDS:6,CNC:4,General:5,CP:5,CJF:4,RA:6,CWIE:6</availability>
 		</model>
-		<model name='F'>
-			<availability>General:3,CJF:5</availability>
-		</model>
 		<model name='C'>
 			<availability>RD:6,General:5,RA:6,CWIE:5</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ryoken III-XP' unitType='Mek' omni='IS'>
 		<availability>CWE:2</availability>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:7</availability>
@@ -14144,20 +14138,20 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Ryoken II' unitType='Mek'>
 		<availability>CHH:4,RD:5,CDS:4,ROS:3,IS:2,CP:4</availability>
-		<model name='2'>
-			<availability>RD:6,ROS:6</availability>
+		<model name='3'>
+			<availability>CHH:8,RD:4,ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>RD:8,CDS:8,IS:8,CP:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CHH:8,RD:4,ROS:4</availability>
+		<model name='2'>
+			<availability>RD:6,ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
@@ -14198,13 +14192,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,CP:8,DC:6,Periphery:6</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,CP:4,DC:8,Periphery:4</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,CP:8,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -14221,33 +14215,27 @@
 		<model name='SB-29'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='SB-31D'>
-			<roles>escort</roles>
-			<availability>DC:6</availability>
+		<model name='SB-28'>
+			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:6</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
+		<model name='SB-31D'>
+			<roles>escort</roles>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
+		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='X'>
-			<availability>General:1,CJF:3,RA:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -14256,17 +14244,23 @@
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='X'>
+			<availability>General:1,CJF:3,RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
 		<availability>FVC:4,ROS:4,FS:6,MERC:4</availability>
+		<model name='SGT-8R'>
+			<availability>FVC:8,FS:4</availability>
+		</model>
 		<model name='SGT-10X'>
 			<availability>ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SGT-14D'>
 			<availability>FS:4</availability>
-		</model>
-		<model name='SGT-8R'>
-			<availability>FVC:8,FS:4</availability>
 		</model>
 		<model name='SGT-9D'>
 			<roles>spotter</roles>
@@ -14275,20 +14269,20 @@
 	</chassis>
 	<chassis name='Sagittarii' unitType='Aero'>
 		<availability>ROS:8</availability>
-		<model name='SGT-4R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
 		</model>
 		<model name='SGT-3R'>
 			<availability>General:6</availability>
 		</model>
+		<model name='SGT-4R'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CWE:4,RD:4,CDS:4,CW:4,ROS:5,CNC:5,FS:4,CP:4,BAN:1,DC:7,CWIE:4</availability>
-		<model name='S-7'>
-			<availability>ROS:6,CNC:6,CP:6,DC:6</availability>
+		<model name='S-4C'>
+			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
 		<model name='S-8'>
 			<availability>ROS:8,DC:8</availability>
@@ -14296,54 +14290,46 @@
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
 		</model>
-		<model name='S-4C'>
-			<availability>ROS:4,CLAN:8,DC:4</availability>
+		<model name='S-7'>
+			<availability>ROS:6,CNC:6,CP:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,DC.AL:7,IS:4,FWL:4,MERC:4,FS:3,CJF:4,DC:5</availability>
-		<model name='(Ultra)'>
-			<availability>IS:8,DC:8</availability>
+		<model name='(LB-X)'>
+			<availability>IS:6,DC:8</availability>
 		</model>
 		<model name='(Clan Cargo)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>IS:6,DC:8</availability>
+		<model name='(Ultra)'>
+			<availability>IS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Mk II HCV' unitType='Tank'>
 		<availability>CNC:4,FWL:4,MERC:4,CP:4,DC:5</availability>
-		<model name='(BC3)'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(BC3)'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>anti_infantry</roles>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='(Laser)' mechanized='true'>
 			<availability>CWE:6,CW:6,RA:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>anti_infantry</roles>
+			<availability>CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:7,ROS:4,FS:5,MERC:5</availability>
-		<model name='PPR-6T'>
-			<roles>fire_support</roles>
-			<availability>LA:6,MERC:4,FS:4</availability>
-		</model>
-		<model name='PPR-5S'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='PPR-7T'>
 			<roles>fire_support</roles>
 			<availability>LA:5</availability>
@@ -14352,13 +14338,21 @@
 			<roles>fire_support</roles>
 			<availability>LA:5,MERC:3,FS:3</availability>
 		</model>
-		<model name='PPR-6S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,FS:2,MERC:2</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='PPR-6T'>
+			<roles>fire_support</roles>
+			<availability>LA:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='PPR-5S'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='PPR-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -14382,13 +14376,13 @@
 	</chassis>
 	<chassis name='Saracen Mk II HCV' unitType='Tank'>
 		<availability>CNC:4,FWL:4,MERC:4,CP:4,DC:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(BC3)'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarath' unitType='Mek' omni='IS'>
@@ -14396,11 +14390,11 @@
 		<model name='SRTH-1OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SRTH-1O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SRTH-1OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SRTH-1O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarissa SecurityMech' unitType='Mek'>
@@ -14425,42 +14419,42 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CNC:3,CP:3,RA:4</availability>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CNC:4,CP:4,RA:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CNC:4,CP:4,RA:4</availability>
+		</model>
 		<model name='XP'>
 			<availability>CNC:8,CP:8</availability>
-		</model>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,CHH:4,CW:5</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='W'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>CWE:3,CHH:3,CW:3</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='J'>
 			<availability>CWE:4,CHH:4,CW:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='W'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>CWE:3,CHH:3,CW:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
@@ -14482,77 +14476,77 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MASH)'>
-			<roles>apc,support</roles>
-			<availability>General:4</availability>
+		<model name='(HQ)'>
+			<roles>apc,support,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(HQ)'>
-			<roles>apc,support,spotter</roles>
-			<availability>General:2</availability>
+		<model name='(MASH)'>
+			<roles>apc,support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scapha Hovertank' unitType='Tank' omni='IS'>
 		<availability>ROS:7+</availability>
-		<model name='(J)'>
-			<availability>General:7</availability>
+		<model name='(Primary)'>
+			<availability>General:8</availability>
 		</model>
-		<model name='(B)'>
+		<model name='(H)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(G)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Primary)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(E)'>
-			<roles>artillery</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(C)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(H)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(D)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(A)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(F)'>
-			<roles>spotter</roles>
+		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(I)'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='(C)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(D)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(J)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(E)'>
+			<roles>artillery</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(F)'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(A)'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>RF:5,LA:3,ROS:5,FS:6,MERC:4,DA:5</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>RF:5,LA:6,ROS:4,FS:2,MERC:5,DA:5</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>RF:5,LA:6,ROS:4,FS:2,MERC:5,DA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Scarecrow' unitType='Mek'>
 		<availability>FS:3</availability>
-		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
-			<availability>General:4</availability>
-		</model>
 		<model name='UCU-F4'>
 			<roles>anti_infantry</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schildkrote Line Tank' unitType='Tank'>
@@ -14566,6 +14560,10 @@
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>DTA:4,OP:4,RD:4,ROS:5,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -14573,6 +14571,10 @@
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support,spotter</roles>
@@ -14582,14 +14584,6 @@
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
@@ -14597,10 +14591,6 @@
 	</chassis>
 	<chassis name='Schrack' unitType='Aero' omni='IS'>
 		<availability>ROS:7</availability>
-		<model name='SCK-OA'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='SCK-OB'>
 			<availability>General:7</availability>
 		</model>
@@ -14608,9 +14598,17 @@
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCK-OA'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>RA.OA:1,RD:2,CNC:2,CP:2,Periphery:2,RA:2</availability>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -14618,10 +14616,6 @@
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:6</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>RD:8,CNC:8,IS:6,CP:8,RA:8</availability>
@@ -14645,21 +14639,15 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(3136 Upgrade)'>
-			<availability>CNC:4,FWL:4,MERC:4,CP:4,DC:4</availability>
-		</model>
 		<model name='(BC3)'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(3136 Upgrade)'>
+			<availability>CNC:4,FWL:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,LA:6,FWL:6,IS:7,Periphery.Deep:5,FS:6,CP:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(MRM)'>
-			<availability>IS:5,DC:5,Periphery:4</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:6,MOC:5,IS:5,FS:6,MERC:6,CP:6,CDP:5,TC:5,LA:6,ROS:6,FWL:6,MH:5,DC:6</availability>
-		</model>
 		<model name='(Minesweeper)'>
 			<roles>minesweeper</roles>
 			<availability>CC:4-,MOC:2-</availability>
@@ -14667,8 +14655,14 @@
 		<model name='(Standard)'>
 			<availability>General:1-</availability>
 		</model>
+		<model name='(LAC)'>
+			<availability>CC:6,MOC:5,IS:5,FS:6,MERC:6,CP:6,CDP:5,TC:5,LA:6,ROS:6,FWL:6,MH:5,DC:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>General:1-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>IS:5,DC:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -14676,18 +14670,18 @@
 		<model name='SCP-1N'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='SCP-10M'>
-			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
-		</model>
-		<model name='SCP-12S'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
 		<model name='SCP-1O'>
 			<availability>IS:1,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='SCP-12S'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
+		</model>
+		<model name='SCP-10M'>
+			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
 		</model>
 		<model name='SCP-1TB'>
 			<availability>ROS:4,MERC:4</availability>
@@ -14717,14 +14711,14 @@
 	</chassis>
 	<chassis name='Scylla' unitType='Mek'>
 		<availability>CHH:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
@@ -14732,26 +14726,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='F'>
 			<availability>General:4</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Fox Amphibious Armor' unitType='BattleArmor'>
@@ -14762,6 +14756,9 @@
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
+		</model>
 		<model name='(SRM6)'>
 			<availability>General:1</availability>
 		</model>
@@ -14770,9 +14767,6 @@
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:1</availability>
-		</model>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SeaBuster Strike Fighter' unitType='Conventional Fighter'>
@@ -14828,26 +14822,26 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2</availability>
-		<model name='SYD-21'>
+		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
-			<availability>MERC.KH:1-,Periphery:1-</availability>
+			<availability>RD:6,LA:8,ROS:4,FS:8,MERC:6</availability>
 		</model>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='SYD-Z3A'>
+			<availability>RD:3,LA:6,ROS:3,MERC:3,FS:3</availability>
+		</model>
 		<model name='SYD-Z4'>
 			<availability>CC:8,FVC:4,LA:6,ROS:4,MERC:5,FS:4,Periphery:4</availability>
 		</model>
-		<model name='SYD-Z2A'>
+		<model name='SYD-21'>
 			<roles>interceptor</roles>
-			<availability>RD:6,LA:8,ROS:4,FS:8,MERC:6</availability>
+			<availability>MERC.KH:1-,Periphery:1-</availability>
 		</model>
 		<model name='SYD-Z2B'>
 			<availability>RA.OA:4,LA:4,ROS:4,PIR:3,FS:4,MERC:4,RA:4</availability>
-		</model>
-		<model name='SYD-Z3A'>
-			<availability>RD:3,LA:6,ROS:3,MERC:3,FS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
@@ -14856,27 +14850,27 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='SYU-4B'>
+		<model name='SYU-6B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SYU-6B'>
+		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat II' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='4'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='3'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
+		</model>
+		<model name='3'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
@@ -14884,56 +14878,56 @@
 		<model name='C'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CWE:3,CW:3,General:6,RA:8</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8,RA:3</availability>
-		</model>
-		<model name='E'>
+		<model name='F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='J'>
-			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CWE:3,CW:3,General:6,RA:3</availability>
 		</model>
+		<model name='J'>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8,RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>OP:3,CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,DTA:3,RA.OA:3,RD:4,CDS:4,RF:3,LA:3,ROS:4,CNC:4,FWL:3,MSC:3,RCM:3,DA:3,DC:3</availability>
-		<model name='2'>
-			<availability>RD:1</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:5,CNC:5,IS:6,CP:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:8</availability>
+		<model name='8'>
+			<availability>CDS:4,LA:6,CNC:6,IS:4,CP:5,CWIE:6</availability>
 		</model>
 		<model name='9'>
 			<availability>ROS:5,MERC:3</availability>
 		</model>
+		<model name='2'>
+			<availability>RD:1</availability>
+		</model>
 		<model name='7'>
 			<availability>RA.OA:8,RA:8</availability>
-		</model>
-		<model name='5'>
-			<availability>RD:4,CDS:8,LA:8,FWL:8,IS:8,FS:8,MERC:8,CP:8,DC:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CDS:5,CNC:5,IS:6,CP:5,RA:6</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:4,LA:6,CNC:6,IS:4,CP:5,CWIE:6</availability>
+		<model name='3'>
+			<availability>CDS:5,CNC:5,IS:6,CP:5</availability>
+		</model>
+		<model name='5'>
+			<availability>RD:4,CDS:8,LA:8,FWL:8,IS:8,FS:8,MERC:8,CP:8,DC:8</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
@@ -14941,47 +14935,47 @@
 		<model name='SHD-2D2'>
 			<availability>FVC:5,FS:4</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,ROS:4,CLAN:4,FWL:2:3139,MSC:4,MERC:4,DA:4,CP:2,BAN:2</availability>
+		<model name='SHD-1R'>
+			<availability>MOC:1-,MH:1-</availability>
 		</model>
 		<model name='SHD-2H'>
 			<availability>General:1-,Periphery:2-</availability>
 		</model>
-		<model name='SHD-9D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='SHD-5M'>
-			<availability>CC:6,Periphery.MW:4,Periphery.ME:4,FWL:4,MERC:6,CP:4,Periphery:4,DC:6</availability>
-		</model>
-		<model name='SHD-3K'>
-			<availability>RD:4,DC:8</availability>
-		</model>
-		<model name='SHD-5D'>
-			<availability>LA:4,ROS:4,FS:8,MERC:6</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,OP:8,MERC:4,CP:7,CDP:3,TC:3,DTA:8,FVC:3,ROS:4,FWL:7:3139,MSC:8,RCM:8</availability>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,ROS:4,CLAN:4,FWL:2:3139,MSC:4,MERC:4,DA:4,CP:2,BAN:2</availability>
 		</model>
 		<model name='SHD-12C'>
 			<availability>RD:8,ROS:5,DC:4</availability>
 		</model>
-		<model name='SHD-1R'>
-			<availability>MOC:1-,MH:1-</availability>
+		<model name='SHD-5M'>
+			<availability>CC:6,Periphery.MW:4,Periphery.ME:4,FWL:4,MERC:6,CP:4,Periphery:4,DC:6</availability>
 		</model>
 		<model name='SHD-8L'>
 			<availability>CC:8</availability>
 		</model>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,OP:8,MERC:4,CP:7,CDP:3,TC:3,DTA:8,FVC:3,ROS:4,FWL:7:3139,MSC:8,RCM:8</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:4,ROS:4,FS:8,MERC:6</availability>
+		</model>
+		<model name='SHD-3K'>
+			<availability>RD:4,DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CWE:5,RD:5,CDS:5,CW:5,ROS:4,CLAN:3,CP:5</availability>
+		<model name='(Flamer)'>
+			<availability>CDS:4,CP:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Interdictor)'>
 			<availability>CWE:4,CHH:4,RD:6,CDS:4,CW:4,ROS:8,CNC:4,CP:4,CJF:4,RA:4,CWIE:4</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CDS:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shandra Advanced Scout Vehicle' unitType='Tank'>
@@ -15000,20 +14994,20 @@
 		<model name='[MRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[Interdictor]' mechanized='false'>
+			<availability>General:4</availability>
+		</model>
 		<model name='[Pop-Up Mine]' mechanized='false'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Interdictor]' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='[David Light Gauss]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shen Yi' unitType='Mek'>
@@ -15047,11 +15041,11 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
-		<model name='SL-17'>
-			<availability>ROS:0,Periphery:2-</availability>
-		</model>
 		<model name='SL-18'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
+		</model>
+		<model name='SL-17'>
+			<availability>ROS:0,Periphery:2-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>RD:2,RA:2</availability>
@@ -15059,11 +15053,11 @@
 	</chassis>
 	<chassis name='Shiro' unitType='Mek'>
 		<availability>DC:3+</availability>
-		<model name='SH-1V'>
-			<availability>General:1+</availability>
-		</model>
 		<model name='SH-2P'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SH-1V'>
+			<availability>General:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Shiva' unitType='Aero'>
@@ -15074,11 +15068,14 @@
 	</chassis>
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>DTA:6,OP:6,RF:6,ROS:4,FWL:6,MSC:6,RCM:6,DA:6,CP:6</availability>
-		<model name='SHV-OB'>
+		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
+		</model>
+		<model name='SHV-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -15086,15 +15083,9 @@
 		<model name='SHV-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SHV-OA'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shockwave' unitType='Mek'>
 		<availability>CC:4,DTA:6,OP:6,ROS:4,FWL:5,MSC:6,FS:3,RCM:4,CP:5,DC:3</availability>
-		<model name='SKW-4G'>
-			<availability>General:2</availability>
-		</model>
 		<model name='SKW-2F'>
 			<availability>General:8</availability>
 		</model>
@@ -15105,18 +15096,21 @@
 		<model name='SKW-6H'>
 			<availability>General:5</availability>
 		</model>
+		<model name='SKW-4G'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CWE:3,CHH:3,RD:4,CDS:4,CW:3,ROS:3,CNC:5,CP:4,CWIE:3,DC:3</availability>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CNC:6,CP:6,DC:6</availability>
+		</model>
 		<model name='(Streak)'>
 			<availability>CWE:6,CDS:4,CW:6,ROS:4,CNC:6,CP:5,CJF:6,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CW:0,General:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CNC:6,CP:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -15160,6 +15154,18 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverback Coastal Cutter' unitType='Naval'>
+		<availability>LA:7</availability>
+		<model name='(Standard)'>
+			<availability>LA:7</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Simian Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:5</availability>
 		<model name='(LRR)' mechanized='true'>
@@ -15168,22 +15174,22 @@
 		<model name='(Flamer)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SL)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Heavy MG)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(SL)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Simurgh' unitType='Aero' omni='IS'>
 		<availability>ROS:7</availability>
-		<model name='SMG-O'>
-			<roles>assault</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SMG-OA'>
 			<roles>assault</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='SMG-O'>
+			<roles>assault</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='SMG-OB'>
 			<roles>assault</roles>
@@ -15192,14 +15198,14 @@
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>DTA:5,CC:3,OP:5,ROS:3,FWL:4:3139,MSC:5,MERC:3,CP:4</availability>
-		<model name='SRC-6C'>
-			<availability>DTA:6,OP:6,ROS:6,FWL:6,MSC:6,CP:6</availability>
-		</model>
 		<model name='SRC-5C'>
 			<availability>DTA:5,OP:5,ROS:5,FWL:5,MSC:5,CP:5</availability>
 		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-6C'>
+			<availability>DTA:6,OP:6,ROS:6,FWL:6,MSC:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Skadi Swift Attack VTOL' unitType='VTOL'>
@@ -15223,9 +15229,9 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,ROS:1-,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:4,IS.pm:4</availability>
+			<availability>General:2-</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -15235,9 +15241,9 @@
 			<roles>recon</roles>
 			<availability>FVC:3,IS.pm:2</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:2-</availability>
+			<availability>FVC:4,IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
@@ -15245,23 +15251,23 @@
 		<model name='SL-15R'>
 			<availability>RA.OA:6,RD:6,ROS:6,FS:6,MERC:6,CDP:4,RA:6,DC:8,TC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>ROS:0,FS:0,Periphery:2-</availability>
-		</model>
 		<model name='SL-15K'>
 			<availability>RD:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='SL-15'>
+			<availability>ROS:0,FS:0,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		<model name='(Huntsman)' mechanized='false'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>LA:1</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Huntsman)' mechanized='false'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Snake' unitType='Mek'>
@@ -15292,11 +15298,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CNC:4,CP:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CNC:8,CP:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sokar Urban Combat Unit' unitType='Tank'>
@@ -15323,11 +15329,11 @@
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
 		<availability>RD:3,CDS:6+,CP:6+</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sortek Assault Craft' unitType='Tank'>
@@ -15350,18 +15356,14 @@
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Spad' unitType='Aero'>
 		<availability>RA.OA:1,ROS:3,RA:1</availability>
-		<model name='SPD-504'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='SPD-503'>
 			<availability>ROS:6,BAN:2</availability>
@@ -15369,17 +15371,17 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
-		<model name='SPR-7D'>
-			<availability>ROS:5,FS:5,MERC:5</availability>
-		</model>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 		</model>
-		<model name='SPR-DH'>
-			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:3-</availability>
+		<model name='SPR-7D'>
+			<availability>ROS:5,FS:5,MERC:5</availability>
 		</model>
 		<model name='SPR-7Dr'>
 			<availability>ROS:3,FS:4,MERC:3</availability>
+		</model>
+		<model name='SPR-DH'>
+			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='SpecOps Paratrooper' unitType='Infantry'>
@@ -15404,11 +15406,11 @@
 	</chassis>
 	<chassis name='Spectre Stealth Battle Armor' unitType='BattleArmor'>
 		<availability>FVC:7,MERC:4,CDP:7,RA:5</availability>
-		<model name='(RA)' mechanized='true'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(RA)' mechanized='true'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sphinx' unitType='Mek'>
@@ -15431,41 +15433,41 @@
 		<model name='SDR-5V'>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='SDR-7Kr'>
+			<availability>ROS:1,MERC:1,DC:1</availability>
+		</model>
+		<model name='SDR-10K'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='SDR-7K'>
+			<availability>ROS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='SDR-7M'>
 			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,CP:8,DC:6</availability>
 		</model>
-		<model name='SDR-7K2'>
-			<availability>ROS:3,MERC:3,DC:4</availability>
+		<model name='SDR-7KC'>
+			<availability>ROS:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:4,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 		<model name='SDR-8K'>
 			<availability>ROS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='SDR-8R'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='SDR-7Kr'>
-			<availability>ROS:1,MERC:1,DC:1</availability>
-		</model>
 		<model name='SDR-8Xr'>
 			<availability>ROS:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-7K2'>
+			<availability>ROS:3,MERC:3,DC:4</availability>
+		</model>
+		<model name='SDR-8R'>
+			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='SDR-8M'>
 			<availability>MOC:4,CC:4,FWL:8,MH:4,MERC:2,CP:8</availability>
 		</model>
 		<model name='SDR-8X'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='SDR-10K'>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:4,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
-		</model>
-		<model name='SDR-7K'>
-			<availability>ROS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='SDR-7KC'>
-			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Spindrift Aquatic SecurityMech' unitType='Mek'>
@@ -15476,34 +15478,34 @@
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
 		<availability>CJF:5-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>MOC:5,FVC:5,LA:7,ROS:7,IS:6,MH:4,FS:7,DC:7</availability>
-		<model name='(Interdictor)'>
-			<roles>spotter</roles>
-			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,CP:4,DC:4</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>IS:4,DC:6</availability>
+		</model>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Interdictor)'>
+			<roles>spotter</roles>
+			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,CP:4,DC:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -15520,17 +15522,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,ROS:2,FWL:6,DC:1</availability>
-		<model name='STK-3H'>
-			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		<model name='STK-8S'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-7D'>
-			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:4,CP:6,DC:6,TC:3</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='STK-7D'>
+			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>Periphery:2-</availability>
@@ -15538,17 +15540,17 @@
 		<model name='STK-3Fb'>
 			<availability>CC:3,MOC:3,OP:3,RF:3,CLAN:8,FWL:3,MERC:3,DA:3,RCM:3,CP:3,BAN:2</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:4,CP:6,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-6M'>
 			<availability>CC:5,MOC:5,OP:6,RF:6,ROS:6,FWL:6,MERC:6,DA:5,RCM:6,CP:6</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CP:3,CJF:3,TC:4</availability>
-		</model>
-		<model name='STK-8S'>
-			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stalking Spider II' unitType='Mek'>
@@ -15575,12 +15577,12 @@
 			<roles>raider</roles>
 			<availability>MOC:4,CC:2,OP:2,LA:4,ROS:2,FWL:2,FS:2,MERC:4,CP:2</availability>
 		</model>
+		<model name='STY-3Dr'>
+			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
+		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
@@ -15589,32 +15591,32 @@
 			<roles>recon,spotter</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='STH-3S'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='STH-1D'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-2D'>
 			<roles>recon</roles>
 			<availability>FS:6,MERC:4</availability>
 		</model>
+		<model name='STH-3S'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='STH-2D1'>
+			<roles>recon</roles>
+			<availability>FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:6,LA:7,MERC:2</availability>
+		<model name='STM-OB'>
+			<availability>General:7</availability>
+		</model>
 		<model name='STM-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='STM-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='STM-OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -15623,14 +15625,14 @@
 		<model name='STO-4C'>
 			<availability>LA:4,MERC:6</availability>
 		</model>
-		<model name='STO-6S'>
-			<availability>LA:6</availability>
+		<model name='STO-4B'>
+			<availability>General:4</availability>
 		</model>
 		<model name='STO-4A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='STO-4B'>
-			<availability>General:4</availability>
+		<model name='STO-6S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger IIC' unitType='Mek'>
@@ -15645,49 +15647,52 @@
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,RD:1-,IS:7,MERC:7,Periphery:6,DC:4</availability>
-		<model name='STG-5R'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FVC:4,PIR:4,MERC:4,CDP:4,TC:4,Periphery:4</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,CP:8,DC:6</availability>
-		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>BAN:8,Periphery:2-</availability>
-		</model>
-		<model name='STG-6L'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:4,DA:4</availability>
-		</model>
-		<model name='STG-7S'>
-			<roles>recon</roles>
-			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 		<model name='STG-5G'>
 			<roles>recon</roles>
 			<availability>CC:5,OP:4,FVC:4,ROS:4,FWL:3:3139,MH:4,RCM:4,DA:4,FS:4,CP:3,CDP:5,TC:5</availability>
 		</model>
+		<model name='STG-6S'>
+			<roles>recon</roles>
+			<availability>LA:8,ROS:5,MERC:8,FS:4</availability>
+		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CC:4,OP:6,CLAN:8,FWL:5,MSC:6,RCM:6,DA:6,MERC:4,CP:5,BAN:2</availability>
+		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,CP:8,DC:6</availability>
+		</model>
+		<model name='STG-6L'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:4,DA:4</availability>
+		</model>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
 			<availability>RD:3,LA:2,ROS:5,IS:6,Periphery.Deep:4,MERC:6,DC:2,Periphery:6</availability>
 		</model>
-		<model name='STG-6S'>
+		<model name='STG-5R'>
 			<roles>recon</roles>
-			<availability>LA:8,ROS:5,MERC:8,FS:4</availability>
+			<availability>CC:4,MOC:4,FVC:4,PIR:4,MERC:4,CDP:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='STG-7S'>
+			<roles>recon</roles>
+			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:3,CC:4,OP:6,IS:2,MERC:4,CP:6,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
+		<model name='F-95'>
+			<availability>CC:5,DTA:6,OP:6,RF:6,LA:5,ROS:5,FWL:7,MSC:6,MERC:5,RCM:6,DA:6,CP:7</availability>
+		</model>
 		<model name='F-94'>
 			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,IS:4,MH:4</availability>
 		</model>
@@ -15697,38 +15702,35 @@
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
 		</model>
-		<model name='F-95'>
-			<availability>CC:5,DTA:6,OP:6,RF:6,LA:5,ROS:5,FWL:7,MSC:6,MERC:5,RCM:6,DA:6,CP:7</availability>
-		</model>
 		<model name='F-96R'>
 			<availability>DTA:4,OP:4,RF:4,LA:3,FWL:4,MSC:4,RCM:4,DA:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>RD:3</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>:0,CLAN:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='F'>
+		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>:0,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -15755,7 +15757,7 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>CC:5,MOC:5,LA:5,ROS:6,FWL:5,FS:6,MERC:5,DA:5,CP:5,DC:7</availability>
-		<model name='SR1-OA'>
+		<model name='SR1-OD'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
@@ -15763,46 +15765,50 @@
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='SR1-OH'>
+		<model name='SR1-OG'>
 			<availability>General:4</availability>
 		</model>
 		<model name='SR1-OR'>
 			<availability>CLAN:6,General:3</availability>
 		</model>
-		<model name='SR1-OG'>
-			<availability>General:4</availability>
-		</model>
 		<model name='SR1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OH'>
+			<availability>General:4</availability>
+		</model>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OF'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,IS:2,FS:5,MERC:3,CP:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,CNC:4,DC:1</availability>
+		<model name='(Narc)'>
+			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:1-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>FVC:1-</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,CDS:6,LA:6,ROS:6,CNC:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2</availability>
@@ -15813,30 +15819,26 @@
 		<model name='(SRM)'>
 			<availability>FVC:1-</availability>
 		</model>
-		<model name='(Narc)'>
-			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(3061 Upgrade)'>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:1-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,CDS:6,LA:6,ROS:6,CNC:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:3,MOC:3</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Strix Stealth VTOL' unitType='VTOL'>
@@ -15863,12 +15865,12 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:2,CDS:2,RF:3,LA:2,ROS:3,CNC:2,FS:2,CP:2,CWIE:2</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Heavy Gauss)'>
 			<availability>RF:6,LA:6,CNC:6,CP:6,CWIE:6</availability>
@@ -15876,13 +15878,13 @@
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,IS:3,CP:5,Periphery:3</availability>
-		<model name='(Standard)'>
-			<roles>recon,fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
@@ -15890,17 +15892,17 @@
 		<model name='E'>
 			<availability>CWE:5,RD:5,CW:5,CLAN:2</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='C'>
 			<availability>RD:6,General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:6,RD:6,CW:6,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:6,General:2,CJF:6</availability>
@@ -15911,30 +15913,27 @@
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
 		<availability>CWE:5,CDS:3,CW:5,ROS:3,FS:5,MERC:2,CP:3</availability>
-		<model name='(Standard)'>
-			<availability>CWE:8,CDS:4,CW:8,CP:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CDS:8,ROS:8,MERC:8,FS:8,CP:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CWE:8,CDS:4,CW:8,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,ROS:5,FS:5,MERC:4,DC:7</availability>
-		<model name='SD1-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='SD1-OF'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='SD1-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
-		</model>
-		<model name='SD1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SD1-OF'>
-			<availability>General:4</availability>
 		</model>
 		<model name='SD1-OA'>
 			<roles>fire_support</roles>
@@ -15949,6 +15948,9 @@
 		<model name='SD1-OE'>
 			<availability>General:4</availability>
 		</model>
+		<model name='SD1-OG'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>CWE:5,RD:3,CDS:4,CW:5,ROS:3,CNC:9,CP:7,CWIE:5</availability>
@@ -15958,11 +15960,11 @@
 		<model name='3'>
 			<availability>ROS:6,CNC:6,CP:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='4'>
 			<availability>ROS:5,CNC:5,CP:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Suzaku' unitType='Aero'>
@@ -15988,28 +15990,28 @@
 	</chassis>
 	<chassis name='Svartalfa Ultra ProtoMech' unitType='ProtoMek'>
 		<availability>CHH:4+</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM Variant)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swallow Attack WIGE' unitType='Tank'>
 		<availability>RF:5,LA:6,ROS:5,FWL:5,MH:4,FS:5,MERC:5,CP:5,TC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<availability>LA:4,MERC:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:1,MOC:1,DA:1,CDP:1,TC:1</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -16021,37 +16023,37 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:2</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>ROS:4,CLAN:4</availability>
-		<model name='C'>
-			<availability>CLAN:8,RA:9</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>ROS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:8,RA:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:2,CP:2,RA:4</availability>
-		<model name='(Standard)' mechanized='true'>
+		<model name='(Upgrade)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Enhanced)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>RA:8</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
@@ -16085,11 +16087,11 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:5,MERC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(RL)'>
 			<availability>MOC:4</availability>
@@ -16103,36 +16105,36 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,DTA:6,OP:6,ROS:4,FWL:6,MSC:6,MERC:4,CP:6,DC:6</availability>
-		<model name='ZPH-5A'>
-			<roles>recon</roles>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='ZPH-3A'>
-			<roles>recon</roles>
-			<availability>DTA:8,OP:8,ROS:5,FWL:8,MSC:8,MERC:4,CP:8,DC:4</availability>
-		</model>
 		<model name='ZPH-2A'>
 			<roles>recon</roles>
 			<availability>MOC:6,CC:3,ROS:3,FWL:3,MERC:3,CP:3,DC:3</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:3,MOC:3,ROS:3,FWL:3,MERC:3,CP:3,DC:3</availability>
 		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>DTA:8,OP:8,ROS:6,MSC:8,MERC:6,DC:8</availability>
 		</model>
+		<model name='ZPH-5A'>
+			<roles>recon</roles>
+			<availability>ROS:5,DC:5</availability>
+		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:3,MOC:3,ROS:3,FWL:3,MERC:3,CP:3,DC:3</availability>
+		</model>
+		<model name='ZPH-3A'>
+			<roles>recon</roles>
+			<availability>DTA:8,OP:8,ROS:5,FWL:8,MSC:8,MERC:4,CP:8,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Targe' unitType='Mek'>
 		<availability>ROS:4,MERC:2</availability>
-		<model name='TRG-1N'>
-			<roles>recon</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='TRG-2N'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='TRG-1N'>
+			<roles>recon</roles>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='TRG-3M'>
 			<roles>recon</roles>
@@ -16141,23 +16143,23 @@
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,CP:4,DC:6</availability>
+		<model name='MIK-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='MIK-OF'>
 			<availability>General:4</availability>
@@ -16172,8 +16174,8 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>DTA:8,OP:8,FWL.MM:8,RF:8,ROS:5,Periphery.MW:4,Periphery.ME:4,FWL:8,MH:4,MSC:8,MERC:4,CP:8</availability>
-		<model name='TMP-3G'>
-			<availability>ROS:2,FWL:2,MERC:2,CP:2</availability>
+		<model name='TMP-3M'>
+			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,CP:4,Periphery:8</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>RF:4,ROS:4,FWL:2:3139,MSC:4,MERC:4,CP:2</availability>
@@ -16181,8 +16183,8 @@
 		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
 			<availability>DTA:6,OP:6,ROS:6,FWL:6:3139,MSC:6,MERC:4,CP:6</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,CP:4,Periphery:8</availability>
+		<model name='TMP-3G'>
+			<availability>ROS:2,FWL:2,MERC:2,CP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar III' unitType='Mek' omni='IS'>
@@ -16190,17 +16192,17 @@
 		<model name='TLR2-OC'>
 			<availability>General:7</availability>
 		</model>
+		<model name='TLR2-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='TLR2-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TLR2-OA'>
+		<model name='TLR2-OD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='TLR2-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='TLR2-OD'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
@@ -16208,45 +16210,48 @@
 		<model name='TLR1-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OH'>
-			<availability>General:5</availability>
+		<model name='TLR1-OB'>
+			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OR'>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OB'>
-			<availability>General:4</availability>
-		</model>
-		<model name='TLR1-OG'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OI'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OE'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
+		<model name='TLR1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OF'>
 			<roles>spotter</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OI'>
-			<availability>General:5</availability>
+		<model name='TLR1-OG'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OU'>
-			<availability>General:2</availability>
+		<model name='TLR1-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Tenshi' unitType='Mek' omni='IS'>
 		<availability>DC.GHO:6,DC:6</availability>
+		<model name='TN-10-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='TN-10-OB'>
 			<availability>General:7</availability>
 		</model>
@@ -16255,9 +16260,6 @@
 		</model>
 		<model name='TN-10-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='TN-10-OA'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Teppo Artillery Vehicle' unitType='Tank'>
@@ -16273,11 +16275,11 @@
 			<roles>recon,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
 		</model>
-		<model name='TSN-C3M'>
+		<model name='TSN-1Cr'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='TSN-1Cr'>
+		<model name='TSN-C3M'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
@@ -16291,25 +16293,25 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CWE:1,CW:1,CJF:1,RA:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
 		<availability>LA:6,ROS:4,MH:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='TNS-4T'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='TNS-6S'>
 			<availability>LA:6,IS:4</availability>
+		</model>
+		<model name='TNS-4T'>
+			<availability>IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thang-Ta APC' unitType='Tank'>
@@ -16328,46 +16330,46 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CHH:1,CLAN:1,CP:1,RA:1,BAN:3,CWIE:2,CWE:1,MERC.WD:1,RD:1,CDS:1,CW:1,ROS:3+,CNC:2,CJF:4</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CWE:4,RD:3,CDS:4,CW:4,CNC:5,General:6,CP:4,CJF:7,CWIE:5</availability>
+		<model name='H'>
+			<availability>CLAN:4,General:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CWE:6,CHH:4,RD:4,CDS:4,CW:6,CNC:4,General:2,CP:4,CJF:5,CWIE:5</availability>
 		</model>
+		<model name='D'>
+			<availability>CWE:8,RD:8,CW:8,CNC:6,General:5,CP:6,CWIE:6</availability>
+		</model>
 		<model name='AA'>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='HH'>
-			<availability>CWE:5,CHH:6,CDS:4,CW:5,CLAN:2,General:2,CP:4,CJF:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,General:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:6,CHH:8,RD:4,CDS:8,CW:6,CNC:6,General:7,CP:7,CJF:8,CWIE:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:3,CP:5,CWIE:5</availability>
+		<model name='A'>
+			<availability>CWE:6,CHH:8,RD:4,CDS:8,CW:6,CNC:6,General:7,CP:7,CJF:8,CWIE:6</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CWE:4,RD:3,CDS:4,CW:4,CNC:5,General:6,CP:4,CJF:7,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CWE:6,RD:6,CDS:9,CW:6,General:8,CP:9,CJF:9</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:8,RD:8,CW:8,CNC:6,General:5,CP:6,CWIE:6</availability>
+		<model name='HH'>
+			<availability>CWE:5,CHH:6,CDS:4,CW:5,CLAN:2,General:2,CP:4,CJF:5</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CWE:6,RD:6,CW:6,General:5,CJF:6</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CW:5,CLAN:4,General:3,CP:5,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -16383,9 +16385,6 @@
 	</chassis>
 	<chassis name='Thor II (Grand Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CC:3,CWE:6,RD:6,CDS:6,CW:6,ROS:4,MERC:3,CP:6,CJF:8,CWIE:4</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -16396,55 +16395,58 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>ROS:5</availability>
-		<model name='THE-N1'>
+		<model name='THE-N2'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='THE-N2'>
+		<model name='THE-N1'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CP:2,RA:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>FVC:2-,Periphery:2-</availability>
+		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:4,MERC:4</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:2,FVC:2,FWL:2,FS:2,MERC:2,CP:2,Periphery:2</availability>
 		</model>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>MOC:4,CHH:2,CLAN:3,IS:4,CP:2,CWIE:4,DC.GHO:4,CWE:4,RA.OA:4,RD:4,CDS:2,CW:4,RF:5,Periphery.MW:4,ROS:4,PIR:4,CNC:2,Periphery.ME:4,FWL:4,MH:4,MSC:5,DA:5,CJF:4</availability>
-		<model name='THG-11Eb'>
-			<availability>ROS:6,CLAN:4,FWL:6,MSC:6,MERC:6,CP:6,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>MOC:8,CLAN:6,IS:8,FS:8,CP:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
 		</model>
-		<model name='THG-12K'>
-			<availability>ROS:5,DC:8</availability>
+		<model name='THG-11Eb'>
+			<availability>ROS:6,CLAN:4,FWL:6,MSC:6,MERC:6,CP:6,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>MOC:1-,RF:1-,PIR:2-,MH:1-,MSC:1-,MERC:1-,DA:1-,Periphery:4</availability>
+		</model>
+		<model name='THG-12K'>
+			<availability>ROS:5,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -16464,25 +16466,22 @@
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
 		<availability>LA:5,ROS:6,DC:4</availability>
-		<model name='TFT-L8'>
-			<availability>LA:8</availability>
+		<model name='TFT-A9'>
+			<availability>ROS:8,General:4</availability>
 		</model>
 		<model name='TFT-F11'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='TFT-A9'>
-			<availability>ROS:8,General:4</availability>
 		</model>
 		<model name='TFT-C3'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='TFT-L8'>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,ROS:6,MERC:4</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -16492,6 +16491,9 @@
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -16508,30 +16510,30 @@
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,RF:5,MERC:4,DA:5,TC:4</availability>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-C4'>
-			<availability>CC:4,MOC:4,CC.LCC:6</availability>
-		</model>
 		<model name='THR-1L'>
 			<availability>General:4</availability>
+		</model>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='THR-C4'>
+			<availability>CC:4,MOC:4,CC.LCC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:8,CP:8,DC:4</availability>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Upgrade](ER Laser)' mechanized='true'>
 			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 		<model name='[Pulse Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -16539,7 +16541,7 @@
 		<model name='(Upgrade)[LBX]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[AP Gauss]' mechanized='true'>
+		<model name='[ER Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -16551,23 +16553,23 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CC:6,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
-		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:2-</availability>
-		</model>
-		<model name='TRB-D36b'>
-			<roles>ground_support</roles>
-			<availability>CLAN:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='TRB-D56'>
 			<availability>LA:8,ROS:4,MERC:4</availability>
 		</model>
 		<model name='TRB-D50'>
 			<availability>TC:8</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CC:6,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
+		</model>
+		<model name='TRB-D36b'>
+			<roles>ground_support</roles>
+			<availability>CLAN:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbolt IIC' unitType='Mek'>
@@ -16578,26 +16580,20 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:4,LA:6,ROS:5,MH:4,FS:5,MERC:6,Periphery:2,TC:4,DC:3</availability>
-		<model name='TDR-5Sb'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='TDR-9M'>
-			<availability>MOC:3,DTA:5,CC:3,OP:5,PIR:3,FWL:4,MH:3,MSC:5,DA:5,MERC:4,CP:4</availability>
-		</model>
-		<model name='TDR-9S'>
-			<availability>FVC:3,LA:4,FS:2,MERC:3</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>MOC:1-,TC:1-</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
 		</model>
 		<model name='TDR-60-RLA'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='TDR-9S'>
+			<availability>FVC:3,LA:4,FS:2,MERC:3</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2,CP:2</availability>
 		</model>
 		<model name='TDR-9T'>
 			<availability>TC:5</availability>
@@ -16605,26 +16601,32 @@
 		<model name='TDR-5S'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='TDR-10S'>
-			<availability>LA:6,MERC:6</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
-		</model>
-		<model name='TDR-10M'>
-			<availability>CC:4,ROS:6,FWL:5,MERC:4,CP:5</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CC:3,MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:3,MH:4,MERC:3,CP:3</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2,CP:2</availability>
+		<model name='TDR-9M'>
+			<availability>MOC:3,DTA:5,CC:3,OP:5,PIR:3,FWL:4,MH:3,MSC:5,DA:5,MERC:4,CP:4</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>TC:6</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>FS:4,MERC:4</availability>
 		</model>
+		<model name='TDR-10M'>
+			<availability>CC:4,ROS:6,FWL:5,MERC:4,CP:5</availability>
+		</model>
+		<model name='TDR-10S'>
+			<availability>LA:6,MERC:6</availability>
+		</model>
 		<model name='TDR-17S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
@@ -16632,9 +16634,8 @@
 		<model name='TSG-9J'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TSG-9H'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='TSG-9DDC'>
+			<availability>CC:6,CC.WHO:8</availability>
 		</model>
 		<model name='TSG-10L'>
 			<roles>spotter</roles>
@@ -16643,8 +16644,9 @@
 		<model name='TSG-9C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
-		<model name='TSG-9DDC'>
-			<availability>CC:6,CC.WHO:8</availability>
+		<model name='TSG-9H'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat II' unitType='Dropship'>
@@ -16694,6 +16696,10 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CLAN:4,RA:5</availability>
+		<model name='(2647)'>
+			<roles>asf_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Monitor)'>
 			<roles>assault</roles>
 			<availability>RA:8</availability>
@@ -16702,56 +16708,52 @@
 			<roles>asf_carrier</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2647)'>
-			<roles>asf_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Titan' unitType='Mek'>
 		<availability>ROS:5,MERC:4,FS:5</availability>
-		<model name='TI-1Ar'>
-			<availability>General:4</availability>
-		</model>
 		<model name='TI-1Aj'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TI-1Ar'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,ROS:5,CNC:6,CP:4,DC:8</availability>
-		<model name='(C3)'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='TKG-150'>
-			<availability>DC:1-</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>DC:2-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>CDS:8,ROS:6,CNC:8,CP:8,DC:6</availability>
+		<model name='(C3)'>
+			<availability>ROS:5,DC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>ROS:8,DC:8</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>CDS:8,ROS:6,CNC:8,CP:8,DC:6</availability>
 		</model>
 		<model name='(MRM)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='TKG-150'>
+			<availability>DC:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Tomahawk II' unitType='Mek' omni='Clan'>
 		<availability>CWE:6,CHH:4,CW:6</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>urban</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>urban</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -16760,15 +16762,15 @@
 		<model name='CH'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>ROS:8</availability>
+		<model name='THK-63'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6,CW:6</availability>
 		</model>
-		<model name='THK-63'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
+		<model name='THK-63CS'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
@@ -16779,10 +16781,10 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -16795,23 +16797,23 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>FWL:1,MH:1,CP:1</availability>
-		<model name='G13 [Grenade Launcher]' mechanized='true'>
-			<availability>MH:4</availability>
-		</model>
-		<model name='G13 [Machine Gun]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 		<model name='G12' mechanized='true'>
 			<roles>specops</roles>
 			<availability>FWL:8,CP:8</availability>
 		</model>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>MH:4</availability>
+		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Machine Gun]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 	</chassis>
@@ -16827,10 +16829,10 @@
 		<model name='(C3)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(aSRM)' mechanized='false'>
+		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)' mechanized='false'>
+		<model name='(aSRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)' mechanized='false'>
@@ -16839,13 +16841,13 @@
 	</chassis>
 	<chassis name='Trajan Assault Infantry Fighting Vehicle' unitType='Tank'>
 		<availability>ROS:6</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>apc</roles>
 			<availability>ROS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -16856,36 +16858,33 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,RCM:3,CP:3,TC:5</availability>
-		<model name='TR-16'>
-			<availability>CC:7,MOC:5,RF:8,FWL:5:3139,MERC:5,RCM:8,CP:5,TC:5</availability>
-		</model>
-		<model name='TR-13'>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='TR-13A'>
 			<availability>CC:8,MOC:7,General:5</availability>
 		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='TR-16'>
+			<availability>CC:7,MOC:5,RF:8,FWL:5:3139,MERC:5,RCM:8,CP:5,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
-		<model name='TR-10'>
-			<availability>MOC:2,General:6,TC:2</availability>
-		</model>
 		<model name='TR-12'>
 			<availability>CC:6,MOC:6</availability>
 		</model>
 		<model name='TR-13G'>
 			<roles>ground_support,assault</roles>
 			<availability>CC:6</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>MOC:2,General:6,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Transportable Field Repair Unit' unitType='Tank'>
@@ -16897,50 +16896,50 @@
 	</chassis>
 	<chassis name='Trebaruna' unitType='Mek'>
 		<availability>CC:5,DTA:4,OP:4,LA:6,ROS:5,FWL:4:3139,MSC:4,MERC:4,DA:4,CP:4</availability>
-		<model name='TR-XJ'>
-			<availability>DTA:8,OP:8,FWL:8,MSC:8,MERC:4,CP:8</availability>
-		</model>
 		<model name='TR-XB'>
 			<availability>CC:4,DTA:4,ROS:8,MSC:4,MERC:4</availability>
-		</model>
-		<model name='TR-XL'>
-			<availability>CC:8</availability>
 		</model>
 		<model name='TR-XH'>
 			<availability>CC:4,DTA:4,LA:8,MSC:4,DA:8</availability>
 		</model>
+		<model name='TR-XJ'>
+			<availability>DTA:8,OP:8,FWL:8,MSC:8,MERC:4,CP:8</availability>
+		</model>
+		<model name='TR-XL'>
+			<availability>CC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,CP:6,Periphery:3,TC:4,DC:4</availability>
-		<model name='TBT-7M'>
+		<model name='TBT-5N'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:4,MH:4,FS:4,MERC:4,CP:4,TC:2,DC:4</availability>
-		</model>
-		<model name='TBT-9K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='TBT-K7R'>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>ROS:6,FWL:4:3139,MSC:6,MERC:5,CP:4</availability>
+			<availability>MOC:4-,Periphery:4-</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>RF:4,ROS:5,FWL:2:3139,MSC:4,MERC:4,CP:2</availability>
 		</model>
-		<model name='TBT-XK7'>
+		<model name='TBT-K7R'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='TBT-7M'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>CC:4,FWL:4,MH:4,FS:4,MERC:4,CP:4,TC:2,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>ROS:6,FWL:4:3139,MSC:6,MERC:5,CP:4</availability>
 		</model>
 		<model name='TBT-9R'>
 			<availability>RF:6</availability>
 		</model>
-		<model name='TBT-5N'>
+		<model name='TBT-9K'>
 			<roles>fire_support</roles>
-			<availability>MOC:4-,Periphery:4-</availability>
+			<availability>DC:8</availability>
+		</model>
+		<model name='TBT-XK7'>
+			<roles>fire_support</roles>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -16954,17 +16953,8 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>MOC:8,CC:8,MH:4,TC:8</availability>
-		<model name='(Theseus RL)[LRR]' mechanized='true'>
-			<availability>MOC:6</availability>
-		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='(Asterion)[PPC]' mechanized='true'>
-			<availability>MH:2,TC:2</availability>
-		</model>
-		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
-			<availability>MOC:6</availability>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Asterion)[MRR]' mechanized='true'>
 			<availability>MH:2,TC:2</availability>
@@ -16972,11 +16962,20 @@
 		<model name='(Ying Long)(Plasma)' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
+		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
+			<availability>MOC:6</availability>
+		</model>
 		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
+		<model name='(Theseus RL)[LRR]' mechanized='true'>
+			<availability>MOC:6</availability>
+		</model>
+		<model name='(Asterion)[PPC]' mechanized='true'>
+			<availability>MH:2,TC:2</availability>
+		</model>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trireme Infantry Transport' unitType='VTOL'>
@@ -17003,14 +17002,14 @@
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
+		<model name='CMT-3T'>
+			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
+		</model>
 		<model name='CMT-4U'>
 			<availability>General:5</availability>
 		</model>
 		<model name='CMT-6T'>
 			<availability>MOC:5,CC:5,MERC:4,DA:4</availability>
-		</model>
-		<model name='CMT-3T'>
-			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
 		</model>
 		<model name='CMT-7T'>
 			<availability>CC:4</availability>
@@ -17032,10 +17031,10 @@
 	</chassis>
 	<chassis name='Tsunami' unitType='Mek'>
 		<availability>MERC:3</availability>
-		<model name='TS-P1D'>
+		<model name='TS-P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TS-P1'>
+		<model name='TS-P1D'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -17052,17 +17051,17 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CWE:6+,CW:6+,ROS:3,CWIE:3</availability>
-		<model name='4'>
-			<availability>General:8</availability>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
 		</model>
 		<model name='3'>
 			<availability>CWE:3,CW:3,ROS:2</availability>
 		</model>
+		<model name='4'>
+			<availability>General:8</availability>
+		</model>
 		<model name='5'>
 			<availability>CWE:2,CW:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
@@ -17077,24 +17076,24 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CWE:2,CW:2,CLAN:3,CJF:2,BAN:1,CWIE:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>RD:6,General:2</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>RD:4,CLAN:2</availability>
 		</model>
+		<model name='D'>
+			<availability>RD:6,General:2</availability>
+		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
@@ -17102,11 +17101,21 @@
 		<model name='A'>
 			<availability>CWE:7,CHH:7,CW:7,CNC:7,CP:7,CJF:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:4,CHH:4,CW:4,CNC:4,CP:4,CJF:4</availability>
+		<model name='Prime'>
+			<availability>CWE:8,CHH:8,CW:8,CNC:8,CP:8,CJF:8</availability>
+		</model>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:6,CHH:6,CW:6,CNC:6,CP:6,CJF:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CWE:7,CHH:7,CW:7,CNC:7,CP:7,CJF:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CHH:4,CW:4,CNC:4,CP:4,CJF:4</availability>
 		</model>
 		<model name='B'>
 			<availability>CWE:9,RD:9,CW:9,General:7</availability>
@@ -17114,19 +17123,13 @@
 		<model name='H'>
 			<availability>CWE:6,CHH:5,CW:6,CNC:5,CP:5,CJF:5</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CWE:8,CHH:8,CW:8,CNC:8,CP:8,CJF:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:6,CHH:6,CW:6,CNC:6,CP:6,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,ROS:3,FS:6,MERC:3</availability>
+		<model name='(RAC)'>
+			<roles>urban</roles>
+			<availability>General:4,FS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
@@ -17134,10 +17137,6 @@
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>urban</roles>
-			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -17149,63 +17148,30 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,RD:5,CDS:4,ROS:3,CP:4,DC:2</availability>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='3'>
 			<roles>assault</roles>
 			<availability>RD:4,CHH:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CWE:2,CHH:2,MERC.WD:1,CW:2,MERC:2+,CJF:3,RA:3,CWIE:2</availability>
-		<model name='B'>
-			<availability>CWE:6,RD:5,CDS:8,CW:6,General:7,CP:8,CWIE:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,IS:2,CP:5</availability>
-		</model>
-		<model name='I'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:4,CDS:4,CW:4,General:2,CP:4,CWIE:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CWE:6,RD:2,CW:6,General:2,CWIE:6</availability>
-		</model>
-		<model name='R'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:6,CHH:6,RD:4,CDS:6,CW:6,General:5,CP:6,CJF:6,CWIE:6</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>General:5,RA:6</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CWE:4,RD:1,CDS:2,CW:4,CNC:2,General:1,CP:2,CJF:2,CWIE:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>RD:8,CDS:9,General:8,CP:9,CJF:9</availability>
-		</model>
 		<model name='F'>
 			<availability>CWE:4,CHH:6,RD:5,CDS:4,CW:4,CLAN:3,IS:1,CP:4,CJF:4</availability>
 		</model>
@@ -17213,12 +17179,45 @@
 			<roles>fire_support</roles>
 			<availability>CWE:2,CHH:5,RD:2,CDS:4,CW:2,CNC:3,General:4,CP:3,CWIE:2</availability>
 		</model>
+		<model name='R'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CWE:6,RD:2,CW:6,General:2,CWIE:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CDS:4,CW:4,General:2,CP:4,CWIE:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CWE:6,CHH:6,RD:4,CDS:6,CW:6,General:5,CP:6,CJF:6,CWIE:6</availability>
+		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>General:5,RA:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:5,CDS:8,CW:6,General:7,CP:8,CWIE:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,CDS:9,General:8,CP:9,CJF:9</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CWE:4,RD:1,CDS:2,CW:4,CNC:2,General:1,CP:2,CJF:2,CWIE:4</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,IS:2,CP:5</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CWE:3,CW:3,General:1,CWIE:2</availability>
+		</model>
+		<model name='I'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Umbra' unitType='Aero'>
@@ -17246,24 +17245,24 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:4</availability>
-		<model name='(3065)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(3071)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(3065)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:5,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:8,IS:8,FS:8</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:5,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Uraeus' unitType='Mek'>
@@ -17285,6 +17284,10 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
+		<model name='UM-R80'>
+			<roles>urban,spotter</roles>
+			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
+		</model>
 		<model name='UM-R69'>
 			<roles>urban</roles>
 			<availability>FWL:6,IS:6,CP:6,Periphery:6</availability>
@@ -17297,30 +17300,26 @@
 			<roles>urban</roles>
 			<availability>Periphery:1</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:6,IS:4,Periphery:4</availability>
-		</model>
-		<model name='UM-R80'>
-			<roles>urban,spotter</roles>
-			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='UM-R93'>
 			<roles>urban</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='UM-R63'>
+		<model name='UM-R60'>
 			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>CC:4,MOC:4,FS.CMM:6,FWL:2:3139,MSC:4,FS:4,CP:2</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R63'>
 			<roles>urban</roles>
-			<availability>Periphery:2-</availability>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:6,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursa' unitType='Mek'>
@@ -17340,23 +17339,23 @@
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
 		<availability>CHH:4,RD:7,ROS:4</availability>
-		<model name='(Standard)'>
+		<model name='3'>
+			<roles>anti_infantry,specops</roles>
 			<deployedWith>IS</deployedWith>
-			<availability>General:8</availability>
+			<availability>RD:1</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>RD:1</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>RD:1</availability>
-		</model>
-		<model name='3'>
-			<roles>anti_infantry,specops</roles>
+		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
-			<availability>RD:1</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -17374,8 +17373,8 @@
 	</chassis>
 	<chassis name='Valiant' unitType='Mek'>
 		<availability>LA:6,IS:5,FS:6,MERC:5,CDP:5,DC:6</availability>
-		<model name='V4-LNT-J3'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
+		<model name='V4-LNT-K7'>
+			<availability>General:8</availability>
 		</model>
 		<model name='VLT-3E'>
 			<availability>ROS:8</availability>
@@ -17383,31 +17382,27 @@
 		<model name='VLN-3T'>
 			<availability>LA:2,General:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='V4-LNT-K7'>
-			<availability>General:8</availability>
+		<model name='V4-LNT-J3'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:2,ROS:4,FS:9,MERC:4,CDP:4,TC:4</availability>
-		<model name='VLK-QD4'>
+		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
-			<availability>ROS:6,FS:6</availability>
+			<availability>LA:6,ROS:4,MERC:4</availability>
+		</model>
+		<model name='VLK-QD'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,LA:4,ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='VLK-QD2'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:4,FS:4</availability>
 		</model>
-		<model name='VLK-QS5'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:6,ROS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QD8'>
 			<roles>recon,fire_support</roles>
 			<availability>FS:5,MERC:4</availability>
-		</model>
-		<model name='VLK-QD'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4,LA:4,ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
@@ -17421,6 +17416,10 @@
 			<roles>recon,fire_support</roles>
 			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='VLK-QD4'>
+			<roles>recon,fire_support</roles>
+			<availability>ROS:6,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
 		<availability>FS:2</availability>
@@ -17431,27 +17430,27 @@
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CWE:3,CW:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>CWE:4,CHH:6,CW:4,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CWE:4,CW:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:4,CHH:6,CW:4,CLAN:2,CJF:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>General:5,RA:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>General:5,RA:6</availability>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Mek' omni='IS'>
@@ -17460,12 +17459,12 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='LI-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LI-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='LI-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -17477,17 +17476,11 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CWE:4,CHH:5,CW:4,IS:10,CJF:4,Periphery:10</availability>
-		<model name='V-G7X'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='V7'>
-			<availability>LA:4,ROS:4,FS:4,MERC:6</availability>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:4,FS:6</availability>
 		</model>
 		<model name='V9'>
 			<availability>LA:4,CLAN:8</availability>
@@ -17495,11 +17488,17 @@
 		<model name='(LB-X)'>
 			<availability>CC:5,MOC:5,DTA:5,RF:5,FWL:4:3139,DA:5,RCM:5,CP:4,CDP:5,TC:5</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>IS:4,FS:6</availability>
+		</model>
 		<model name='(Light Gauss)'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
+		<model name='V-G7X'>
+			<availability>LA:1</availability>
+		</model>
+		<model name='V7'>
+			<availability>LA:4,ROS:4,FS:4,MERC:6</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>CC:6,LA:4,FWL:6,IS:4,FS:4,MERC:5,CP:6,DC:4,Periphery:4</availability>
@@ -17507,6 +17506,10 @@
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,CP:4,Periphery:1,TC:1,DC:4</availability>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:4,CC:4</availability>
 		</model>
@@ -17514,51 +17517,60 @@
 			<roles>asf_carrier</roles>
 			<availability>IS:4,FS:8</availability>
 		</model>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
 		<availability>ROS:4,FWL:2:3139,MERC:3,RCM:4,CP:2,DC:8</availability>
+		<model name='SDR-9KC'>
+			<availability>ROS:6,FWL:6,MERC:6,RCM:6,CP:6,DC:6</availability>
+		</model>
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
-		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,RCM:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,RCM:5,CP:5,DC:5</availability>
 		</model>
-		<model name='SDR-9KC'>
-			<availability>ROS:6,FWL:6,MERC:6,RCM:6,CP:6,DC:6</availability>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,RCM:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:3,LA:3,ROS:3,CWIE:2</availability>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:2,CC:5,RA.OA:2,LA:3,Periphery.HR:2,FWL:2,FS:7,Periphery.OS:2,CP:2,Periphery:3,TC:2,DC:4</availability>
-		<model name='VTR-C'>
-			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9B'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
+		</model>
+		<model name='VTR-9Ka'>
+			<availability>CC:4,FVC:4,ROS:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
+		</model>
+		<model name='VTR-Cr'>
+			<availability>FS:1,DC:2</availability>
 		</model>
 		<model name='VTR-10S'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='VTR-9B'>
-			<availability>Periphery:2-</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
+		</model>
+		<model name='VTR-11D'>
+			<roles>urban</roles>
+			<availability>ROS:2,FS:2,MERC:1</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
@@ -17566,21 +17578,8 @@
 		<model name='VTR-10D'>
 			<availability>ROS:5,FS:6,MERC:2</availability>
 		</model>
-		<model name='VTR-11D'>
-			<roles>urban</roles>
-			<availability>ROS:2,FS:2,MERC:1</availability>
-		</model>
-		<model name='VTR-Cr'>
-			<availability>FS:1,DC:2</availability>
-		</model>
 		<model name='VTR-10L'>
 			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
-		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
-		</model>
-		<model name='VTR-9Ka'>
-			<availability>CC:4,FVC:4,ROS:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vidar Heavy Defense Tank' unitType='Tank'>
@@ -17598,12 +17597,12 @@
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>RD:7,ROS:6,MERC:5</availability>
+		<model name='VKG-2G'>
+			<availability>RD:6,ROS:6,MERC:6</availability>
+		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-2G'>
-			<availability>RD:6,ROS:6,MERC:6</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
@@ -17623,20 +17622,20 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,PIR:5,MERC:4,TC:6</availability>
+		<model name='VND-5L'>
+			<availability>CC:2,MOC:1,MERC:1</availability>
+		</model>
 		<model name='VND-4L'>
 			<availability>CC:8,MOC:6</availability>
-		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:6,MOC:6,PIR:4,MERC:6,TC:6</availability>
 		</model>
 		<model name='VND-3L'>
 			<availability>CC:2,MOC:2,General:2,TC:2</availability>
 		</model>
-		<model name='VND-5L'>
-			<availability>CC:2,MOC:1,MERC:1</availability>
-		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
+		</model>
+		<model name='VND-3Lr'>
+			<availability>CC:6,MOC:6,PIR:4,MERC:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Violator' unitType='Mek'>
@@ -17659,23 +17658,23 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:2,CJF:6,RA:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CJF:6,RA:6</availability>
+		</model>
 		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
@@ -17683,27 +17682,27 @@
 		<model name='(Standard)'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='5'>
+		<model name='4'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CNC:5,CP:5,DC:6+</availability>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Nova Cat)' mechanized='true'>
-			<availability>CNC:8,CP:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='(Nova Cat)' mechanized='true'>
+			<availability>CNC:8,CP:8</availability>
+		</model>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
@@ -17717,18 +17716,14 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>PIR:2,FS:1,DC:2</availability>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
-		</model>
 		<model name='VNL-K75N'>
 			<availability>LA:8,FWL:8,FS:8,CP:8,DC:8</availability>
+		</model>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -17742,9 +17737,17 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>MOC:4,RD:4,LA:4,FWL:4,IS:1,CP:4,Periphery:4,TC:4</availability>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>OP:6,FWL:4:3139,DA:6,RCM:6,CP:4</availability>
+		</model>
 		<model name='VL-2T'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:2-,General:2-</availability>
+		</model>
+		<model name='VL-5T'>
+			<roles>anti_infantry</roles>
+			<availability>MOC:2,FVC:2,PIR:2,IS:2,Periphery:2,TC:2</availability>
 		</model>
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
@@ -17754,17 +17757,9 @@
 			<roles>anti_infantry</roles>
 			<availability>FVC:6,RD:6,LA:6,ROS:6,MH:4,FS:6,MERC:6</availability>
 		</model>
-		<model name='VL-5T'>
-			<roles>anti_infantry</roles>
-			<availability>MOC:2,FVC:2,PIR:2,IS:2,Periphery:2,TC:2</availability>
-		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:4,LA:8,MH:5,FS:4,MERC:5</availability>
-		</model>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>OP:6,FWL:4:3139,DA:6,RCM:6,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulpes' unitType='Mek'>
@@ -17775,11 +17770,20 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,MERC.WD:4,RD:4,ROS:4+,CLAN:3,MERC:2+,CJF:3,BAN:5,CWIE:4,DC:3+</availability>
+		<model name='B'>
+			<availability>CWE:7,CDS:7,CW:7,General:6,CP:7,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CWE:7,RD:4,CDS:7,CW:7,CNC:7,General:6,CP:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,CNC:7,General:8,CP:7,CJF:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:5,RD:3,CDS:7,CNC:7,General:5,CP:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CHH:5,CDS:3,CW:4,General:2,CP:3,CJF:4</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:5,CDS:5,General:4,CP:5,RA:5</availability>
@@ -17790,15 +17794,6 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:7,CDS:7,CW:7,General:6,CP:7,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:5,RD:3,CDS:7,CNC:7,General:5,CP:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:4,CHH:5,CDS:3,CW:4,General:2,CP:3,CJF:4</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CNC:5,CLAN:4,General:3,CP:5</availability>
 		</model>
@@ -17808,27 +17803,27 @@
 	</chassis>
 	<chassis name='Vulture Mk III (Mad Dog Mk III)' unitType='Mek' omni='Clan'>
 		<availability>RD:7,ROS:5,RA:7</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Prime)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vulture Mk IV (Mad Dog Mk IV)' unitType='Mek' omni='Clan'>
 		<availability>IS:4+,CLAN.IS:5</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
@@ -17837,7 +17832,7 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
@@ -17855,109 +17850,109 @@
 	</chassis>
 	<chassis name='Warg Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,CW:4</availability>
-		<model name='(Reactive)' mechanized='false'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Reactive)' mechanized='false'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>MOC:3,CLAN:7,IS:4,TC:3</availability>
-		<model name='6'>
-			<availability>RD:6,RA:6</availability>
+		<model name='9'>
+			<availability>CDS:6,CP:6</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:5,IS:4,CP:5</availability>
+		</model>
+		<model name='10'>
+			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
+		</model>
+		<model name='8'>
+			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
 		</model>
 		<model name='12'>
 			<availability>CDS:4,CP:4</availability>
+		</model>
+		<model name='6'>
+			<availability>RD:6,RA:6</availability>
+		</model>
+		<model name='7'>
+			<availability>RA:7</availability>
+		</model>
+		<model name='4'>
+			<availability>CC:4,CHH:5,RD:5,CDS:6,LA:4,ROS:4,CNC:5,FS:4,CP:5,RA:5,CWIE:5,DC:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,CP:4,DC:4</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>IS:3</availability>
 		</model>
-		<model name='9'>
-			<availability>CDS:6,CP:6</availability>
-		</model>
-		<model name='3'>
-			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,CP:4,DC:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:5,IS:4,CP:5</availability>
-		</model>
-		<model name='8'>
-			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
-		</model>
-		<model name='7'>
-			<availability>RA:7</availability>
-		</model>
 		<model name='11'>
 			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
-		</model>
-		<model name='10'>
-			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CC:4,CHH:5,RD:5,CDS:6,LA:4,ROS:4,CNC:5,FS:4,CP:5,RA:5,CWIE:5,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>LA:7,IS:6,FWL:7,CP:7,TC:8,Periphery:5</availability>
-		<model name='WHM-6R'>
-			<availability>BAN:8,Periphery:2-</availability>
+		<model name='WHM-9S'>
+			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
 		</model>
-		<model name='WHM-10T'>
-			<availability>FS:4,TC:8</availability>
+		<model name='WHM-8M'>
+			<availability>RF:6,FWL:4,CP:4</availability>
 		</model>
 		<model name='WHM-7K'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:8,MERC:4</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='WHM-8M'>
-			<availability>RF:6,FWL:4,CP:4</availability>
-		</model>
-		<model name='WHM-11T'>
-			<availability>MOC:4,TC:6</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='WHD-10CT'>
-			<availability>CC:4,OP:4,LA:4,ROS:4</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
-		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:2,PIR:4,IS:2,MH:4,FS:2,MERC:3,CDP:4,TC:4</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:4,LA:4,FS:2,MERC:4</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CC:3,FVC:3,ROS:4,FWL:4,MERC:1,CP:4,Periphery:3</availability>
-		</model>
-		<model name='WHM-9S'>
-			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
-		</model>
-		<model name='WHM-8D2'>
-			<availability>FS:6</availability>
+		<model name='WHM-6R'>
+			<availability>BAN:8,Periphery:2-</availability>
 		</model>
 		<model name='WHM-4L'>
 			<availability>CC:6,MOC:4</availability>
 		</model>
+		<model name='WHM-11T'>
+			<availability>MOC:4,TC:6</availability>
+		</model>
+		<model name='WHM-8K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='WHD-10CT'>
+			<availability>CC:4,OP:4,LA:4,ROS:4</availability>
+		</model>
+		<model name='WHM-8D2'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='WHM-5L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='WHM-7M'>
+			<availability>CC:3,FVC:3,ROS:4,FWL:4,MERC:1,CP:4,Periphery:3</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:4,LA:4,FS:2,MERC:4</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:8,MERC:4</availability>
+		</model>
+		<model name='WHM-10T'>
+			<availability>FS:4,TC:8</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:6,ROS:4,FS:6</availability>
-		<model name='BLR-2G'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BLR-2D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BLR-2G'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:6</availability>
@@ -17975,11 +17970,11 @@
 		<model name='H-8'>
 			<availability>RD:8,LA:3,FS.CH:8,ROS:6,IS:6,FWL:3,FS:6,CP:3,RA:8</availability>
 		</model>
-		<model name='H-9'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='H-9'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Stealth Helicopter' unitType='VTOL'>
@@ -17991,32 +17986,52 @@
 	</chassis>
 	<chassis name='Warwolf' unitType='Mek' omni='Clan'>
 		<availability>CWE:2+,CW:2+</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Prime)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='H'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>IS:8,Periphery:6,RA:4</availability>
-		<model name='WSP-1'>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
+		</model>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>MOC:1-,FVC:1-,Periphery:1-</availability>
+			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='WSP-8T'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:6,ROS:2,IS:4,TC:8</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,ROS:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WSP-1S'>
+			<roles>recon</roles>
+			<availability>FVC:3,LA:3,MERC:2</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,CP:8,DC:6</availability>
+		</model>
+		<model name='WSP-1'>
+			<roles>recon</roles>
+			<availability>MOC:1-,FVC:1-,Periphery:1-</availability>
 		</model>
 		<model name='WSP-3L'>
 			<roles>recon</roles>
@@ -18025,29 +18040,9 @@
 		<model name='WSP-3P'>
 			<availability>FVC:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:5,FS:4,MERC:4</availability>
-		</model>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
-		</model>
 		<model name='WSP-3A'>
 			<roles>recon</roles>
 			<availability>RA.OA:6,RA:8</availability>
-		</model>
-		<model name='WSP-1S'>
-			<roles>recon</roles>
-			<availability>FVC:3,LA:3,MERC:2</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,CP:8,DC:6</availability>
 		</model>
 		<model name='WSP-3K'>
 			<availability>DC:5</availability>
@@ -18064,15 +18059,18 @@
 	</chassis>
 	<chassis name='Wendigo-VP' unitType='Mek' omni='Clan'>
 		<availability>CNC:2,FWL:1:3143,CP:2,DC:1</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Wendigo' unitType='Mek' omni='Clan'>
 		<availability>CDS:3,CNC:5,FWL:4:3143,CP:5,DC:3</availability>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
@@ -18081,9 +18079,6 @@
 		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -18102,12 +18097,6 @@
 		<model name='WTH-3'>
 			<availability>FS.CMM:8</availability>
 		</model>
-		<model name='WTH-1H'>
-			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
-		</model>
-		<model name='WTH-K'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='WTH-2A'>
 			<availability>DC:1</availability>
 		</model>
@@ -18115,29 +18104,35 @@
 			<roles>fire_support</roles>
 			<availability>RA.OA:6,MH:6,MERC:6,CDP:6,TC:6</availability>
 		</model>
+		<model name='WTH-1H'>
+			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
+		</model>
+		<model name='WTH-K'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:6,LA:5,CNC:2-,FWL:5,IS:4,CP:3-,MERC:5,DC:8</availability>
-		<model name='WGT-3SC'>
-			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
-		</model>
-		<model name='WGT-1LAW/SC3'>
-			<availability>ROS:5,DC:6</availability>
+		<model name='WGT-2LAW'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='WGT-4NC &apos;Dezgra&apos;'>
 			<availability>CNC:8,CP:8</availability>
 		</model>
+		<model name='WGT-1LAW/SC3'>
+			<availability>ROS:5,DC:6</availability>
+		</model>
 		<model name='WGT-2LAWC3'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WGT-2LAW'>
-			<availability>DC:6</availability>
+		<model name='WGT-1LAW/SC'>
+			<availability>LA:4,FWL:4,IS:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 		<model name='WGT-2SC'>
 			<availability>LA:6,FWL:6,IS:4,MERC:6,CP:6</availability>
 		</model>
-		<model name='WGT-1LAW/SC'>
-			<availability>LA:4,FWL:4,IS:4,MERC:4,CP:4,DC:4</availability>
+		<model name='WGT-3SC'>
+			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wildkatze' unitType='Aero'>
@@ -18151,8 +18146,8 @@
 	</chassis>
 	<chassis name='Winston Combat Vehicle' unitType='Tank'>
 		<availability>ROS:5,ROS.pm:8</availability>
-		<model name='(LAC)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(TSEMP)'>
 			<availability>General:5</availability>
@@ -18161,10 +18156,10 @@
 			<roles>fire_support,spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(XXL)'>
+			<availability>General:4</availability>
+		</model>
+		<model name='(LAC)'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -18177,14 +18172,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>ROS:2,MERC:2,DC:5-</availability>
-		<model name='WFT-C'>
-			<availability>MERC:4,DC:4</availability>
-		</model>
 		<model name='WFT-2'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:8,DC:6</availability>
 		</model>
 		<model name='WFT-B'>
 			<availability>ROS:6</availability>
@@ -18192,21 +18181,15 @@
 		<model name='WFT-1'>
 			<availability>General:4</availability>
 		</model>
+		<model name='WFT-C'>
+			<availability>MERC:4,DC:4</availability>
+		</model>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:8,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,OP:3,MERC.KH:7,MERC:4,FS:1,CP:3,CWIE:5,DTA:3,MERC.WD:5,FVC:1,LA:7,ROS:5,FWL:3:3139,MH:4,MSC:3</availability>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
-		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
-		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-3M'>
-			<availability>DTA:8,OP:8,FWL:8,MSC:8,CP:8</availability>
-		</model>
 		<model name='WLF-4WA'>
 			<roles>ew_support</roles>
 			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
@@ -18214,65 +18197,77 @@
 		<model name='WLF-1'>
 			<availability>Periphery.Deep:6,Periphery:8</availability>
 		</model>
-		<model name='WLF-3S'>
-			<availability>LA:4</availability>
+		<model name='WLF-3M'>
+			<availability>DTA:8,OP:8,FWL:8,MSC:8,CP:8</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
 		</model>
 		<model name='WLF-2H'>
 			<availability>LA:6,MERC:3,CWIE:4</availability>
 		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
+		</model>
+		<model name='WLF-3S'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,RD:2,LA:5,CNC:2,IS:5,FWL:8,MH:4,FS:6,CP:6,DC:5,Periphery:4,TC:4</availability>
-		<model name='WVR-9K'>
-			<availability>ROS:3,DC:5</availability>
-		</model>
-		<model name='WVR-6R'>
+		<model name='WVR-7M'>
 			<roles>recon</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>FVC:5,LA:3,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,MERC:4,DC:8</availability>
-		</model>
-		<model name='WVR-9W2'>
-			<availability>IS:4,DC:8</availability>
+			<availability>CC:4,MOC:6,FWL:4,MH:6,MERC:6,CP:4,DC:4</availability>
 		</model>
 		<model name='WVR-9D'>
 			<roles>spotter</roles>
 			<availability>FS:6,MERC:4</availability>
 		</model>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:6,FWL:4,MH:6,MERC:6,CP:4,DC:4</availability>
+		<model name='WVR-8K'>
+			<availability>RD:5,ROS:4,CNC:4,MERC:3,CP:4</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:6</availability>
+		<model name='WVR-9W2'>
+			<availability>IS:4,DC:8</availability>
 		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>RD:8,MERC:6,DC:6</availability>
 		</model>
-		<model name='WVR-9M'>
-			<availability>LA:4,ROS:4,FWL:6,MH:4,MERC:4,CP:6</availability>
+		<model name='WVR-8D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='WVR-6M'>
 			<roles>recon</roles>
 			<availability>Periphery.MW:2-,PIR:2-,Periphery.ME:2-,MH:2-</availability>
 		</model>
-		<model name='WVR-8K'>
-			<availability>RD:5,ROS:4,CNC:4,MERC:3,CP:4</availability>
+		<model name='WVR-8C'>
+			<availability>ROS:4,MERC:4,DC:8</availability>
+		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='WVR-9M'>
+			<availability>LA:4,ROS:4,FWL:6,MH:4,MERC:4,CP:6</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>FVC:5,LA:3,ROS:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>ROS:3,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith Battle Armor' unitType='BattleArmor'>
@@ -18296,12 +18291,6 @@
 	</chassis>
 	<chassis name='Wulfen' unitType='Mek' omni='Clan'>
 		<availability>CWE:4+,CW:4+</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
@@ -18311,10 +18300,16 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='H'>
 			<availability>General:7</availability>
 		</model>
-		<model name='H'>
+		<model name='E'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -18327,10 +18322,7 @@
 	</chassis>
 	<chassis name='Wusun' unitType='Aero' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -18339,29 +18331,32 @@
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
 		<availability>CWE:4,CHH:4,CW:4</availability>
+		<model name='2'>
+			<availability>CWE:8,CW:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CWE:8,CW:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>CC:1,OP:1,IS:1,FS:7,MERC:5,DC.GHO:2,DTA:1,FVC:2,RF:1,ROS:5,MSC:1,DA:1,RCM:1,DC:6</availability>
-		<model name='WVE-9N'>
-			<roles>urban</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
+		</model>
+		<model name='WVE-9N'>
+			<roles>urban</roles>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -18377,20 +18372,20 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:6,LA:4,ROS:4,Periphery.CM:4,MERC:4,DA:4,Periphery:2,TC:4</availability>
-		<model name='XNT-2O'>
-			<availability>General:1-</availability>
-		</model>
 		<model name='XNT-6O'>
 			<availability>CC:6,MOC:6,DA:8</availability>
 		</model>
-		<model name='XNT-7O'>
-			<availability>CC:4</availability>
+		<model name='XNT-2O'>
+			<availability>General:1-</availability>
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:6,MOC:6,LA:6,ROS:6,MERC:6</availability>
 		</model>
 		<model name='XNT-4O'>
 			<availability>CC:6,MOC:6,LA:6</availability>
+		</model>
+		<model name='XNT-7O'>
+			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -18402,25 +18397,25 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
-		<model name='2'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CHH:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Xiphos Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DTA:5,OP:5,FWL:5:3139,MSC:6,CP:5</availability>
-		<model name='(B)' mechanized='false'>
+		<model name='(C)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(A)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C)' mechanized='false'>
+		<model name='(B)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -18432,6 +18427,9 @@
 	</chassis>
 	<chassis name='Yasha VTOL' unitType='VTOL'>
 		<availability>CHH:4,CDS:4,CNC:5,IS:5,CP:4,CWIE:5</availability>
+		<model name='&apos;Spectre&apos;'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Interdictor)'>
 			<roles>ew_support</roles>
 			<availability>General:4</availability>
@@ -18439,17 +18437,11 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='&apos;Spectre&apos;'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>FVC:8,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
 		<model name='(RAC)'>
 			<availability>IS:3,FS:5</availability>
-		</model>
-		<model name='(PPC)'>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2,FS:4</availability>
@@ -18461,15 +18453,18 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(PPC)'>
+			<availability>IS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
 		<availability>ROS:4,FWL:4,MH:3,MERC:3,CP:4</availability>
-		<model name='YMN-10-OR'>
-			<availability>ROS:4,FWL:4,MERC:4,CP:4</availability>
-		</model>
 		<model name='YMN-6Y'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='YMN-10-OR'>
+			<availability>ROS:4,FWL:4,MERC:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yinghuochong' unitType='Mek'>
@@ -18495,18 +18490,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='Y-H10G'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Y-H9G'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='Y-H10G'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Yun' unitType='Aero'>
@@ -18542,11 +18537,11 @@
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='(Omnidrone) C'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Omnidrone) A'>
 			<roles>spotter</roles>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(Omnidrone) C'>
 			<availability>ROS:4</availability>
 		</model>
 		<model name='(Omnidrone) Prime'>
@@ -18555,13 +18550,13 @@
 	</chassis>
 	<chassis name='Zephyros Infantry Support Vehicle' unitType='Tank'>
 		<availability>CWE:4,CHH:8,RD:4,CW:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Dual Turret)'>
 			<roles>apc</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
@@ -18572,8 +18567,8 @@
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:5,ROS:3</availability>
-		<model name='ZEU-X4'>
-			<availability>LA:8</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:4-</availability>
 		</model>
 		<model name='ZEU-X3'>
 			<availability>LA:2-</availability>
@@ -18584,26 +18579,26 @@
 		<model name='ZEU-9WD'>
 			<availability>General:4</availability>
 		</model>
-		<model name='ZEU-X2'>
-			<availability>LA:4-</availability>
+		<model name='ZEU-X4'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,ROS:5,PIR:2,MH:2,FS:1-,MERC:5,CDP:2,TC:2</availability>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
-		<model name='ZEU-6S'>
-			<availability>Periphery:2</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>FVC:6,LA:8,PIR:6,MH:6,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,ROS:4,FS:8,MERC:4</availability>
 		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
+		<model name='ZEU-6S'>
+			<availability>Periphery:2</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -18633,39 +18628,43 @@
 		<model name='(A)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CWE:10,CW:10,ROS:6,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CLAN:4,CJF:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(ATM)'>
 			<availability>CWE:6,CW:6,ROS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Zou Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>DC:5</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:6-</availability>
-		</model>
 		<model name='(C3)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Zugvogel Omni Support Aircraft' unitType='Conventional Fighter'>
 		<availability>RD:2,LA:4,IS:2,Periphery:2</availability>
+		<model name='Prime'>
+			<roles>cargo</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<roles>support</roles>
 			<availability>General:6</availability>
@@ -18674,23 +18673,19 @@
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>cargo</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>support,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<roles>support</roles>
+		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
 		<model name='F'>
 			<roles>support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>

--- a/megamek/data/forcegenerator/3145.xml
+++ b/megamek/data/forcegenerator/3145.xml
@@ -1169,28 +1169,28 @@
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
+		<model name='[David]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='[David]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Achilles' unitType='Dropship'>
 		<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,CP:4,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,FWL:4,DC:6</availability>
+		<model name='(3088)'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='(2582)'>
 			<roles>assault</roles>
 			<availability>General:2</availability>
-		</model>
-		<model name='(3088)'>
-			<availability>DC:6</availability>
 		</model>
 		<model name='(3055)'>
 			<roles>assault</roles>
@@ -1254,17 +1254,17 @@
 	</chassis>
 	<chassis name='Afreet Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:5,CJF:6</availability>
-		<model name='(Jade Falcon)' mechanized='true'>
-			<availability>CJF:8</availability>
+		<model name='(Hell&apos;s Horses)' mechanized='true'>
+			<availability>CHH:8</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Hell&apos;s Horses)' mechanized='true'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Interdictor)' mechanized='true'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Jade Falcon)' mechanized='true'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Agrotera' unitType='Mek'>
@@ -1303,13 +1303,12 @@
 	</chassis>
 	<chassis name='Ajax Assault Tank' unitType='Tank' omni='IS'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='B'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='D'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:4</availability>
@@ -1317,17 +1316,15 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='B'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Akuma' unitType='Mek'>
 		<availability>ROS:4,CP:4,DC:6</availability>
-		<model name='AKU-2X'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='AKU-1XJ'>
-			<availability>CP:5,DC:5</availability>
+		<model name='AKU-2XK'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='AKU-1X'>
 			<availability>DC:4</availability>
@@ -1335,17 +1332,20 @@
 		<model name='AKU-2XC'>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='AKU-2XK'>
-			<availability>DC:6</availability>
+		<model name='AKU-1XJ'>
+			<availability>CP:5,DC:5</availability>
+		</model>
+		<model name='AKU-2X'>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Alacorn Heavy Tank' unitType='Tank'>
 		<availability>CWE:4,CDS:4,LA:6,ROS:5,FS:5,CP:4,CWIE:6,DC:3</availability>
-		<model name='Mk VII'>
-			<availability>LA:4,FS:4</availability>
-		</model>
 		<model name='Mk VI'>
 			<availability>General:8</availability>
+		</model>
+		<model name='Mk VII'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Albatross' unitType='Mek'>
@@ -1353,11 +1353,11 @@
 		<model name='ALB-3U'>
 			<availability>FWL:8,MERC:8,CP:8</availability>
 		</model>
-		<model name='ALB-3Ur'>
-			<availability>ROS:4,FWL:4,MERC:4,CP:4</availability>
-		</model>
 		<model name='ALB-4U'>
 			<availability>FWL:6,CP:6</availability>
+		</model>
+		<model name='ALB-3Ur'>
+			<availability>ROS:4,FWL:4,MERC:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Amazon Battle Armor' unitType='BattleArmor'>
@@ -1371,11 +1371,11 @@
 	</chassis>
 	<chassis name='Ammon' unitType='Aero'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CP:5</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>RD:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Anat APC' unitType='Tank'>
@@ -1414,6 +1414,9 @@
 	</chassis>
 	<chassis name='Annihilator' unitType='Mek'>
 		<availability>MERC.KH:2,MERC.WD:8,CHH:3,LA:2,ROS:3,MERC:3,CWIE:2,BAN:2,RA:3</availability>
+		<model name='C 2'>
+			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
+		</model>
 		<model name='ANH-4A'>
 			<availability>MERC.WD:5,CHH:5,MERC.KH:5,LA:5,ROS:5,MERC:5,CWIE:5</availability>
 		</model>
@@ -1425,9 +1428,6 @@
 		</model>
 		<model name='ANH-3A'>
 			<availability>MERC.WD:5,CHH:4,LA:6,ROS:6,MERC:6,CWIE:4</availability>
-		</model>
-		<model name='C 2'>
-			<availability>MERC.WD:6,CLAN:6,IS:4,BAN:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Anti-&apos;Mech Jump Infantry' unitType='Infantry'>
@@ -1456,38 +1456,32 @@
 		<model name='ABS-5Y'>
 			<availability>MOC:6,CC:6</availability>
 		</model>
-		<model name='ABS-5Z'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:6</availability>
+		<model name='ABS-3R'>
+			<availability>General:4</availability>
 		</model>
 		<model name='ABS-3T'>
 			<availability>CC:5,MOC:5,TC:5</availability>
 		</model>
-		<model name='ABS-3R'>
-			<availability>General:4</availability>
+		<model name='ABS-4C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='ABS-5Z'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 		<model name='ABS-3L'>
 			<roles>fire_support</roles>
 			<availability>FVC:0,General:8</availability>
 		</model>
-		<model name='ABS-4C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Anvil' unitType='Mek'>
 		<availability>RF:6,ROS:4,FWL:6,MERC:4,DA:6,CP:6</availability>
-		<model name='ANV-5M'>
-			<availability>FWL:4,DA:4,CP:4</availability>
-		</model>
 		<model name='ANV-8M'>
 			<roles>missile_artillery</roles>
 			<availability>RF:5,FWL:5,DA:5,CP:5</availability>
 		</model>
-		<model name='ANV-3M'>
-			<availability>ROS:6,FWL:2,MERC:2,CP:2</availability>
-		</model>
-		<model name='ANV-3R'>
-			<availability>FWL:4,MERC:4,CP:4</availability>
+		<model name='ANV-5M'>
+			<availability>FWL:4,DA:4,CP:4</availability>
 		</model>
 		<model name='ANV-6M'>
 			<roles>spotter</roles>
@@ -1496,34 +1490,40 @@
 		<model name='ANV-5Q'>
 			<availability>RF:4,FWL:4,CP:4</availability>
 		</model>
+		<model name='ANV-3R'>
+			<availability>FWL:4,MERC:4,CP:4</availability>
+		</model>
+		<model name='ANV-3M'>
+			<availability>ROS:6,FWL:2,MERC:2,CP:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Anzu' unitType='Mek'>
 		<availability>FWL:7,CP:7</availability>
+		<model name='ZU-J70'>
+			<availability>FWL:6,CP:6</availability>
+		</model>
 		<model name='ZU-G60'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='ZU-J70'>
-			<availability>FWL:6,CP:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Apollo' unitType='Mek'>
 		<availability>CC:5,Periphery.MW:3,ROS:4,Periphery.ME:3,FWL:8,MH:4,MERC:4,CP:8,DC:6</availability>
-		<model name='APL-3T'>
-			<roles>fire_support</roles>
-			<availability>FWL:4,CP:4,DC:3</availability>
-		</model>
 		<model name='APL-1R'>
 			<roles>fire_support</roles>
 			<availability>CC:3,FWL:4,MERC:3,CP:4,DC:3</availability>
 		</model>
-		<model name='APL-2S'>
+		<model name='APL-3T'>
 			<roles>fire_support</roles>
-			<availability>CC:3,FWL:4,CP:4,DC:3</availability>
+			<availability>FWL:4,CP:4,DC:3</availability>
 		</model>
 		<model name='APL-4M'>
 			<roles>fire_support</roles>
 			<availability>FWL:3,CP:3</availability>
+		</model>
+		<model name='APL-2S'>
+			<roles>fire_support</roles>
+			<availability>CC:3,FWL:4,CP:4,DC:3</availability>
 		</model>
 		<model name='APL-1M'>
 			<roles>fire_support</roles>
@@ -1549,14 +1549,14 @@
 	</chassis>
 	<chassis name='Arbalest' unitType='Mek'>
 		<availability>CDS:2,ROS:4,MERC:4,FS:3,CP:4,DC:3</availability>
-		<model name='2'>
-			<availability>General:4</availability>
-		</model>
 		<model name='3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='2'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Arbiter SecurityMech' unitType='Mek'>
@@ -1585,90 +1585,81 @@
 	</chassis>
 	<chassis name='Archer' unitType='Mek'>
 		<availability>CC:4,RD:4,LA:6,FWL:6,CP:6,Periphery:3,DC:5</availability>
-		<model name='ARC-6W'>
+		<model name='ARC-7L'>
 			<roles>fire_support</roles>
-			<availability>FVC:4,TC:6,Periphery:4</availability>
+			<availability>CC:8,MOC:4</availability>
 		</model>
 		<model name='ARC-9W'>
 			<roles>fire_support</roles>
 			<availability>ROS:6</availability>
 		</model>
-		<model name='ARC-6S'>
+		<model name='ARC-2Rb'>
 			<roles>fire_support</roles>
-			<availability>RD:4,LA:2,ROS:4,MERC:2</availability>
-		</model>
-		<model name='ARC-8M'>
-			<roles>fire_support</roles>
-			<availability>MOC:3,ROS:4,PIR:3,FWL:5,MH:3,MERC:4,CP:5</availability>
-		</model>
-		<model name='(Wolf)'>
-			<availability>MERC.KH:6,MERC.WD:6</availability>
-		</model>
-		<model name='ARC-7L'>
-			<roles>fire_support</roles>
-			<availability>CC:8,MOC:4</availability>
-		</model>
-		<model name='ARC-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
+			<availability>CLAN:4,FWL:4,MERC:4,CP:4,BAN:2</availability>
 		</model>
 		<model name='ARC-9KC'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='ARC-5R'>
+		<model name='ARC-5W'>
 			<roles>fire_support</roles>
-			<availability>RD:6,MERC:2</availability>
+			<availability>MERC.WD:8</availability>
+		</model>
+		<model name='ARC-6S'>
+			<roles>fire_support</roles>
+			<availability>RD:4,LA:2,ROS:4,MERC:2</availability>
+		</model>
+		<model name='ARC-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:6</availability>
+		</model>
+		<model name='ARC-6W'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,TC:6,Periphery:4</availability>
 		</model>
 		<model name='ARC-9K'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
+		<model name='ARC-9M'>
+			<roles>fire_support</roles>
+			<availability>LA:6,ROS:4,FWL:4,MERC:4,CP:4,DC:4</availability>
+		</model>
 		<model name='ARC-5S'>
 			<roles>fire_support</roles>
 			<availability>LA:4,MERC:4</availability>
 		</model>
-		<model name='ARC-9M'>
+		<model name='(Wolf)'>
+			<availability>MERC.KH:6,MERC.WD:6</availability>
+		</model>
+		<model name='ARC-5R'>
 			<roles>fire_support</roles>
-			<availability>LA:6,ROS:4,FWL:4,MERC:4,CP:4,DC:4</availability>
+			<availability>RD:6,MERC:2</availability>
 		</model>
 		<model name='ARC-2R'>
 			<roles>fire_support</roles>
 			<availability>BAN:2,Periphery:2-</availability>
 		</model>
-		<model name='ARC-5W'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='ARC-2Rb'>
-			<roles>fire_support</roles>
-			<availability>CLAN:4,FWL:4,MERC:4,CP:4,BAN:2</availability>
-		</model>
 		<model name='ARC-4M'>
 			<roles>fire_support</roles>
 			<availability>FVC:4,PIR:5,FWL:2,CP:2,Periphery:4</availability>
 		</model>
+		<model name='ARC-8M'>
+			<roles>fire_support</roles>
+			<availability>MOC:3,ROS:4,PIR:3,FWL:5,MH:3,MERC:4,CP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Fox' unitType='Mek' omni='IS'>
 		<availability>MERC.KH:5,LA:5,ROS:4,MERC:2,CP:2-,CWIE:3-</availability>
-		<model name='AF1U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='AF1A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='AF1'>
-			<availability>General:8</availability>
+		<model name='AF1E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AF1F'>
 			<roles>fire_support</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='AF1E'>
-			<availability>General:6</availability>
+		<model name='AF1C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='AF1D'>
 			<roles>fire_support</roles>
@@ -1677,21 +1668,30 @@
 		<model name='AF1B'>
 			<availability>General:5</availability>
 		</model>
+		<model name='AF1U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='AF1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='AF1A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Arctic Wolf II' unitType='Mek' omni='Clan'>
 		<availability>MERC.KH:6,CWIE:7</availability>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Arctic Wolf' unitType='Mek'>
@@ -1708,11 +1708,11 @@
 		<model name='A'>
 			<availability>General:2</availability>
 		</model>
-		<model name='J'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:4</availability>
+		</model>
+		<model name='J'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -1742,11 +1742,11 @@
 	</chassis>
 	<chassis name='Ares' unitType='Mek' omni='IS'>
 		<availability>ROS:2+</availability>
-		<model name='ARS-V1 Zeus'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ARS-V1A Hera'>
 			<availability>General:7</availability>
+		</model>
+		<model name='ARS-V1 Zeus'>
+			<availability>General:8</availability>
 		</model>
 		<model name='ARS-V1B Hades'>
 			<availability>General:7</availability>
@@ -1761,12 +1761,6 @@
 	</chassis>
 	<chassis name='Argus' unitType='Mek'>
 		<availability>FS:6</availability>
-		<model name='AGS-2D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='AGS-5D'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AGS-8DX'>
 			<availability>General:2</availability>
 		</model>
@@ -1775,6 +1769,12 @@
 		</model>
 		<model name='AGS-6F'>
 			<availability>General:4</availability>
+		</model>
+		<model name='AGS-5D'>
+			<availability>General:4</availability>
+		</model>
+		<model name='AGS-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Arion' unitType='Mek'>
@@ -1785,37 +1785,17 @@
 	</chassis>
 	<chassis name='Armored Personnel Carrier' unitType='Tank'>
 		<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
-		<model name='(Tracked MG)'>
-			<roles>apc,support</roles>
-			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
-		</model>
 		<model name='(Hover SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
 		</model>
-		<model name='(Wheeled LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
-		</model>
-		<model name='(Hover Sensors)'>
-			<roles>recon,apc</roles>
-			<availability>MH:3,TC:3</availability>
-		</model>
-		<model name='(Hover MG)'>
+		<model name='(Tracked MG)'>
 			<roles>apc,support</roles>
-			<availability>General:2</availability>
+			<availability>RA.OA:3,RD:2,PIR:4,IS:2,Periphery:3</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Wheeled MG)'>
 			<roles>apc,support</roles>
-			<availability>PIR:6,General:9</availability>
-		</model>
-		<model name='(Hover)'>
-			<roles>apc,support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Tracked LRM)'>
-			<roles>apc</roles>
-			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+			<availability>PIR:3,General:2</availability>
 		</model>
 		<model name='(Wheeled SRM)'>
 			<roles>apc</roles>
@@ -1825,17 +1805,37 @@
 			<roles>apc</roles>
 			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
 		</model>
+		<model name='(Hover)'>
+			<roles>apc,support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Hover MG)'>
+			<roles>apc,support</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Tracked)'>
+			<roles>apc,support</roles>
+			<availability>PIR:6,General:9</availability>
+		</model>
+		<model name='(Wheeled LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
+		</model>
 		<model name='(Tracked SRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:3,Periphery:3-</availability>
+		</model>
+		<model name='(Tracked LRM)'>
+			<roles>apc</roles>
+			<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
 		</model>
 		<model name='(Wheeled)'>
 			<roles>apc,support</roles>
 			<availability>PIR:6,General:8</availability>
 		</model>
-		<model name='(Wheeled MG)'>
-			<roles>apc,support</roles>
-			<availability>PIR:3,General:2</availability>
+		<model name='(Hover Sensors)'>
+			<roles>recon,apc</roles>
+			<availability>MH:3,TC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Arondight Pocket Warship' unitType='Dropship'>
@@ -1862,16 +1862,16 @@
 	</chassis>
 	<chassis name='Assassin' unitType='Mek'>
 		<availability>Periphery:1-</availability>
-		<model name='ASN-30'>
-			<availability>LA:2,MERC:2</availability>
+		<model name='ASN-99'>
+			<roles>spotter</roles>
+			<availability>CC:2,MOC:2</availability>
 		</model>
 		<model name='ASN-23'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
 		</model>
-		<model name='ASN-99'>
-			<roles>spotter</roles>
-			<availability>CC:2,MOC:2</availability>
+		<model name='ASN-30'>
+			<availability>LA:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Assault Triumph' unitType='Dropship'>
@@ -1900,11 +1900,11 @@
 	</chassis>
 	<chassis name='Athena Combat Vehicle' unitType='Tank'>
 		<availability>CWE:5,CHH:8,RD:6,CDS:5,ROS:4,CP:5,CJF:3,RA:5</availability>
-		<model name='(HAG)'>
-			<availability>CHH:8,ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Atlas III' unitType='Mek'>
@@ -1927,63 +1927,51 @@
 		<model name='AS7-Dr'>
 			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
-		<model name='AS7-K-DC'>
-			<availability>IS:4,DC:4</availability>
+		<model name='AS7-K4'>
+			<availability>RF:4,LA:4,DC:4</availability>
+		</model>
+		<model name='AS7-K'>
+			<availability>MOC:3,RA.OA:4,FVC:4,MERC:4,CP:5,CDP:3,DC:4,Periphery:4,TC:3</availability>
+		</model>
+		<model name='AS7-S3'>
+			<availability>LA:6,ROS:4,MERC:3</availability>
+		</model>
+		<model name='AS7-K3'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
+		</model>
+		<model name='AS8-D'>
+			<availability>ROS:3,FS:6</availability>
+		</model>
+		<model name='AS7-K2'>
+			<availability>LA:8,IS:6,CLAN.IS:4,CP:6,Periphery:6,CWIE:6</availability>
 		</model>
 		<model name='C'>
 			<availability>LA:4,CLAN:8,IS:4,FS:4,DC:4</availability>
+		</model>
+		<model name='AS7-K-DC'>
+			<availability>IS:4,DC:4</availability>
+		</model>
+		<model name='AS7-D'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='AS7-C'>
+			<availability>MERC:2,DC:2</availability>
 		</model>
 		<model name='AS7-CM'>
 			<roles>spotter</roles>
 			<availability>MERC:6,DC:6</availability>
 		</model>
-		<model name='AS7-S'>
-			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
-		</model>
-		<model name='AS7-C'>
-			<availability>MERC:2,DC:2</availability>
-		</model>
 		<model name='AS7-S2'>
 			<availability>LA:1,ROS:3,MERC:3</availability>
 		</model>
-		<model name='AS7-D'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='AS7-S3'>
-			<availability>LA:6,ROS:4,MERC:3</availability>
-		</model>
-		<model name='AS7-K4'>
-			<availability>RF:4,LA:4,DC:4</availability>
-		</model>
-		<model name='AS8-D'>
-			<availability>ROS:3,FS:6</availability>
-		</model>
-		<model name='AS7-K3'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
-		<model name='AS7-K'>
-			<availability>MOC:3,RA.OA:4,FVC:4,MERC:4,CP:5,CDP:3,DC:4,Periphery:4,TC:3</availability>
-		</model>
-		<model name='AS7-K2'>
-			<availability>LA:8,IS:6,CLAN.IS:4,CP:6,Periphery:6,CWIE:6</availability>
+		<model name='AS7-S'>
+			<availability>MOC:2,FVC:2,LA:4,PIR:2,FS:2,MERC:3,CDP:2,TC:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Aurora' unitType='Dropship'>
 		<availability>LA:6,FS:6</availability>
 		<model name='(Vehicle)'>
 			<roles>vee_carrier</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(Combined Arms)'>
-			<roles>troop_carrier</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(CV)'>
@@ -1994,6 +1982,14 @@
 			<roles>ba_carrier</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Combined Arms)'>
+			<roles>troop_carrier</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='(Gunship)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
@@ -2001,6 +1997,10 @@
 		<model name='(Tanker)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalanche' unitType='Mek' omni='IS'>
@@ -2014,14 +2014,14 @@
 		<model name='AVL-1OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='AVL-1ON'>
+			<availability>General:6</availability>
+		</model>
 		<model name='AVL-1OR'>
 			<availability>General:6,CLAN:8</availability>
 		</model>
 		<model name='AVL-1O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AVL-1ON'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Avalon Cruiser' unitType='Warship'>
@@ -2033,24 +2033,24 @@
 	</chassis>
 	<chassis name='Avar' unitType='Aero' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CP:3,RA:2,BAN:5,CWIE:3</availability>
+		<model name='A'>
+			<availability>General:6,RA:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>CDS:9,General:7,CP:9,RA:8</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6,CP:7</availability>
 		</model>
+		<model name='C'>
+			<availability>CHH:6,General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CWE:4,CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6,RA:7</availability>
-		</model>
 		<model name='D'>
 			<availability>CWE:6,CLAN:4,CP:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:6,General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Avatar' unitType='Mek' omni='IS'>
@@ -2058,40 +2058,40 @@
 		<model name='AV1-OG'>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OJ'>
-			<availability>General:4</availability>
-		</model>
 		<model name='AV1-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='AV1-OI'>
-			<availability>General:3</availability>
-		</model>
-		<model name='AV1-OA'>
-			<availability>General:7</availability>
 		</model>
 		<model name='AV1-OH'>
 			<availability>General:4</availability>
 		</model>
-		<model name='AV1-OE'>
+		<model name='AV1-OI'>
+			<availability>General:3</availability>
+		</model>
+		<model name='AV1-OD'>
 			<availability>General:6</availability>
+		</model>
+		<model name='AV1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='AV1-OU'>
+			<roles>spotter</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='AV1-OF'>
+			<availability>General:5</availability>
 		</model>
 		<model name='AV1-OC'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='AV1-OD'>
-			<availability>General:6</availability>
-		</model>
 		<model name='AV1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
 		</model>
-		<model name='AV1-OF'>
-			<availability>General:5</availability>
+		<model name='AV1-OJ'>
+			<availability>General:4</availability>
 		</model>
-		<model name='AV1-OU'>
-			<roles>spotter</roles>
-			<availability>General:2</availability>
+		<model name='AV1-OE'>
+			<availability>General:6</availability>
 		</model>
 		<model name='AV1-OB'>
 			<availability>General:7</availability>
@@ -2099,34 +2099,34 @@
 	</chassis>
 	<chassis name='Avenger' unitType='Dropship'>
 		<availability>MOC:2,CC:2,RA.OA:2,LA:4,IS:2,FWL:3,FS:4,CP:3,TC:2,Periphery:1,DC:3</availability>
-		<model name='(3048)'>
-			<roles>assault</roles>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(2816)'>
 			<roles>assault</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(3048)'>
+			<roles>assault</roles>
+			<availability>LA:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Awesome' unitType='Mek'>
 		<availability>MOC:6,CC:5,RA.OA:6,LA:4,ROS:5,IS:4,FWL:8,FS:4,CP:8,Periphery:8,TC:5,DC:6</availability>
-		<model name='AWS-8Q'>
-			<availability>Periphery:2-</availability>
+		<model name='AWS-11R'>
+			<availability>RF:5,FWL:4,CP:4</availability>
 		</model>
 		<model name='AWS-10KM'>
 			<availability>ROS:4,FWL:4,CP:4,DC:6</availability>
 		</model>
+		<model name='AWS-8Q'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='AWS-9M'>
 			<availability>MOC:2,PIR:2,FWL:4,IS:2,MH:2,CP:4,TC:2,Periphery:4</availability>
-		</model>
-		<model name='AWS-9Ma'>
-			<availability>LA:2,ROS:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
 		<model name='AWS-9Q'>
 			<availability>MOC:6,FWL:4,IS:6,MH:6,CP:4,TC:6,Periphery:4</availability>
 		</model>
-		<model name='AWS-11R'>
-			<availability>RF:5,FWL:4,CP:4</availability>
+		<model name='AWS-9Ma'>
+			<availability>LA:2,ROS:2,FWL:2,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Axel Heavy Tank IIC' unitType='Tank'>
@@ -2146,8 +2146,18 @@
 	</chassis>
 	<chassis name='Axman' unitType='Mek'>
 		<availability>FVC:1,LA:5,ROS:4,FS:1</availability>
+		<model name='AXM-6T'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='AXM-3S'>
+			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
+		</model>
 		<model name='AXM-4D'>
 			<availability>FS:6</availability>
+		</model>
+		<model name='AXM-2N'>
+			<roles>fire_support</roles>
+			<availability>LA:1</availability>
 		</model>
 		<model name='AXM-1N'>
 			<availability>FVC:2,LA:2,MERC:2,FS:2</availability>
@@ -2155,19 +2165,13 @@
 		<model name='AXM-3Sr'>
 			<availability>LA:6,ROS:4,FS:6,MERC:4</availability>
 		</model>
-		<model name='AXM-6T'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='AXM-3S'>
-			<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='AXM-2N'>
-			<roles>fire_support</roles>
-			<availability>LA:1</availability>
-		</model>
 	</chassis>
 	<chassis name='Baboon (Howler)' unitType='Mek'>
 		<availability>CJF:5,RA:5</availability>
+		<model name='2'>
+			<roles>fire_support</roles>
+			<availability>RA:6</availability>
+		</model>
 		<model name='3 &apos;Devil&apos;'>
 			<availability>RA:8</availability>
 		</model>
@@ -2175,14 +2179,30 @@
 			<roles>fire_support</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<roles>fire_support</roles>
-			<availability>RA:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
 		<availability>CWE:6,MERC.WD:5,LA:4,ROS:5</availability>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>CLAN:5,General:3</availability>
+		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<roles>apc</roles>
+			<availability>CLAN:6,General:4</availability>
+		</model>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
@@ -2194,38 +2214,14 @@
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='E'>
-			<roles>apc</roles>
-			<availability>CLAN:6,General:4</availability>
-		</model>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<roles>apc</roles>
-			<availability>CLAN:5,General:3</availability>
-		</model>
-		<model name='B'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Badger Tracked Transport' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,LA:2,MERC:3</availability>
-		<model name='F'>
-			<roles>apc</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='A'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
@@ -2241,7 +2237,7 @@
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
@@ -2249,15 +2245,13 @@
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='F'>
+			<roles>apc</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Balac Strike VTOL' unitType='VTOL'>
 		<availability>RA.OA:7,IS:7,CLAN.IS:7</availability>
-		<model name='(Hybrid)'>
-			<availability>CLAN:3,IS:3</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>spotter</roles>
 			<availability>CLAN:2,IS:2</availability>
@@ -2265,24 +2259,30 @@
 		<model name='(Standard)'>
 			<availability>CLAN:8,IS:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>General:2</availability>
+		</model>
+		<model name='(Hybrid)'>
+			<availability>CLAN:3,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Balius' unitType='Mek' omni='Clan'>
 		<availability>CHH:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='U'>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
-			<availability>General:7</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -2293,33 +2293,41 @@
 	</chassis>
 	<chassis name='Bandersnatch' unitType='Mek'>
 		<availability>MOC:4,LA:4,ROS:4,FWL:4,FS:4,MERC:8,DA:4,CP:4,Periphery:4</availability>
+		<model name='BNDR-01Ar'>
+			<availability>General:2</availability>
+		</model>
 		<model name='BNDR-01A'>
 			<availability>General:8</availability>
 		</model>
 		<model name='BNDR-01B'>
 			<availability>General:4,MERC:8</availability>
 		</model>
-		<model name='BNDR-01Ar'>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Bandit (C) Hovercraft' unitType='Tank' omni='Clan'>
 		<availability>MERC.WD:5,CHH:2,CLAN:1</availability>
-		<model name='D'>
+		<model name='C'>
 			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3</availability>
 		</model>
+		<model name='A'>
+			<roles>apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='G'>
 			<roles>apc,anti_infantry</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='C'>
-			<roles>apc</roles>
-			<availability>General:7</availability>
+		<model name='F'>
+			<roles>apc,anti_infantry</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>apc</roles>
@@ -2329,16 +2337,8 @@
 			<roles>apc</roles>
 			<availability>CLAN:5,General:3</availability>
 		</model>
-		<model name='F'>
-			<roles>apc,anti_infantry</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='A'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>apc,fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -2351,9 +2351,13 @@
 	</chassis>
 	<chassis name='Bandit Hovercraft' unitType='Tank' omni='IS'>
 		<availability>MERC.WD:2,MERC:5</availability>
-		<model name='C'>
+		<model name='D'>
 			<roles>apc</roles>
-			<availability>General:2</availability>
+			<availability>General:3</availability>
+		</model>
+		<model name='G'>
+			<roles>apc</roles>
+			<availability>General:1</availability>
 		</model>
 		<model name='E'>
 			<roles>apc</roles>
@@ -2363,9 +2367,9 @@
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='H'>
+		<model name='Prime'>
 			<roles>apc</roles>
-			<availability>General:6</availability>
+			<availability>General:2</availability>
 		</model>
 		<model name='F'>
 			<roles>apc</roles>
@@ -2375,39 +2379,41 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='C'>
+			<roles>apc</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='H'>
+			<roles>apc</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='G'>
-			<roles>apc</roles>
-			<availability>General:1</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:2</availability>
-		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Banshee' unitType='Mek'>
 		<availability>MOC:4-,RA.OA:4-,FVC:2-,RF:2-,LA:2-,FWL:1-,MH:4-,MERC:1-,CP:1-,Periphery:7-,TC:4-</availability>
-		<model name='BNC-3MC'>
-			<availability>MOC:1-</availability>
-		</model>
-		<model name='BNC-3S'>
-			<availability>Periphery:1-</availability>
-		</model>
-		<model name='BNC-6S'>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BNC-3Mr'>
 			<availability>MOC:6,FWL:6,CP:6,CDP:6,TC:6</availability>
 		</model>
+		<model name='BNC-3MC'>
+			<availability>MOC:1-</availability>
+		</model>
+		<model name='BNC-7S'>
+			<availability>LA:1</availability>
+		</model>
 		<model name='BNC-9S2'>
 			<availability>RF:3,LA:5</availability>
+		</model>
+		<model name='BNC-9S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-8S'>
+			<availability>LA:6</availability>
+		</model>
+		<model name='BNC-3M'>
+			<availability>MOC:1-,FVC:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='BNC-3Q'>
 			<availability>RF:1-</availability>
@@ -2415,20 +2421,14 @@
 		<model name='BNC-3E'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='BNC-7S'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='BNC-8S'>
-			<availability>LA:6</availability>
+		<model name='BNC-3S'>
+			<availability>Periphery:1-</availability>
 		</model>
 		<model name='BNC-5S'>
 			<availability>LA:2,MH:4,MERC:5</availability>
 		</model>
-		<model name='BNC-9S'>
-			<availability>LA:6</availability>
-		</model>
-		<model name='BNC-3M'>
-			<availability>MOC:1-,FVC:1-,MH:1-,MERC:1-,CDP:1-,Periphery:1-,TC:1-</availability>
+		<model name='BNC-6S'>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bardiche Heavy Strike Tank' unitType='Tank'>
@@ -2443,21 +2443,21 @@
 	</chassis>
 	<chassis name='Barghest' unitType='Mek'>
 		<availability>LA:5,ROS:4,MERC:4</availability>
-		<model name='BGS-2T'>
-			<availability>LA:4,ROS:4,MERC:4</availability>
-		</model>
-		<model name='BGS-7S'>
-			<roles>fire_support</roles>
-			<availability>LA:4</availability>
-		</model>
 		<model name='BGS-1T'>
 			<availability>General:2</availability>
+		</model>
+		<model name='BGS-3T'>
+			<availability>LA:3,ROS:3,MERC:3</availability>
+		</model>
+		<model name='BGS-2T'>
+			<availability>LA:4,ROS:4,MERC:4</availability>
 		</model>
 		<model name='BGS-4T'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='BGS-3T'>
-			<availability>LA:3,ROS:3,MERC:3</availability>
+		<model name='BGS-7S'>
+			<roles>fire_support</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Barouche Military Transport' unitType='Tank'>
@@ -2469,21 +2469,21 @@
 	</chassis>
 	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
 		<availability>ROS:3+,CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
-		<model name='D'>
-			<availability>CLAN:2,CP:3,RA:6</availability>
-		</model>
-		<model name='B'>
-			<availability>CHH:7,General:6</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>General:7,CP:8,RA:8</availability>
 		</model>
-		<model name='C'>
-			<availability>General:5</availability>
+		<model name='D'>
+			<availability>CLAN:2,CP:3,RA:6</availability>
 		</model>
 		<model name='A'>
 			<availability>RD:8,General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>CHH:7,General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
 		</model>
 		<model name='E'>
 			<roles>ground_support</roles>
@@ -2492,25 +2492,25 @@
 	</chassis>
 	<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
 		<availability>CJF:6</availability>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
+		<model name='H'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='F'>
-			<availability>General:5</availability>
-		</model>
 		<model name='X'>
 			<availability>General:3</availability>
 		</model>
-		<model name='H'>
+		<model name='F'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='C'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -2540,17 +2540,26 @@
 	</chassis>
 	<chassis name='BattleMaster' unitType='Mek'>
 		<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
-		<model name='BLR-4L'>
-			<availability>CC:6</availability>
+		<model name='BLR-1Gc'>
+			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
 		</model>
-		<model name='BLR-3M'>
-			<availability>CC:2,MERC:2,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
+		<model name='BLR-1Gb'>
+			<availability>CC:4,CLAN:8,FWL:3,FS:4,MERC:4,CP:3,BAN:2,DC:4</availability>
+		</model>
+		<model name='BLR-6X'>
+			<availability>LA:2</availability>
 		</model>
 		<model name='BLR-4S'>
 			<availability>LA:2,ROS:4,MERC:4</availability>
 		</model>
 		<model name='BLR-10S'>
 			<availability>LA:6,ROS:4,FS:4</availability>
+		</model>
+		<model name='BLR-3S'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='BLR-1G'>
+			<availability>BAN:8,Periphery:1-</availability>
 		</model>
 		<model name='BLR-10S2'>
 			<availability>LA:6,ROS:4,FS:4</availability>
@@ -2562,30 +2571,21 @@
 			<roles>spotter</roles>
 			<availability>ROS:4,FWL:4,DA:5,MERC:4,CP:4</availability>
 		</model>
-		<model name='BLR-K4'>
-			<availability>RD:4,ROS:4,DC:6</availability>
-		</model>
-		<model name='BLR-6X'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BLR-3S'>
-			<availability>LA:2</availability>
-		</model>
-		<model name='BLR-1G'>
-			<availability>BAN:8,Periphery:1-</availability>
-		</model>
-		<model name='BLR-1Gb'>
-			<availability>CC:4,CLAN:8,FWL:3,FS:4,MERC:4,CP:3,BAN:2,DC:4</availability>
-		</model>
-		<model name='BLR-1Gc'>
-			<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
-		</model>
 		<model name='BLR-5M'>
 			<availability>FWL:8,CP:8</availability>
+		</model>
+		<model name='BLR-K4'>
+			<availability>RD:4,ROS:4,DC:6</availability>
 		</model>
 		<model name='BLR-CM'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='BLR-3M'>
+			<availability>CC:2,MERC:2,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
+		</model>
+		<model name='BLR-4L'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='BLR-K3'>
 			<roles>spotter</roles>
@@ -2601,16 +2601,9 @@
 	</chassis>
 	<chassis name='Batu' unitType='Aero' omni='Clan'>
 		<availability>CWE:6,CHH:5,RD:5,CDS:5,CP:5,CJF:6,CWIE:3</availability>
-		<model name='D'>
-			<availability>CWE:5,CLAN:2,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<roles>interceptor</roles>
 			<availability>CHH:7,General:8,CP:9</availability>
-		</model>
-		<model name='B'>
-			<roles>interceptor,ground_support</roles>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,General:5,CJF:6</availability>
@@ -2618,65 +2611,72 @@
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
 		</model>
+		<model name='D'>
+			<availability>CWE:5,CLAN:2,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<roles>interceptor,ground_support</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Beagle Hover Scout' unitType='Tank'>
 		<availability>ROS:6</availability>
-		<model name='(Sealed)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Sealed)'>
+			<availability>ROS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Bear Cub' unitType='Mek'>
 		<availability>RD:6,ROS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>General:3</availability>
 		</model>
 		<model name='2'>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
 		<availability>CHH:5,RA:3</availability>
-		<model name='(Standard)'>
-			<availability>RA:2</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:7</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>RA:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Behemoth Heavy Tank' unitType='Tank'>
 		<availability>CC:1,RA.OA:2,LA:1,PIR:1,IS:1,FWL:2,MERC:2,FS:2,CP:2,Periphery:2,DC:2</availability>
+		<model name='(Kurita)'>
+			<availability>CLAN:6,IS:6,DC:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>FVC:4,CDS:4,General:8,CP:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>urban</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='(Kurita)'>
-			<availability>CLAN:6,IS:6,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>FVC:4,CDS:4,General:8,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth II Heavy Tank' unitType='Tank'>
 		<availability>CC:7,MOC:6,LA:4,ROS:7,FWL:6,MH:4,MERC:4,CP:6,TC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Support)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Behemoth' unitType='Dropship'>
@@ -2688,11 +2688,11 @@
 	</chassis>
 	<chassis name='Bellona Hover Tank' unitType='Tank'>
 		<availability>CHH:6</availability>
-		<model name='(Laser)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Beowulf IIC' unitType='Mek'>
@@ -2704,28 +2704,28 @@
 	</chassis>
 	<chassis name='Beowulf' unitType='Mek'>
 		<availability>RD:6,ROS:6,CP:4</availability>
-		<model name='BEO-14'>
-			<roles>recon</roles>
-			<availability>ROS:6</availability>
-		</model>
 		<model name='BEO-12'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BEO-14'>
+			<roles>recon</roles>
+			<availability>ROS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Berserker' unitType='Mek'>
 		<availability>RF:5,LA:7,ROS:4,FS:3,MERC:3</availability>
+		<model name='BRZ-A3'>
+			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
+		</model>
 		<model name='BRZ-D4'>
 			<availability>LA:6</availability>
-		</model>
-		<model name='BRZ-B3'>
-			<availability>LA:1</availability>
 		</model>
 		<model name='BRZ-C3'>
 			<availability>RF:4,LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='BRZ-A3'>
-			<availability>RF:8,LA:4,FS:8,MERC:8</availability>
+		<model name='BRZ-B3'>
+			<availability>LA:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Bishamon' unitType='Mek'>
@@ -2750,122 +2750,122 @@
 	</chassis>
 	<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
 		<availability>CWE:1,CHH:1,RD:1,ROS:4+,CJF:1,RA:1,BAN:2,CWIE:1</availability>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
 		<model name='B'>
 			<availability>CWE:6,RD:4,General:6,CP:7,CJF:8</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:5,CHH:6,CDS:5,CLAN:4,General:2,CP:5</availability>
+		<model name='C'>
+			<availability>CWE:3,CHH:6,General:5,CJF:6</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CWE:2,RD:2,CDS:2,CLAN:1,General:2,CP:2,CJF:2,CWIE:2</availability>
 		</model>
-		<model name='I'>
-			<availability>General:6</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:3,CHH:6,General:5,CJF:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CWE:5,RD:7,General:6,CJF:8</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
+		<model name='D'>
+			<availability>CWE:3,CHH:6,General:4,CP:5,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='T'>
 			<availability>General:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>CWE:5,RD:7,General:6,CJF:8</availability>
+		</model>
 		<model name='A'>
 			<availability>RD:8,CDS:8,General:7,CP:8,CJF:9</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:3,CHH:6,General:4,CP:5,CJF:6,CWIE:5</availability>
+		<model name='E'>
+			<availability>CWE:5,CHH:6,CDS:5,CLAN:4,General:2,CP:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:4,General:2</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:5,General:2</availability>
+		</model>
+		<model name='I'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Hawk-KU' unitType='Mek' omni='IS'>
 		<availability>CC:5,LA:6,IS:5,FS:5,MERC:5,DC:8</availability>
-		<model name='BHKU-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='BHKU-OU'>
-			<roles>marine</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='BHKU-OX'>
 			<availability>FS:2,DC:2</availability>
-		</model>
-		<model name='BHKU-OR'>
-			<availability>General:3+,DC:3+</availability>
-		</model>
-		<model name='BHKU-OD'>
-			<availability>General:7</availability>
 		</model>
 		<model name='BHKU-OE'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BHKU-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='BHKU-OA'>
 			<availability>General:7</availability>
-		</model>
-		<model name='BHKU-OF'>
-			<availability>General:4</availability>
 		</model>
 		<model name='BHKU-OG'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='BHKU-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-OU'>
+			<roles>marine</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='BHKU-OR'>
+			<availability>General:3+,DC:3+</availability>
+		</model>
+		<model name='BHKU-OF'>
+			<availability>General:4</availability>
+		</model>
+		<model name='BHKU-OD'>
+			<availability>General:7</availability>
+		</model>
+		<model name='BHKU-O'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Hawk' unitType='Mek'>
 		<availability>CHH:8,CDS:6,IS:5,MERC:6,CP:5,CWIE:6</availability>
-		<model name='3'>
-			<availability>General:4</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='3'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Black Knight' unitType='Mek'>
 		<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,ROS:6,DA:6,CJF:3,DC:4</availability>
-		<model name='BL-12-KNT'>
-			<availability>ROS:3,FS:8</availability>
-		</model>
-		<model name='BL-6-KNT'>
-			<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
-		</model>
 		<model name='BL-6b-KNT'>
 			<availability>LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
 		</model>
-		<model name='BLK-NT-5H'>
-			<availability>FWL:4,FS:5,MERC:4,CP:4,DC:4</availability>
-		</model>
-		<model name='BLK-NT-4D'>
-			<availability>CWE:6,CDS:6,ROS:6,FS:5,MERC:4,CP:5,CWIE:6</availability>
-		</model>
-		<model name='BLK-NT-3B'>
-			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:6,MERC:5</availability>
+		<model name='BL-9-KNT'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='BLK-NT-2Y'>
 			<availability>FVC:4,ROS:6,IS:6,FS:6,CDP:4</availability>
 		</model>
+		<model name='BL-6-KNT'>
+			<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+		</model>
+		<model name='BLK-NT-4D'>
+			<availability>CWE:6,CDS:6,ROS:6,FS:5,MERC:4,CP:5,CWIE:6</availability>
+		</model>
 		<model name='BLK-NT-3A'>
 			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:6,MERC:5</availability>
 		</model>
-		<model name='BL-9-KNT'>
-			<availability>ROS:8</availability>
+		<model name='BL-12-KNT'>
+			<availability>ROS:3,FS:8</availability>
+		</model>
+		<model name='BLK-NT-3B'>
+			<availability>LA:5,ROS:5,FWL:5,IS:4,FS:6,MERC:5</availability>
+		</model>
+		<model name='BLK-NT-5H'>
+			<availability>FWL:4,FS:5,MERC:4,CP:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Lanner' unitType='Mek' omni='Clan'>
@@ -2873,19 +2873,15 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
-			<roles>recon,spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<roles>urban</roles>
-			<availability>General:2</availability>
+		<model name='H'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='X'>
 			<availability>CJF:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:6</availability>
+		<model name='A'>
+			<roles>recon,spotter</roles>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
@@ -2893,6 +2889,10 @@
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<roles>urban</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -2911,23 +2911,17 @@
 	</chassis>
 	<chassis name='Black Watch' unitType='Mek'>
 		<availability>ROS:6,MERC:3</availability>
-		<model name='BKW-7R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BKW-9R'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='BKW-7R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Black Wolf Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:6,CWIE:4</availability>
 		<model name='[LBX]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Plasma]' mechanized='true'>
-			<availability>General:5</availability>
-		</model>
-		<model name='[Heavy Flamer]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[ERSPL]' mechanized='true'>
@@ -2936,32 +2930,44 @@
 		<model name='[Heavy Mortar]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[Heavy Flamer]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Plasma]' mechanized='true'>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek'>
 		<availability>MOC:2,RA.OA:3,FVC:4,FS:4,MERC:2,TC:2,Periphery:4</availability>
-		<model name='BJ-3'>
-			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
-		</model>
-		<model name='BJ-4'>
-			<availability>FVC:6,FS:8,MERC:6</availability>
+		<model name='BJ-2r'>
+			<availability>FVC:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='BJ-1'>
 			<availability>Periphery:1</availability>
 		</model>
+		<model name='BJ-3'>
+			<availability>CC:6,FVC:2,FS:2,MERC:2,Periphery:2</availability>
+		</model>
 		<model name='BJ-2'>
 			<availability>FVC:3,LA:4,FS:2,MERC:4</availability>
 		</model>
-		<model name='BJ-2r'>
-			<availability>FVC:6,FS:6,MERC:6</availability>
+		<model name='BJ-4'>
+			<availability>FVC:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Blackjack' unitType='Mek' omni='IS'>
 		<availability>CC:4,MOC:4,FVC:2,ROS:4,FWL:5,IS:1,FS:6,MERC:3,DA:4,CP:5,DC:6</availability>
-		<model name='BJ2-O'>
-			<availability>General:7</availability>
+		<model name='BJ2-OE'>
+			<availability>General:7,FWL:8,CP:8</availability>
 		</model>
-		<model name='BJ2-OX'>
-			<availability>General:2</availability>
+		<model name='BJ2-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='BJ2-OR'>
+			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		</model>
+		<model name='BJ2-OF'>
+			<availability>General:4,FWL:7,CP:7</availability>
 		</model>
 		<model name='BJ2-OB'>
 			<availability>General:6</availability>
@@ -2969,23 +2975,17 @@
 		<model name='BJ2-OA'>
 			<availability>General:6</availability>
 		</model>
-		<model name='BJ2-OC'>
+		<model name='BJ2-OD'>
 			<availability>General:6</availability>
 		</model>
 		<model name='BJ2-OU'>
 			<availability>General:2</availability>
 		</model>
-		<model name='BJ2-OE'>
-			<availability>General:7,FWL:8,CP:8</availability>
+		<model name='BJ2-O'>
+			<availability>General:7</availability>
 		</model>
-		<model name='BJ2-OD'>
-			<availability>General:6</availability>
-		</model>
-		<model name='BJ2-OF'>
-			<availability>General:4,FWL:7,CP:7</availability>
-		</model>
-		<model name='BJ2-OR'>
-			<availability>CLAN:6,IS:3+,DC:3+</availability>
+		<model name='BJ2-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Blade' unitType='Mek'>
@@ -2997,15 +2997,15 @@
 			<roles>fire_support</roles>
 			<availability>ROS:5,FS:8</availability>
 		</model>
-		<model name='BLD-XS'>
-			<availability>ROS:4,FS:4</availability>
+		<model name='BLD-XX'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:2</availability>
 		</model>
 		<model name='BLD-XL'>
 			<availability>ROS:8,FS:8</availability>
 		</model>
-		<model name='BLD-XX'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:2</availability>
+		<model name='BLD-XS'>
+			<availability>ROS:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Blitzkrieg' unitType='Mek'>
@@ -3019,39 +3019,39 @@
 	</chassis>
 	<chassis name='Blizzard Hover Transport' unitType='Tank'>
 		<availability>CC:6,MERC:5</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='&apos;Black Blizzard&apos;'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Blood Asp' unitType='Mek' omni='Clan'>
 		<availability>CHH:5</availability>
-		<model name='Prime'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:8</availability>
+		<model name='Prime'>
+			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
 		<model name='C'>
 			<availability>General:4</availability>
 		</model>
-		<model name='G'>
+		<model name='E'>
 			<availability>General:5</availability>
 		</model>
 		<model name='D'>
@@ -3060,28 +3060,28 @@
 	</chassis>
 	<chassis name='Blood Reaper' unitType='Mek'>
 		<availability>CWE:9</availability>
-		<model name='2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:6</availability>
+		</model>
+		<model name='2'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bloodhound' unitType='Mek'>
 		<availability>RF:5,ROS:4,FWL:6,MH:4,MERC:4,DA:6,CP:6</availability>
-		<model name='B3-HND'>
-			<roles>anti_infantry</roles>
-			<availability>:0,IS:4</availability>
+		<model name='B2-HND'>
+			<availability>RF:0,General:4</availability>
 		</model>
 		<model name='B1-HND'>
 			<availability>:0,General:8</availability>
 		</model>
-		<model name='B2-HND'>
-			<availability>RF:0,General:4</availability>
+		<model name='B3-HND'>
+			<roles>anti_infantry</roles>
+			<availability>:0,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
-		<availability>MOC:6,FS:2,Periphery:4,DC:2,OA.RA:5</availability>
+		<availability>MOC:6,OA.RA:5,FS:2,Periphery:4,DC:2</availability>
 		<model name='MSF-42'>
 			<availability>General:6</availability>
 		</model>
@@ -3095,11 +3095,11 @@
 	</chassis>
 	<chassis name='Bolla Stealth Tank (RotS)' unitType='Tank' omni='IS'>
 		<availability>ROS:4</availability>
-		<model name='A'>
-			<roles>spotter</roles>
+		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='D'>
+		<model name='A'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
@@ -3117,6 +3117,10 @@
 	</chassis>
 	<chassis name='Bombardier' unitType='Mek'>
 		<availability>RA.OA:5,FVC:4,CDS:3,CLAN:1,CP:3,DC:4,RA:4</availability>
+		<model name='BMB-12D'>
+			<roles>fire_support</roles>
+			<availability>RA.OA:2,FVC:6,ROS:2,CLAN:8,MERC.SI:8,BAN:8</availability>
+		</model>
 		<model name='BMB-05A'>
 			<roles>missile_artillery,fire_support</roles>
 			<availability>RA.OA:8</availability>
@@ -3124,10 +3128,6 @@
 		<model name='BMB-14K'>
 			<roles>fire_support</roles>
 			<availability>DC:8</availability>
-		</model>
-		<model name='BMB-12D'>
-			<roles>fire_support</roles>
-			<availability>RA.OA:2,FVC:6,ROS:2,CLAN:8,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -3139,7 +3139,11 @@
 	</chassis>
 	<chassis name='Boreas' unitType='Mek' omni='Clan'>
 		<availability>CHH:5</availability>
-		<model name='A'>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='B'>
@@ -3149,11 +3153,7 @@
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -3166,42 +3166,42 @@
 			<roles>missile_artillery</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='4'>
-			<roles>missile_artillery</roles>
-			<availability>CHH:2</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:6</availability>
 		</model>
+		<model name='4'>
+			<roles>missile_artillery</roles>
+			<availability>CHH:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Brahma' unitType='Mek'>
 		<availability>MERC:3,TC:6</availability>
-		<model name='BRM-5A'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BRM-5B'>
 			<availability>TC:2</availability>
+		</model>
+		<model name='BRM-5A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Brigand' unitType='Mek'>
 		<availability>PIR:5,MH:2,MERC:2</availability>
-		<model name='LDT-5'>
+		<model name='LDT-X3'>
 			<availability>PIR:4</availability>
 		</model>
-		<model name='LDT-X3'>
+		<model name='LDT-X4'>
 			<availability>PIR:4</availability>
 		</model>
 		<model name='LDT-1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='LDT-X4'>
+		<model name='LDT-5'>
 			<availability>PIR:4</availability>
 		</model>
-		<model name='LDT-X1'>
+		<model name='LDT-X2'>
 			<availability>General:4</availability>
 		</model>
-		<model name='LDT-X2'>
+		<model name='LDT-X1'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -3213,16 +3213,19 @@
 	</chassis>
 	<chassis name='Bruin' unitType='Mek'>
 		<availability>RD:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Brutus Assault Tank' unitType='Tank'>
 		<availability>CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+		<model name='(PPC 2)'>
+			<availability>IS:4</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
@@ -3234,9 +3237,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:6,MOC:6,RA.OA:6,RD:6,IS:6,FS:6</availability>
-		</model>
-		<model name='(PPC 2)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Buccaneer' unitType='Dropship'>
@@ -3261,13 +3261,13 @@
 	</chassis>
 	<chassis name='Buffel Engineering Support Vehicle VII' unitType='Tank'>
 		<availability>CC:2,LA:3,FWL:2,FS:2,MERC:2,CP:2,DC:2</availability>
-		<model name='(Cargo)'>
-			<roles>support,engineer</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>support,engineer</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Cargo)'>
+			<roles>support,engineer</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Reverse)'>
 			<roles>support,engineer</roles>
@@ -3279,14 +3279,14 @@
 		<model name='(LRM)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Cell)'>
+			<availability>LA:8,ROS:8,FS:8,MERC:8,DC:8</availability>
 		</model>
 		<model name='(AC2)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Cell)'>
-			<availability>LA:8,ROS:8,FS:8,MERC:8,DC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Bulwark Assault Vehicle' unitType='Tank'>
@@ -3300,14 +3300,14 @@
 	</chassis>
 	<chassis name='Buraq Fast Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6</availability>
-		<model name='(Support)' mechanized='false'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8</availability>
 		</model>
 		<model name='(Hunter-Killer)' mechanized='false'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Support)' mechanized='false'>
+			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
 	</chassis>
@@ -3329,14 +3329,14 @@
 	</chassis>
 	<chassis name='Bushwacker' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:5,MERC:3</availability>
+		<model name='BSW-S2r'>
+			<availability>General:4</availability>
+		</model>
 		<model name='BSW-S2'>
 			<availability>LA:6,MERC:4</availability>
 		</model>
 		<model name='BSW-L1'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='BSW-S2r'>
-			<availability>General:4</availability>
 		</model>
 		<model name='BSW-X2'>
 			<availability>LA:4,MERC:4</availability>
@@ -3347,11 +3347,11 @@
 	</chassis>
 	<chassis name='Cadaver' unitType='Mek'>
 		<availability>RA.OA:7,IS:3,MERC:4,TC:7,RA:6,Periphery:3</availability>
-		<model name='CVR-A1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='CVR-T1'>
 			<availability>RA.OA:6,TC:4,RA:6</availability>
+		</model>
+		<model name='CVR-A1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Caerleon' unitType='Small Craft'>
@@ -3363,17 +3363,17 @@
 	</chassis>
 	<chassis name='Caesar' unitType='Mek'>
 		<availability>FVC:4,LA:2,FS:2,MERC:2</availability>
-		<model name='CES-3R'>
-			<availability>FVC:8,FS:1,MERC:1</availability>
-		</model>
-		<model name='CES-4S'>
-			<availability>LA:6,FS:6</availability>
-		</model>
 		<model name='CES-4R'>
 			<availability>FS:6</availability>
 		</model>
 		<model name='CES-3S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='CES-3R'>
+			<availability>FVC:8,FS:1,MERC:1</availability>
+		</model>
+		<model name='CES-4S'>
+			<availability>LA:6,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Calliope' unitType='Mek'>
@@ -3401,22 +3401,22 @@
 	</chassis>
 	<chassis name='Cardinal Transport' unitType='VTOL'>
 		<availability>CDS:8,LA:5,ROS:5,MERC:6,CP:8,CJF:7,DC:6</availability>
-		<model name='(RAF)'>
-			<roles>apc</roles>
-			<availability>ROS:8,MERC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>ROS:4,General:8</availability>
 		</model>
+		<model name='(RAF)'>
+			<roles>apc</roles>
+			<availability>ROS:8,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Carnivore Assault Tank' unitType='Tank'>
 		<availability>CC:4,CWE:6,CHH:4,LA:4,FS:4,MERC:4,CJF:5,CWIE:4,DC:4</availability>
-		<model name='(Standard)'>
-			<availability>CWE:8,CJF:4</availability>
-		</model>
 		<model name='(HAG)'>
 			<availability>CWE:6,CJF:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CWE:8,CJF:4</availability>
 		</model>
 		<model name='(Second Line)'>
 			<availability>CWE:4-,General:8,CJF:4-</availability>
@@ -3424,13 +3424,13 @@
 	</chassis>
 	<chassis name='Carrack Transport' unitType='Warship'>
 		<availability>CWE:1,CHH:1,RD:2,CDS:3,CP:4,CJF:1,RA:3</availability>
-		<model name='(Clan)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Merchant 2985)'>
 			<roles>cargo</roles>
 			<availability>RD:4,CDS:8,CP:8,CJF:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<roles>cargo</roles>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Carrier' unitType='Dropship'>
@@ -3455,11 +3455,17 @@
 	</chassis>
 	<chassis name='Cataphract' unitType='Mek'>
 		<availability>CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,Periphery.ME:1,MH:1,FS:2,MERC:3,CDP:3,TC:3</availability>
-		<model name='CTF-1X'>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='CTF-3D'>
 			<availability>FVC:3,MH:4,FS:2,MERC:4</availability>
+		</model>
+		<model name='CTF-3L'>
+			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
+		</model>
+		<model name='CTF-5D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='CTF-3LL'>
+			<availability>CC:6,MOC:6,MERC:3,TC:6</availability>
 		</model>
 		<model name='CTF-4X'>
 			<availability>FVC:4,FS:4,MERC:3</availability>
@@ -3467,53 +3473,55 @@
 		<model name='CTF-4L'>
 			<availability>CC:6,MOC:6</availability>
 		</model>
-		<model name='CTF-5D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='CTF-3L'>
-			<availability>CC:8,MOC:5,MERC:5,TC:5</availability>
-		</model>
-		<model name='CTF-3LL'>
-			<availability>CC:6,MOC:6,MERC:3,TC:6</availability>
+		<model name='CTF-1X'>
+			<availability>Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Catapult II' unitType='Mek'>
 		<availability>CC:6,MOC:6,DA:6,MERC:4</availability>
-		<model name='CPLT-L7'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='CPLT-L7L'>
 			<roles>fire_support</roles>
 			<availability>General:4,MERC:0</availability>
 		</model>
+		<model name='CPLT-L7'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Catapult' unitType='Mek'>
 		<availability>MOC:2,CC:4,FWL:3,MH:3,MERC:1,CP:2,DA:4,Periphery:2,TC:2,DC:6</availability>
+		<model name='CPLT-C4C'>
+			<roles>fire_support</roles>
+			<availability>CC:2,MOC:2,MERC:2,CDP:2,TC:2</availability>
+		</model>
+		<model name='CPLT-H2'>
+			<roles>fire_support</roles>
+			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
+		</model>
 		<model name='CPLT-K4'>
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='CPLT-C1'>
+			<roles>fire_support</roles>
+			<availability>BAN:2</availability>
+		</model>
+		<model name='CPLT-C5'>
+			<roles>missile_artillery,fire_support</roles>
+			<availability>CC:6,MOC:6,MERC:4,TC:6</availability>
+		</model>
+		<model name='CPLT-K5'>
+			<roles>fire_support</roles>
+			<availability>DC:8</availability>
 		</model>
 		<model name='CPLT-C3'>
 			<roles>missile_artillery</roles>
 			<deployedWith>Raven</deployedWith>
 			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,CDP:3,TC:3,DC:4</availability>
 		</model>
-		<model name='CPLT-C1'>
-			<roles>fire_support</roles>
-			<availability>BAN:2</availability>
-		</model>
 		<model name='CPLT-C6'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:4,MERC:4,TC:4</availability>
-		</model>
-		<model name='CPLT-H2'>
-			<roles>fire_support</roles>
-			<availability>FVC:4,PIR:4,MH:8,Periphery:4</availability>
-		</model>
-		<model name='CPLT-K5'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
 		</model>
 		<model name='CPLT-C1b'>
 			<roles>fire_support</roles>
@@ -3527,14 +3535,6 @@
 			<roles>fire_support</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='CPLT-C5'>
-			<roles>missile_artillery,fire_support</roles>
-			<availability>CC:6,MOC:6,MERC:4,TC:6</availability>
-		</model>
-		<model name='CPLT-C4C'>
-			<roles>fire_support</roles>
-			<availability>CC:2,MOC:2,MERC:2,CDP:2,TC:2</availability>
-		</model>
 		<model name='CPLT-C2'>
 			<roles>fire_support</roles>
 			<deployedWith>Raven</deployedWith>
@@ -3543,12 +3543,6 @@
 	</chassis>
 	<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CP:5,RA:5,DC:3+</availability>
-		<model name='A'>
-			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<availability>CLAN:5,IS:3</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
@@ -3558,10 +3552,6 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='B'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -3569,26 +3559,46 @@
 		<model name='D'>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CLAN:5,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Cavalier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:8</availability>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Cavalry Attack Helicopter' unitType='VTOL'>
 		<availability>LA:3,ROS:3,IS:2,FS:6,MERC:3</availability>
+		<model name='(Infiltrator)'>
+			<roles>apc</roles>
+			<availability>FS:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
@@ -3597,16 +3607,6 @@
 		<model name='(TAG)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Infiltrator)'>
-			<roles>apc</roles>
-			<availability>FS:6</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cave Lion' unitType='Mek'>
@@ -3626,15 +3626,11 @@
 	</chassis>
 	<chassis name='Celerity' unitType='Mek' omni='IS'>
 		<availability>ROS:3</availability>
-		<model name='CLR-03-OB'>
-			<roles>specops</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='CLR-03-OC'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='CLR-03-OE'>
+		<model name='CLR-03-OB'>
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
@@ -3650,6 +3646,10 @@
 			<roles>specops</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='CLR-03-OE'>
+			<roles>specops</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Centaur Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:4</availability>
@@ -3660,22 +3660,22 @@
 	</chassis>
 	<chassis name='Centaur' unitType='ProtoMek'>
 		<availability>CHH:5,CP:6,RA:5</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8,CP:8</availability>
-		</model>
 		<model name='3'>
 			<availability>RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Centipede Scout Car' unitType='Tank'>
 		<availability>LA:8,FS:5,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)'>
 			<roles>recon,spotter</roles>
@@ -3693,69 +3693,69 @@
 		<model name='CNT-2D'>
 			<availability>General:3</availability>
 		</model>
-		<model name='CNT-1A'>
-			<availability>General:2</availability>
-		</model>
 		<model name='CNT-3S'>
 			<roles>spotter</roles>
 			<availability>LA:8</availability>
 		</model>
+		<model name='CNT-1A'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek'>
 		<availability>CC:4,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2,FVC:8,LA:3,Periphery.HR:4,ROS:5,FWL:1,MH:6</availability>
-		<model name='CN9-D3'>
-			<availability>FVC:2,ROS:2,FS:1,MERC:1,CDP:3</availability>
-		</model>
-		<model name='CN9-D9'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='CN9-D5'>
-			<availability>FS:3</availability>
-		</model>
-		<model name='CN9-Ar'>
-			<availability>IS:3,Periphery:4</availability>
-		</model>
-		<model name='CN9-H'>
-			<availability>MH:1-</availability>
-		</model>
-		<model name='CN10-B'>
-			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
-		</model>
-		<model name='CN9-D'>
-			<availability>FVC:2,MERC:1,Periphery:4</availability>
-		</model>
 		<model name='CN9-A'>
 			<deployedWith>Trebuchet</deployedWith>
 			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
+		<model name='CN9-D'>
+			<availability>FVC:2,MERC:1,Periphery:4</availability>
+		</model>
+		<model name='CN9-D5'>
+			<availability>FS:3</availability>
+		</model>
 		<model name='CN9-D3D'>
 			<availability>FVC:3,ROS:3,FWL:3,FS:3,MERC:3,CP:3,CDP:3</availability>
 		</model>
-		<model name='CN9-Da'>
-			<availability>FVC:4,ROS:2,FWL:2,MERC:2,FS:2,CP:2,Periphery:4</availability>
+		<model name='CN9-D9'>
+			<availability>FS:2</availability>
+		</model>
+		<model name='CN9-H'>
+			<availability>MH:1-</availability>
 		</model>
 		<model name='CN9-D4D'>
 			<availability>ROS:3,FWL:3,FS:3,MERC:3,CP:3</availability>
 		</model>
+		<model name='CN9-Ar'>
+			<availability>IS:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-D3'>
+			<availability>FVC:2,ROS:2,FS:1,MERC:1,CDP:3</availability>
+		</model>
+		<model name='CN10-B'>
+			<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
+		</model>
+		<model name='CN9-Da'>
+			<availability>FVC:4,ROS:2,FWL:2,MERC:2,FS:2,CP:2,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Centurion' unitType='Mek' omni='IS'>
 		<availability>LA:6,ROS:6,FS:8,MERC:5</availability>
-		<model name='CN11-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='CN11-OB'>
-			<availability>General:7</availability>
-		</model>
 		<model name='CN11-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='CN11-OD'>
+		<model name='CN11-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='CN11-OA'>
 			<availability>General:7</availability>
 		</model>
+		<model name='CN11-OC'>
+			<availability>General:7</availability>
+		</model>
 		<model name='CN11-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='CN11-OD'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -3764,11 +3764,11 @@
 		<model name='MR-5M'>
 			<availability>CC:4,MOC:4,ROS:5,FWL:6,CP:6</availability>
 		</model>
-		<model name='MR-V3'>
-			<availability>IS:6</availability>
-		</model>
 		<model name='MR-V2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MR-V3'>
+			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -3788,15 +3788,15 @@
 	</chassis>
 	<chassis name='Chaeronea' unitType='Aero'>
 		<availability>CWE:5,RD:5,CLAN:6,CJF:5</availability>
-		<model name='4'>
-			<roles>spotter</roles>
-			<availability>RA:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='4'>
+			<roles>spotter</roles>
+			<availability>RA:4</availability>
 		</model>
 		<model name='3'>
 			<availability>RA:5</availability>
@@ -3804,11 +3804,11 @@
 	</chassis>
 	<chassis name='Chalchiuhtotolin Support Tank' unitType='Tank'>
 		<availability>CWE:4,CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Challenger MBT' unitType='Tank'>
@@ -3820,33 +3820,33 @@
 			<roles>spotter</roles>
 			<availability>LA:6,FS:6,DC:6</availability>
 		</model>
+		<model name='Mk. XV'>
+			<availability>FS.PMM:8,ROS:4,FS.CMM:8,FS.DMM:8,FS:6,FS.CrMM:8</availability>
+		</model>
 		<model name='XIVs'>
 			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
 		</model>
 		<model name='XII'>
 			<availability>LA:5,ROS:5,FS:5,DC:5</availability>
 		</model>
-		<model name='Mk. XV'>
-			<availability>FS.PMM:8,ROS:4,FS.CMM:8,FS.DMM:8,FS:6,FS.CrMM:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Chameleon' unitType='Mek'>
 		<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,CP:5,TC:5,Periphery:4,DC:4</availability>
-		<model name='TRC-4B'>
-			<roles>training</roles>
-			<availability>General:1-</availability>
-		</model>
 		<model name='CLN-7V'>
 			<roles>training</roles>
 			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='CLN-7W'>
-			<roles>training</roles>
-			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
-		</model>
 		<model name='CLN-7Z'>
 			<roles>training</roles>
 			<availability>LA:4,IS:3,FS:4,Periphery:3</availability>
+		</model>
+		<model name='TRC-4B'>
+			<roles>training</roles>
+			<availability>General:1-</availability>
+		</model>
+		<model name='CLN-7W'>
+			<roles>training</roles>
+			<availability>LA:6,IS:4,FS:6,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Champion' unitType='Mek'>
@@ -3854,12 +3854,12 @@
 		<model name='CHP-3N'>
 			<availability>ROS:6</availability>
 		</model>
+		<model name='CHP-1N2'>
+			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4</availability>
+		</model>
 		<model name='CHP-1N'>
 			<roles>recon</roles>
 			<availability>CHH:1,RD:1,LA:2,MERC.SI:4,MERC:2,BAN:2</availability>
-		</model>
-		<model name='CHP-1N2'>
-			<availability>CC:4,RD:4,LA:4,ROS:4,MERC:4</availability>
 		</model>
 		<model name='C'>
 			<availability>CHH:6,RD:6,CLAN:8</availability>
@@ -3867,10 +3867,6 @@
 	</chassis>
 	<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
 		<availability>RD:2,ROS:4,IS:3,MERC:2,BAN:4,Periphery:2</availability>
-		<model name='(CASE)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
@@ -3879,22 +3875,36 @@
 			<roles>missile_artillery</roles>
 			<availability>RD:4,IS:4,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 		</model>
-		<model name='(ERML)'>
-			<roles>missile_artillery</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(MG)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(CASE)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(ERML)'>
+			<roles>missile_artillery</roles>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Charger' unitType='Mek'>
 		<availability>MOC:1-,RA.OA:2-,FVC:1,RD:3-,LA:1-,ROS:2-,TC:1-,Periphery:1,DC:4-</availability>
+		<model name='CGR-2A2'>
+			<availability>MOC:5,RA.OA:10,FVC:5,PIR:5,MH:5,Periphery:4</availability>
+		</model>
+		<model name='CGR-SA5'>
+			<roles>urban</roles>
+			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
 		<model name='CGR-3K'>
 			<availability>MERC:1-,DC:2-</availability>
 		</model>
-		<model name='CGR-1L'>
-			<availability>FVC:2-,Periphery:2-</availability>
+		<model name='CGR-3Kr'>
+			<availability>CC:4,RD:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='CGR-C'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='CGR-1A9'>
 			<availability>RA.OA:2-,FVC:2-,Periphery:2-</availability>
@@ -3902,71 +3912,61 @@
 		<model name='CGR-1A5'>
 			<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 		</model>
-		<model name='CGR-2A2'>
-			<availability>MOC:5,RA.OA:10,FVC:5,PIR:5,MH:5,Periphery:4</availability>
+		<model name='CGR-KMZ'>
+			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='CGR-SB &apos;Challenger&apos;'>
 			<availability>LA:2,MERC:2</availability>
 		</model>
-		<model name='CGR-KMZ'>
-			<availability>DC.GHO:6,LA:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-C'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='CGR-3Kr'>
-			<availability>CC:4,RD:4,ROS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='CGR-SA5'>
-			<roles>urban</roles>
-			<availability>LA:4,ROS:4,MERC:4,DC:4</availability>
+		<model name='CGR-1L'>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Cheetah' unitType='Aero'>
 		<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,DA:8</availability>
-		<model name='F-11'>
-			<availability>CC:4,MOC:4,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MERC:6,DA:8,CP:8</availability>
-		</model>
-		<model name='F-14-S'>
-			<availability>RF:8,FWL:8,MH:4,MERC:5,DA:8,CP:8</availability>
-		</model>
-		<model name='OF-17A-R'>
-			<roles>recon</roles>
-			<availability>ROS:4,FWL:4,CP:4</availability>
-		</model>
-		<model name='F-10'>
-			<roles>recon</roles>
-			<availability>CC:1-,RF:1-,FWL:1-,MERC:1-,DA:1-,CP:1-,Periphery:1-</availability>
+		<model name='F-13'>
+			<availability>CC:4,ROS:4,FWL:4,FS:4,CP:4,MERC:4</availability>
 		</model>
 		<model name='F-11-RR'>
 			<roles>recon</roles>
 			<availability>CC:2,FVC:2,RF:2,FWL:2,MERC:2,DA:2,CP:2,Periphery:2</availability>
 		</model>
-		<model name='F-13'>
-			<availability>CC:4,ROS:4,FWL:4,FS:4,CP:4,MERC:4</availability>
-		</model>
 		<model name='F-11-R'>
 			<roles>recon</roles>
 			<availability>FVC:2,Periphery:2</availability>
 		</model>
+		<model name='F-10'>
+			<roles>recon</roles>
+			<availability>CC:1-,RF:1-,FWL:1-,MERC:1-,DA:1-,CP:1-,Periphery:1-</availability>
+		</model>
+		<model name='F-11'>
+			<availability>CC:4,MOC:4,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MERC:6,DA:8,CP:8</availability>
+		</model>
+		<model name='OF-17A-R'>
+			<roles>recon</roles>
+			<availability>ROS:4,FWL:4,CP:4</availability>
+		</model>
+		<model name='F-14-S'>
+			<availability>RF:8,FWL:8,MH:4,MERC:5,DA:8,CP:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Chevalier Light Tank' unitType='Tank'>
 		<availability>CDS:4,LA:3,ROS:5,FWL:3,FS:3,CP:4,DC:3</availability>
-		<model name='(Speed)'>
-			<roles>recon</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MML)'>
 			<roles>recon</roles>
 			<availability>CDS:6,LA:6,ROS:6,FWL:5,FS:6,CP:5,DC:6</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Speed)'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Chimeisho JumpShip' unitType='Jumpship'>
@@ -3986,23 +3986,23 @@
 	</chassis>
 	<chassis name='Chippewa' unitType='Aero'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
-		<model name='CHP-W7T'>
-			<availability>TC:8</availability>
-		</model>
-		<model name='CHP-W7'>
-			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
+		<model name='CHP-W5'>
+			<availability>:0,BAN:3,Periphery:2-</availability>
 		</model>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
 		</model>
-		<model name='CHP-W8'>
-			<availability>LA:8</availability>
-		</model>
 		<model name='CHP-W5b'>
 			<availability>CLAN:2,BAN:2</availability>
 		</model>
-		<model name='CHP-W5'>
-			<availability>:0,BAN:3,Periphery:2-</availability>
+		<model name='CHP-W7T'>
+			<availability>TC:8</availability>
+		</model>
+		<model name='CHP-W8'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='CHP-W7'>
+			<availability>LA:8,ROS:6,CLAN:6,FS:6,MERC:6,BAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Chrysaor' unitType='ProtoMek'>
@@ -4016,13 +4016,6 @@
 	</chassis>
 	<chassis name='Cicada' unitType='Mek'>
 		<availability>CC:1,RF:2,FWL:2,MERC:1,CP:2,CDP:2,Periphery:2</availability>
-		<model name='CDA-3P'>
-			<availability>RF:8,FWL:8,CP:8</availability>
-		</model>
-		<model name='CDA-3MA'>
-			<roles>training</roles>
-			<availability>CC:4,MOC:4,FWL:2,MERC:4,CP:2</availability>
-		</model>
 		<model name='CDA-3G'>
 			<roles>recon</roles>
 			<availability>CC:6,FWL:4,MERC:6,CP:4</availability>
@@ -4031,9 +4024,16 @@
 			<roles>recon</roles>
 			<availability>FWL:8,IS:6,MERC:6,CP:8,Periphery:4</availability>
 		</model>
+		<model name='CDA-3MA'>
+			<roles>training</roles>
+			<availability>CC:4,MOC:4,FWL:2,MERC:4,CP:2</availability>
+		</model>
 		<model name='CDA-3F'>
 			<roles>recon</roles>
 			<availability>FWL:2,IS:4,CP:2</availability>
+		</model>
+		<model name='CDA-3P'>
+			<availability>RF:8,FWL:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cizin Hover Tank' unitType='Tank'>
@@ -4067,20 +4067,20 @@
 	</chassis>
 	<chassis name='Clan Foot Point' unitType='Infantry'>
 		<availability>CLAN:10,BAN:10</availability>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
@@ -4100,14 +4100,11 @@
 	</chassis>
 	<chassis name='Clan Jump Point' unitType='Infantry'>
 		<availability>CLAN:8,BAN:6</availability>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
@@ -4115,29 +4112,32 @@
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Rifle)'>
+		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
 		<availability>CLAN:6,BAN:3</availability>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>CLAN:7</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>CLAN:7</availability>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Infantry' unitType='Infantry'>
@@ -4148,8 +4148,11 @@
 	</chassis>
 	<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:4</availability>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -4157,18 +4160,24 @@
 		<model name='(Flamer)'>
 			<availability>CLAN:8</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
 		<availability>CLAN:7,BAN:5</availability>
+		<model name='(Rifle)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>CLAN:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
 		</model>
@@ -4177,15 +4186,6 @@
 		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -4206,14 +4206,14 @@
 	</chassis>
 	<chassis name='Clan Motorized Point' unitType='Infantry'>
 		<availability>CLAN:9,BAN:7</availability>
-		<model name='(Rifle)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>CLAN:7</availability>
 		</model>
-		<model name='(Flamer)'>
+		<model name='(Rifle)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>CLAN:5</availability>
@@ -4221,8 +4221,8 @@
 		<model name='(Laser)'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>CLAN:5</availability>
+		<model name='(Flamer)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Clan Space Marine' unitType='Infantry'>
@@ -4234,13 +4234,13 @@
 	</chassis>
 	<chassis name='Claymore' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='Interceptor'>
-			<roles>assault</roles>
-			<availability>LA:3</availability>
-		</model>
 		<model name='V3'>
 			<roles>assault</roles>
 			<availability>LA:4,ROS:8,FS:4</availability>
+		</model>
+		<model name='Interceptor'>
+			<roles>assault</roles>
+			<availability>LA:3</availability>
 		</model>
 		<model name='(3054)'>
 			<roles>assault</roles>
@@ -4258,47 +4258,47 @@
 	</chassis>
 	<chassis name='Clint' unitType='Mek'>
 		<availability>CC:2,MOC:2,FVC:2,RF:2,LA:2,ROS:2,FS:2,MERC:1,DA:2,CDP:2,TC:2,Periphery:3</availability>
-		<model name='CLNT-2-3UL'>
-			<availability>CC:8,MOC:4,TC:8</availability>
-		</model>
-		<model name='CLNT-3-3T'>
-			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
-		</model>
-		<model name='CLNT-5U'>
-			<roles>spotter</roles>
-			<availability>LA:8,General:6,MERC:8</availability>
-		</model>
 		<model name='CLNT-2-3U'>
 			<availability>CC:2,General:6</availability>
 		</model>
 		<model name='CLNT-6S'>
 			<availability>LA:6,ROS:6</availability>
 		</model>
+		<model name='CLNT-5U'>
+			<roles>spotter</roles>
+			<availability>LA:8,General:6,MERC:8</availability>
+		</model>
+		<model name='CLNT-2-3UL'>
+			<availability>CC:8,MOC:4,TC:8</availability>
+		</model>
+		<model name='CLNT-3-3T'>
+			<availability>MOC:6,Periphery.HR:6,Periphery.CM:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Cobra Transport VTOL' unitType='VTOL'>
 		<availability>MOC:4,IS:4</availability>
-		<model name='(Command)'>
+		<model name='(MASH)'>
 			<roles>support</roles>
-			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
+			<availability>MOC:2,IS:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>cargo</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(MASH)'>
+		<model name='(Command)'>
 			<roles>support</roles>
-			<availability>MOC:2,IS:2</availability>
+			<availability>LA:4,ROS:4,FS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cobra' unitType='Mek'>
 		<availability>LA:6,ROS:4,MH:4,MERC:3</availability>
-		<model name='CBR-03'>
-			<roles>fire_support</roles>
-			<availability>LA:8,General:6</availability>
-		</model>
 		<model name='CBR-02'>
 			<roles>fire_support</roles>
 			<availability>IS:3</availability>
+		</model>
+		<model name='CBR-03'>
+			<roles>fire_support</roles>
+			<availability>LA:8,General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Colossus' unitType='Dropship'>
@@ -4323,53 +4323,53 @@
 	</chassis>
 	<chassis name='Commando' unitType='Mek'>
 		<availability>MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
-		<model name='COM-1A'>
+		<model name='COM-5S'>
 			<roles>recon</roles>
-			<availability>FVC:1-,Periphery:1-</availability>
+			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
 		</model>
-		<model name='COM-7B'>
+		<model name='COM-4H'>
 			<roles>recon</roles>
-			<availability>LA:8,ROS:8</availability>
+			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
 		</model>
 		<model name='COM-2Dr'>
 			<roles>recon</roles>
 			<availability>LA:5,MERC:5,Periphery:5</availability>
 		</model>
-		<model name='COM-7S'>
+		<model name='COM-7B'>
 			<roles>recon</roles>
-			<availability>LA:8,MERC:8</availability>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 		<model name='COM-8S'>
 			<availability>LA:7,MERC:4</availability>
 		</model>
-		<model name='COM-5S'>
+		<model name='COM-1A'>
 			<roles>recon</roles>
-			<availability>MOC:5,FVC:2,LA:8,MH:5,FS:2,MERC:5,CDP:5,TC:5</availability>
+			<availability>FVC:1-,Periphery:1-</availability>
 		</model>
 		<model name='COM-3A'>
 			<roles>recon</roles>
 			<availability>Periphery:1-</availability>
-		</model>
-		<model name='COM-4H'>
-			<roles>recon</roles>
-			<availability>MOC:6,FVC:6,PIR:8,MH:10,CDP:6,TC:6,Periphery:4</availability>
 		</model>
 		<model name='COM-2D'>
 			<roles>recon</roles>
 			<deployedWith>Commando</deployedWith>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='COM-7S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
 		<availability>CC:2,FVC:2,LA:2,ROS:3,IS:2,FWL:2,FS:3,CP:2,TC:2,DC:2,Periphery:2</availability>
-		<model name='(Upgrade) (Standard)'>
-			<availability>LA:8,FWL:6,MERC:6,CP:6</availability>
+		<model name='(Standard)'>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='(Upgrade) (Laser)'>
 			<availability>LA:6,IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>Periphery:2-</availability>
+		<model name='(Upgrade) (Standard)'>
+			<availability>LA:8,FWL:6,MERC:6,CP:6</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>LA:2,IS:2</availability>
@@ -4380,11 +4380,11 @@
 	</chassis>
 	<chassis name='Condor Multi-Purpose Tank' unitType='Tank'>
 		<availability>ROS:5</availability>
-		<model name='(Reactive)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Reactive)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Condor' unitType='Dropship'>
@@ -4414,24 +4414,24 @@
 	</chassis>
 	<chassis name='Confederate' unitType='Dropship'>
 		<availability>CLAN:4,BAN:3</availability>
-		<model name='(2602)'>
-			<roles>mech_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(2602) (Mech)'>
 			<roles>mech_carrier,asf_carrier</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(2602)'>
+			<roles>mech_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Congress Frigate' unitType='Warship'>
 		<availability>CWE:1,CHH:1,MERC.WD:1,CJF:2,RA:1</availability>
-		<model name='(2914)'>
-			<roles>frigate</roles>
-			<availability>MERC.WD:8,CLAN:8</availability>
-		</model>
 		<model name='(2542)'>
 			<roles>frigate</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(2914)'>
+			<roles>frigate</roles>
+			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Conqueror Battlecruiser Carrier' unitType='Warship'>
@@ -4453,36 +4453,36 @@
 	</chassis>
 	<chassis name='Constable Pacification Suit' unitType='BattleArmor'>
 		<availability>RD:3</availability>
-		<model name='(LMG)' mechanized='true'>
+		<model name='(SRM)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(ECM)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)' mechanized='true'>
+		<model name='(LMG)' mechanized='true'>
 			<availability>General:6</availability>
-		</model>
-		<model name='(Sensors)' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Sensors)' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Coolant Truck' unitType='Tank'>
 		<availability>General:4</availability>
-		<model name='(Hover)'>
+		<model name='(Tracked)'>
 			<roles>support</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='135-K'>
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Tracked)'>
+		<model name='(Hover)'>
 			<roles>support</roles>
-			<availability>General:4</availability>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Corax' unitType='Aero'>
@@ -4499,17 +4499,17 @@
 		<model name='CRX-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='CRX-OD'>
-			<availability>General:5</availability>
-		</model>
-		<model name='CRX-OR'>
-			<availability>RA.OA:4,CLAN:8</availability>
-		</model>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='CRX-OD'>
+			<availability>General:5</availability>
+		</model>
 		<model name='CRX-OA'>
 			<availability>General:7</availability>
+		</model>
+		<model name='CRX-OR'>
+			<availability>RA.OA:4,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Corona Heavy Battle Armor' unitType='BattleArmor'>
@@ -4520,8 +4520,14 @@
 	</chassis>
 	<chassis name='Corsair' unitType='Aero'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
-		<model name='CSR-V18'>
-			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
+		<model name='CSR-V14'>
+			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
+		</model>
+		<model name='CSR-12D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='CSR-V12b'>
+			<availability>ROS:4,CLAN:6,FS:4,MERC:4,BAN:2</availability>
 		</model>
 		<model name='CSR-V20'>
 			<availability>FVC:1,Periphery:1</availability>
@@ -4529,14 +4535,8 @@
 		<model name='CSR-V12'>
 			<availability>BAN:4,Periphery:2-</availability>
 		</model>
-		<model name='CSR-V14'>
-			<availability>FVC:6,LA:6,ROS:4,FS:6,MERC:6</availability>
-		</model>
-		<model name='CSR-V12b'>
-			<availability>ROS:4,CLAN:6,FS:4,MERC:4,BAN:2</availability>
-		</model>
-		<model name='CSR-12D'>
-			<availability>FS:8</availability>
+		<model name='CSR-V18'>
+			<availability>FVC:5,ROS:4,FS:5,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Corvis' unitType='Mek'>
@@ -4560,9 +4560,6 @@
 	</chassis>
 	<chassis name='Cougar' unitType='Mek'>
 		<availability>CJF:2</availability>
-		<model name='XR'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='G'>
 			<availability>CHH:6,General:4</availability>
 		</model>
@@ -4572,50 +4569,53 @@
 		<model name='X'>
 			<availability>CJF:4</availability>
 		</model>
+		<model name='XR'>
+			<availability>CJF:8</availability>
+		</model>
 		<model name='X 3'>
 			<availability>CJF:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Cougar' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,CJF:5,CWIE:4</availability>
-		<model name='H'>
-			<availability>General:5</availability>
-		</model>
-		<model name='F'>
-			<roles>anti_infantry</roles>
-			<availability>CWE:3,CJF:3,CWIE:3</availability>
-		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='D'>
+		<model name='I'>
 			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<roles>anti_infantry</roles>
+			<availability>CWE:3,CJF:3,CWIE:3</availability>
 		</model>
 		<model name='E'>
 			<availability>General:6</availability>
 		</model>
-		<model name='I'>
+		<model name='H'>
+			<availability>General:5</availability>
+		</model>
+		<model name='D'>
 			<availability>General:4</availability>
+		</model>
+		<model name='C'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Coyotl' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='Prime'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='A'>
 			<availability>CLAN:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crab' unitType='Mek'>
@@ -4624,12 +4624,12 @@
 			<roles>raider</roles>
 			<availability>ROS:8,CLAN:4,FWL:8,MERC:8,CP:8,BAN:2,DC:6</availability>
 		</model>
+		<model name='CRB-C'>
+			<availability>DC:6</availability>
+		</model>
 		<model name='CRB-27'>
 			<roles>raider</roles>
 			<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
-		</model>
-		<model name='CRB-C'>
-			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Crane Heavy Transport' unitType='VTOL'>
@@ -4644,42 +4644,45 @@
 		<model name='(Standard)'>
 			<availability>ROS:8,FWL:8,CLAN.IS:8,FS:8,CP:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CC:8,CDS:4,MERC:8,CP:4,DC:8</availability>
+		<model name='4'>
+			<availability>CDS:8,ROS:8,MERC:6,CP:8,CJF:8</availability>
 		</model>
 		<model name='3'>
 			<availability>LA:8,CWIE:8</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:8,ROS:8,MERC:6,CP:8,CJF:8</availability>
+		<model name='2'>
+			<availability>CC:8,CDS:4,MERC:8,CP:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crimson Langur' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,CP:4,RA:4</availability>
+		<model name='D'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Crockett' unitType='Mek'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:3,ROS:3,CLAN:4,CP:3,CJF:3,RA:3,CWIE:5</availability>
-		<model name='CRK-5003-3'>
-			<availability>ROS:8</availability>
+		<model name='CRK-5004-1'>
+			<availability>ROS:6</availability>
+		</model>
+		<model name='CRK-5003-1b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='CRK-5005-1'>
 			<availability>ROS:8</availability>
@@ -4687,20 +4690,17 @@
 		<model name='CRK-5003-1'>
 			<availability>ROS:4,CLAN:6,BAN:8</availability>
 		</model>
-		<model name='CRK-5004-1'>
-			<availability>ROS:6</availability>
-		</model>
-		<model name='CRK-5003-1b'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='CRK-5003-3'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cronus' unitType='Mek'>
 		<availability>RF:4,Periphery.MW:4,ROS:3,Periphery.ME:4,FWL:4,MERC:4,DA:4,CP:4,Periphery:4</availability>
-		<model name='CNS-5M'>
-			<availability>PIR:4,IS:8</availability>
-		</model>
 		<model name='CNS-3M'>
 			<availability>General:4</availability>
+		</model>
+		<model name='CNS-5M'>
+			<availability>PIR:4,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek'>
@@ -4711,28 +4711,28 @@
 	</chassis>
 	<chassis name='Crossbow' unitType='Mek' omni='Clan'>
 		<availability>CDS:2,CP:2,RA:5,CWIE:2</availability>
-		<model name='D'>
+		<model name='A'>
+			<availability>General:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
 			<availability>General:4</availability>
 		</model>
 		<model name='U'>
 			<availability>CLAN:2</availability>
 		</model>
-		<model name='A'>
-			<availability>General:5</availability>
-		</model>
-		<model name='C'>
+		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='E'>
+		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -4742,67 +4742,67 @@
 			<roles>recon</roles>
 			<availability>ROS:6,DC:6</availability>
 		</model>
-		<model name='(Export)'>
-			<roles>recon</roles>
-			<availability>CC:8,MOC:8,ROS:6,FWL:8,MERC:8,CP:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>MOC:4,IS:4,DC:8</availability>
 		</model>
+		<model name='(Export)'>
+			<roles>recon</roles>
+			<availability>CC:8,MOC:8,ROS:6,FWL:8,MERC:8,CP:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Crusader' unitType='Mek'>
 		<availability>CLAN:5,IS:6,Periphery:5</availability>
-		<model name='CRD-4D'>
-			<availability>FVC:8,FS:8</availability>
-		</model>
-		<model name='CRD-2R'>
-			<availability>FVC:4,ROS:5,CLAN:4,FWL:5,IS:4,MERC:5,CP:5,BAN:2</availability>
-		</model>
-		<model name='CRD-4BR'>
-			<availability>ROS:4,MERC:3</availability>
-		</model>
-		<model name='CRD-5K'>
-			<availability>MERC:6,DC:8</availability>
-		</model>
-		<model name='CRD-6M'>
-			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
+		<model name='CRD-8S'>
+			<availability>LA:8,FS:4</availability>
 		</model>
 		<model name='CRD-7L'>
 			<availability>CC:8</availability>
 		</model>
-		<model name='CRD-5S'>
-			<availability>LA:4,MERC:4</availability>
-		</model>
 		<model name='CRD-3R'>
 			<availability>BAN:1,Periphery:2-</availability>
-		</model>
-		<model name='CRD-4L'>
-			<availability>CC:2,MOC:4</availability>
-		</model>
-		<model name='CRD-7W'>
-			<availability>ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:5,MH:4,MERC:2,CP:5</availability>
-		</model>
-		<model name='CRD-8S'>
-			<availability>LA:8,FS:4</availability>
 		</model>
 		<model name='CRD-5M'>
 			<availability>MOC:4,FWL:8,MERC:4,CP:8,CDP:4,TC:4</availability>
 		</model>
+		<model name='CRD-7W'>
+			<availability>ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:5,MH:4,MERC:2,CP:5</availability>
+		</model>
 		<model name='CRD-4K'>
 			<availability>DC:4</availability>
+		</model>
+		<model name='CRD-4BR'>
+			<availability>ROS:4,MERC:3</availability>
+		</model>
+		<model name='CRD-5S'>
+			<availability>LA:4,MERC:4</availability>
+		</model>
+		<model name='CRD-4L'>
+			<availability>CC:2,MOC:4</availability>
+		</model>
+		<model name='CRD-5K'>
+			<availability>MERC:6,DC:8</availability>
 		</model>
 		<model name='CRD-8L'>
 			<availability>CC:6</availability>
 		</model>
+		<model name='CRD-2R'>
+			<availability>FVC:4,ROS:5,CLAN:4,FWL:5,IS:4,MERC:5,CP:5,BAN:2</availability>
+		</model>
+		<model name='CRD-6M'>
+			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
+		</model>
+		<model name='CRD-4D'>
+			<availability>FVC:8,FS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Cuchulainn Support Armor' unitType='BattleArmor'>
 		<availability>CWE:3,MERC.KH:7,MERC.WD:6,LA:4,MERC:5,CWIE:7</availability>
-		<model name='(IS Model)' mechanized='true'>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(Clan Model)' mechanized='true'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(IS Model)' mechanized='true'>
+			<availability>IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Cuirass' unitType='Mek'>
@@ -4810,69 +4810,69 @@
 		<model name='CDR-1X'>
 			<availability>General:8</availability>
 		</model>
-		<model name='CDR-2X'>
-			<availability>General:5</availability>
-		</model>
 		<model name='CDR-2BC'>
 			<availability>General:6</availability>
+		</model>
+		<model name='CDR-2X'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cutlass' unitType='Aero'>
 		<availability>FS:8</availability>
-		<model name='CUT-01E'>
-			<availability>General:4</availability>
-		</model>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='CUT-01E'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Cyclops' unitType='Mek'>
 		<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,Periphery:2,TC:2,RA.OA:2,RD:4,LA:3,ROS:3,FWL:2,DC:5</availability>
+		<model name='CP-11-G'>
+			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='CP-12-K'>
+			<availability>MERC:8,DC:8</availability>
+		</model>
+		<model name='CP-11-A'>
+			<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:4,CP:4,CDP:4,TC:4,Periphery:2</availability>
+		</model>
+		<model name='CP-10-Z'>
+			<availability>General:2-</availability>
+		</model>
+		<model name='CP-11-A-DC'>
+			<availability>CC:4,IS:2</availability>
+		</model>
+		<model name='CP-11-B'>
+			<availability>CC:8,MOC:6,IS:4,MERC:8,DC:8</availability>
+		</model>
 		<model name='CP-11-C'>
 			<roles>spotter</roles>
 			<availability>CC:1,LA:2,FWL:3,IS:2,FS:4,CP:3,DC:5</availability>
 		</model>
-		<model name='CP-11-C2'>
-			<roles>spotter</roles>
-			<availability>RD:5,IS:5</availability>
-		</model>
 		<model name='CP-11-H'>
 			<availability>FVC:6,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:6</availability>
-		</model>
-		<model name='CP-10-Z'>
-			<availability>General:2-</availability>
 		</model>
 		<model name='CP-11-C3'>
 			<roles>spotter</roles>
 			<availability>FS:4,DC:4</availability>
 		</model>
-		<model name='CP-11-A'>
-			<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:4,CP:4,CDP:4,TC:4,Periphery:2</availability>
-		</model>
-		<model name='CP-11-G'>
-			<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
-		</model>
 		<model name='CP-10-HQ'>
 			<availability>IS:1</availability>
 		</model>
-		<model name='CP-11-A-DC'>
-			<availability>CC:4,IS:2</availability>
-		</model>
-		<model name='CP-12-K'>
-			<availability>MERC:8,DC:8</availability>
-		</model>
-		<model name='CP-11-B'>
-			<availability>CC:8,MOC:6,IS:4,MERC:8,DC:8</availability>
+		<model name='CP-11-C2'>
+			<roles>spotter</roles>
+			<availability>RD:5,IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Cygnus' unitType='Mek'>
 		<availability>CHH:5,MERC.WD:3,ROS:3,CWIE:4</availability>
-		<model name='3'>
-			<availability>CHH:4</availability>
-		</model>
 		<model name='4'>
 			<availability>General:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:4</availability>
@@ -4893,6 +4893,10 @@
 			<roles>recon,escort</roles>
 			<availability>CC:4,MERC:4,TC:2,Periphery:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon,escort</roles>
+			<availability>CC:4,ROS:4,General:4,MERC:4,Periphery:4</availability>
+		</model>
 		<model name='(Royal)'>
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
@@ -4901,57 +4905,53 @@
 			<roles>recon,escort</roles>
 			<availability>MOC:4,CDP:4,TC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>recon,escort</roles>
-			<availability>CC:4,ROS:4,General:4,MERC:4,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Morgan Assault Tank' unitType='Tank'>
 		<availability>LA:6,IS:5</availability>
 		<model name='(Gauss)'>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='DI Multipurpose VTOL' unitType='VTOL'>
 		<availability>LA:8,CLAN:5,IS:6,Periphery:5</availability>
-		<model name='(Gunship)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Gunship)'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='DI Schmitt Tank' unitType='Tank'>
 		<availability>LA:6,ROS:4,MERC:4,FS:4</availability>
-		<model name='(Targetting Computer)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Targetting Computer)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dagger' unitType='Aero' omni='IS'>
 		<availability>FS:6</availability>
-		<model name='DARO-1'>
-			<availability>General:6,FS:8</availability>
-		</model>
-		<model name='DARO-1B'>
-			<availability>General:6</availability>
-		</model>
 		<model name='DARO-1C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1'>
+			<availability>General:6,FS:8</availability>
 		</model>
 		<model name='DARO-1D'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='DARO-1B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='DARO-1A'>
 			<availability>General:7</availability>
@@ -4959,11 +4959,11 @@
 	</chassis>
 	<chassis name='Daikyu' unitType='Mek'>
 		<availability>ROS:5,DC:8</availability>
-		<model name='DAI-01r'>
-			<availability>General:4</availability>
-		</model>
 		<model name='DAI-01'>
 			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='DAI-01r'>
 			<availability>General:4</availability>
 		</model>
 		<model name='DAI-02'>
@@ -4977,13 +4977,13 @@
 	</chassis>
 	<chassis name='Daimyo HQ' unitType='Tank'>
 		<availability>RD:2,DC:3+</availability>
-		<model name='67-K'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='67-K2'>
 			<roles>support</roles>
 			<availability>DC:4</availability>
+		</model>
+		<model name='67-K'>
+			<roles>support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Daimyo' unitType='Mek'>
@@ -4991,52 +4991,52 @@
 		<model name='DMO-4K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='DMO-5K'>
-			<roles>spotter</roles>
-			<availability>DC:4</availability>
+		<model name='DMO-2K'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='DMO-1K'>
 			<availability>General:8,DC:2</availability>
 		</model>
-		<model name='DMO-2K'>
-			<availability>DC:6</availability>
+		<model name='DMO-5K'>
+			<roles>spotter</roles>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CLAN:4,FS:4+,MERC:4+,CP:5,BAN:3,CWIE:6,CWE:6,MERC.WD:6,RD:5,CDS:5,LA:4+,ROS:4+,CJF:5,DC:4+</availability>
-		<model name='E'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='X'>
-			<availability>General:3</availability>
-		</model>
-		<model name='W'>
-			<availability>MERC.WD:6,General:1,CWIE:3</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:5,CHH:6,CLAN:4,General:3,CJF:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CWE:5,CDS:7,General:8,CP:7,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:5,General:7,CJF:8,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
 			<availability>CWE:2,CHH:2,RD:2,CLAN:1,General:2,CP:2,CJF:2</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		<model name='W'>
+			<availability>MERC.WD:6,General:1,CWIE:3</availability>
+		</model>
+		<model name='X'>
+			<availability>General:3</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:5,CHH:6,CLAN:4,General:3,CJF:5</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:8,RD:4,General:5,CP:4,CJF:6,CWIE:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CWE:5,CDS:5,General:4,CP:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:8,RD:4,General:5,CP:4,CJF:6,CWIE:7</availability>
+		<model name='E'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='A'>
+			<availability>CWE:5,General:7,CJF:8,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Danai Support Vehicle' unitType='Tank'>
@@ -5059,11 +5059,11 @@
 			<roles>marine</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='4'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_aircraft</roles>
@@ -5072,24 +5072,21 @@
 	</chassis>
 	<chassis name='Dart' unitType='Mek'>
 		<availability>LA:5,ROS:4,MH:4,FS:6,MERC:4</availability>
-		<model name='DRT-3S'>
-			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='DRT-4S'>
-			<availability>LA:1,MH:4,MERC:4,FS:2</availability>
-		</model>
 		<model name='DRT-6T'>
 			<availability>LA:6,ROS:8,FS:6,MERC:6</availability>
+		</model>
+		<model name='DRT-3S'>
+			<availability>LA:8,MH:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='DRT-6S'>
 			<availability>LA:4,FS:5,MERC:3</availability>
 		</model>
+		<model name='DRT-4S'>
+			<availability>LA:1,MH:4,MERC:4,FS:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Darter Scout Car' unitType='Tank'>
 		<availability>FVC:7,LA:3,ROS:3,FS:7,CDP:4</availability>
-		<model name='(SRM-2)'>
-			<availability>FVC:2,FS:1,CDP:2</availability>
-		</model>
 		<model name='(ECM)'>
 			<roles>recon</roles>
 			<availability>FVC:4,General:5,CDP:3</availability>
@@ -5097,6 +5094,10 @@
 		<model name='(BAP)'>
 			<roles>recon</roles>
 			<availability>FVC:4,General:5,CDP:3</availability>
+		</model>
+		<model name='(C3)'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>recon</roles>
@@ -5106,13 +5107,18 @@
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C3)'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
+		<model name='(SRM-2)'>
+			<availability>FVC:2,FS:1,CDP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
 		<availability>CHH:3,MERC.WD:2,RD:4,IS:3+,CJF:2,BAN:2</availability>
+		<model name='H'>
+			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CHH:7,RD:6,General:2,CWIE:5</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>RD:2,CDS:5,General:3,CP:5,CJF:4</availability>
@@ -5120,21 +5126,18 @@
 		<model name='E'>
 			<availability>CWE:4,CDS:3,General:2,CP:3</availability>
 		</model>
+		<model name='G'>
+			<availability>General:6</availability>
+		</model>
+		<model name='K'>
+			<availability>RD:4,General:2</availability>
+		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
 			<availability>CWE:4,CHH:8,RD:4,CDS:6,General:5,CP:5</availability>
 		</model>
-		<model name='H'>
-			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<availability>General:6</availability>
-		</model>
 		<model name='D'>
 			<availability>CWE:8,CHH:8,RD:8,CDS:4,General:6,CP:6,CWIE:8</availability>
-		</model>
-		<model name='F'>
-			<availability>CHH:7,RD:6,General:2,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CHH:8,RD:8,CDS:7,General:6,CP:7,CWIE:7</availability>
@@ -5142,17 +5145,14 @@
 		<model name='B'>
 			<availability>CWE:7,CHH:6,RD:7,CDS:6,General:5,CP:6,CWIE:7</availability>
 		</model>
-		<model name='K'>
-			<availability>RD:4,General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Dasher II' unitType='Mek'>
 		<availability>RD:4,CDS:5,LA:3,ROS:4,IS:3,FS:3,CP:4,RA:4,DC:3</availability>
-		<model name='3'>
-			<availability>MERC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:2</availability>
+		</model>
+		<model name='3'>
+			<availability>MERC:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CLAN:8,IS:6</availability>
@@ -5175,19 +5175,19 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Aero' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2,CP:2</availability>
-		<model name='DFC-OD'>
-			<roles>ground_support</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='DFC-OB'>
-			<roles>ground_support</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='DFC-OA'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='DFC-OD'>
+			<roles>ground_support</roles>
+			<availability>General:5</availability>
+		</model>
 		<model name='DFC-OC'>
+			<roles>ground_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='DFC-OB'>
 			<roles>ground_support</roles>
 			<availability>General:7</availability>
 		</model>
@@ -5198,11 +5198,11 @@
 	</chassis>
 	<chassis name='Defiance' unitType='Mek'>
 		<availability>LA:6,MERC:4</availability>
-		<model name='DFN-3T'>
-			<availability>General:8</availability>
-		</model>
 		<model name='DFN-3S'>
 			<availability>General:4</availability>
+		</model>
+		<model name='DFN-3T'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Deimos' unitType='Mek'>
@@ -5213,46 +5213,46 @@
 	</chassis>
 	<chassis name='Deimos' unitType='Mek' omni='Clan'>
 		<availability>RA:8</availability>
-		<model name='Prime'>
-			<roles>anti_aircraft</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='S'>
-			<availability>General:5</availability>
-		</model>
-		<model name='E'>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='E'>
+			<availability>General:6</availability>
+		</model>
 		<model name='B'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>anti_aircraft</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='S'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Demolisher Heavy Tank' unitType='Tank'>
 		<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
-		<model name='(Arrow IV)'>
-			<roles>missile_artillery</roles>
-			<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
+		<model name='(Standard Mk. II)'>
+			<availability>Periphery:2</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,IS:8,FS:8,CP:8,DC:8,TC:8,CWIE:4</availability>
 		</model>
-		<model name='(MRM)'>
-			<availability>FVC:4,DC:8,Periphery:4</availability>
-		</model>
 		<model name='(Clan)'>
 			<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
 		</model>
-		<model name='(Standard Mk. II)'>
-			<availability>Periphery:2</availability>
+		<model name='(Arrow IV)'>
+			<roles>missile_artillery</roles>
+			<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>FVC:4,DC:8,Periphery:4</availability>
 		</model>
 		<model name='(Standard Mk. I)'>
 			<roles>urban</roles>
@@ -5261,15 +5261,15 @@
 	</chassis>
 	<chassis name='Demolisher II Heavy Tank' unitType='Tank'>
 		<availability>LA:6,ROS:4,MERC:4,CWIE:4</availability>
+		<model name='(Standard)'>
+			<roles>urban</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(MML)'>
 			<availability>LA:5,ROS:5,CWIE:5</availability>
 		</model>
 		<model name='(Thunderbolt)'>
 			<availability>LA:4,CWIE:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='DemolitionMech' unitType='Mek'>
@@ -5285,17 +5285,17 @@
 	</chassis>
 	<chassis name='Demon Medium Tank' unitType='Tank'>
 		<availability>ROS:6-</availability>
-		<model name='(Standard)'>
+		<model name='(Armor)'>
 			<roles>urban</roles>
-			<availability>General:8</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Rifle)'>
 			<roles>urban</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Armor)'>
+		<model name='(Standard)'>
 			<roles>urban</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Demon Tank' unitType='Tank'>
@@ -5312,17 +5312,17 @@
 		<model name='DV-8D'>
 			<availability>ROS:4,FS:4,MERC:4,CDP:4</availability>
 		</model>
-		<model name='DV-6Mr'>
-			<availability>General:1</availability>
-		</model>
-		<model name='DV-7D'>
-			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+		<model name='DV-6M'>
+			<availability>CLAN:4,Periphery:2-</availability>
 		</model>
 		<model name='DV-9D'>
 			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
-		<model name='DV-6M'>
-			<availability>CLAN:4,Periphery:2-</availability>
+		<model name='DV-7D'>
+			<availability>FVC:4,LA:4,FS:4,MERC:4,CDP:4,TC:4</availability>
+		</model>
+		<model name='DV-6Mr'>
+			<availability>General:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Destrier Siege Vehicle' unitType='Tank'>
@@ -5340,14 +5340,14 @@
 	</chassis>
 	<chassis name='Devastator' unitType='Mek'>
 		<availability>CC:3,FVC:6,LA:6,ROS:5,FS:6,MERC:3,TC:4</availability>
-		<model name='DVS-1D'>
-			<availability>FVC:8,TC:8</availability>
+		<model name='DVS-3'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='DVS-2'>
 			<availability>IS:8</availability>
 		</model>
-		<model name='DVS-3'>
-			<availability>LA:4,ROS:4,FS:4</availability>
+		<model name='DVS-1D'>
+			<availability>FVC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dig Lord' unitType='Mek'>
@@ -5364,6 +5364,9 @@
 	</chassis>
 	<chassis name='Diomede' unitType='Mek'>
 		<availability>CC:7,MOC:7,LA:7,ROS:7,FWL:7,IS:5,MH:7,MERC:7,CP:7,Periphery:5</availability>
+		<model name='D-M3D-M'>
+			<availability>General:4</availability>
+		</model>
 		<model name='D-M3D-3 ConstructionMech'>
 			<roles>support</roles>
 			<availability>CC:4,MOC:4,LA:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4</availability>
@@ -5371,9 +5374,6 @@
 		<model name='D-M3D-4 DemolitionMech'>
 			<roles>support</roles>
 			<availability>CC:8,MOC:8,LA:8,ROS:8,FWL:8,MH:8,MERC:8,CP:8</availability>
-		</model>
-		<model name='D-M3D-M'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Dola' unitType='Mek'>
@@ -5388,17 +5388,17 @@
 	</chassis>
 	<chassis name='Doloire' unitType='Mek' omni='IS'>
 		<availability>ROS:8,MERC:4</availability>
-		<model name='DLR-OB'>
+		<model name='DLR-OC'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='DLR-OD'>
+		<model name='DLR-OB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='DLR-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='DLR-OC'>
-			<roles>spotter</roles>
+		<model name='DLR-OD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='DLR-O'>
@@ -5407,12 +5407,12 @@
 	</chassis>
 	<chassis name='Donar Assault Helicopter' unitType='VTOL'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8,CJF:2</availability>
-		</model>
 		<model name='(Close Support)'>
 			<roles>spotter</roles>
 			<availability>CHH:6,RD:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8,CJF:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Dragau II Assault Interceptor' unitType='Dropship'>
@@ -5440,22 +5440,22 @@
 	</chassis>
 	<chassis name='Dragon II' unitType='Mek'>
 		<availability>DC:8</availability>
-		<model name='DRG-11K'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='DRG-11R'>
 			<roles>missile_artillery</roles>
 			<availability>General:2+</availability>
 		</model>
+		<model name='DRG-11K'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Dragon' unitType='Mek'>
 		<availability>Periphery.DD:3,MERC:3,DC:2</availability>
-		<model name='DRG-5N'>
-			<availability>Periphery.Deep:4,MERC:4,DC:4,Periphery:6</availability>
-		</model>
 		<model name='DRG-7N'>
 			<availability>MERC:8,DC:8</availability>
+		</model>
+		<model name='DRG-5N'>
+			<availability>Periphery.Deep:4,MERC:4,DC:4,Periphery:6</availability>
 		</model>
 		<model name='DRG-5Nr'>
 			<availability>MERC:4,DC:4</availability>
@@ -5467,18 +5467,14 @@
 			<roles>anti_infantry</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='D'>
-			<availability>CHH:7,RD:7,CDS:8,General:6,CP:8,CJF:8,RA:7,CWIE:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,General:4,CP:5,CWIE:5</availability>
-		</model>
-		<model name='G'>
-			<roles>anti_infantry</roles>
-			<availability>RD:5,General:2</availability>
-		</model>
 		<model name='A'>
 			<availability>RD:8,CDS:8,General:6,CP:8,CJF:8,CWIE:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:6,CDS:6,General:4,CP:5,CJF:6,CWIE:6</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:6,CDS:9,General:8,CP:9,CJF:9</availability>
@@ -5486,16 +5482,20 @@
 		<model name='H'>
 			<availability>CLAN:3,General:2,CP:5</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:6,RD:6,CDS:6,General:4,CP:5,CJF:6,CWIE:6</availability>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,General:4,CP:5,CWIE:5</availability>
 		</model>
 		<model name='C'>
 			<availability>CWE:7,RD:7,CDS:6,General:5,CP:6,CJF:6</availability>
 		</model>
-		<model name='I'>
-			<availability>General:2</availability>
+		<model name='G'>
+			<roles>anti_infantry</roles>
+			<availability>RD:5,General:2</availability>
 		</model>
-		<model name='U'>
+		<model name='D'>
+			<availability>CHH:7,RD:7,CDS:8,General:6,CP:8,CJF:8,RA:7,CWIE:7</availability>
+		</model>
+		<model name='I'>
 			<availability>General:2</availability>
 		</model>
 	</chassis>
@@ -5514,11 +5514,11 @@
 	</chassis>
 	<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
 		<availability>LA:5,ROS:2,FS:4</availability>
-		<model name='(Streak)'>
-			<availability>LA:8,FS:8</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>LA:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -5546,62 +5546,62 @@
 	</chassis>
 	<chassis name='Eagle' unitType='Aero'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
-		<model name='EGL-R6'>
-			<availability>General:2-</availability>
-		</model>
 		<model name='EGL-R6b'>
 			<availability>FWL:6,CP:6</availability>
 		</model>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 		</model>
+		<model name='EGL-R6'>
+			<availability>General:2-</availability>
+		</model>
 	</chassis>
 	<chassis name='Eagle' unitType='Mek'>
 		<availability>CC:4,MOC:4,FWL.MM:7,RF:6,FWL:6,MH:4,FWL.FO:7,MERC:4,DA:5,CP:6</availability>
-		<model name='EGL-3M'>
-			<availability>FWL:5,CP:5</availability>
-		</model>
-		<model name='EGL-1M'>
-			<availability>CC:2,MOC:2,FWL:1,MH:2,CP:1</availability>
-		</model>
 		<model name='EGL-2M'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='EGL-1M'>
+			<availability>CC:2,MOC:2,FWL:1,MH:2,CP:1</availability>
+		</model>
+		<model name='EGL-3M'>
+			<availability>FWL:5,CP:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Ebony' unitType='Mek'>
 		<availability>MOC:5,CC:4</availability>
-		<model name='MEB-12'>
+		<model name='MEB-10'>
 			<roles>recon</roles>
-			<availability>CC:6</availability>
-		</model>
-		<model name='MEB-11'>
-			<roles>recon</roles>
-			<availability>General:2</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='MEB-9'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='MEB-10'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='MEB-13'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='MEB-11'>
+			<roles>recon</roles>
+			<availability>General:2</availability>
+		</model>
+		<model name='MEB-12'>
+			<roles>recon</roles>
+			<availability>CC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Eisenfaust' unitType='Mek'>
 		<availability>LA:6,ROS:4,MERC:4,Periphery:4-</availability>
+		<model name='EFT-7X'>
+			<availability>IS:8,MH:6</availability>
+		</model>
 		<model name='EFT-4J'>
 			<availability>MERC:1-,Periphery:8</availability>
 		</model>
 		<model name='EFT-8X'>
 			<availability>IS:4</availability>
-		</model>
-		<model name='EFT-7X'>
-			<availability>IS:8,MH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero'>
@@ -5612,81 +5612,81 @@
 	</chassis>
 	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
-		<model name='EST-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='EST-OA'>
-			<availability>General:7</availability>
+		<model name='EST-OD'>
+			<availability>General:4</availability>
 		</model>
 		<model name='EST-OB'>
 			<availability>General:7</availability>
 		</model>
+		<model name='EST-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='EST-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='EST-OD'>
-			<availability>General:4</availability>
+		<model name='EST-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Eldingar Hover Sled' unitType='Tank'>
 		<availability>CHH:4,RD:5,LA:3,ROS:3,FS:3,MERC:3,CWIE:4</availability>
-		<model name='(Streak)'>
-			<roles>fire_support</roles>
-			<availability>RD:4</availability>
+		<model name='(Standard)'>
+			<availability>RD:8</availability>
 		</model>
 		<model name='&apos;HumHov&apos;'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>RD:8</availability>
+		<model name='(Streak)'>
+			<roles>fire_support</roles>
+			<availability>RD:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4,CHH:4,MERC.WD:4,CLAN:4,CP:4+</availability>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Space) [Flamer]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>MERC.WD:6,CLAN:6</availability>
-		</model>
 		<model name='(Fire) [AP Gauss]' mechanized='true'>
 			<availability>CWE:2,CHH:2,CJF:4</availability>
-		</model>
-		<model name='(Headhunter)' mechanized='true'>
-			<availability>CWE:2,RD:2,CWIE:2</availability>
-		</model>
-		<model name='(Fire) [MicroPL]' mechanized='true'>
-			<availability>CWE:2,CHH:2,CJF:4</availability>
-		</model>
-		<model name='[HMG]' mechanized='true'>
-			<availability>CLAN:7</availability>
-		</model>
-		<model name='[MicroPL]' mechanized='true'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='(Space) [MG]' mechanized='true'>
-			<roles>marine</roles>
-			<availability>CLAN:2,RA:3</availability>
-		</model>
-		<model name='[AP Gauss]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Space) [MicroPL]' mechanized='true'>
 			<roles>marine</roles>
 			<availability>CLAN:2,RA:4</availability>
 		</model>
+		<model name='(Space) [Flamer]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Fire) [Flamer]' mechanized='true'>
 			<availability>CWE:2,CHH:2,CJF:4</availability>
+		</model>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(Space) [MG]' mechanized='true'>
+			<roles>marine</roles>
+			<availability>CLAN:2,RA:3</availability>
+		</model>
+		<model name='[HMG]' mechanized='true'>
+			<availability>CLAN:7</availability>
+		</model>
+		<model name='[ER Laser]' mechanized='true'>
+			<availability>MERC.WD:6,CLAN:6</availability>
+		</model>
+		<model name='(Fire) [MicroPL]' mechanized='true'>
+			<availability>CWE:2,CHH:2,CJF:4</availability>
+		</model>
+		<model name='[MicroPL]' mechanized='true'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(Headhunter)' mechanized='true'>
+			<availability>CWE:2,RD:2,CWIE:2</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Elemental II Battle Armor' unitType='BattleArmor'>
@@ -5697,23 +5697,23 @@
 	</chassis>
 	<chassis name='Emperor' unitType='Mek'>
 		<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,LA:4,FWL:4,MH:3,DC:4</availability>
-		<model name='EMP-6D'>
-			<availability>ROS:8,FS:8</availability>
-		</model>
 		<model name='EMP-6L'>
 			<availability>CC:3</availability>
 		</model>
-		<model name='EMP-8L'>
+		<model name='EMP-7L'>
 			<availability>CC:6</availability>
-		</model>
-		<model name='EMP-6S'>
-			<availability>LA:8</availability>
 		</model>
 		<model name='EMP-6A'>
 			<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 		</model>
-		<model name='EMP-7L'>
+		<model name='EMP-6S'>
+			<availability>LA:8</availability>
+		</model>
+		<model name='EMP-8L'>
 			<availability>CC:6</availability>
+		</model>
+		<model name='EMP-6D'>
+			<availability>ROS:8,FS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enfield' unitType='Mek'>
@@ -5722,6 +5722,10 @@
 			<roles>urban</roles>
 			<availability>LA:4,MERC:4,FS:4</availability>
 		</model>
+		<model name='END-6Q'>
+			<roles>urban</roles>
+			<availability>LA:4,MERC:4</availability>
+		</model>
 		<model name='END-6S'>
 			<roles>urban</roles>
 			<availability>LA:2,MERC:2</availability>
@@ -5729,21 +5733,17 @@
 		<model name='END-6Sr'>
 			<availability>LA:3,ROS:8,MERC:3</availability>
 		</model>
-		<model name='END-6Q'>
-			<roles>urban</roles>
-			<availability>LA:4,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Enforcer III' unitType='Mek'>
 		<availability>FVC:5,ROS:4,MERC:5,FS:7</availability>
-		<model name='ENF-6Ma'>
-			<availability>FVC:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='ENF-6NAIS'>
-			<availability>FS:1</availability>
+		<model name='ENF-6M'>
+			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 		<model name='ENF-6H'>
 			<availability>FS:1</availability>
+		</model>
+		<model name='ENF-6Ma'>
+			<availability>FVC:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='ENF-6T'>
 			<availability>FS:4</availability>
@@ -5754,11 +5754,11 @@
 		<model name='ENF-7C3BS'>
 			<availability>FS:1</availability>
 		</model>
+		<model name='ENF-6NAIS'>
+			<availability>FS:1</availability>
+		</model>
 		<model name='ENF-7D'>
 			<availability>FS:6</availability>
-		</model>
-		<model name='ENF-6M'>
-			<availability>FVC:8,FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Enforcer' unitType='Mek'>
@@ -5796,14 +5796,6 @@
 	</chassis>
 	<chassis name='Epona Pursuit Tank' unitType='Tank' omni='Clan'>
 		<availability>CWE:4+,CHH:6+,RD:3+,CDS:4+,CP:3+,CWIE:4+</availability>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>CHH:8</availability>
-		</model>
-		<model name='Prime'>
-			<roles>apc</roles>
-			<availability>General:9</availability>
-		</model>
 		<model name='E'>
 			<roles>apc</roles>
 			<availability>CHH:6</availability>
@@ -5812,38 +5804,46 @@
 			<roles>apc,fire_support,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='C'>
-			<roles>apc,spotter</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>apc</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>CHH:8</availability>
+		</model>
+		<model name='C'>
+			<roles>apc,spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>apc</roles>
+			<availability>General:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Essex II Destroyer' unitType='Warship'>
 		<availability>CDS:2,ROS:1,CP:2,RA:1</availability>
-		<model name='(2711)'>
-			<roles>destroyer</roles>
-			<availability>IS:8</availability>
-		</model>
 		<model name='(2862)'>
 			<roles>destroyer</roles>
 			<availability>CLAN:8,DC:8</availability>
 		</model>
+		<model name='(2711)'>
+			<roles>destroyer</roles>
+			<availability>IS:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Dropship'>
 		<availability>MOC:3,CC:5,RA.OA:2,LA:5,IS:5,FWL:5,FS:2,CP:5,Periphery:2,TC:3,DC:6</availability>
+		<model name='(2786)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='(3056)'>
 			<roles>troop_carrier</roles>
 			<availability>LA:8,IS:4,FS:6</availability>
 		</model>
 		<model name='&apos;Pocket Warship&apos;'>
 			<availability>FS:4,MERC:2</availability>
-		</model>
-		<model name='(2786)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Excalibur' unitType='Mek'>
@@ -5859,10 +5859,10 @@
 	</chassis>
 	<chassis name='Exhumer' unitType='Mek'>
 		<availability>DC.BR:2,MERC:4,DC:1</availability>
-		<model name='EXR-2X'>
+		<model name='EXR-3P'>
 			<availability>General:8</availability>
 		</model>
-		<model name='EXR-3P'>
+		<model name='EXR-2X'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -5879,13 +5879,13 @@
 	</chassis>
 	<chassis name='Eyleuka' unitType='Mek'>
 		<availability>MOC:8,CC:4</availability>
-		<model name='EYL-45A'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='EYL-45B'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='EYL-45A'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Eyrie' unitType='Mek'>
@@ -5896,27 +5896,27 @@
 	</chassis>
 	<chassis name='Fa Shih Battle Armor' unitType='BattleArmor'>
 		<availability>CC:5,MERC:4</availability>
-		<model name='[TAG]' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>CC:5</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>CC:6</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
+			<availability>CC:8</availability>
+		</model>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>CC:7</availability>
+		</model>
+		<model name='[LRR]' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
 		<model name='(Support) [Plasma]' mechanized='true'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>CC:7</availability>
+		<model name='[TAG]' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>CC:5</availability>
 		</model>
 		<model name='(Support) [King David]' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='true'>
-			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Fafnir' unitType='Mek'>
@@ -5931,12 +5931,12 @@
 		<model name='FNHK-9K1A'>
 			<availability>General:8</availability>
 		</model>
+		<model name='FNHK-9K'>
+			<availability>FWL:8,IS:4,CP:8</availability>
+		</model>
 		<model name='FNHK-9K1B'>
 			<roles>spotter</roles>
 			<availability>ROS:8,FWL:4,CP:4</availability>
-		</model>
-		<model name='FNHK-9K'>
-			<availability>FWL:8,IS:4,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Falcon Hover Tank' unitType='Tank'>
@@ -5947,11 +5947,11 @@
 	</chassis>
 	<chassis name='Falconer' unitType='Mek'>
 		<availability>LA:8,ROS:4,FS:8,MERC:3</availability>
-		<model name='FLC-8R'>
-			<availability>General:4</availability>
-		</model>
 		<model name='FLC-9R'>
 			<availability>General:8</availability>
+		</model>
+		<model name='FLC-8R'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fast Recon' unitType='Infantry'>
@@ -5963,39 +5963,33 @@
 	</chassis>
 	<chassis name='Feng Huang Cruiser' unitType='Warship'>
 		<availability>CC:2</availability>
-		<model name='(Upgrade)'>
-			<roles>cruiser</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>cruiser</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='(Upgrade)'>
+			<roles>cruiser</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Fennec' unitType='Mek'>
 		<availability>FS:5</availability>
-		<model name='FEC-3C'>
-			<availability>General:4</availability>
+		<model name='FEC-1CM'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='FEC-5CM'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='FEC-1CM'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='FEC-3C'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4</availability>
-		<model name='[SRM]' mechanized='false'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Mortar]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='[SL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 		<model name='&apos;Longshot&apos;' mechanized='false'>
 			<availability>General:4</availability>
@@ -6003,32 +5997,38 @@
 		<model name='[ERML]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SPL]' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[MPL]' mechanized='false'>
 			<availability>General:5</availability>
 		</model>
-		<model name='[SL]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='[VSP]' mechanized='false'>
 			<availability>General:4</availability>
+		</model>
+		<model name='[Mortar]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='[SRM]' mechanized='false'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SPL]' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Fenrir II Assault Battle Armor' unitType='BattleArmor'>
 		<availability>LA:6</availability>
-		<model name='(LRM)' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(SRM)' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Med. Laser)' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(AI)' mechanized='false'>
 			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(MRR)' mechanized='false'>
@@ -6037,51 +6037,51 @@
 	</chassis>
 	<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,MERC.WD:4,MERC.KH:2+,CHH:1,RD:1,CJF:2,CWIE:4</availability>
-		<model name='B'>
-			<availability>CWE:6,RD:6,CDS:7,General:5,CP:5,CJF:7,CWIE:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CLAN:4,General:2,CP:5,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:3,CDS:6,General:4,CP:5,CWIE:3</availability>
-		</model>
-		<model name='H'>
-			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8,CJF:9</availability>
-		</model>
-		<model name='A'>
-			<availability>CDS:7,General:6,CP:5,CJF:7</availability>
+		<model name='L'>
+			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:6,RD:6,CDS:7,General:4,CP:6,CJF:6</availability>
 		</model>
-		<model name='L'>
-			<availability>MERC.WD:3,MERC.KH:3,General:2,CWIE:4</availability>
+		<model name='A'>
+			<availability>CDS:7,General:6,CP:5,CJF:7</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:6,CDS:7,General:5,CP:5,CJF:7,CWIE:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8,CJF:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CLAN:4,General:2,CP:5,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<availability>MERC.KH:4,MERC.WD:4,General:2,CWIE:5</availability>
+		</model>
+		<model name='C'>
+			<availability>CWE:3,CDS:6,General:4,CP:5,CWIE:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Fensalir Combat WiGE' unitType='Tank'>
 		<availability>MERC.KH:4,LA:6,CWIE:6</availability>
+		<model name='(Infantry)'>
+			<availability>General:4</availability>
+		</model>
 		<model name='(HAG)'>
 			<availability>MERC.KH:8,General:2,CWIE:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>LA:8,General:4</availability>
 		</model>
-		<model name='(Infantry)'>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
 		<availability>LA:1,ROS:1,FS:2</availability>
-		<model name='(Cargo)'>
-			<roles>cargo</roles>
-			<availability>LA:5,FS:5</availability>
+		<model name='&apos;Fermi&apos;'>
+			<roles>apc</roles>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Armor) &apos;Wild Weasel&apos;'>
 			<roles>recon</roles>
@@ -6091,9 +6091,9 @@
 			<roles>recon,apc</roles>
 			<availability>General:8,FS:1</availability>
 		</model>
-		<model name='&apos;Fermi&apos;'>
-			<roles>apc</roles>
-			<availability>FS:4</availability>
+		<model name='(Cargo)'>
+			<roles>cargo</roles>
+			<availability>LA:5,FS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Field Artillery' unitType='Infantry'>
@@ -6120,63 +6120,15 @@
 	</chassis>
 	<chassis name='Field Gunners' unitType='Infantry'>
 		<availability>IS:1,Periphery:1</availability>
-		<model name='(LAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(RAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
 		<model name='(LBX20)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
-		</model>
-		<model name='(AC20)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(AC10)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='(AC5)'>
-			<roles>field_gun</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='(Light Gauss)'>
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(UAC20)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(AC2)'>
-			<roles>field_gun</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<roles>field_gun</roles>
-			<availability>IS:5</availability>
-		</model>
-		<model name='(UAC5)'>
-			<roles>field_gun</roles>
-			<availability>IS:7</availability>
-		</model>
 		<model name='(LBX5)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX2)'>
-			<roles>field_gun</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(LBX10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
 		</model>
@@ -6184,9 +6136,57 @@
 			<roles>field_gun</roles>
 			<availability>IS:4</availability>
 		</model>
+		<model name='(Gauss)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(AC20)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(RAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(LBX2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(AC10)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='(LAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(AC2)'>
+			<roles>field_gun</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(AC5)'>
+			<roles>field_gun</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(UAC10)'>
 			<roles>field_gun</roles>
 			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC20)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(LBX10)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC2)'>
+			<roles>field_gun</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(UAC5)'>
+			<roles>field_gun</roles>
+			<availability>IS:7</availability>
 		</model>
 		<model name='(RAC5)'>
 			<roles>field_gun</roles>
@@ -6195,55 +6195,55 @@
 	</chassis>
 	<chassis name='Fire Falcon' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CP:3,CJF:7</availability>
-		<model name='Prime'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:9</availability>
-		</model>
-		<model name='E'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='A'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CWE:6,RD:6,General:8,CWIE:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
-		</model>
 		<model name='F'>
 			<roles>anti_infantry</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:3</availability>
-		</model>
-		<model name='H'>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='D'>
-			<roles>spotter</roles>
-			<deployedWith>Black Lanner</deployedWith>
-			<availability>General:7</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<deployedWith>Black Lanner</deployedWith>
 			<availability>General:8</availability>
 		</model>
+		<model name='C'>
+			<roles>recon</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:9</availability>
+		</model>
+		<model name='D'>
+			<roles>spotter</roles>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CWE:6,RD:6,General:8,CWIE:6</availability>
+		</model>
+		<model name='H'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
+			<deployedWith>Black Lanner</deployedWith>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Fireball' unitType='Mek'>
 		<availability>FVC:7,LA:7,ROS:5,FS:7,MERC:5</availability>
-		<model name='ALM-8D'>
-			<roles>recon,raider</roles>
-			<availability>LA:6,MERC:6,FS:6</availability>
-		</model>
 		<model name='ALM-10D'>
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='ALM-7D'>
 			<roles>recon,raider</roles>
 			<availability>FVC:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='ALM-8D'>
+			<roles>recon,raider</roles>
+			<availability>LA:6,MERC:6,FS:6</availability>
 		</model>
 		<model name='ALM-9D'>
 			<roles>recon,raider</roles>
@@ -6265,27 +6265,23 @@
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek'>
 		<availability>LA:6,IS:5,Periphery.Deep:5,Periphery:7</availability>
-		<model name='FS9-M3'>
-			<roles>spotter</roles>
-			<availability>LA:3,IS:2,TC:2,Periphery:2</availability>
+		<model name='FS9-S2'>
+			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4,CP:3</availability>
 		</model>
 		<model name='FS9-M4'>
 			<availability>FVC:3,RF:4,LA:4,ROS:4,IS:4,MH:3,FS:4,DA:4,TC:3</availability>
+		</model>
+		<model name='FS9-M2'>
+			<roles>incendiary</roles>
+			<availability>LA:4,IS:3,MH:3,TC:3,Periphery:3</availability>
+		</model>
+		<model name='FS9-C'>
+			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
 		</model>
 		<model name='FS9-H'>
 			<roles>recon</roles>
 			<deployedWith>Vulcan</deployedWith>
 			<availability>General:1-,Periphery:2-</availability>
-		</model>
-		<model name='FS9-S'>
-			<roles>recon</roles>
-			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
-		</model>
-		<model name='FS9-C'>
-			<availability>MOC:4,FVC:5,PIR:5,MH:5,Periphery:3,TC:4</availability>
-		</model>
-		<model name='FS9-S2'>
-			<availability>LA:7,ROS:5,FWL:3,FS:3,MERC:4,CP:3</availability>
 		</model>
 		<model name='FS9-P'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -6293,56 +6289,60 @@
 		<model name='FS9-S3'>
 			<availability>LA:6,ROS:5,FWL:3,FS:3,MERC:3,CP:3</availability>
 		</model>
-		<model name='FS9-M2'>
-			<roles>incendiary</roles>
-			<availability>LA:4,IS:3,MH:3,TC:3,Periphery:3</availability>
+		<model name='FS9-S'>
+			<roles>recon</roles>
+			<availability>CC:1,MOC:2,LA:2,General:2,FS:2,TC:1</availability>
 		</model>
 		<model name='FS9-S1'>
 			<roles>recon</roles>
 			<availability>LA:2,General:1,FS:1</availability>
 		</model>
+		<model name='FS9-M3'>
+			<roles>spotter</roles>
+			<availability>LA:3,IS:2,TC:2,Periphery:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Firestarter' unitType='Mek' omni='IS'>
 		<availability>CC:4,FVC:2,LA:5,IS:2,FS:3,MERC:4,DC:7</availability>
-		<model name='FS9-OE'>
+		<model name='FS9-OD'>
 			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OX'>
-			<availability>General:2</availability>
 		</model>
 		<model name='FS9-OU'>
 			<roles>marine</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='FS9-OC'>
-			<roles>fire_support</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='FS9-OF'>
-			<availability>General:6</availability>
+		<model name='FS9-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='FS9-OH'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='FS9-OD'>
+		<model name='FS9-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OR'>
+			<availability>CLAN:4,IS:3,DC:3</availability>
+		</model>
+		<model name='FS9-OB'>
+			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
 		<model name='FS9-OG'>
 			<availability>General:6</availability>
 		</model>
-		<model name='FS9-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='FS9-OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='FS9-OR'>
-			<availability>CLAN:4,IS:3,DC:3</availability>
+		<model name='FS9-OF'>
+			<availability>General:6</availability>
+		</model>
+		<model name='FS9-OC'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='FS9-OX'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek'>
@@ -6356,18 +6356,18 @@
 	</chassis>
 	<chassis name='Flamberge' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='C'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='B'>
 			<availability>General:6</availability>
@@ -6375,51 +6375,51 @@
 	</chassis>
 	<chassis name='Flashman' unitType='Mek'>
 		<availability>DC.GHO:5,CHH:1,RD:2,CDS:1,LA:4,ROS:2,CLAN:1,FWL:4,CP:2,CJF:2,DC:4</availability>
-		<model name='FLS-9M'>
-			<availability>FWL:7,CP:7</availability>
-		</model>
 		<model name='FLS-8K'>
 			<availability>DC.GHO:5,LA:8,ROS:6,CLAN:8,FWL:4,MERC.SI:5,CP:4,BAN:8</availability>
+		</model>
+		<model name='FLS-9M'>
+			<availability>FWL:7,CP:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Flatbed Truck' unitType='Tank'>
 		<availability>CLAN:4,IS:10,Periphery.Deep:8,BAN:4,Periphery:10</availability>
+		<model name='(Standard)'>
+			<roles>cargo,support</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Armor)'>
 			<roles>cargo,support</roles>
 			<availability>IS:6,Periphery.Deep:4,CLAN.IS:6,Periphery:6</availability>
-		</model>
-		<model name='(Mortar)'>
-			<roles>cargo,support</roles>
-			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>cargo,support</roles>
 			<availability>IS:5,Periphery:5</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(LRM)'>
+			<roles>cargo</roles>
+			<availability>IS:4,BAN:6,Periphery:4</availability>
+		</model>
+		<model name='(Mortar)'>
 			<roles>cargo,support</roles>
-			<availability>General:8</availability>
+			<availability>IS:4,Periphery:4</availability>
 		</model>
 		<model name='(AC)'>
 			<roles>cargo</roles>
 			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<roles>cargo</roles>
-			<availability>IS:4,BAN:6,Periphery:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Flea' unitType='Mek'>
 		<availability>CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2,DA:3</availability>
+		<model name='FLE-19'>
+			<roles>urban</roles>
+			<availability>MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,CP:2-,DA:4-,Periphery:6-,TC:4-</availability>
+		</model>
 		<model name='FLE-20'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='FLE-17'>
 			<availability>CC:4,RF:8,ROS:8,FWL:8,MERC:8,DA:8,CP:8,Periphery:6</availability>
-		</model>
-		<model name='FLE-19'>
-			<roles>urban</roles>
-			<availability>MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,CP:2-,DA:4-,Periphery:6-,TC:4-</availability>
 		</model>
 	</chassis>
 	<chassis name='Foot Infantry' unitType='Infantry'>
@@ -6430,20 +6430,18 @@
 	</chassis>
 	<chassis name='Foot Platoon' unitType='Infantry'>
 		<availability>IS:10,Periphery.Deep:8,Periphery:10</availability>
-		<model name='(MG)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Gauss)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Flechette)'>
 			<availability>IS:5</availability>
@@ -6454,33 +6452,35 @@
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>General:6</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
+		</model>
+		<model name='(LRM)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fortress' unitType='Dropship'>
 		<availability>LA:4,FS:4</availability>
-		<model name='(2613)'>
-			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(3058)'>
 			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
 			<availability>LA:8,FS:8</availability>
 		</model>
+		<model name='(2613)'>
+			<roles>artillery,assault,mech_carrier,vee_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Fortune Wheeled Assault Vehicle' unitType='Tank'>
 		<availability>RF:4,LA:6,ROS:4</availability>
-		<model name='(Thunderbolt)'>
-			<availability>RF:4,LA:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>LA:6,ROS:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='(Thunderbolt)'>
+			<availability>RF:4,LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Armored Car' unitType='Tank'>
@@ -6488,14 +6488,14 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Interdictor)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(VSP)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Interdictor)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fox Corvette' unitType='Warship'>
@@ -6537,36 +6537,36 @@
 			<roles>spotter</roles>
 			<availability>LA:5,FS:3</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='III'>
 			<roles>spotter</roles>
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Fury Command Tank' unitType='Tank'>
 		<availability>CWE:1,CHH:3,RD:3,ROS:5,FS:5,MERC:4,CJF:1</availability>
-		<model name='(Fury IIIm)'>
-			<roles>spotter</roles>
-			<availability>FS:4</availability>
+		<model name='(Fury III)'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>apc,spotter</roles>
 			<availability>ROS:3,FS:3</availability>
 		</model>
-		<model name='CX-17'>
-			<availability>ROS:4</availability>
+		<model name='(Fury IIIm)'>
+			<roles>spotter</roles>
+			<availability>FS:4</availability>
 		</model>
-		<model name='(Fury III)'>
-			<availability>FS:6</availability>
+		<model name='(Royal)'>
+			<availability>ROS:4,CLAN:4,BAN:2</availability>
 		</model>
 		<model name='(C3S)'>
 			<availability>ROS:5,FS:5</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>ROS:4,CLAN:4,BAN:2</availability>
+		<model name='CX-17'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -6586,29 +6586,29 @@
 	</chassis>
 	<chassis name='Fusilier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:5,MERC:3</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>FS:7</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Fwltur' unitType='Mek'>
 		<availability>IS:5,MERC:4,Periphery:4</availability>
-		<model name='FWL-3R SalvageMech'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='FWL-3V SalvageMech'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='FWL-3R SalvageMech'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='GD Infiltrator Suit' unitType='BattleArmor'>
 		<availability>MERC.KH:6,RF:4,LA:6,ROS:4,MERC:4</availability>
-		<model name='(Mines)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>General:6</availability>
+		<model name='(Remote Sensors)' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
@@ -6617,9 +6617,9 @@
 		<model name='(Firedrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Remote Sensors)' mechanized='true'>
-			<roles>recon</roles>
-			<availability>General:5</availability>
+		<model name='(Mines)' mechanized='true'>
+			<roles>minelayer</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Sensors)' mechanized='true'>
 			<roles>recon</roles>
@@ -6628,10 +6628,6 @@
 	</chassis>
 	<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
 		<availability>TC:4</availability>
-		<model name='(TDF)'>
-			<roles>recon</roles>
-			<availability>TC:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
@@ -6639,14 +6635,18 @@
 		<model name='(ERSL)'>
 			<availability>TC:4</availability>
 		</model>
+		<model name='(TDF)'>
+			<roles>recon</roles>
+			<availability>TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Galahad (Glass Spider)' unitType='Mek'>
 		<availability>CWE:2,ROS:2,RA:2</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CWE:6,ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Galahad' unitType='Mek'>
@@ -6657,25 +6657,18 @@
 	</chassis>
 	<chassis name='Gallant' unitType='Mek'>
 		<availability>MOC:4,LA:6,ROS:6,IS:4,FS:6,MERC:4,CP:4,CDP:4,CWIE:4,TC:4</availability>
-		<model name='GLT-8-0'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
-		</model>
 		<model name='GLT-10-0'>
 			<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
 		</model>
 		<model name='GLT-7-0'>
 			<availability>General:8,FS:4</availability>
 		</model>
+		<model name='GLT-8-0'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Galleon Light Tank' unitType='Tank'>
 		<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
-		<model name='GAL-200'>
-			<availability>MOC:1,LA:1,IS:1,DC:1,Periphery:1</availability>
-		</model>
-		<model name='GAL-100'>
-			<deployedWith>Harasser</deployedWith>
-			<availability>General:5-</availability>
-		</model>
 		<model name='Maxwell'>
 			<availability>FWL:3,CP:3</availability>
 		</model>
@@ -6683,40 +6676,50 @@
 			<roles>recon</roles>
 			<availability>MOC:5,RA.OA:3,RD:5,LA:5,IS:3,FWL:7,FS:5,MERC:5,CP:7,TC:5,DC:4,Periphery:4</availability>
 		</model>
+		<model name='GAL-200'>
+			<availability>MOC:1,LA:1,IS:1,DC:1,Periphery:1</availability>
+		</model>
+		<model name='GAL-100'>
+			<deployedWith>Harasser</deployedWith>
+			<availability>General:5-</availability>
+		</model>
 	</chassis>
 	<chassis name='Gallowglas' unitType='Mek'>
 		<availability>MERC.WD:5,ROS:4,MH:4,MERC:4,CWIE:5</availability>
-		<model name='GAL-2GLS'>
-			<availability>IS:4-,Periphery:4-</availability>
-		</model>
-		<model name='GAL-1GLS'>
-			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
-		</model>
 		<model name='GAL-4GLS'>
 			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
 		</model>
 		<model name='GAL-2GLSA'>
 			<availability>MERC.WD:2,ROS:2,MERC:2</availability>
 		</model>
-		<model name='GAL-3GLS'>
-			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		<model name='GAL-2GLS'>
+			<availability>IS:4-,Periphery:4-</availability>
 		</model>
 		<model name='WD'>
 			<availability>MERC.WD:8-,CWIE:8</availability>
 		</model>
+		<model name='GAL-3GLS'>
+			<availability>MERC.WD:7,ROS:6,MERC:6</availability>
+		</model>
+		<model name='GAL-1GLS'>
+			<availability>ROS:4,IS:8,Periphery.Deep:6,MERC:4,Periphery:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Gambit' unitType='Mek'>
 		<availability>IS:5</availability>
-		<model name='GBT-1G'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GBT-1L'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='GBT-1G'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Garm' unitType='Mek'>
 		<availability>FVC:4,FS:6,MERC:4,CDP:4,TC:4</availability>
+		<model name='GRM-01C'>
+			<availability>FS:5,MERC:5</availability>
+		</model>
 		<model name='GRM-01A2'>
 			<availability>FS:6</availability>
 		</model>
@@ -6725,9 +6728,6 @@
 		</model>
 		<model name='GRM-01A'>
 			<availability>General:8</availability>
-		</model>
-		<model name='GRM-01C'>
-			<availability>FS:5,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Garrot Superheavy Transport' unitType='VTOL'>
@@ -6746,16 +6746,16 @@
 	</chassis>
 	<chassis name='Gauntlet' unitType='Mek' omni='IS'>
 		<availability>LA:8</availability>
-		<model name='GTL-1O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='GTL-1OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='GTL-1OB'>
-			<availability>General:7</availability>
+		<model name='GTL-1O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='GTL-1OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='GTL-1OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -6775,64 +6775,64 @@
 		<model name='GST-50'>
 			<availability>FWL:6,CP:6</availability>
 		</model>
-		<model name='GST-11'>
-			<availability>General:4</availability>
-		</model>
 		<model name='GST-90'>
 			<availability>PIR:8,MERC:6</availability>
 		</model>
 		<model name='GST-10'>
 			<availability>General:8</availability>
 		</model>
+		<model name='GST-11'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Giggins APC' unitType='Tank'>
 		<availability>ROS:7</availability>
-		<model name='(Fire Support)'>
-			<roles>apc,fire_support</roles>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Fire Support)'>
+			<roles>apc,fire_support</roles>
+			<availability>General:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
 		<availability>RD:8,CDS:4,ROS:4+,CLAN:4,CP:4,CJF:3,BAN:4</availability>
-		<model name='Prime'>
-			<availability>CWE:7,RD:8,General:8,CJF:9,CWIE:7</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:3,RD:4,CDS:2,General:2,CP:2,CJF:2,CWIE:3</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5,CP:7,CJF:7</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:8,RD:7,CDS:5,General:6,CP:5,CJF:5,CWIE:8</availability>
-		</model>
-		<model name='P'>
-			<availability>CWE:5,CHH:6,RD:6,CDS:5,CLAN:4,General:3,CP:5,CJF:5,CWIE:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:5</availability>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='G'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		<model name='C'>
+			<availability>General:5,CP:7,CJF:7</availability>
 		</model>
-		<model name='B'>
-			<availability>RD:4,General:7</availability>
+		<model name='K'>
+			<availability>CWE:5,CHH:6,RD:6,CDS:5,General:3,CLAN:4,CP:5,CJF:5,CWIE:5</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:5,RD:5,CDS:5,CLAN:4,General:3,CP:5</availability>
+		<model name='Prime'>
+			<availability>CWE:7,RD:8,General:8,CJF:9,CWIE:7</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='I'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='K'>
-			<availability>CWE:5,CHH:6,RD:6,CDS:5,General:3,CLAN:4,CP:5,CJF:5,CWIE:5</availability>
+		<model name='A'>
+			<availability>CWE:8,RD:7,CDS:5,General:6,CP:5,CJF:5,CWIE:8</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,RD:5,CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:3,RD:4,CDS:2,General:2,CP:2,CJF:2,CWIE:3</availability>
+		</model>
+		<model name='P'>
+			<availability>CWE:5,CHH:6,RD:6,CDS:5,CLAN:4,General:3,CP:5,CJF:5,CWIE:5</availability>
+		</model>
+		<model name='B'>
+			<availability>RD:4,General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Gladiator Battle Armor' unitType='BattleArmor'>
@@ -6849,22 +6849,22 @@
 	</chassis>
 	<chassis name='Gladius Medium Hover Tank' unitType='Tank'>
 		<availability>CC:2,MOC:4,Periphery.CM:3,Periphery.ME:3,MH:6,CDP:4,TC:5,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Mk II'>
 			<availability>MH:6,TC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Glaive Medium Tank' unitType='Tank'>
 		<availability>LA:5,ROS:3</availability>
-		<model name='(MFB)'>
-			<roles>support</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MFB)'>
+			<roles>support</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Glory Heavy Fire Support Vehicle' unitType='Tank'>
@@ -6872,6 +6872,10 @@
 		<model name='(Light Gauss)'>
 			<roles>fire_support</roles>
 			<availability>General:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
 		</model>
 		<model name='(3090 Upgrade)'>
 			<roles>fire_support</roles>
@@ -6881,27 +6885,23 @@
 			<roles>missile_artillery</roles>
 			<availability>FS:1</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Gnome Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:6,CLAN:2</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Upgrade) [MRR]' mechanized='true'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='(Upgrade) [Pulse Laser]' mechanized='true'>
+		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
 			<availability>CHH:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(LRM)' mechanized='true'>
 			<availability>CHH:4</availability>
-		</model>
-		<model name='(Upgrade) [Bearhunter]' mechanized='true'>
-			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Goblin II Infantry Support Vehicle' unitType='Tank'>
@@ -6923,45 +6923,45 @@
 	</chassis>
 	<chassis name='Golem Assault Armor' unitType='BattleArmor'>
 		<availability>CHH:6,RD:7</availability>
-		<model name='(Fast Assault)' mechanized='false'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>RD:8</availability>
 		</model>
-		<model name='(Rock Golem)' mechanized='false'>
-			<availability>CHH:8</availability>
+		<model name='(Fast Assault)' mechanized='false'>
+			<availability>CHH:6</availability>
 		</model>
 		<model name='(Support)' mechanized='false'>
 			<roles>urban,anti_infantry</roles>
 			<availability>RD:4</availability>
 		</model>
+		<model name='(Rock Golem)' mechanized='false'>
+			<availability>CHH:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Goliath' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,TC:4,Periphery:3,RA.OA:3,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2</availability>
-		<model name='GOL-3L'>
+		<model name='GOL-4S'>
 			<roles>fire_support</roles>
-			<availability>CC:6,MOC:6</availability>
+			<availability>LA:6</availability>
 		</model>
 		<model name='GOL-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:5,MOC:6,FWL:5,MH:6,MERC:6,CP:5,CDP:6,TC:6</availability>
 		</model>
-		<model name='GOL-5D'>
-			<roles>fire_support</roles>
-			<availability>FS:8</availability>
-		</model>
 		<model name='GOL-6M'>
 			<roles>fire_support</roles>
 			<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
 		</model>
+		<model name='GOL-3L'>
+			<roles>fire_support</roles>
+			<availability>CC:6,MOC:6</availability>
+		</model>
+		<model name='GOL-5D'>
+			<roles>fire_support</roles>
+			<availability>FS:8</availability>
+		</model>
 		<model name='GOL-6H'>
 			<roles>fire_support</roles>
 			<availability>Periphery.HR:6,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,MH:8,Periphery:4</availability>
-		</model>
-		<model name='GOL-4S'>
-			<roles>fire_support</roles>
-			<availability>LA:6</availability>
 		</model>
 		<model name='GOL-2H'>
 			<roles>fire_support</roles>
@@ -6981,28 +6981,28 @@
 	</chassis>
 	<chassis name='Gorgon' unitType='ProtoMek'>
 		<availability>CP:4,RA:6</availability>
-		<model name='(Standard)'>
-			<availability>CP:5,RA:5</availability>
-		</model>
 		<model name='3'>
 			<availability>RA:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CP:5,RA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Goshawk II' unitType='Mek'>
 		<availability>ROS:2,RA:7</availability>
-		<model name='(Standard)'>
-			<availability>RA:8</availability>
+		<model name='3'>
+			<roles>marine</roles>
+			<availability>RA:4</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<availability>RA:4</availability>
 		</model>
-		<model name='3'>
-			<roles>marine</roles>
-			<availability>RA:4</availability>
-		</model>
 		<model name='RISC'>
 			<availability>ROS:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>RA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gossamer VTOL' unitType='VTOL'>
@@ -7016,14 +7016,14 @@
 	</chassis>
 	<chassis name='Gotha' unitType='Aero'>
 		<availability>CDS:4,ROS:7,CLAN:3,FWL:7,CP:5,MERC:4</availability>
-		<model name='GTHA-600'>
-			<availability>ROS:8,FWL:6,CP:6</availability>
+		<model name='GTHA-500b'>
+			<availability>ROS:6,CLAN:4,FWL:6,CP:6,MERC:6,BAN:2</availability>
 		</model>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,FWL:3,CP:3,MERC:3,BAN:2,Periphery:3</availability>
 		</model>
-		<model name='GTHA-500b'>
-			<availability>ROS:6,CLAN:4,FWL:6,CP:6,MERC:6,BAN:2</availability>
+		<model name='GTHA-600'>
+			<availability>ROS:8,FWL:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Gotterdammerung' unitType='Mek'>
@@ -7034,6 +7034,15 @@
 	</chassis>
 	<chassis name='Grand Dragon' unitType='Mek'>
 		<availability>RD:4,ROS:4,MERC:4,CP:5,DC:4</availability>
+		<model name='DRG-10K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='DRG-7KC'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='DRG-5K'>
+			<availability>RD:8,ROS:6,MERC:6,CP:8,DC:2</availability>
+		</model>
 		<model name='DRG-C'>
 			<availability>ROS:4,DC:2</availability>
 		</model>
@@ -7041,53 +7050,44 @@
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
-		<model name='DRG-7KC'>
-			<availability>DC:8</availability>
+		<model name='DRG-5K-DC'>
+			<availability>DC:2</availability>
 		</model>
 		<model name='DRG-7K'>
 			<availability>ROS:6,MERC:4,DC:1</availability>
 		</model>
-		<model name='DRG-10K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='DRG-5K-DC'>
-			<availability>DC:2</availability>
-		</model>
-		<model name='DRG-5K'>
-			<availability>RD:8,ROS:6,MERC:6,CP:8,DC:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Grand Titan' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:4,MERC:4,CP:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,DA:7,DC:4</availability>
-		<model name='T-IT-N10M'>
-			<availability>ROS:2,FWL:2,MERC:2,CP:2,Periphery:2</availability>
+		<model name='T-IT-N13M'>
+			<availability>RF:8,ROS:8,FWL:8,DA:8,MERC:8,CP:8</availability>
 		</model>
 		<model name='T-IT-N11M'>
 			<availability>CC:8,MOC:8,ROS:8,FWL:6,MERC:4,FS:8,CP:6,DC:8</availability>
 		</model>
-		<model name='T-IT-N13M'>
-			<availability>RF:8,ROS:8,FWL:8,DA:8,MERC:8,CP:8</availability>
+		<model name='T-IT-N10M'>
+			<availability>ROS:2,FWL:2,MERC:2,CP:2,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Grasshopper' unitType='Mek'>
 		<availability>MOC:6,IS:3,Periphery.Deep:4,MERC:7,Periphery:6,DC:4,TC:6</availability>
-		<model name='GHR-5J'>
-			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
-		</model>
 		<model name='GHR-7K'>
 			<availability>ROS:5,DC:6</availability>
 		</model>
-		<model name='GHR-5H'>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='GHR-C'>
-			<availability>IS:2,DC:2</availability>
+		<model name='GHR-5J'>
+			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
 		</model>
 		<model name='GHR-6K'>
 			<availability>ROS:4,MERC:2,FS:2,DC:4</availability>
 		</model>
+		<model name='GHR-5H'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='GHR-7P'>
 			<availability>LA:8,MERC:4</availability>
+		</model>
+		<model name='GHR-C'>
+			<availability>IS:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Gravedigger' unitType='Mek'>
@@ -7120,14 +7120,14 @@
 		<model name='[SRM]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gray Death Strike Armor' unitType='BattleArmor'>
@@ -7145,61 +7145,61 @@
 	</chassis>
 	<chassis name='Great Wyrm' unitType='Mek'>
 		<availability>CHH:5,RD:5</availability>
-		<model name='2'>
-			<availability>CHH:8,RD:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:8,RD:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4,TC:2</availability>
-		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='(Hunter-Killer)[C3/HRR]' mechanized='false'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='[Heavy Flamer]' mechanized='false'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='[LRR]' mechanized='false'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Hunter-Killer)[SVSP/Magshot]' mechanized='false'>
 			<availability>FS:5</availability>
 		</model>
 		<model name='[Flamer]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
+		<model name='[MagShot]' mechanized='false'>
+			<availability>FS:5</availability>
+		</model>
+		<model name='(Hunter-Killer) [MagShot]' mechanized='false'>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Hunter-Killer)[SVSP/Magshot]' mechanized='false'>
-			<availability>FS:5</availability>
+		<model name='(Hunter-Killer) [NARC]' mechanized='false'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='[TAG]' mechanized='false'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='[MagShot]' mechanized='false'>
-			<availability>FS:5</availability>
-		</model>
-		<model name='[LRR]' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='[SL]' mechanized='false'>
 			<availability>General:6</availability>
-		</model>
-		<model name='[Heavy Flamer]' mechanized='false'>
-			<availability>FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grenadier II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:4,FS:5</availability>
-		<model name='A' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='C' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='B' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='A' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='D' mechanized='true'>
 			<roles>artillery</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='C' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Grendel (Mongrel)' unitType='Mek' omni='Clan'>
@@ -7207,8 +7207,14 @@
 		<model name='B'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 		<model name='C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
 		</model>
 		<model name='H'>
 			<availability>CHH:8,CLAN:5,IS:3</availability>
@@ -7219,23 +7225,26 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:4</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Griffin IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.WD:5,CDS:6,LA:3,IS:3,CP:6,CJF:2,CWIE:4,DC:4</availability>
+		<model name='4'>
+			<availability>CDS:6,IS:6,CP:7</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:8,IS:8,CP:6</availability>
+		</model>
+		<model name='2'>
+			<availability>MERC.WD:8</availability>
+		</model>
 		<model name='6'>
 			<availability>ROS:4,CP:6,DC:6</availability>
 		</model>
-		<model name='4'>
-			<availability>CDS:6,IS:6,CP:7</availability>
+		<model name='(Standard)'>
+			<availability>MERC.WD:6,CP:4</availability>
 		</model>
 		<model name='7'>
 			<availability>ROS:4,CP:6</availability>
@@ -7246,26 +7255,17 @@
 		<model name='5'>
 			<availability>CDS:4,CP:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>MERC.WD:6,CP:4</availability>
-		</model>
-		<model name='2'>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:8,IS:8,CP:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Griffin' unitType='Mek'>
 		<availability>MOC:2,CC:5,RA.OA:1,RD:4,LA:7,ROS:5,IS:6,MERC:7,CP:2,TC:5,Periphery:4,DC:7</availability>
+		<model name='GRF-2N'>
+			<availability>CC:4,MOC:4,CLAN:6,FWL:4,MH:4,FS:4,MERC:4,CP:4,BAN:4,DC:4</availability>
+		</model>
+		<model name='GRF-5M'>
+			<availability>ROS:5,FWL:6,MERC:5,CP:6</availability>
+		</model>
 		<model name='GRF-3M'>
 			<availability>MOC:4,RF:6,LA:3,FWL:5,IS:4,MH:4,DA:6,CP:5,DC:1</availability>
-		</model>
-		<model name='GRF-6S'>
-			<availability>LA:8,FS:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='GRF-4N'>
-			<availability>TC:6</availability>
 		</model>
 		<model name='GRF-6S2'>
 			<availability>LA:5,FS:4,DC:4</availability>
@@ -7273,79 +7273,75 @@
 		<model name='GRF-4R'>
 			<availability>CC:4,RD:5,ROS:6,FWL:4,FS:4,CP:4,DC:4</availability>
 		</model>
-		<model name='GRF-2N'>
-			<availability>CC:4,MOC:4,CLAN:6,FWL:4,MH:4,FS:4,MERC:4,CP:4,BAN:4,DC:4</availability>
-		</model>
-		<model name='GRF-5M'>
-			<availability>ROS:5,FWL:6,MERC:5,CP:6</availability>
-		</model>
-		<model name='GRF-1N'>
-			<availability>BAN:2,Periphery:2-</availability>
+		<model name='GRF-1DS'>
+			<availability>FVC:3,ROS:2,DC:1</availability>
 		</model>
 		<model name='GRF-5K'>
 			<availability>CP:8,DC:8</availability>
 		</model>
-		<model name='GRF-1DS'>
-			<availability>FVC:3,ROS:2,DC:1</availability>
+		<model name='GRF-4N'>
+			<availability>TC:6</availability>
 		</model>
 		<model name='GRF-5L'>
 			<availability>CC:6</availability>
 		</model>
+		<model name='GRF-1N'>
+			<availability>BAN:2,Periphery:2-</availability>
+		</model>
+		<model name='GRF-6S'>
+			<availability>LA:8,FS:4,MERC:4,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Grim Reaper' unitType='Mek'>
 		<availability>ROS:6,MERC:5,DC:5</availability>
+		<model name='GRM-R-PR31'>
+			<roles>fire_support</roles>
+			<availability>MERC:4</availability>
+		</model>
 		<model name='GRM-R-PR30'>
 			<availability>ROS:4,MERC:3</availability>
 		</model>
 		<model name='GRM-R-PR29'>
 			<availability>ROS:8,MERC:8,DC:8</availability>
 		</model>
-		<model name='GRM-R-PR31'>
-			<roles>fire_support</roles>
-			<availability>MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Grizzly' unitType='Mek'>
 		<availability>CHH:1,RD:6,CLAN:1,RA:1</availability>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
+		</model>
 		<model name='2'>
 			<roles>urban</roles>
 			<availability>RD:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 		<availability>CC:3,MOC:2,FVC:1,RF:3,ROS:3,FWL:2,MERC:2,TC:2,Periphery:1</availability>
-		<model name='D'>
-			<availability>CC:3,MOC:3,RF:2,MERC:2</availability>
-		</model>
-		<model name='B'>
-			<availability>Periphery:2</availability>
-		</model>
-		<model name='C'>
-			<availability>CC:5,MOC:5,RF:3,MERC:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>ground_support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='C'>
+			<availability>CC:5,MOC:5,RF:3,MERC:3</availability>
+		</model>
+		<model name='B'>
+			<availability>Periphery:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CC:3,MOC:3,RF:2,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Guillotine IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.KH:4,MERC.WD:4,CHH:2-,LA:4,ROS:4,CP:2-,CWIE:4</availability>
-		<model name='2'>
-			<availability>CWE:4,IS:8,CWIE:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>ROS:4,CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CWE:4,IS:8,CWIE:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Guillotine' unitType='Mek'>
 		<availability>CC:3,CHH:1,ROS:5,FWL:3,FS:4,CP:3,MERC:2,RA:1,Periphery:1</availability>
-		<model name='GLT-3N'>
-			<roles>raider</roles>
-			<availability>ROS:6,CLAN:8,MERC.SI:8,BAN:8</availability>
-		</model>
 		<model name='GLT-6WB3'>
 			<roles>raider</roles>
 			<availability>ROS:3,FWL:4,MERC:3,CP:4</availability>
@@ -7361,6 +7357,10 @@
 		<model name='GLT-5M'>
 			<roles>raider</roles>
 			<availability>CC:8,ROS:8,FWL:8,FS:8,MERC:4,CP:8</availability>
+		</model>
+		<model name='GLT-3N'>
+			<roles>raider</roles>
+			<availability>ROS:6,CLAN:8,MERC.SI:8,BAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gulltoppr OmniMonitor' unitType='Tank' omni='IS'>
@@ -7391,16 +7391,16 @@
 	</chassis>
 	<chassis name='Gunslinger' unitType='Mek'>
 		<availability>FVC:5,LA:8,IS:5,MH:4,FS:5,DC:7</availability>
-		<model name='GUN-2ERDr'>
-			<roles>spotter</roles>
-			<availability>FS:4,DC:4</availability>
-		</model>
 		<model name='GUN-2ERD'>
 			<roles>spotter</roles>
 			<availability>LA:6,General:4,FS:6,DC:6</availability>
 		</model>
 		<model name='GUN-1ERD'>
 			<availability>General:8</availability>
+		</model>
+		<model name='GUN-2ERDr'>
+			<roles>spotter</roles>
+			<availability>FS:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Gunsmith' unitType='Mek'>
@@ -7411,12 +7411,12 @@
 	</chassis>
 	<chassis name='Gurteltier MBT' unitType='Tank'>
 		<availability>LA:6,ROS:4,FS:4</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Gurzil Support Tank' unitType='Tank'>
@@ -7449,30 +7449,30 @@
 	</chassis>
 	<chassis name='Ha Otoko' unitType='Mek'>
 		<availability>CHH:3,CDS:5,LA:4,IS:4,CP:5,DC:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
-		</model>
-		<model name='2'>
-			<availability>CDS:4,CP:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CP:5,DC:4+</availability>
-		</model>
 		<model name='HKO-1C'>
 			<roles>fire_support</roles>
 			<availability>LA:4,DC:4</availability>
 		</model>
+		<model name='3'>
+			<availability>CHH:6,CDS:6,LA:4+,ROS:4+,CP:5,DC:4+</availability>
+		</model>
+		<model name='2'>
+			<availability>CDS:4,CP:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>LA:4+,CLAN:4,IS:4+,DC:4+</availability>
+		</model>
 	</chassis>
 	<chassis name='Hachiman Fire Support Tank' unitType='Tank'>
 		<availability>RA.OA:5,CHH:7,LA:3,ROS:4,CLAN:5,FS:3,MERC:3</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
-		</model>
 		<model name='(AAA)'>
 			<roles>fire_support</roles>
 			<availability>RA.OA:8,RD:4,CDS:4,CP:4,RA:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>MERC.WD:8,CLAN:8,IS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hadur Fast Support Vehicle' unitType='Tank'>
@@ -7513,23 +7513,23 @@
 	</chassis>
 	<chassis name='Hammerhands' unitType='Mek'>
 		<availability>ROS:3,FS:5,MERC:3</availability>
-		<model name='HMH-6E'>
-			<availability>General:6,MERC:6</availability>
+		<model name='HMH-6D'>
+			<availability>ROS:6,General:6</availability>
 		</model>
 		<model name='HMH-5D'>
 			<availability>General:2,MERC:4</availability>
 		</model>
-		<model name='HMH-6D'>
-			<availability>ROS:6,General:6</availability>
+		<model name='HMH-6E'>
+			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Hammerhead' unitType='Aero'>
 		<availability>ROS:5,CLAN:2,CP:3</availability>
-		<model name='HMR-HD'>
-			<availability>General:8,CP:4</availability>
-		</model>
 		<model name='HMR-HE'>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='HMR-HD'>
+			<availability>General:8,CP:4</availability>
 		</model>
 		<model name='HMR-HDb'>
 			<availability>ROS:4,CLAN:4,RA:6,BAN:2</availability>
@@ -7537,34 +7537,34 @@
 	</chassis>
 	<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
 		<availability>RD:3,CDS:4,ROS:3+,CP:4,CJF:4</availability>
-		<model name='C'>
-			<roles>urban</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='E'>
-			<roles>anti_infantry</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='B'>
 			<availability>General:6,CP:7</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='D'>
-			<roles>fire_support</roles>
-			<availability>General:5</availability>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
-		<model name='Prime'>
-			<roles>spotter</roles>
-			<availability>General:8,CP:9</availability>
+		<model name='E'>
+			<roles>anti_infantry</roles>
+			<availability>General:3</availability>
 		</model>
 		<model name='F'>
 			<roles>spotter</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='D'>
+			<roles>fire_support</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='C'>
+			<roles>urban</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='Prime'>
+			<roles>spotter</roles>
+			<availability>General:8,CP:9</availability>
 		</model>
 	</chassis>
 	<chassis name='Hannibal' unitType='Dropship'>
@@ -7582,11 +7582,11 @@
 	</chassis>
 	<chassis name='Harasser Missile Platform' unitType='Tank'>
 		<availability>MOC:5,CC:5,FWL.pm:7,RF:7,LA:5,FWL:7,MH:5,MERC:5,CP:7,DA:7</availability>
-		<model name='(Thunderbolt)'>
-			<availability>CC:6,MOC:6,RF:6,FWL:6,MH:6,DA:6,CP:6,MERC:5</availability>
-		</model>
 		<model name='(MML)'>
 			<availability>MOC:6,CC:6,RF:8,LA:6,FWL:8,DA:8,MERC:6,CP:8</availability>
+		</model>
+		<model name='(Thunderbolt)'>
+			<availability>CC:6,MOC:6,RF:6,FWL:6,MH:6,DA:6,CP:6,MERC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Harpagos' unitType='Mek'>
@@ -7600,10 +7600,10 @@
 		<model name='(Standard)'>
 			<availability>CHH:4</availability>
 		</model>
-		<model name='4'>
+		<model name='2'>
 			<availability>CHH:8</availability>
 		</model>
-		<model name='2'>
+		<model name='4'>
 			<availability>CHH:8</availability>
 		</model>
 	</chassis>
@@ -7619,11 +7619,11 @@
 		<model name='HTM-28T'>
 			<availability>ROS:4,DC:2</availability>
 		</model>
-		<model name='HTM-27T'>
-			<availability>MERC:2,DC:2</availability>
-		</model>
 		<model name='HTM-28Tr'>
 			<availability>ROS:6,DC:8</availability>
+		</model>
+		<model name='HTM-27T'>
+			<availability>MERC:2,DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hatamoto-Godai' unitType='Mek'>
@@ -7656,46 +7656,46 @@
 	</chassis>
 	<chassis name='Hatchetman' unitType='Mek'>
 		<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,CP:4,Periphery:2,Periphery.R:3,FVC:5,LA:6,ROS:5,Periphery.MW:3,FWL:4,DC:4</availability>
-		<model name='HCT-7R'>
-			<availability>ROS:8</availability>
-		</model>
-		<model name='HCT-5DD'>
-			<availability>ROS:6,FS:8,MERC:6,CDP:4</availability>
+		<model name='HCT-6S'>
+			<availability>LA:8,MERC:6</availability>
 		</model>
 		<model name='HCT-5D'>
 			<availability>CDP:1</availability>
 		</model>
-		<model name='HCT-6D'>
-			<availability>ROS:4,FS:2,MERC:6</availability>
-		</model>
 		<model name='HCT-6M'>
 			<availability>ROS:5,FWL:8,MERC:6,CP:8</availability>
 		</model>
-		<model name='HCT-7S'>
-			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
+		<model name='HCT-7R'>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='HCT-5S'>
 			<availability>FVC:3,LA:2,FS:2,MERC:4,DC:2,Periphery:4</availability>
 		</model>
-		<model name='HCT-5K'>
-			<availability>DC:8</availability>
+		<model name='HCT-5DD'>
+			<availability>ROS:6,FS:8,MERC:6,CDP:4</availability>
+		</model>
+		<model name='HCT-7S'>
+			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='HCT-3F'>
 			<roles>urban</roles>
 			<availability>FVC:1-,TC.PL:1-,Periphery:1-</availability>
 		</model>
-		<model name='HCT-6S'>
-			<availability>LA:8,MERC:6</availability>
+		<model name='HCT-6D'>
+			<availability>ROS:4,FS:2,MERC:6</availability>
+		</model>
+		<model name='HCT-5K'>
+			<availability>DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk Battle Armor' unitType='BattleArmor'>
 		<availability>FS:4</availability>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
-		</model>
 		<model name='Commando' mechanized='false'>
 			<roles>urban</roles>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hauberk II Battle Armor' unitType='BattleArmor'>
@@ -7707,34 +7707,34 @@
 	</chassis>
 	<chassis name='Hauptmann' unitType='Mek' omni='IS'>
 		<availability>LA:6</availability>
-		<model name='HA1-OT'>
-			<availability>General:4</availability>
+		<model name='HA1-O'>
+			<availability>General:8</availability>
 		</model>
-		<model name='HA1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='HA1-OB'>
-			<availability>General:7</availability>
+		<model name='HA1-OE'>
+			<availability>General:5</availability>
 		</model>
 		<model name='HA1-OM'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='HA1-OE'>
-			<availability>General:5</availability>
-		</model>
-		<model name='HA1-OC'>
+		<model name='HA1-OB'>
 			<availability>General:7</availability>
-		</model>
-		<model name='HA1-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='HA1-OD'>
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='HA1-OA'>
+			<availability>General:7</availability>
+		</model>
+		<model name='HA1-OT'>
+			<availability>General:4</availability>
+		</model>
 		<model name='HA1-OF'>
 			<availability>General:4</availability>
+		</model>
+		<model name='HA1-OC'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Havoc' unitType='Mek'>
@@ -7757,16 +7757,16 @@
 	</chassis>
 	<chassis name='Hawk Moth II Gunship' unitType='VTOL'>
 		<availability>IS:5</availability>
-		<model name='(MML)'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
+		<model name='(Sniper)'>
+			<roles>artillery</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Sniper)'>
-			<roles>artillery</roles>
-			<availability>General:2</availability>
+		<model name='(MML)'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='HawkWolf' unitType='Mek'>
@@ -7795,25 +7795,25 @@
 	</chassis>
 	<chassis name='Heavy Hover APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:4,IS:6,TC:6,Periphery:5</availability>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		<model name='(Standard)'>
+			<roles>apc,support</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Scout Tank)'>
 			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support,urban</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc,support</roles>
-			<availability>General:8</availability>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support,urban</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Infantry' unitType='Infantry'>
@@ -7860,8 +7860,8 @@
 	</chassis>
 	<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:5</availability>
-		<model name='Bat Hawk'>
-			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
+		<model name='Meteor'>
+			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CP:4,TC:1</availability>
 		</model>
 		<model name='Inseki'>
 			<availability>DC:2</availability>
@@ -7869,14 +7869,14 @@
 		<model name='Meteor-U'>
 			<availability>ROS:2,FS:3,MERC:2</availability>
 		</model>
-		<model name='Inseki II'>
-			<availability>DC:3</availability>
-		</model>
-		<model name='Meteor'>
-			<availability>MOC:4,CC:3,RA.OA:5,LA:2,General:4,FWL:4,MH:5,MERC:4,FS:3,CP:4,TC:1</availability>
+		<model name='Bat Hawk'>
+			<availability>CC:2,MOC:3,Periphery.CM:4,Periphery.HR:4,Periphery.ME:3,CDP:5,TC:5</availability>
 		</model>
 		<model name='Meteor-G'>
 			<availability>General:3,FWL:4,CP:4</availability>
+		</model>
+		<model name='Inseki II'>
+			<availability>DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Heavy Support Infantry' unitType='Infantry'>
@@ -7887,10 +7887,6 @@
 	</chassis>
 	<chassis name='Heavy Tracked APC' unitType='Tank'>
 		<availability>CHH:7,CLAN:5,IS:7,Periphery.Deep:4,Periphery:6,TC:7</availability>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
@@ -7898,6 +7894,10 @@
 		<model name='(Standard)'>
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)'>
 			<roles>apc</roles>
@@ -7906,6 +7906,14 @@
 	</chassis>
 	<chassis name='Heavy Wheeled APC' unitType='Tank'>
 		<availability>CHH:6,CLAN:5,IS:7,Periphery.Deep:4,TC:7,Periphery:6</availability>
+		<model name='(MG)'>
+			<roles>apc,support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='(SRM)'>
+			<roles>apc</roles>
+			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>apc</roles>
 			<availability>PIR:5-,IS.pm:4,Periphery:5-</availability>
@@ -7914,17 +7922,16 @@
 			<roles>apc,support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SRM)'>
-			<roles>apc</roles>
-			<availability>PIR:6-,IS.pm:4,Periphery:6-</availability>
-		</model>
-		<model name='(MG)'>
-			<roles>apc,support</roles>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Heimdall Ground Monitor Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4,CDS:4,LA:4+,CP:4,RA:4,CWIE:5</availability>
+		<model name='A'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>General:4</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -7932,15 +7939,8 @@
 		<model name='Prime'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='D'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Helepolis' unitType='Mek'>
@@ -7952,14 +7952,14 @@
 	</chassis>
 	<chassis name='Helios' unitType='Mek'>
 		<availability>CC:5,MOC:5,FS:3,MERC:3,DC:3,TC:5</availability>
-		<model name='HEL-3D'>
-			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
+		<model name='HEL-4A'>
+			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
 		</model>
 		<model name='HEL-C'>
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='HEL-4A'>
-			<availability>CC:5,MOC:5,MERC:5,DC:5,TC:5</availability>
+		<model name='HEL-3D'>
+			<availability>CC:8,MOC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellcat II' unitType='Aero'>
@@ -7970,27 +7970,42 @@
 	</chassis>
 	<chassis name='Hellcat' unitType='Aero'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
-		<model name='HCT-213'>
-			<availability>General:2</availability>
-		</model>
 		<model name='HCT-313'>
 			<availability>RA.OA:8,FVC:8,CDP:8,RA:8</availability>
+		</model>
+		<model name='HCT-213'>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellhound (Conjurer)' unitType='Mek'>
 		<availability>CHH:3,CDS:2,ROS:2,CP:4,CJF:3</availability>
+		<model name='5'>
+			<availability>ROS:5,CP:5</availability>
+		</model>
 		<model name='2'>
 			<availability>CDS:6,CP:7,CWIE:8,DC:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CHH:4,CJF:4</availability>
 		</model>
-		<model name='5'>
-			<availability>ROS:5,CP:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Hellion' unitType='Mek' omni='Clan'>
 		<availability>CHH:5,CDS:5,CP:5,CJF:2</availability>
+		<model name='B'>
+			<availability>General:7,CJF:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<availability>General:7,CJF:3</availability>
+		</model>
+		<model name='G'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>General:5</availability>
+		</model>
 		<model name='E'>
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
@@ -7999,57 +8014,42 @@
 			<roles>fire_support</roles>
 			<availability>General:6,CJF:3</availability>
 		</model>
-		<model name='G'>
-			<availability>General:6</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7,CJF:3</availability>
-		</model>
 		<model name='F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7,CJF:3</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellspawn' unitType='Mek'>
 		<availability>LA:4,ROS:4,FS:6,MERC:4</availability>
+		<model name='HSN-9F'>
+			<roles>fire_support</roles>
+			<availability>FS:4</availability>
+		</model>
 		<model name='HSN-10SR'>
 			<roles>spotter</roles>
 			<availability>FS:6</availability>
 		</model>
-		<model name='HSN-7D'>
-			<roles>fire_support</roles>
-			<availability>FS:8,MERC:8</availability>
+		<model name='HSN-10G'>
+			<availability>LA:4,ROS:4,FS:4</availability>
 		</model>
 		<model name='HSN-8E'>
 			<roles>fire_support</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='HSN-10G'>
-			<availability>LA:4,ROS:4,FS:4</availability>
-		</model>
-		<model name='HSN-9F'>
+		<model name='HSN-7D'>
 			<roles>fire_support</roles>
-			<availability>FS:4</availability>
+			<availability>FS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hellstar' unitType='Mek'>
 		<availability>CC:3,CHH:6,MERC.WD:4,MERC.KH:4,LA:4,ROS:4,FS:3,CWIE:6,DC:4</availability>
+		<model name='2'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='3'>
 			<availability>CLAN:3</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hephaestus Jump Tank' unitType='Tank'>
@@ -8065,6 +8065,18 @@
 	</chassis>
 	<chassis name='Hephaestus Scout Tank' unitType='Tank' omni='Clan'>
 		<availability>CHH:4+</availability>
+		<model name='B'>
+			<roles>recon,apc</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='C'>
+			<roles>recon,apc,fire_support</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<roles>recon,apc</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='A'>
 			<roles>recon,apc,fire_support</roles>
 			<availability>General:7</availability>
@@ -8072,18 +8084,6 @@
 		<model name='Prime'>
 			<roles>recon,apc,spotter</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='C'>
-			<roles>recon,apc,fire_support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
-			<roles>recon,apc</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<roles>recon,apc</roles>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Hercules' unitType='Dropship'>
@@ -8108,13 +8108,13 @@
 			<roles>recon</roles>
 			<availability>ROS:2-,MERC:2-</availability>
 		</model>
+		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+			<roles>recon</roles>
+			<availability>FWL:4,CP:4</availability>
+		</model>
 		<model name='HER-6D'>
 			<roles>recon</roles>
 			<availability>FS.LG:10</availability>
-		</model>
-		<model name='HER-5Sr'>
-			<roles>recon</roles>
-			<availability>MOC:4,IS:4,MH:4</availability>
 		</model>
 		<model name='HER-5SA'>
 			<roles>training</roles>
@@ -8128,9 +8128,9 @@
 			<roles>recon</roles>
 			<availability>MOC:6,CC:6,LA:6,PIR:6,FWL:8,MH:6,FS:6,CP:8,MERC:6,DC:6</availability>
 		</model>
-		<model name='HER-5ME &apos;Mercury Elite&apos;'>
+		<model name='HER-5Sr'>
 			<roles>recon</roles>
-			<availability>FWL:4,CP:4</availability>
+			<availability>MOC:4,IS:4,MH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hermes' unitType='Mek'>
@@ -8139,34 +8139,34 @@
 			<roles>recon,spotter</roles>
 			<availability>FWL:1,CP:1</availability>
 		</model>
-		<model name='HER-4K'>
+		<model name='HER-1S'>
 			<roles>recon</roles>
-			<availability>FWL:6,MERC:6,CP:6,DC:8</availability>
-		</model>
-		<model name='HER-3S1'>
-			<roles>recon</roles>
-			<availability>FWL:1,CP:1</availability>
+			<availability>CLAN:6,BAN:8</availability>
 		</model>
 		<model name='HER-3S'>
 			<roles>recon</roles>
 			<availability>FWL:1,CP:1</availability>
 		</model>
-		<model name='HER-1S'>
+		<model name='HER-4K'>
 			<roles>recon</roles>
-			<availability>CLAN:6,BAN:8</availability>
+			<availability>FWL:6,MERC:6,CP:6,DC:8</availability>
 		</model>
 		<model name='HER-4S'>
 			<roles>recon</roles>
 			<availability>FWL:4,CP:4</availability>
 		</model>
+		<model name='HER-3S1'>
+			<roles>recon</roles>
+			<availability>FWL:1,CP:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
 		<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,IS:2-,Periphery.Deep:4,MERC:4,Periphery:6,CWIE:2</availability>
-		<model name='(SRM)'>
-			<availability>IS:1,Periphery:1</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:2-</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>IS:1,Periphery:1</availability>
 		</model>
 		<model name='(LRM)'>
 			<availability>IS:1,Periphery:1</availability>
@@ -8199,29 +8199,29 @@
 	</chassis>
 	<chassis name='Highlander IIC' unitType='Mek'>
 		<availability>CWE:6,CHH:6,RD:6,CDS:4,LA:3,ROS:4,CP:5,CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>CWE:4,CDS:4,IS:8,CP:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CWE:4</availability>
 		</model>
 		<model name='3'>
 			<availability>CWE:4,CHH:8,RD:8,ROS:4,CJF:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CWE:4,CDS:4,IS:8,CP:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Highlander' unitType='Mek'>
 		<availability>CC:5,MOC:4,LA:4,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
-		<model name='HGN-732b'>
-			<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
-		</model>
 		<model name='HGN-734'>
 			<availability>LA:6,ROS:6,MERC:6</availability>
 		</model>
-		<model name='HGN-738'>
-			<availability>LA:8,ROS:8</availability>
+		<model name='HGN-732b'>
+			<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
 		</model>
 		<model name='HGN-732'>
 			<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+		</model>
+		<model name='HGN-738'>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hippogriff' unitType='ProtoMek'>
@@ -8232,7 +8232,7 @@
 	</chassis>
 	<chassis name='Hiryo Armored Infantry Transport' unitType='Tank'>
 		<availability>DC:5</availability>
-		<model name='(MRM)'>
+		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8240,7 +8240,7 @@
 			<roles>recon,apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Light PPC)'>
+		<model name='(MRM)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
@@ -8266,11 +8266,11 @@
 	</chassis>
 	<chassis name='Hitotsume Kozo' unitType='Mek'>
 		<availability>DC.GHO:7,DC:6</availability>
-		<model name='HKZ-1P'>
-			<availability>General:8</availability>
-		</model>
 		<model name='HKZ-1F'>
 			<availability>DC.GHO:6,General:4</availability>
+		</model>
+		<model name='HKZ-1P'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander III' unitType='Mek'>
@@ -8287,11 +8287,11 @@
 	</chassis>
 	<chassis name='Hollander II' unitType='Mek'>
 		<availability>LA:6,MERC:5,FS:5</availability>
-		<model name='BZK-F5'>
-			<availability>General:8</availability>
-		</model>
 		<model name='BZK-F7'>
 			<availability>General:6</availability>
+		</model>
+		<model name='BZK-F5'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hollander' unitType='Mek'>
@@ -8305,18 +8305,18 @@
 	</chassis>
 	<chassis name='Hornet' unitType='Mek'>
 		<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+		<model name='HNT-182'>
+			<availability>FVC:4,FS.PMM:4,FS.CMM:4,FS.DMM:4,FS.CrMM:4</availability>
+		</model>
+		<model name='HNT-181'>
+			<availability>FVC:6,FS.PMM:6,FS.CMM:6,FS.DMM:6,FS.CrMM:6</availability>
+		</model>
 		<model name='HNT-151'>
 			<roles>recon,urban</roles>
 			<availability>General:1-</availability>
 		</model>
 		<model name='HNT-171'>
 			<availability>FVC:8,FS:6,MERC:8</availability>
-		</model>
-		<model name='HNT-181'>
-			<availability>FVC:6,FS.PMM:6,FS.CMM:6,FS.DMM:6,FS.CrMM:6</availability>
-		</model>
-		<model name='HNT-182'>
-			<availability>FVC:4,FS.PMM:4,FS.CMM:4,FS.DMM:4,FS.CrMM:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hound' unitType='Mek'>
@@ -8340,13 +8340,13 @@
 	</chassis>
 	<chassis name='Huitzilopochtli Assault Tank &apos;Huey&apos;' unitType='Tank'>
 		<availability>ROS:4,CLAN:5</availability>
-		<model name='(AAA)'>
-			<roles>missile_artillery,anti_aircraft</roles>
-			<availability>CHH:4,RD:5,RA:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>missile_artillery</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(AAA)'>
+			<roles>missile_artillery,anti_aircraft</roles>
+			<availability>CHH:4,RD:5,RA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Humming Bird VTOL' unitType='VTOL'>
@@ -8358,37 +8358,39 @@
 	</chassis>
 	<chassis name='Hunchback IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.WD:3,RD:4,CDS:7,CP:7,CJF:4,CWIE:3,RA:4</availability>
-		<model name='3'>
-			<availability>RA:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:8,CP:8,RA:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8,RA:2</availability>
 		</model>
+		<model name='3'>
+			<availability>RA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Hunchback' unitType='Mek'>
 		<availability>MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
-		<model name='HBK-6S'>
-			<availability>LA:8,ROS:6,MERC:6</availability>
-		</model>
-		<model name='HBK-7S'>
-			<roles>spotter</roles>
-			<availability>LA:4</availability>
-		</model>
-		<model name='HBK-5P'>
-			<availability>ROS:6,FWL:8,MERC:4,CP:8</availability>
-		</model>
-		<model name='HBK-7R'>
-			<roles>spotter</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='HBK-5SS'>
 			<availability>LA:8</availability>
 		</model>
 		<model name='HBK-4G'>
 			<availability>Periphery:2-</availability>
+		</model>
+		<model name='HBK-6S'>
+			<availability>LA:8,ROS:6,MERC:6</availability>
+		</model>
+		<model name='HBK-7R'>
+			<roles>spotter</roles>
+			<availability>ROS:8</availability>
+		</model>
+		<model name='HBK-5P'>
+			<availability>ROS:6,FWL:8,MERC:4,CP:8</availability>
+		</model>
+		<model name='HBK-5H'>
+			<availability>FVC:3,MH:6,Periphery:4</availability>
+		</model>
+		<model name='HBK-5N'>
+			<availability>MOC:3,CC:3,FWL:4,MERC:3,CP:4,CDP:3,TC:3</availability>
 		</model>
 		<model name='HBK-4P'>
 			<availability>Periphery:2-</availability>
@@ -8399,11 +8401,9 @@
 		<model name='HBK-6N'>
 			<availability>ROS:3,FWL:2,MH:4,MERC:3,CP:2,DC:3</availability>
 		</model>
-		<model name='HBK-5H'>
-			<availability>FVC:3,MH:6,Periphery:4</availability>
-		</model>
-		<model name='HBK-5N'>
-			<availability>MOC:3,CC:3,FWL:4,MERC:3,CP:4,CDP:3,TC:3</availability>
+		<model name='HBK-7S'>
+			<roles>spotter</roles>
+			<availability>LA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Hunter Jumpship' unitType='Jumpship'>
@@ -8417,26 +8417,32 @@
 	</chassis>
 	<chassis name='Hunter Light Support Tank' unitType='Tank'>
 		<availability>MOC:2,CC:4,IS:3,MERC:3,FS:3,CP:2,Periphery:3,TC:3,RA.OA:3,LA:5,ROS:2,FWL:2,DC:2</availability>
-		<model name='(LPL)'>
-			<availability>LA:3,FS:2</availability>
+		<model name='(ERLL)'>
+			<availability>LA:4,FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:1-</availability>
 		</model>
-		<model name='(ERLL)'>
-			<availability>LA:4,FS:4</availability>
-		</model>
-		<model name='(Amphibious)'>
-			<availability>LA:2,MERC:2</availability>
-		</model>
 		<model name='(3054 Upgrade)'>
 			<roles>fire_support</roles>
 			<availability>RF:6,LA:8,ROS:6,FWL:4,FS:6,MERC:6,DA:6,CP:4</availability>
 		</model>
+		<model name='(LPL)'>
+			<availability>LA:3,FS:2</availability>
+		</model>
+		<model name='(Amphibious)'>
+			<availability>LA:2,MERC:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Huron Warrior' unitType='Mek'>
 		<availability>CC:7,MOC:6,FWL:5,MERC:2,CP:5,TC:6</availability>
+		<model name='HUR-WO-R4O'>
+			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
+		</model>
+		<model name='HUR-WO-R4L'>
+			<availability>General:8</availability>
+		</model>
 		<model name='HUR-WO-R4M'>
 			<availability>CC:4,MOC:4,FWL:5,CP:5</availability>
 		</model>
@@ -8444,42 +8450,36 @@
 			<roles>fire_support</roles>
 			<availability>CC:6</availability>
 		</model>
-		<model name='HUR-WO-R4L'>
-			<availability>General:8</availability>
-		</model>
-		<model name='HUR-WO-R4O'>
-			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Huscarl' unitType='Aero' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,MERC:4,FS:4,CP:4,DC:4</availability>
-		<model name='HSCL-1-OD'>
-			<availability>General:4</availability>
+		<model name='HSCL-1-OR'>
+			<availability>CLAN:8,IS:3+</availability>
 		</model>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
 		</model>
-		<model name='HSCL-1-OA'>
+		<model name='HSCL-1-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OB'>
+		<model name='HSCL-1-OD'>
+			<availability>General:4</availability>
+		</model>
+		<model name='HSCL-1-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='HSCL-1-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='HSCL-1-OR'>
-			<availability>CLAN:8,IS:3+</availability>
-		</model>
 	</chassis>
 	<chassis name='Hussar' unitType='Mek'>
 		<availability>ROS:2,CLAN:3</availability>
-		<model name='HSR-400-D'>
-			<availability>LA:8,ROS:8,MERC:8</availability>
-		</model>
 		<model name='HSR-200-D'>
 			<roles>recon</roles>
 			<availability>General:8,CLAN:6,MERC.SI:4,BAN:8</availability>
+		</model>
+		<model name='HSR-400-D'>
+			<availability>LA:8,ROS:8,MERC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Hwacha Urban Combat Vehicle' unitType='Tank'>
@@ -8491,25 +8491,25 @@
 	</chassis>
 	<chassis name='Hydaspes' unitType='Aero'>
 		<availability>CLAN:6,RA:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Algar)'>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='2'>
-			<availability>CLAN:6</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:8,CLAN:6,CJF:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
+		<model name='2'>
+			<availability>CLAN:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Hydra' unitType='ProtoMek'>
 		<availability>CHH:5</availability>
-		<model name='(Standard)'>
+		<model name='2'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='2'>
+		<model name='(Standard)'>
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
@@ -8522,11 +8522,8 @@
 	</chassis>
 	<chassis name='IS Standard Battle Armor' unitType='BattleArmor'>
 		<availability>CC:2,MOC:8,LA:1,ROS:4,IS:8,FWL:3,MH:8,CP:3,TC:8</availability>
-		<model name='[SRM]' mechanized='true'>
-			<availability>General:7</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[MG]' mechanized='true'>
+			<availability>General:8</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<availability>General:6</availability>
@@ -8534,8 +8531,11 @@
 		<model name='[LRR]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
-			<availability>General:8</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[SRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Icarus II' unitType='Mek'>
@@ -8560,11 +8560,11 @@
 		<model name='C'>
 			<availability>MERC.WD:3,CLAN:8</availability>
 		</model>
-		<model name='IMP-3E'>
-			<availability>MERC.WD:6</availability>
-		</model>
 		<model name='IMP-4E'>
 			<availability>MERC.WD:6,MERC.KH:8</availability>
+		</model>
+		<model name='IMP-3E'>
+			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Impavido Destroyer' unitType='Warship'>
@@ -8589,23 +8589,23 @@
 	</chassis>
 	<chassis name='Indra Infantry Transport' unitType='Tank'>
 		<availability>CHH:7,CLAN:5</availability>
-		<model name='(BA)'>
-			<availability>CWE:6,CJF:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(BA)'>
+			<availability>CWE:6,CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Infiltrator Mk. II Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,FS:4,TC:3</availability>
-		<model name='(Sensor)' mechanized='true'>
-			<availability>FS:4</availability>
+		<model name='&apos;Puma&apos;' mechanized='true'>
+			<availability>FS:8,TC:8</availability>
 		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>ROS:4,FS:4</availability>
 		</model>
-		<model name='&apos;Puma&apos;' mechanized='true'>
-			<availability>FS:8,TC:8</availability>
+		<model name='(Sensor)' mechanized='true'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Marine)' mechanized='true'>
 			<roles>marine</roles>
@@ -8614,21 +8614,21 @@
 	</chassis>
 	<chassis name='Interdictor Pocket Warship' unitType='Dropship'>
 		<availability>CC:4,LA:4,ROS:5,FWL:4,FS:4,CP:4,DC:4</availability>
-		<model name='(SCC)'>
-			<roles>assault</roles>
-			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
-		</model>
 		<model name='(3115)'>
 			<roles>assault</roles>
 			<availability>ROS:6</availability>
 		</model>
-		<model name='(Sub-Capital)'>
-			<roles>assault</roles>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>assault</roles>
 			<availability>CC:8,ROS:4,FWL:8,CP:8</availability>
+		</model>
+		<model name='(SCC)'>
+			<roles>assault</roles>
+			<availability>LA:8,ROS:8,FS:8,DC:8</availability>
+		</model>
+		<model name='(Sub-Capital)'>
+			<roles>assault</roles>
+			<availability>ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Intruder' unitType='Dropship'>
@@ -8644,29 +8644,29 @@
 	</chassis>
 	<chassis name='Invader Jumpship' unitType='Jumpship'>
 		<availability>MOC:8,CC:9,CLAN:9,IS:7,Periphery.Deep:6,FS:9,CP:9,BAN:6,Periphery:8,TC:8,RA.OA:8,LA:9,PIR:5,FWL:9</availability>
-		<model name='(2631 PPC)'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(2631)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(2850)'>
-			<availability>CLAN:6</availability>
+		<model name='(2631 PPC)'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(2631) (LF)'>
+			<availability>CLAN:6</availability>
+		</model>
+		<model name='(2850)'>
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ironhold Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CJF:5</availability>
-		<model name='(Fire)' mechanized='false'>
-			<availability>General:6</availability>
+		<model name='(Standard)' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Tank)' mechanized='false'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='(Fire)' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Isegrim Assault DropShip' unitType='Dropship'>
@@ -8707,15 +8707,15 @@
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>General:8</availability>
 		</model>
-		<model name='K-27 &apos;Killjoy&apos;'>
-			<roles>support</roles>
-			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
-		</model>
 		<model name='(Fusion)'>
 			<roles>support</roles>
 			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
 			<availability>CLAN:2,IS:2</availability>
+		</model>
+		<model name='K-27 &apos;Killjoy&apos;'>
+			<roles>support</roles>
+			<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
+			<availability>FVC:2,LA:2,ROS:3,FS:3</availability>
 		</model>
 		<model name='(Armor)'>
 			<roles>support</roles>
@@ -8732,11 +8732,11 @@
 	</chassis>
 	<chassis name='JES I Tactical Missile Carrier' unitType='Tank'>
 		<availability>RD:3,IS:4,TC:4,Periphery:4</availability>
-		<model name='(Standard)'>
-			<availability>TC:2</availability>
-		</model>
 		<model name='(3082 Upgrade)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
@@ -8756,17 +8756,13 @@
 	</chassis>
 	<chassis name='JES III Missile Carrier' unitType='Tank'>
 		<availability>IS:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Thunderbolt)'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Speed)'>
+		<model name='(Standard)'>
 			<roles>fire_support</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(MML)'>
 			<roles>fire_support</roles>
@@ -8776,16 +8772,20 @@
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='(Speed)'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='JI2A1 Attack APC' unitType='Tank'>
 		<availability>CC:4,FVC:5,ROS:4,FS:6,MERC:4</availability>
-		<model name='(MML)'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(MML)'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jabberwocky ConstructionMech' unitType='Mek'>
@@ -8826,10 +8826,6 @@
 	</chassis>
 	<chassis name='Jackalope' unitType='Mek'>
 		<availability>ROS:6,MERC:4</availability>
-		<model name='JLP-KA'>
-			<roles>recon</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='JLP-BD'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
@@ -8842,48 +8838,52 @@
 			<roles>recon</roles>
 			<availability>General:3</availability>
 		</model>
+		<model name='JLP-KA'>
+			<roles>recon</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Jade Hawk' unitType='Mek'>
 		<availability>MERC:5,CJF:5</availability>
-		<model name='JHK-04'>
-			<availability>MERC:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
+		<model name='JHK-04'>
+			<availability>MERC:4</availability>
 		</model>
 		<model name='JHK-03'>
 			<availability>MERC:8</availability>
 		</model>
+		<model name='3'>
+			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CJF:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
 		<availability>CWE:8,CLAN:6</availability>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='X'>
+			<roles>ew_support</roles>
+			<availability>CWE:2,General:1</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:5,General:2,RA:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:4,CLAN:2,RA:6</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='C'>
 			<availability>General:5</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CLAN:2,RA:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='X'>
-			<roles>ew_support</roles>
-			<availability>CWE:2,General:1</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='JagerMech III' unitType='Mek'>
@@ -8897,35 +8897,16 @@
 	</chassis>
 	<chassis name='JagerMech' unitType='Mek'>
 		<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
-		<model name='JM6-DD'>
-			<roles>anti_aircraft</roles>
-			<availability>MOC:6,RA.OA:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
-		</model>
-		<model name='JM7-G'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='JM7-C3BS'>
-			<roles>anti_aircraft</roles>
-			<availability>FS:2</availability>
-		</model>
 		<model name='JM6-S'>
 			<roles>anti_aircraft</roles>
 			<availability>Periphery:4</availability>
 		</model>
-		<model name='JM6-DGr'>
-			<roles>anti_aircraft</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:1,MERC:2,CDP:3,DC:2</availability>
+		<model name='JM6-DG'>
+			<availability>General:1</availability>
 		</model>
 		<model name='JM7-D'>
 			<roles>anti_aircraft</roles>
 			<availability>ROS:5,FS:3,MERC:6</availability>
-		</model>
-		<model name='JM7-F'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:4,FS:4</availability>
-		</model>
-		<model name='JM6-DG'>
-			<availability>General:1</availability>
 		</model>
 		<model name='JM6-DDa'>
 			<roles>anti_aircraft</roles>
@@ -8935,27 +8916,42 @@
 			<roles>anti_aircraft</roles>
 			<availability>FVC:2,PIR:2,MH:6,Periphery:2</availability>
 		</model>
+		<model name='JM7-F'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:4,FS:4</availability>
+		</model>
+		<model name='JM6-DGr'>
+			<roles>anti_aircraft</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:1,MERC:2,CDP:3,DC:2</availability>
+		</model>
+		<model name='JM7-C3BS'>
+			<roles>anti_aircraft</roles>
+			<availability>FS:2</availability>
+		</model>
+		<model name='JM7-G'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='JM6-DD'>
+			<roles>anti_aircraft</roles>
+			<availability>MOC:6,RA.OA:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Jaguar' unitType='Mek'>
 		<availability>LA:5,ROS:5,FS:4,CJF:4,CWIE:5</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Javelin' unitType='Mek'>
 		<availability>MOC:3,FVC:6,Periphery.HR:3,ROS:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3,TC:3</availability>
-		<model name='JVN-11D'>
+		<model name='JVN-10P'>
 			<roles>recon</roles>
-			<availability>ROS:6,FS:6</availability>
-		</model>
-		<model name='JVN-11A &apos;Fire Javelin&apos;'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:2,MERC:6,CDP:6,TC:6</availability>
 		</model>
 		<model name='JVN-11F'>
 			<roles>recon</roles>
@@ -8965,12 +8961,16 @@
 			<roles>recon</roles>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='JVN-11A &apos;Fire Javelin&apos;'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:2,ROS:2,FS:2,MERC:2,CDP:2</availability>
+		</model>
 		<model name='JVN-11P'>
 			<availability>FVC:6</availability>
 		</model>
-		<model name='JVN-10P'>
+		<model name='JVN-11D'>
 			<roles>recon</roles>
-			<availability>MOC:6,LA:6,Periphery.HR:6,PIR:6,FS:2,MERC:6,CDP:6,TC:6</availability>
+			<availability>ROS:6,FS:6</availability>
 		</model>
 		<model name='JVN-11B'>
 			<roles>recon</roles>
@@ -8979,14 +8979,14 @@
 	</chassis>
 	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
 		<availability>CWE:8,RD:9,CLAN:6,CWIE:7</availability>
-		<model name='B'>
-			<availability>General:4</availability>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
-		<model name='A'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -8994,67 +8994,59 @@
 		<model name='X'>
 			<availability>General:1,CJF:2,RA:2</availability>
 		</model>
-		<model name='C'>
-			<availability>General:4</availability>
-		</model>
 		<model name='F'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
+		<model name='C'>
+			<availability>General:4</availability>
+		</model>
+		<model name='B'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner IIC' unitType='Mek'>
 		<availability>CWE:6,CDS:6,ROS:4,CP:7,DC:3</availability>
-		<model name='4'>
-			<availability>CDS:8,IS:8,CP:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CWE:2,CP:3</availability>
+		</model>
+		<model name='4'>
+			<availability>CDS:8,IS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jenner' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:5,FS.DMM:5,MERC:4,Periphery.OS:5,FS:4,RA:4,DC:8,Periphery:3</availability>
-		<model name='JR7-K'>
+		<model name='JR7-C4'>
 			<roles>raider</roles>
-			<availability>MOC:2,RA.OA:2,MERC:2,RA:2,DC:1,TC:2</availability>
-		</model>
-		<model name='JR7-D'>
-			<roles>raider</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='JR7-C2'>
-			<roles>raider</roles>
-			<availability>ROS:4,DC:8</availability>
-		</model>
-		<model name='JR7-C3'>
-			<roles>raider</roles>
-			<availability>ROS:5,MERC:5,DC:6</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='JR7-F'>
 			<roles>raider</roles>
 			<availability>FS.DMM:1,DC:2</availability>
 		</model>
+		<model name='JR7-D'>
+			<roles>raider</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='JR7-C3'>
+			<roles>raider</roles>
+			<availability>ROS:5,MERC:5,DC:6</availability>
+		</model>
+		<model name='JR7-K'>
+			<roles>raider</roles>
+			<availability>MOC:2,RA.OA:2,MERC:2,RA:2,DC:1,TC:2</availability>
+		</model>
 		<model name='JR7-C'>
 			<roles>raider</roles>
 			<availability>MERC:4,FS:4,DC:2</availability>
 		</model>
-		<model name='JR7-C4'>
+		<model name='JR7-C2'>
 			<roles>raider</roles>
-			<availability>DC:4</availability>
+			<availability>ROS:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Jifty Transportable Field Repair Unit' unitType='Tank'>
 		<availability>CC:4,FS:6,TC:4</availability>
-		<model name='JI-50 (Q-Vehicle)'>
-			<roles>support</roles>
-			<availability>TC:2</availability>
-		</model>
-		<model name='JI-50'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='JI-50 (ML)'>
+		<model name='JI-50 (Hoist)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9062,21 +9054,29 @@
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='JI-50 (Hoist)'>
+		<model name='JI-50'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='JI-50 (Q-Vehicle)'>
+			<roles>support</roles>
+			<availability>TC:2</availability>
+		</model>
+		<model name='JI-50 (ML)'>
 			<roles>support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Jinggau' unitType='Mek'>
 		<availability>CC:6,MOC:5,TC:4</availability>
-		<model name='JN-G8A'>
-			<availability>General:8</availability>
+		<model name='JN-G9CC'>
+			<availability>CC:3</availability>
 		</model>
 		<model name='JN-G7L'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='JN-G9CC'>
-			<availability>CC:3</availability>
+		<model name='JN-G8A'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Joust Medium Tank' unitType='Tank'>
@@ -9098,11 +9098,11 @@
 	</chassis>
 	<chassis name='Jump Platoon' unitType='Infantry'>
 		<availability>IS:8,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
@@ -9114,8 +9114,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(LRM)'>
-			<availability>General:5</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -9135,32 +9135,31 @@
 		<model name='2'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='3'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='4'>
 			<availability>CJF:6</availability>
 		</model>
+		<model name='3'>
+			<availability>CJF:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Kabuto' unitType='Mek'>
 		<availability>ROS:4,DC:5</availability>
-		<model name='KBO-7B'>
+		<model name='KBO-7A'>
 			<availability>General:6</availability>
 		</model>
-		<model name='KBO-7A'>
+		<model name='KBO-7B'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Kage Light Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:3,DC:4</availability>
-		<model name='[ECM]' mechanized='true'>
-			<roles>recon</roles>
-			<availability>MERC:2,DC:5</availability>
+		<model name='C' mechanized='true'>
+			<availability>DC:3</availability>
 		</model>
-		<model name='(DEST)' mechanized='true'>
+		<model name='(Vibro-Claw)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
@@ -9168,28 +9167,29 @@
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C' mechanized='true'>
-			<availability>DC:3</availability>
+		<model name='[MG]' mechanized='true'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='[TAG]' mechanized='true'>
+			<roles>recon,spotter</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='[Laser]' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='[MG]' mechanized='true'>
+		<model name='(DEST)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:8</availability>
+			<availability>DC:4</availability>
 		</model>
 		<model name='(Space)' mechanized='true'>
 			<roles>marine</roles>
 			<availability>ROS:2,DC:2</availability>
 		</model>
-		<model name='(Vibro-Claw)' mechanized='true'>
+		<model name='[ECM]' mechanized='true'>
 			<roles>recon</roles>
-			<availability>DC:4</availability>
-		</model>
-		<model name='[TAG]' mechanized='true'>
-			<roles>recon,spotter</roles>
-			<availability>General:5</availability>
+			<availability>MERC:2,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kalki Cruise Missile Launcher' unitType='Tank'>
@@ -9210,6 +9210,13 @@
 	</chassis>
 	<chassis name='Kanazuchi Assault Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
+		<model name='[Battle Claw]' mechanized='false'>
+			<availability>General:6</availability>
+		</model>
+		<model name='[Salvage Arm]' mechanized='false'>
+			<roles>support</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='[Industrial Drill]' mechanized='false'>
 			<roles>support</roles>
 			<availability>General:4</availability>
@@ -9217,18 +9224,12 @@
 		<model name='(Upgrade) [Battle Claw]' mechanized='false'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Salvage Arm]' mechanized='false'>
-			<roles>support</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='[Battle Claw]' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Karhu' unitType='Mek' omni='Clan'>
 		<availability>RD:8</availability>
-		<model name='A'>
-			<availability>General:7</availability>
+		<model name='G'>
+			<roles>spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
@@ -9236,15 +9237,14 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='G'>
-			<roles>spotter</roles>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Karnov UR Gunship' unitType='VTOL'>
@@ -9259,22 +9259,22 @@
 			<roles>cargo</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(3055 Upgrade)'>
-			<roles>cargo</roles>
-			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
-		</model>
 		<model name='(AC)'>
 			<availability>MH:2,MERC:2</availability>
 		</model>
-		<model name='(BA)'>
-			<roles>apc</roles>
-			<availability>FWL:5,IS:6,CP:5</availability>
+		<model name='(Periphery)'>
+			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
 		</model>
 		<model name='(Heavy Stealth)'>
 			<availability>PIR:4</availability>
 		</model>
-		<model name='(Periphery)'>
-			<availability>MOC:5,CC:5,RA.OA:5,FVC:5,PIR:7,MH:6,DA:5,Periphery:5,TC:5</availability>
+		<model name='(3055 Upgrade)'>
+			<roles>cargo</roles>
+			<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='(BA)'>
+			<roles>apc</roles>
+			<availability>FWL:5,IS:6,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Katana (Crockett)' unitType='Mek'>
@@ -9282,12 +9282,12 @@
 		<model name='CRK-5003-CJ'>
 			<availability>DC.GR:8,DC:8</availability>
 		</model>
+		<model name='CRK-5003-C'>
+			<availability>DC:4</availability>
+		</model>
 		<model name='CRK-5003-CM'>
 			<roles>spotter</roles>
 			<availability>DC:7</availability>
-		</model>
-		<model name='CRK-5003-C'>
-			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kelswa Assault Tank' unitType='Tank'>
@@ -9302,21 +9302,21 @@
 			<roles>specops</roles>
 			<availability>MERC.WD:6,IS:4</availability>
 		</model>
+		<model name='(ML)'>
+			<availability>IS:4</availability>
+		</model>
+		<model name='(Clan)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(SL)'>
 			<availability>IS:2</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>IS:3</availability>
 		</model>
-		<model name='(Clan)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(MedEvac)'>
 			<roles>support</roles>
 			<availability>IS:2</availability>
-		</model>
-		<model name='(ML)'>
-			<availability>IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Kheper' unitType='Mek'>
@@ -9330,8 +9330,17 @@
 		<model name='KGC-001'>
 			<availability>LA:1,IS:3,MH:6</availability>
 		</model>
+		<model name='KGC-000b'>
+			<availability>ROS:6,CLAN:4,BAN:2,DC:6</availability>
+		</model>
+		<model name='KGC-007'>
+			<availability>LA:2,ROS:8,FS:8,MERC:8</availability>
+		</model>
 		<model name='KGC-008B'>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='KGC-000'>
+			<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
 		</model>
 		<model name='KGC-005r'>
 			<availability>ROS:4,MERC:4</availability>
@@ -9339,41 +9348,32 @@
 		<model name='KGC-009'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='KGC-000b'>
-			<availability>ROS:6,CLAN:4,BAN:2,DC:6</availability>
-		</model>
-		<model name='KGC-000'>
-			<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
-		</model>
-		<model name='KGC-007'>
-			<availability>LA:2,ROS:8,FS:8,MERC:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
 		<availability>RD:6,CDS:3,ROS:3+,CP:2,RA:3</availability>
 		<model name='C'>
 			<availability>RD:3,General:5</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:5,General:6</availability>
-		</model>
 		<model name='E'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4,IS:2</availability>
+		<model name='D'>
+			<availability>RD:5,General:6</availability>
 		</model>
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='F'>
+			<availability>CLAN:4,IS:2</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Kinnol MBT' unitType='Tank'>
@@ -9381,20 +9381,20 @@
 		<model name='(PPC)'>
 			<availability>General:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(RAC)'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kintaro' unitType='Mek'>
 		<availability>DC.GHO:5,ROS:6,MERC:2,DC:2</availability>
+		<model name='KTO-C'>
+			<availability>MERC:6,DC:5</availability>
+		</model>
 		<model name='KTO-19'>
 			<availability>DC.GHO:2,DC.SL:4,ROS:3,CLAN:6,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
-		</model>
-		<model name='KTO-19b'>
-			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
 		<model name='KTO-K'>
 			<availability>DC:8</availability>
@@ -9402,29 +9402,29 @@
 		<model name='KTO-20'>
 			<availability>MERC:2,DC:2</availability>
 		</model>
-		<model name='KTO-C'>
-			<availability>MERC:6,DC:5</availability>
+		<model name='KTO-19b'>
+			<availability>ROS:6,CLAN:4,FS:6,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:4</availability>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
 		<model name='E'>
 			<availability>General:4</availability>
-		</model>
-		<model name='D'>
-			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Kirishima Cruiser' unitType='Warship'>
@@ -9478,6 +9478,9 @@
 	</chassis>
 	<chassis name='Kodiak' unitType='Mek'>
 		<availability>RD:6,ROS:4,RA:5</availability>
+		<model name='5'>
+			<availability>RD:4</availability>
+		</model>
 		<model name='3'>
 			<roles>anti_aircraft</roles>
 			<availability>RA:5</availability>
@@ -9487,9 +9490,6 @@
 		</model>
 		<model name='4'>
 			<availability>RD:4,ROS:4</availability>
-		</model>
-		<model name='5'>
-			<availability>RD:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
@@ -9501,9 +9501,6 @@
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='KIM-2C'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='KIM-2'>
 			<roles>spotter,anti_infantry</roles>
 			<availability>General:8,DC:2</availability>
@@ -9512,14 +9509,14 @@
 			<roles>spotter</roles>
 			<availability>DC:1</availability>
 		</model>
+		<model name='KIM-2C'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Kopis Assault Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
-		<model name='(AI Mk IIr)' mechanized='false'>
-			<availability>FWL:4,MERC:3,CP:4</availability>
-		</model>
-		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
-			<availability>General:8</availability>
+		<model name='(AI Mk II)' mechanized='false'>
+			<availability>FWL:5,MERC:4,CP:5</availability>
 		</model>
 		<model name='(Mortar)' mechanized='false'>
 			<availability>FWL:4,MERC:3,CP:4</availability>
@@ -9528,8 +9525,11 @@
 			<roles>anti_infantry</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(AI Mk II)' mechanized='false'>
-			<availability>FWL:5,MERC:4,CP:5</availability>
+		<model name='(AI Mk IIr)' mechanized='false'>
+			<availability>FWL:4,MERC:3,CP:4</availability>
+		</model>
+		<model name='&apos;The Dark Alley&apos;' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Koroshiya' unitType='Aero'>
@@ -9540,48 +9540,52 @@
 	</chassis>
 	<chassis name='Koschei' unitType='Mek'>
 		<availability>MOC:5,CC:4,ROS:3,MERC:4,CC.TG:6</availability>
-		<model name='KSC-5X'>
-			<roles>urban</roles>
-			<availability>MERC:5</availability>
-		</model>
 		<model name='KSC-4I'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='KSC-4L'>
 			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='KSC-5I'>
 			<availability>ROS:8,MERC:8</availability>
 		</model>
+		<model name='KSC-5MC'>
+			<availability>MOC:8,CC:8,MERC:4</availability>
+		</model>
+		<model name='KSC-5X'>
+			<roles>urban</roles>
+			<availability>MERC:5</availability>
+		</model>
+		<model name='KSC-4L'>
+			<availability>ROS:6,MERC:4</availability>
+		</model>
 		<model name='KSC-6L'>
 			<roles>artillery</roles>
 			<availability>CC:6,MOC:6</availability>
 		</model>
-		<model name='KSC-5MC'>
-			<availability>MOC:8,CC:8,MERC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,CHH:3,MERC.WD:3,CDS:3,IS:4+,CP:3,CJF:2,BAN:4,RA:3</availability>
+		<model name='H'>
+			<roles>recon</roles>
+			<availability>General:2,CP:3</availability>
+		</model>
+		<model name='P'>
+			<roles>recon</roles>
+			<availability>CLAN:2,IS:2</availability>
+		</model>
 		<model name='C'>
 			<roles>recon</roles>
 			<availability>CWE:7,RD:8,CDS:3,General:4,CP:3</availability>
 		</model>
-		<model name='D'>
-			<roles>recon</roles>
-			<availability>CWE:7,RD:2,CDS:5,General:3,CP:3,CJF:2,CWIE:7</availability>
-		</model>
-		<model name='E'>
-			<roles>recon</roles>
+		<model name='F'>
+			<roles>recon,spotter</roles>
 			<availability>CLAN:5,IS:3</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>RD:6,CDS:9,General:8,CP:7</availability>
 		</model>
 		<model name='A'>
 			<roles>recon,spotter</roles>
 			<availability>CWE:4,RD:4,CDS:7,General:5,CP:7,CWIE:4</availability>
-		</model>
-		<model name='F'>
-			<roles>recon,spotter</roles>
-			<availability>CLAN:5,IS:3</availability>
 		</model>
 		<model name='G'>
 			<roles>recon,anti_infantry</roles>
@@ -9591,22 +9595,18 @@
 			<roles>recon</roles>
 			<availability>CWE:6,RD:5,CDS:6,General:5,CP:6,CWIE:5</availability>
 		</model>
-		<model name='P'>
+		<model name='D'>
 			<roles>recon</roles>
-			<availability>CLAN:2,IS:2</availability>
+			<availability>CWE:7,RD:2,CDS:5,General:3,CP:3,CJF:2,CWIE:7</availability>
 		</model>
-		<model name='Prime'>
+		<model name='E'>
 			<roles>recon</roles>
-			<availability>RD:6,CDS:9,General:8,CP:7</availability>
-		</model>
-		<model name='H'>
-			<roles>recon</roles>
-			<availability>General:2,CP:3</availability>
+			<availability>CLAN:5,IS:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Koshi' unitType='Mek'>
 		<availability>CLAN:6,IS:5</availability>
-		<model name='(Standard) 2'>
+		<model name='(Standard) 3'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9614,7 +9614,7 @@
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard) 3'>
+		<model name='(Standard) 2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
@@ -9650,12 +9650,12 @@
 	</chassis>
 	<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
 		<availability>CWE:4,CHH:6,RD:6,CP:2,CJF:4,RA:6</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(IFV) &apos;Turhan II&apos;'>
 			<roles>apc</roles>
 			<availability>CHH:8,CJF:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kuan Ti' unitType='Dropship'>
@@ -9670,11 +9670,11 @@
 		<model name='4'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Kyudo' unitType='Mek'>
@@ -9709,14 +9709,14 @@
 	</chassis>
 	<chassis name='Lament' unitType='Mek'>
 		<availability>ROS:6</availability>
+		<model name='LMT-4RC'>
+			<availability>General:3</availability>
+		</model>
 		<model name='LMT-3C'>
 			<availability>General:5</availability>
 		</model>
 		<model name='LMT-2R'>
 			<availability>General:8</availability>
-		</model>
-		<model name='LMT-4RC'>
-			<availability>General:3</availability>
 		</model>
 		<model name='LMT-3R'>
 			<availability>General:5</availability>
@@ -9741,33 +9741,33 @@
 	</chassis>
 	<chassis name='Lancer' unitType='Aero'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
-		<model name='LX-2'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LX-2A'>
 			<availability>RF:5,LA:5,ROS:5,FWL:5,MERC:5,DA:5,CP:5</availability>
 		</model>
 		<model name='LX-3'>
 			<availability>IS:4,MERC:0</availability>
 		</model>
+		<model name='LX-2'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Lao Hu' unitType='Mek'>
 		<availability>CC:8,MOC:6,FS:4,TC:4</availability>
-		<model name='LHU-3C'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
-		<model name='LHU-2B'>
-			<availability>MOC:8,CC:8,TC:8</availability>
-		</model>
-		<model name='LHU-3B'>
-			<roles>spotter</roles>
-			<availability>CC:6,MOC:6</availability>
-		</model>
 		<model name='LHU-4E'>
 			<availability>CC:6</availability>
 		</model>
 		<model name='LHU-3L'>
 			<availability>CC:6,MOC:8,FS:8</availability>
+		</model>
+		<model name='LHU-2B'>
+			<availability>MOC:8,CC:8,TC:8</availability>
+		</model>
+		<model name='LHU-3C'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
+		<model name='LHU-3B'>
+			<roles>spotter</roles>
+			<availability>CC:6,MOC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Laser Carrier' unitType='Tank'>
@@ -9779,56 +9779,56 @@
 	</chassis>
 	<chassis name='Legionnaire' unitType='Mek'>
 		<availability>ROS:4,FS:8,MERC:4</availability>
-		<model name='LGN-2XU'>
-			<availability>FS:4</availability>
+		<model name='LGN-2K'>
+			<roles>raider</roles>
+			<availability>ROS:6</availability>
 		</model>
 		<model name='LGN-2F'>
 			<availability>FS:8</availability>
 		</model>
-		<model name='LGN-2D'>
-			<availability>General:8</availability>
+		<model name='LGN-1X'>
+			<availability>FS.CH:4,FS:1</availability>
 		</model>
-		<model name='LGN-2K'>
-			<roles>raider</roles>
-			<availability>ROS:6</availability>
+		<model name='LGN-2XU'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='LGN-2XA'>
 			<roles>missile_artillery</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='LGN-1X'>
-			<availability>FS.CH:4,FS:1</availability>
+		<model name='LGN-2D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leonidas Battle Armor' unitType='BattleArmor'>
 		<availability>CC:4,MOC:4,FWL:6,MH:4,MERC:4,CP:6</availability>
-		<model name='(MG)' mechanized='true'>
+		<model name='(Sensor)' mechanized='true'>
+			<roles>recon</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(David)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(FireDrake)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(TAG)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Sensor)' mechanized='true'>
-			<roles>recon</roles>
+		<model name='(FireDrake)' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
+		<model name='(MG)' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard CV' unitType='Dropship'>
 		<availability>RA.OA:8,IS:7,Periphery.Deep:5,MH:6,BAN:4,Periphery:7</availability>
-		<model name='(3054)'>
-			<roles>asf_carrier</roles>
-			<availability>CC:8,RF:8,LA:8,ROS:8,General:4,FWL:8,FS:8,DA:8,CP:8</availability>
-		</model>
 		<model name='(2581)'>
 			<roles>asf_carrier</roles>
 			<availability>General:5-</availability>
+		</model>
+		<model name='(3054)'>
+			<roles>asf_carrier</roles>
+			<availability>CC:8,RF:8,LA:8,ROS:8,General:4,FWL:8,FS:8,DA:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Leopard' unitType='Dropship'>
@@ -9885,27 +9885,27 @@
 	</chassis>
 	<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
 		<availability>General:6</availability>
-		<model name='Comet'>
-			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
-		</model>
-		<model name='Angel (Upgrade)'>
-			<availability>MOC:4,FWL:8,IS:4,CP:8</availability>
-		</model>
-		<model name='Owl III'>
-			<availability>LA:4,ROS:3,MERC:3</availability>
+		<model name='Owl'>
+			<availability>LA:1,ROS:1,MERC:1</availability>
 		</model>
 		<model name='Angel'>
 			<roles>recon</roles>
 			<availability>CC:2,Periphery.MW:3,General:2,Periphery.ME:3,FWL:1,DC:2,Periphery:4</availability>
 		</model>
-		<model name='Owl'>
-			<availability>LA:1,ROS:1,MERC:1</availability>
+		<model name='Comet'>
+			<availability>FVC:5,ROS:2,FS:5,MERC:1</availability>
 		</model>
 		<model name='Owl II'>
 			<availability>Periphery.R:2,LA:2</availability>
 		</model>
 		<model name='Suzume (&apos;Sparrow&apos;)'>
 			<availability>Periphery.DD:1,DC:5</availability>
+		</model>
+		<model name='Angel (Upgrade)'>
+			<availability>MOC:4,FWL:8,IS:4,CP:8</availability>
+		</model>
+		<model name='Owl III'>
+			<availability>LA:4,ROS:3,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Light Thunderbolt Carrier' unitType='Tank'>
@@ -9916,9 +9916,6 @@
 	</chassis>
 	<chassis name='Lightning Attack Hovercraft' unitType='Tank'>
 		<availability>CLAN:3,CJF:4</availability>
-		<model name='(ERSL)'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
@@ -9926,71 +9923,74 @@
 			<roles>spotter</roles>
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
+		<model name='(ERSL)'>
+			<availability>ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Lightning' unitType='Aero'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
-		<model name='LTN-G15b'>
-			<availability>CC:5,MOC:5,CLAN:3,IS:4,MERC:4</availability>
-		</model>
-		<model name='LTN-G16L'>
-			<availability>CC:6,MOC:6,RF:4,FWL:3,MERC:4,DA:6,CP:3</availability>
-		</model>
 		<model name='LTN-G15'>
 			<availability>General:2-</availability>
 		</model>
-		<model name='LTN-G16T'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='LTN-G16S'>
-			<availability>LA:6</availability>
+		<model name='LTN-G15b'>
+			<availability>CC:5,MOC:5,CLAN:3,IS:4,MERC:4</availability>
 		</model>
 		<model name='LTN-G16D'>
 			<availability>ROS:6,FS:6,MERC:4</availability>
 		</model>
+		<model name='LTN-G16L'>
+			<availability>CC:6,MOC:6,RF:4,FWL:3,MERC:4,DA:6,CP:3</availability>
+		</model>
+		<model name='LTN-G16T'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='LTN-G16O'>
 			<availability>RA.OA:6,FVC:4,CDP:4</availability>
+		</model>
+		<model name='LTN-G16S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Linebacker' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,MERC.KH:4+,CJF:4,RA:5,CWIE:6</availability>
-		<model name='B'>
-			<availability>RD:6,CDS:4,General:5,CP:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:6,RD:7,General:5,CWIE:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
-		</model>
 		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='Prime'>
-			<availability>RD:9,CDS:7,General:8,CP:7,CWIE:9</availability>
+		<model name='B'>
+			<availability>RD:6,CDS:4,General:5,CP:4</availability>
 		</model>
 		<model name='A'>
 			<availability>CWE:6,RD:6,General:7,CWIE:6</availability>
 		</model>
+		<model name='H'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
 		<model name='C'>
 			<availability>CWE:4,CHH:4,RD:5,General:3,CP:3,CJF:2,CWIE:5</availability>
 		</model>
-		<model name='H'>
+		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:9,CDS:7,General:8,CP:7,CWIE:9</availability>
+		</model>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:6,RD:7,General:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Lineholder' unitType='Mek'>
 		<availability>CC:4,ROS:4,FWL:4,IS:3,FS:5,CP:4,TC:6,Periphery:4</availability>
-		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
-			<availability>ROS:6,FS:7,MERC:6,CDP:4</availability>
-		</model>
 		<model name='KW1-LH3'>
 			<availability>General:2,FS:3</availability>
 		</model>
 		<model name='KW1-LH2'>
 			<availability>General:4,FS:2</availability>
+		</model>
+		<model name='KW1-LH8 &apos;Linebreaker&apos;'>
+			<availability>ROS:6,FS:7,MERC:6,CDP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Lion' unitType='Dropship'>
@@ -10020,90 +10020,90 @@
 	</chassis>
 	<chassis name='Locust IIC' unitType='Mek'>
 		<availability>CWE:7,CHH:6,RD:6,ROS:3,CJF:6,DC:3</availability>
-		<model name='4'>
-			<availability>CWE:5,CHH:5,LA:6,CJF:6</availability>
-		</model>
 		<model name='6'>
 			<availability>CWE:6,RD:6</availability>
-		</model>
-		<model name='5'>
-			<availability>CWE:4,CHH:4,RD:4,ROS:4</availability>
 		</model>
 		<model name='9'>
 			<availability>CJF:6</availability>
 		</model>
+		<model name='8'>
+			<availability>RD:6,ROS:5,DC:5</availability>
+		</model>
 		<model name='7'>
 			<availability>CHH:6,ROS:2</availability>
 		</model>
-		<model name='8'>
-			<availability>RD:6,ROS:5,DC:5</availability>
+		<model name='4'>
+			<availability>CWE:5,CHH:5,LA:6,CJF:6</availability>
 		</model>
 		<model name='2'>
 			<availability>CJF:2</availability>
 		</model>
+		<model name='5'>
+			<availability>CWE:4,CHH:4,RD:4,ROS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Locust' unitType='Mek'>
 		<availability>CLAN:2-,IS:6,Periphery:3</availability>
-		<model name='LCT-3M'>
+		<model name='LCT-6M'>
 			<roles>recon</roles>
-			<availability>MOC:2,RF:5,FWL:4,IS:2,MERC:4,DA:5,CP:4</availability>
+			<availability>ROS:2,FWL:4,MERC:3,CP:4</availability>
+		</model>
+		<model name='LCT-5M2'>
+			<availability>ROS:4,FWL:5,CP:5</availability>
 		</model>
 		<model name='LCT-5T'>
 			<roles>recon,anti_infantry</roles>
 			<availability>MOC:4,CC:4,FVC:5,TC:6</availability>
 		</model>
-		<model name='LCT-5M2'>
-			<availability>ROS:4,FWL:5,CP:5</availability>
-		</model>
-		<model name='LCT-5M'>
-			<roles>recon</roles>
-			<availability>FVC:2,ROS:4,PIR:4,FWL:2,CP:2</availability>
-		</model>
-		<model name='LCT-6M'>
-			<roles>recon</roles>
-			<availability>ROS:2,FWL:4,MERC:3,CP:4</availability>
-		</model>
-		<model name='LCT-5W2'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:6,CLAN:4,IS:4,FS:6,DC:6</availability>
+		<model name='LCT-5M3'>
+			<availability>ROS:5,FWL:4,CP:4</availability>
 		</model>
 		<model name='LCT-1Vb'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:4,CLAN:6,FWL:4,MERC:4,CP:4,BAN:2</availability>
 		</model>
-		<model name='LCT-5V'>
+		<model name='LCT-5M'>
 			<roles>recon</roles>
-			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
-		</model>
-		<model name='LCT-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
-		<model name='LCT-3S'>
-			<roles>recon</roles>
-			<availability>LA:8,MERC:6</availability>
-		</model>
-		<model name='LCT-5M3'>
-			<availability>ROS:5,FWL:4,CP:4</availability>
+			<availability>FVC:2,ROS:4,PIR:4,FWL:2,CP:2</availability>
 		</model>
 		<model name='LCT-1V2'>
 			<roles>recon</roles>
 			<availability>PIR:4,MH:4,MERC:3</availability>
 		</model>
+		<model name='LCT-5W2'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,ROS:6,CLAN:4,IS:4,FS:6,DC:6</availability>
+		</model>
+		<model name='LCT-5V'>
+			<roles>recon</roles>
+			<availability>MOC:4,CC:4,FVC:3,PIR:4,MERC:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='LCT-3S'>
+			<roles>recon</roles>
+			<availability>LA:8,MERC:6</availability>
+		</model>
+		<model name='LCT-3M'>
+			<roles>recon</roles>
+			<availability>MOC:2,RF:5,FWL:4,IS:2,MERC:4,DA:5,CP:4</availability>
+		</model>
+		<model name='LCT-3D'>
+			<roles>recon</roles>
+			<availability>FVC:8,FS:8,MERC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
 		<availability>CWE:3,CHH:4,BAN:4,CWIE:3</availability>
-		<model name='G'>
-			<availability>CLAN:6</availability>
+		<model name='E'>
+			<availability>CWE:5,CHH:6,CLAN:4,General:3,CJF:5</availability>
 		</model>
-		<model name='A'>
-			<availability>RD:5,General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>RD:8,General:8,CJF:9</availability>
+		<model name='F'>
+			<availability>General:4</availability>
 		</model>
 		<model name='C'>
 			<availability>RD:5,CDS:5,General:4,CP:5,CWIE:5</availability>
+		</model>
+		<model name='G'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:4,CP:5</availability>
@@ -10111,28 +10111,28 @@
 		<model name='B'>
 			<availability>CWE:4,CHH:6,RD:3,CDS:6,General:5,CP:6,CJF:7,CWIE:4</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CHH:6,CLAN:4,General:3,CJF:5</availability>
-		</model>
 		<model name='D'>
 			<roles>anti_infantry</roles>
 			<availability>CWE:5,CHH:6,RD:5,General:4,CJF:6,CWIE:5</availability>
 		</model>
+		<model name='A'>
+			<availability>RD:5,General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,General:8,CJF:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Loki Mk II (Hel)' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,CHH:7,RD:5,MERC.WD:3,MERC.KH:3,CDS:5,CP:5,CJF:7,RA:5</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -10148,51 +10148,51 @@
 	</chassis>
 	<chassis name='Longbow' unitType='Mek'>
 		<availability>MOC:6,CC:4,IS:6,FS:5,CP:7,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7,DC:6</availability>
-		<model name='LGB-14C2'>
+		<model name='LGB-7V'>
 			<roles>fire_support</roles>
-			<availability>IS:6</availability>
+			<availability>MOC:2,FVC:4,FWL:2,IS:2,CP:2,Periphery:4</availability>
 		</model>
 		<model name='LGB-8V'>
 			<roles>missile_artillery,fire_support</roles>
 			<availability>RD:4,LA:4,FWL:4,IS:4,FS:6,MERC:4,CP:4</availability>
 		</model>
-		<model name='LGB-14C'>
-			<roles>fire_support</roles>
-			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
-		</model>
-		<model name='LGB-13NAIS'>
-			<availability>FS:4</availability>
-		</model>
 		<model name='LGB-12R'>
 			<roles>fire_support</roles>
 			<availability>LA:4,ROS:8,FWL:2,FS:4,CP:2,DC:4</availability>
-		</model>
-		<model name='LGB-7V'>
-			<roles>fire_support</roles>
-			<availability>MOC:2,FVC:4,FWL:2,IS:2,CP:2,Periphery:4</availability>
 		</model>
 		<model name='LGB-12C'>
 			<roles>fire_support</roles>
 			<availability>CC:4,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CP:4,CDP:4,TC:4</availability>
 		</model>
+		<model name='LGB-13NAIS'>
+			<availability>FS:4</availability>
+		</model>
 		<model name='LGB-13C'>
 			<roles>fire_support</roles>
 			<availability>CC:6,MOC:5,ROS:6,FWL:6,FS:6,MERC:6,DA:6,CP:6,DC:6</availability>
 		</model>
+		<model name='LGB-14C2'>
+			<roles>fire_support</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='LGB-14C'>
+			<roles>fire_support</roles>
+			<availability>CC:6,LA:6,IS:4,FS:6,MERC:6,DC:6,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
 		<availability>RF:8,FWL:8,MH:6,DA:8,CP:8</availability>
+		<model name='[Flamer]' mechanized='true'>
+			<availability>General:7</availability>
+		</model>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Magnetic)' mechanized='true'>
 			<availability>FWL:6,CP:6</availability>
 		</model>
 		<model name='[David]' mechanized='true'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
-		<model name='[Flamer]' mechanized='true'>
-			<availability>General:7</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
@@ -10212,20 +10212,20 @@
 	</chassis>
 	<chassis name='Lucifer II' unitType='Aero'>
 		<availability>ROS:4,MERC:3,DC:4</availability>
-		<model name='LCF-R16K'>
-			<availability>General:5-</availability>
-		</model>
 		<model name='LCF-R16KR'>
 			<availability>ROS:5,MERC:3,DC:6</availability>
+		</model>
+		<model name='LCF-R16K'>
+			<availability>General:5-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lucifer' unitType='Aero'>
 		<availability>Periphery.R:4,FVC:2,LA:3,Periphery.MW:3,Periphery:2</availability>
-		<model name='LCF-R15'>
-			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
-		</model>
 		<model name='LCF-R16'>
 			<availability>LA:8,MH:4,MERC:6</availability>
+		</model>
+		<model name='LCF-R15'>
+			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Luduan Scout Vehicle' unitType='Tank'>
@@ -10237,20 +10237,20 @@
 	</chassis>
 	<chassis name='Lumberjack' unitType='Mek'>
 		<availability>Periphery.R:3,LA:2,General:1</availability>
-		<model name='LM4/C'>
-			<roles>support</roles>
-			<availability>LA:8</availability>
-		</model>
 		<model name='LM4/P'>
 			<roles>support</roles>
 			<availability>LA:2</availability>
 		</model>
-		<model name='LM5/M'>
-			<availability>LA:1-</availability>
-		</model>
 		<model name='LM1/A'>
 			<roles>support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='LM4/C'>
+			<roles>support</roles>
+			<availability>LA:8</availability>
+		</model>
+		<model name='LM5/M'>
+			<availability>LA:1-</availability>
 		</model>
 	</chassis>
 	<chassis name='Lung Wang' unitType='Dropship'>
@@ -10291,13 +10291,13 @@
 	</chassis>
 	<chassis name='Lyonesse Escort' unitType='Small Craft'>
 		<availability>FWL:3,CP:3</availability>
-		<model name='(Standard)'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='M1'>
 			<roles>escort</roles>
 			<availability>FWL:6,CP:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='M.A.S.H. Truck' unitType='Tank'>
@@ -10342,8 +10342,11 @@
 	</chassis>
 	<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,MERC.KH:3+,MERC.WD:4,CDS:2,ROS:3+,CLAN:1,MERC:2+,CP:2,CJF:2,BAN:1,CWIE:4</availability>
-		<model name='Prime'>
-			<availability>RD:7,CDS:8,General:8,CP:7,CJF:8</availability>
+		<model name='B'>
+			<availability>CWE:5,CHH:7,RD:4,CDS:7,General:6,CP:7,CJF:7,CWIE:5</availability>
+		</model>
+		<model name='F'>
+			<availability>CWE:5,CHH:5,RD:5,CLAN:4,General:3,CJF:6,CWIE:5</availability>
 		</model>
 		<model name='S'>
 			<roles>urban</roles>
@@ -10353,31 +10356,29 @@
 			<roles>spotter</roles>
 			<availability>CWE:5,CHH:4,CLAN:5,General:5,CP:4,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:5,General:4,CP:3</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:7,RD:2,General:5,CJF:6,CWIE:7</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:5,General:4,CP:3</availability>
 		</model>
 		<model name='A'>
 			<availability>CWE:7,RD:8,CDS:8,General:7,CP:8,CJF:8</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:5,CHH:7,RD:4,CDS:7,General:6,CP:7,CJF:7,CWIE:5</availability>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
-		<model name='F'>
-			<availability>CWE:5,CHH:5,RD:5,CLAN:4,General:3,CJF:6,CWIE:5</availability>
+		<model name='Prime'>
+			<availability>RD:7,CDS:8,General:8,CP:7,CJF:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CWE:7,RD:2,General:5,CJF:6,CWIE:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat III' unitType='Mek'>
 		<availability>CDS:6,LA:5,ROS:5,IS:4,CP:5,CWIE:4,DC:5</availability>
-		<model name='2'>
+		<model name='4'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)'>
@@ -10388,8 +10389,7 @@
 			<roles>fire_support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='4'>
-			<roles>fire_support</roles>
+		<model name='2'>
 			<availability>General:6</availability>
 		</model>
 		<model name='3'>
@@ -10399,26 +10399,26 @@
 	</chassis>
 	<chassis name='Mad Cat Mk II' unitType='Mek'>
 		<availability>CDS:5,LA:4,CLAN:4,IS:4,FS:4,CP:5,CWIE:4,DC:4</availability>
-		<model name='6'>
-			<availability>CDS:5,CP:5</availability>
-		</model>
 		<model name='Enhanced'>
 			<availability>CLAN:6,CP:4,CWIE:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CDS:4,CP:4</availability>
+		</model>
+		<model name='4'>
+			<availability>General:6</availability>
+		</model>
+		<model name='6'>
+			<availability>CDS:5,CP:5</availability>
 		</model>
 		<model name='2'>
 			<availability>CWE:4,CDS:4,LA:4,IS:4,FS:4,CP:4,DC:4,CWIE:4</availability>
 		</model>
 		<model name='5'>
 			<availability>General:6</availability>
-		</model>
-		<model name='4'>
-			<availability>General:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mad Cat Mk IV (Savage Wolf)' unitType='Mek'>
@@ -10432,36 +10432,42 @@
 		<model name='(Prime)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='B'>
 			<availability>General:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Maelstrom' unitType='Mek'>
 		<availability>LA:6,IS:4,FS:4,MERC:4,DC:6</availability>
-		<model name='MTR-6E'>
-			<roles>recon,spotter</roles>
-			<availability>DC:1</availability>
+		<model name='MTR-5K'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='MTR-7K'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='MTR-6K'>
 			<roles>recon,spotter</roles>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:4</availability>
 		</model>
-		<model name='MTR-7K'>
-			<availability>DC:5</availability>
-		</model>
-		<model name='MTR-5K'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='MTR-6E'>
+			<roles>recon,spotter</roles>
+			<availability>DC:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
 		<availability>CC:6,MOC:6,Periphery.MM:6,MERC:6,CP:8,RF:8,LA:6,ROS:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,DA:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(XL)'>
+			<availability>MOC:4,IS:4</availability>
+		</model>
 		<model name='(IFV)'>
 			<roles>apc</roles>
 			<availability>General:4</availability>
@@ -10469,18 +10475,9 @@
 		<model name='(C3)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(XL)'>
-			<availability>MOC:4,IS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Malice' unitType='Mek'>
 		<availability>ROS:5,MERC:4</availability>
-		<model name='MAL-XT'>
-			<availability>General:8</availability>
-		</model>
 		<model name='MAL-XV'>
 			<availability>General:3</availability>
 		</model>
@@ -10490,6 +10487,9 @@
 		</model>
 		<model name='MAL-XP'>
 			<availability>General:6</availability>
+		</model>
+		<model name='MAL-XT'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mammoth' unitType='Dropship'>
@@ -10508,9 +10508,6 @@
 	</chassis>
 	<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
 		<availability>CWE:4,CHH:2,MERC.WD:4,CDS:4,CP:4,CJF:4,BAN:4,CWIE:4</availability>
-		<model name='E'>
-			<availability>CLAN:6,General:3</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
@@ -10521,35 +10518,38 @@
 		<model name='G'>
 			<availability>General:2</availability>
 		</model>
-		<model name='T'>
-			<availability>General:6</availability>
+		<model name='E'>
+			<availability>CLAN:6,General:3</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:6,CDS:7,General:8,CP:7,CJF:9</availability>
 		</model>
-		<model name='C'>
-			<availability>CWE:7,RD:7,CDS:7,General:6,CP:7,CJF:5,CWIE:7</availability>
+		<model name='A'>
+			<availability>CWE:8,RD:9,CDS:4,General:7,CP:6,CJF:9</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:4,CDS:4,General:5,CP:5,CJF:2</availability>
 		</model>
-		<model name='A'>
-			<availability>CWE:8,RD:9,CDS:4,General:7,CP:6,CJF:9</availability>
+		<model name='C'>
+			<availability>CWE:7,RD:7,CDS:7,General:6,CP:7,CJF:5,CWIE:7</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:5,RD:5,CDS:3,General:4,CP:4</availability>
 		</model>
+		<model name='T'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Mangonel' unitType='Mek'>
 		<availability>MERC.KH:4,RF:4,LA:4,ROS:4,MERC:4,CWIE:6</availability>
+		<model name='MNL-4S'>
+			<availability>General:6</availability>
+		</model>
 		<model name='MNL-3L'>
 			<availability>MERC.KH:6,ROS:4,CWIE:6</availability>
 		</model>
 		<model name='MNL-3W'>
 			<availability>ROS:2,CWIE:4</availability>
-		</model>
-		<model name='MNL-4S'>
-			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -10566,28 +10566,40 @@
 		<model name='B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>General:6</availability>
+		<model name='D'>
+			<roles>apc</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7,FS:6</availability>
 		</model>
 		<model name='C'>
 			<roles>spotter</roles>
 			<availability>General:7,FS:5</availability>
 		</model>
-		<model name='D'>
-			<roles>apc</roles>
-			<availability>General:4</availability>
+		<model name='E'>
+			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
-			<availability>General:7,FS:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Manticore Heavy Tank' unitType='Tank'>
 		<availability>MOC:3,CC:3,IS:4,MERC:4,FS:4,CP:3,Periphery:4,TC:4,RA.OA:4,LA:4,ROS:3,FWL:3,DC:5</availability>
+		<model name='(LB-X)'>
+			<availability>LA:8,ROS:8,FS:8</availability>
+		</model>
 		<model name='(C3S)'>
 			<availability>ROS:8,FS:6,DC:8</availability>
+		</model>
+		<model name='(3055 Upgrade)'>
+			<availability>FVC:8,LA:8,ROS:8,FS:8,MERC:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:1-,Periphery:2</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -10595,18 +10607,6 @@
 		</model>
 		<model name='(HPPC)'>
 			<availability>CC:6,MOC:6,LA:6,ROS:6,FWL:6,FS:6,MERC:6,CP:6,DC:6</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>FS:4</availability>
-		</model>
-		<model name='(LB-X)'>
-			<availability>LA:8,ROS:8,FS:8</availability>
-		</model>
-		<model name='(3055 Upgrade)'>
-			<availability>FVC:8,LA:8,ROS:8,FS:8,MERC:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:1-,Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Manticore II Heavy Tank' unitType='Tank'>
@@ -10626,37 +10626,37 @@
 	</chassis>
 	<chassis name='Marauder Battle Armor' unitType='BattleArmor'>
 		<availability>MH:7,MERC:2,TC:4</availability>
-		<model name='(Standard)' mechanized='true'>
-			<roles>spotter</roles>
-			<availability>MERC:8,TC:8</availability>
-		</model>
 		<model name='(MH)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>MH:8</availability>
 		</model>
+		<model name='(Standard)' mechanized='true'>
+			<roles>spotter</roles>
+			<availability>MERC:8,TC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Marauder IIC' unitType='Mek'>
 		<availability>CWE:4,MERC.WD:6,RD:5,CP:4,CJF:5,RA:4,CWIE:4</availability>
-		<model name='3'>
-			<availability>RD:5,CJF:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CWE:6,CJF:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>MERC.WD:8,RD:2,CJF:2</availability>
-		</model>
-		<model name='2'>
-			<availability>RD:3,CJF:3</availability>
 		</model>
 		<model name='5'>
 			<availability>CJF:1,CWIE:6</availability>
 		</model>
-		<model name='4'>
-			<availability>RD:4,CP:6,RA:4</availability>
+		<model name='6'>
+			<availability>CWE:6,CJF:4</availability>
+		</model>
+		<model name='3'>
+			<availability>RD:5,CJF:5</availability>
 		</model>
 		<model name='7'>
 			<availability>RD:6</availability>
+		</model>
+		<model name='2'>
+			<availability>RD:3,CJF:3</availability>
+		</model>
+		<model name='4'>
+			<availability>RD:4,CP:6,RA:4</availability>
 		</model>
 		<model name='8'>
 			<availability>RD:1,CJF:1</availability>
@@ -10664,8 +10664,8 @@
 	</chassis>
 	<chassis name='Marauder II' unitType='Mek'>
 		<availability>CC:4,MOC:4,FS:6,MERC:4,CP:5,TC:4,MERC.WD:6,LA:1,ROS:6,PIR:4,FWL:5,MH:4,DC:5</availability>
-		<model name='MAD-4H'>
-			<availability>PIR:4,MH:4,TC:4</availability>
+		<model name='MAD-6D'>
+			<availability>ROS:4,FS:6</availability>
 		</model>
 		<model name='MAD-5A'>
 			<availability>MERC.WD:8</availability>
@@ -10673,111 +10673,111 @@
 		<model name='MAD-6M'>
 			<availability>ROS:4,FWL:6,MERC:6,CP:6</availability>
 		</model>
-		<model name='MAD-6D'>
-			<availability>ROS:4,FS:6</availability>
-		</model>
 		<model name='MAD-4L'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='C'>
-			<availability>MERC.WD:6</availability>
 		</model>
 		<model name='MAD-4S'>
 			<availability>LA:4,ROS:6,FS:2,MERC:8,CP:8</availability>
 		</model>
+		<model name='MAD-6S'>
+			<availability>LA:6</availability>
+		</model>
 		<model name='MAD-4K'>
 			<availability>DC:8</availability>
 		</model>
-		<model name='MAD-6S'>
-			<availability>LA:6</availability>
+		<model name='MAD-4H'>
+			<availability>PIR:4,MH:4,TC:4</availability>
+		</model>
+		<model name='C'>
+			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Marauder' unitType='Mek'>
 		<availability>CC:4,RA.OA:2,MOC:2,RD:3,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
-		<model name='MAD-5T'>
-			<availability>FS:4</availability>
+		<model name='MAD-9M'>
+			<roles>spotter</roles>
+			<availability>FWL:8,MERC:3,DA:8,CP:8</availability>
 		</model>
-		<model name='MAD-5D'>
-			<availability>FVC:3,FS:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='MAD-9S'>
-			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4</availability>
+		<model name='MAD-9D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='MAD-9M2'>
 			<roles>spotter</roles>
 			<availability>RF:6,ROS:4,FWL:4,MERC:4,DA:6,CP:4,DC:4</availability>
 		</model>
-		<model name='MAD-9W2'>
-			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
-		</model>
-		<model name='MAD-6L'>
-			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='MAD-5S'>
-			<availability>FVC:2,LA:2,MERC:2</availability>
-		</model>
-		<model name='MAD-7D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='MAD-9M'>
-			<roles>spotter</roles>
-			<availability>FWL:8,MERC:3,DA:8,CP:8</availability>
+		<model name='MAD-5D'>
+			<availability>FVC:3,FS:2,MERC:2,DC:4</availability>
 		</model>
 		<model name='MAD-5M'>
 			<availability>MOC:4,ROS:4,FWL:6,MERC:4,CP:6</availability>
 		</model>
-		<model name='MAD-5R'>
-			<availability>FS:4,MERC:3</availability>
+		<model name='MAD-6L'>
+			<availability>CC:6,MOC:4</availability>
 		</model>
 		<model name='MAD-3R'>
 			<availability>Periphery:2-,TC:2-</availability>
 		</model>
-		<model name='MAD-5L'>
-			<availability>CC:6,MOC:5</availability>
+		<model name='MAD-9S'>
+			<availability>RD:4,LA:6,ROS:4,MH:4,MERC:4</availability>
 		</model>
 		<model name='MAD-2R'>
 			<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
 		</model>
-		<model name='MAD-9D'>
-			<availability>FS:6</availability>
+		<model name='MAD-5R'>
+			<availability>FS:4,MERC:3</availability>
+		</model>
+		<model name='MAD-5L'>
+			<availability>CC:6,MOC:5</availability>
+		</model>
+		<model name='MAD-5S'>
+			<availability>FVC:2,LA:2,MERC:2</availability>
+		</model>
+		<model name='MAD-9W2'>
+			<availability>LA:6,ROS:6,FS:6,MERC:4,DC:6</availability>
+		</model>
+		<model name='MAD-7D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='MAD-5T'>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
 		<availability>CHH:4,LA:6,IS:4</availability>
-		<model name='(Light PPC)'>
-			<roles>artillery</roles>
-			<availability>LA:8,IS:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>artillery</roles>
 			<availability>CHH:8,BAN:4</availability>
 		</model>
+		<model name='(Light PPC)'>
+			<roles>artillery</roles>
+			<availability>LA:8,IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Marksman MBT' unitType='Tank'>
 		<availability>ROS:8,IS:5</availability>
-		<model name='M1J'>
-			<availability>General:6</availability>
+		<model name='M1'>
+			<availability>ROS:1,ROS.pm:8,General:8</availability>
 		</model>
 		<model name='M1A'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='M1'>
-			<availability>ROS:1,ROS.pm:8,General:8</availability>
+		<model name='M1J'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mars Assault Vehicle' unitType='Tank'>
 		<availability>LA:4,ROS:5,CLAN:7</availability>
-		<model name='(HAG)'>
-			<availability>CHH:6,RD:4,CDS:4,ROS:4,CP:4</availability>
-		</model>
-		<model name='(ATM)'>
-			<availability>General:5,CJF:2</availability>
-		</model>
 		<model name='(XL)'>
 			<availability>CHH:4,RD:3,ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(ATM)'>
+			<availability>General:5,CJF:2</availability>
+		</model>
+		<model name='(HAG)'>
+			<availability>CHH:6,RD:4,CDS:4,ROS:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Marsden II MBT' unitType='Tank'>
@@ -10788,14 +10788,14 @@
 	</chassis>
 	<chassis name='Marshal' unitType='Mek'>
 		<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
-		<model name='MHL-6MC'>
-			<availability>MOC:6,CC:4</availability>
-		</model>
 		<model name='MHL-X1'>
 			<availability>General:8</availability>
 		</model>
 		<model name='MHL-3MC'>
 			<availability>MOC:6</availability>
+		</model>
+		<model name='MHL-6MC'>
+			<availability>MOC:6,CC:4</availability>
 		</model>
 		<model name='MHL-2L'>
 			<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
@@ -10803,36 +10803,36 @@
 	</chassis>
 	<chassis name='Marten Scout VTOL' unitType='VTOL'>
 		<availability>FS.CH:3,IS:2,FS:3,Periphery:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Infantry)'>
 			<roles>apc</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
 		<availability>CWE:2,RD:3,CDS:3,MERC:3+,CP:2,CJF:3,RA:1,BAN:3</availability>
-		<model name='Prime'>
-			<availability>RD:8,CDS:9,General:8,CP:9</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='C'>
-			<availability>CWE:6,RD:6,CDS:5,General:4,CP:5</availability>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='B'>
-			<availability>CDS:8,General:5,CP:8</availability>
+		<model name='E'>
+			<availability>General:4</availability>
 		</model>
 		<model name='A'>
 			<availability>RD:5,CDS:8,General:5,CP:8</availability>
+		</model>
+		<model name='C'>
+			<availability>CWE:6,RD:6,CDS:5,General:4,CP:5</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,CDS:9,General:8,CP:9</availability>
+		</model>
+		<model name='B'>
+			<availability>CDS:8,General:5,CP:8</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:5,CDS:5,General:4,CP:5</availability>
@@ -10840,11 +10840,11 @@
 	</chassis>
 	<chassis name='Matador' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauler' unitType='Mek'>
@@ -10852,21 +10852,21 @@
 		<model name='MAL-1R'>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='MAL-1K'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='MAL-C'>
 			<availability>DC:1</availability>
 		</model>
 		<model name='MAL-3R'>
 			<availability>DC:4</availability>
 		</model>
+		<model name='MAL-1K'>
+			<availability>DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Maultier Hover APC' unitType='Tank'>
 		<availability>CC:6,MOC:5,CHH:3,CLAN:1,MH:4,TC:6</availability>
-		<model name='(BA)'>
+		<model name='(Fusion)'>
 			<roles>apc</roles>
-			<availability>TC:6</availability>
+			<availability>TC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
@@ -10876,9 +10876,9 @@
 			<roles>apc</roles>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Fusion)'>
+		<model name='(BA)'>
 			<roles>apc</roles>
-			<availability>TC:4</availability>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mauna Kea Command Vessel' unitType='Naval'>
@@ -10898,28 +10898,28 @@
 	</chassis>
 	<chassis name='Maxim (I) Heavy Hover Transport' unitType='Tank'>
 		<availability>IS:6</availability>
-		<model name='(Company Command)'>
-			<roles>spotter</roles>
-			<availability>General:3</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Company Command)'>
+			<roles>spotter</roles>
+			<availability>General:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Maxim Mk II Transport' unitType='Tank'>
 		<availability>LA:5,ROS:6,MERC:4</availability>
-		<model name='(Standard)'>
+		<model name='(ECM)'>
 			<roles>apc</roles>
-			<availability>LA:8,ROS:8</availability>
+			<availability>General:4</availability>
 		</model>
 		<model name='(Infantry Support) &apos;Shiloh&apos;'>
 			<roles>apc</roles>
 			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='(ECM)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>General:4</availability>
+			<availability>LA:8,ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='McKenna Battleship' unitType='Warship'>
@@ -10943,12 +10943,12 @@
 			<roles>interceptor</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(Laser)'>
 			<roles>interceptor</roles>
 			<availability>FVC:1,MERC:1,Periphery:1,DC:1</availability>
+		</model>
+		<model name='(LB-X)'>
+			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Field Artillery' unitType='Infantry'>
@@ -10963,8 +10963,11 @@
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
 		<model name='(Rifle)'>
 			<availability>General:8</availability>
@@ -10973,11 +10976,8 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
@@ -10985,35 +10985,35 @@
 	</chassis>
 	<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(SRM)'>
 			<availability>General:5</availability>
-		</model>
-		<model name='(MG)'>
-			<availability>General:7</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
+		<model name='(Flamer)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(MG)'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
 		<availability>IS:7,Periphery.Deep:5,Periphery:7</availability>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
+		<model name='(Laser)'>
+			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(LRM)'>
+		<model name='(SRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
@@ -11026,11 +11026,11 @@
 			<roles>anti_aircraft</roles>
 			<availability>IS:6</availability>
 		</model>
-		<model name='(SRM)'>
+		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(Laser)'>
-			<availability>General:6,Periphery:5</availability>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Medium Strike Fighter Crane' unitType='Conventional Fighter'>
@@ -11065,15 +11065,26 @@
 	</chassis>
 	<chassis name='Men Shen' unitType='Mek' omni='IS'>
 		<availability>CC:7,MOC:5</availability>
+		<model name='MS1-OE'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='MS1-OD'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OC'>
+		<model name='MS1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='MS1-OB'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='MS1-OB'>
+		<model name='MS1-OF'>
+			<roles>spotter</roles>
+			<availability>General:5</availability>
+		</model>
+		<model name='MS1-OC'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
@@ -11081,20 +11092,9 @@
 			<roles>spotter</roles>
 			<availability>CC:2</availability>
 		</model>
-		<model name='MS1-OE'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='MS1-OA'>
 			<roles>recon,spotter</roles>
 			<availability>General:7</availability>
-		</model>
-		<model name='MS1-OF'>
-			<roles>spotter</roles>
-			<availability>General:5</availability>
-		</model>
-		<model name='MS1-OG'>
-			<availability>General:4</availability>
 		</model>
 		<model name='MS1-O'>
 			<roles>recon</roles>
@@ -11150,14 +11150,14 @@
 	</chassis>
 	<chassis name='Merlin' unitType='Mek'>
 		<availability>RA.OA:8,MERC:6,RA:5,Periphery:4</availability>
-		<model name='MLN-1C'>
-			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
-		</model>
 		<model name='MLN-1A'>
 			<availability>General:2-</availability>
 		</model>
 		<model name='MLN-1B'>
 			<availability>RA.OA:8,Periphery.Deep:4,MERC:6,Periphery:6</availability>
+		</model>
+		<model name='MLN-1C'>
+			<availability>RA.OA:6,FVC:4,MERC:4,CDP:4,RA:6,TC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Minion Advanced Tactical Vehicle' unitType='Tank'>
@@ -11166,6 +11166,11 @@
 			<roles>urban,spotter</roles>
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>CC:6,ROS:6</availability>
+		</model>
+		<model name='(Gauss) &apos;Sandblaster&apos;'>
+			<roles>urban</roles>
+			<deployedWith>Morningstar City Command Vehicle</deployedWith>
+			<availability>FS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
@@ -11177,25 +11182,20 @@
 			<deployedWith>Morningstar City Command Vehicle</deployedWith>
 			<availability>FS:4</availability>
 		</model>
-		<model name='(Gauss) &apos;Sandblaster&apos;'>
-			<roles>urban</roles>
-			<deployedWith>Morningstar City Command Vehicle</deployedWith>
-			<availability>FS:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Minotaur' unitType='ProtoMek'>
 		<availability>CHH:8,RA:3</availability>
 		<model name='(Standard)'>
 			<availability>CLAN:5</availability>
 		</model>
-		<model name='P2'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='XP'>
 			<availability>CHH:4</availability>
 		</model>
 		<model name='2'>
 			<availability>CHH:8</availability>
+		</model>
+		<model name='P2'>
+			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Miraborg' unitType='Dropship'>
@@ -11221,34 +11221,34 @@
 	</chassis>
 	<chassis name='Mjolnir' unitType='Mek'>
 		<availability>LA:6,ROS:4,FS:4,MERC:4</availability>
-		<model name='MLR-BX'>
-			<availability>LA:2</availability>
-		</model>
 		<model name='MLR-B2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='MLR-BX'>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Mobile Headquarters' unitType='Tank'>
 		<availability>MERC.WD:3,IS:5+,MERC:2+,CP:5+,DC:5+</availability>
-		<model name='(Standard)'>
+		<model name='(ICE)'>
 			<roles>support</roles>
-			<availability>CC:6,General:8,MERC:4,DC:6</availability>
+			<availability>MERC:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>support</roles>
 			<availability>CC:8,General:4,MERC:2,DC:8</availability>
 		</model>
-		<model name='(ICE - LRM)'>
-			<roles>support</roles>
-			<availability>MERC:6</availability>
-		</model>
 		<model name='(ICE - LL)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
 		</model>
-		<model name='(ICE)'>
+		<model name='(ICE - LRM)'>
 			<roles>support</roles>
 			<availability>MERC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>CC:6,General:8,MERC:4,DC:6</availability>
 		</model>
 		<model name='(LL)'>
 			<roles>support</roles>
@@ -11271,15 +11271,15 @@
 	</chassis>
 	<chassis name='Moltke MBT' unitType='Tank'>
 		<availability>CC:5,MOC:5,RF:4,DA:7,MERC:4</availability>
-		<model name='M2'>
-			<availability>General:6</availability>
-		</model>
 		<model name='M1'>
 			<availability>General:8</availability>
 		</model>
 		<model name='M3'>
 			<roles>spotter</roles>
 			<availability>FWL:2,DA:4</availability>
+		</model>
+		<model name='M2'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Monarch' unitType='Dropship'>
@@ -11302,6 +11302,10 @@
 	</chassis>
 	<chassis name='Mongoose' unitType='Mek'>
 		<availability>DC.GHO:3,RD:4,ROS:5,MERC:3,FS:3,DC:4</availability>
+		<model name='MON-67'>
+			<roles>recon</roles>
+			<availability>NIOPS:0,Periphery:8</availability>
+		</model>
 		<model name='MON-76'>
 			<roles>recon</roles>
 			<availability>RD:6,ROS:6,MERC:6,FS:6,DC:6</availability>
@@ -11309,10 +11313,6 @@
 		<model name='MON-86'>
 			<roles>recon</roles>
 			<availability>RD:6,ROS:6,MERC:6,DC:6</availability>
-		</model>
-		<model name='MON-67'>
-			<roles>recon</roles>
-			<availability>NIOPS:0,Periphery:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Mongrel' unitType='Mek'>
@@ -11338,9 +11338,6 @@
 		<model name='(2776)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(2776)'>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Moray Heavy Attack Submarine' unitType='Naval'>
 		<availability>ROS:4</availability>
@@ -11353,20 +11350,20 @@
 		<model name='MR-1SE'>
 			<availability>General:6</availability>
 		</model>
-		<model name='MR-1S'>
-			<availability>General:8</availability>
-		</model>
-		<model name='MR-1SA'>
-			<roles>interceptor,ground_support</roles>
+		<model name='MR-1SB'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MR-1SD'>
 			<availability>General:7</availability>
 		</model>
-		<model name='MR-1SB'>
-			<availability>General:7</availability>
+		<model name='MR-1S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='MR-1SC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MR-1SA'>
+			<roles>interceptor,ground_support</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -11383,6 +11380,14 @@
 	</chassis>
 	<chassis name='Morrigan' unitType='Mek'>
 		<availability>CDS:3,ROS:4,CP:4,DC:5</availability>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<roles>specops</roles>
+			<availability>IS:4</availability>
+		</model>
 		<model name='5'>
 			<roles>recon</roles>
 			<availability>CP:4,DC:4</availability>
@@ -11391,17 +11396,9 @@
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='3'>
-			<roles>specops</roles>
-			<availability>IS:4</availability>
-		</model>
 		<model name='2'>
 			<roles>recon</roles>
 			<availability>CLAN:4,IS:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Morrigu Fire Support Vehicle' unitType='Tank'>
@@ -11446,33 +11443,33 @@
 	</chassis>
 	<chassis name='Motorized Platoon' unitType='Infantry'>
 		<availability>IS:9,Periphery.Deep:7,Periphery:9</availability>
+		<model name='(Flechette)'>
+			<availability>IS:5</availability>
+		</model>
+		<model name='(Rifle)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='(SRM)'>
+			<availability>General:5</availability>
+		</model>
+		<model name='(Rifle AA)'>
+			<roles>anti_aircraft</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>General:5</availability>
 		</model>
 		<model name='(Flamer)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Flechette)'>
-			<availability>IS:5</availability>
+		<model name='(Gauss)'>
+			<availability>IS:4</availability>
 		</model>
 		<model name='(Laser)'>
 			<availability>General:6,Periphery:5</availability>
 		</model>
-		<model name='(SRM)'>
-			<availability>General:5</availability>
-		</model>
-		<model name='(Rifle)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MG)'>
 			<availability>General:7</availability>
-		</model>
-		<model name='(Gauss)'>
-			<availability>IS:4</availability>
-		</model>
-		<model name='(Rifle AA)'>
-			<roles>anti_aircraft</roles>
-			<availability>IS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Mountaineer' unitType='Infantry'>
@@ -11498,29 +11495,29 @@
 	</chassis>
 	<chassis name='Musketeer Hover Tank' unitType='Tank'>
 		<availability>ROS:4,FS:6</availability>
-		<model name='(Armor)'>
+		<model name='(3080 Upgrade)'>
 			<roles>spotter</roles>
-			<availability>FS:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='(3080 Upgrade)'>
+		<model name='(Armor)'>
 			<roles>spotter</roles>
-			<availability>General:8</availability>
+			<availability>FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Myrmidon Medium Tank' unitType='Tank'>
 		<availability>MOC:2,CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
-		<model name='Type 2'>
-			<availability>CC:8</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(Anti-Infantry)'>
 			<availability>ROS:5,FS:4,MERC:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='Type 2'>
+			<availability>CC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='NL-45 Gunboat' unitType='Small Craft'>
@@ -11543,21 +11540,21 @@
 			<roles>missile_artillery</roles>
 			<availability>CWE:4,CHH:4,MERC.WD:4,RD:3,CDS:4,General:2,CP:4</availability>
 		</model>
-		<model name='B'>
+		<model name='A'>
 			<roles>missile_artillery</roles>
-			<availability>CWE:6,CHH:6,CDS:6,General:5,CP:6,CWIE:6</availability>
+			<availability>CWE:4,CHH:3,RD:3,CDS:4,General:2,CP:4,CWIE:4</availability>
 		</model>
 		<model name='Prime'>
 			<roles>missile_artillery</roles>
 			<availability>CDS:9,General:8,CP:9</availability>
 		</model>
-		<model name='A'>
-			<roles>missile_artillery</roles>
-			<availability>CWE:4,CHH:3,RD:3,CDS:4,General:2,CP:4,CWIE:4</availability>
-		</model>
 		<model name='C'>
 			<roles>missile_artillery</roles>
 			<availability>CWE:4,CHH:3,MERC.WD:4,RD:3,CDS:4,General:2,CP:4,CWIE:4</availability>
+		</model>
+		<model name='B'>
+			<roles>missile_artillery</roles>
+			<availability>CWE:6,CHH:6,CDS:6,General:5,CP:6,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Nagasawa' unitType='Dropship'>
@@ -11569,17 +11566,17 @@
 	</chassis>
 	<chassis name='Naginata' unitType='Mek'>
 		<availability>ROS:4,MERC:4,DC:6</availability>
-		<model name='NG-C3A'>
-			<roles>fire_support,spotter</roles>
-			<availability>DC:8</availability>
+		<model name='NG-C3C'>
+			<roles>fire_support</roles>
+			<availability>DC:2</availability>
 		</model>
 		<model name='NG-C3Ar'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='NG-C3C'>
-			<roles>fire_support</roles>
-			<availability>DC:2</availability>
+		<model name='NG-C3A'>
+			<roles>fire_support,spotter</roles>
+			<availability>DC:8</availability>
 		</model>
 		<model name='NG-C3B'>
 			<roles>spotter</roles>
@@ -11626,11 +11623,11 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRT)'>
-			<availability>General:3</availability>
-		</model>
 		<model name='(SRT)'>
 			<availability>FS:2</availability>
+		</model>
+		<model name='(LRT)'>
+			<availability>General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Newgrange Yardship' unitType='Warship'>
@@ -11642,11 +11639,17 @@
 	</chassis>
 	<chassis name='Night Gyr' unitType='Mek' omni='Clan'>
 		<availability>CJF:5</availability>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='F'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:5,IS:3</availability>
@@ -11654,44 +11657,38 @@
 		<model name='E'>
 			<availability>CLAN:5,IS:3</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
-		</model>
-		<model name='F'>
-			<availability>CJF:4</availability>
-		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Night Hawk' unitType='Mek'>
 		<availability>RA.OA:3,CWE:4,FVC:2,RD:4,LA:5,ROS:4,CLAN:1,MERC:3</availability>
-		<model name='NTK-2S'>
-			<roles>recon</roles>
-			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NTK-2Q'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='NTK-2S'>
+			<roles>recon</roles>
+			<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Night Stalker' unitType='Mek'>
 		<availability>LA:5,ROS:3,FS:5,MERC:5</availability>
-		<model name='NSR-K4'>
-			<availability>General:4</availability>
-		</model>
-		<model name='NSR-KC'>
-			<availability>General:4</availability>
-		</model>
 		<model name='NSR-K3'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
 		<model name='NSR-K1'>
 			<availability>General:6</availability>
+		</model>
+		<model name='NSR-K4'>
+			<availability>General:4</availability>
+		</model>
+		<model name='NSR-KC'>
+			<availability>General:4</availability>
 		</model>
 		<model name='NSR-K7'>
 			<availability>General:2</availability>
@@ -11715,6 +11712,9 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
+		<model name='(Royal)'>
+			<availability>CLAN:8,BAN:4</availability>
+		</model>
 		<model name='(LAC)'>
 			<roles>spotter</roles>
 			<availability>ROS:6</availability>
@@ -11723,29 +11723,26 @@
 			<roles>apc</roles>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(Royal)'>
-			<availability>CLAN:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Nightsky' unitType='Mek'>
 		<availability>Periphery.R:2,RF:5,LA:8,ROS:6,FWL:4,FS:7,MERC:6,CP:4</availability>
-		<model name='NGS-4T'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='NGS-4S'>
 			<availability>:0,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 		</model>
-		<model name='NGS-5T'>
-			<availability>RF:5,LA:4,ROS:5,FWL:5,FS:4,MERC:4,CP:5</availability>
+		<model name='NGS-4T'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='NGS-6T'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 		</model>
-		<model name='NGS-5S'>
-			<availability>LA:4,FS:4,MERC:3</availability>
+		<model name='NGS-5T'>
+			<availability>RF:5,LA:4,ROS:5,FWL:5,FS:4,MERC:4,CP:5</availability>
 		</model>
 		<model name='NGS-6S'>
 			<availability>LA:8,ROS:6,MERC:4</availability>
+		</model>
+		<model name='NGS-5S'>
+			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Nightstar' unitType='Mek'>
@@ -11753,11 +11750,11 @@
 		<model name='NSR-9FC'>
 			<availability>LA:5,FS:5,MERC:3</availability>
 		</model>
-		<model name='NSR-9SS'>
-			<availability>LA:4,MERC:2,FS:4</availability>
-		</model>
 		<model name='NSR-9J'>
 			<availability>General:8</availability>
+		</model>
+		<model name='NSR-9SS'>
+			<availability>LA:4,MERC:2,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nike Air Defense Platform' unitType='Tank'>
@@ -11771,11 +11768,11 @@
 		<model name='NJT-2'>
 			<availability>General:8</availability>
 		</model>
-		<model name='NJT-4'>
-			<availability>DC:4</availability>
-		</model>
 		<model name='NJT-3'>
 			<availability>General:2</availability>
+		</model>
+		<model name='NJT-4'>
+			<availability>DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nishikigoi Support Aircraft' unitType='Tank'>
@@ -11798,34 +11795,43 @@
 	</chassis>
 	<chassis name='No-Dachi' unitType='Mek'>
 		<availability>RD:4,DC.LV:8,DC.SL:2,LA:3,ROS:5,MERC:3,DC:8</availability>
-		<model name='NDA-3S'>
-			<availability>LA:8</availability>
-		</model>
-		<model name='NDA-2KC'>
-			<availability>ROS:6,MERC:6,DC:8</availability>
+		<model name='NDA-2KO'>
+			<availability>ROS:4,MERC:4,DC:4</availability>
 		</model>
 		<model name='NDA-2K'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
 		</model>
+		<model name='NDA-2KC'>
+			<availability>ROS:6,MERC:6,DC:8</availability>
+		</model>
 		<model name='NDA-1K'>
 			<availability>RD:4,ROS:6,MERC:4,DC:4</availability>
 		</model>
-		<model name='NDA-2KO'>
-			<availability>ROS:4,MERC:4,DC:4</availability>
+		<model name='NDA-3S'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Nobori-nin (Huntsman)' unitType='Mek' omni='Clan'>
 		<availability>ROS:3+,CP:8</availability>
+		<model name='E'>
+			<roles>spotter</roles>
+			<availability>CDS:4,ROS:4,CP:4</availability>
+		</model>
+		<model name='N'>
+			<availability>CDS:4,ROS:4,CP:4</availability>
+		</model>
 		<model name='F'>
 			<availability>ROS:6</availability>
 		</model>
-		<model name='C'>
-			<roles>fire_support</roles>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='D'>
+			<availability>CDS:4,ROS:4,CP:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -11834,18 +11840,9 @@
 			<roles>recon</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<roles>spotter</roles>
-			<availability>CDS:4,ROS:4,CP:4</availability>
-		</model>
-		<model name='B'>
+		<model name='C'>
+			<roles>fire_support</roles>
 			<availability>General:6</availability>
-		</model>
-		<model name='N'>
-			<availability>CDS:4,ROS:4,CP:4</availability>
-		</model>
-		<model name='D'>
-			<availability>CDS:4,ROS:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Noruff' unitType='Dropship'>
@@ -11857,6 +11854,18 @@
 	</chassis>
 	<chassis name='Nova Cat' unitType='Mek' omni='Clan'>
 		<availability>RD:3,CDS:6,ROS:4+,CP:7,CWIE:4</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:5</availability>
+		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -11865,42 +11874,27 @@
 			<roles>urban</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:5</availability>
-		</model>
-		<model name='D'>
-			<availability>CLAN:5</availability>
-		</model>
 		<model name='G'>
 			<roles>fire_support,anti_infantry</roles>
 			<availability>CLAN:3</availability>
 		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
 		<model name='I'>
 			<availability>CLAN:4</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
 		</model>
 		<model name='E'>
 			<roles>fire_support</roles>
 			<availability>CLAN:6</availability>
 		</model>
-	</chassis>
-	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
-		<availability>RA.OA:3,RA:4-</availability>
-		<model name='2 &apos;Numantia&apos;'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
+		<model name='F'>
+			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Nuberu Anti Aircraft Tank' unitType='Tank'>
 		<availability>RA.OA:6,RA:8-</availability>
+		<model name='2 &apos;Numantia&apos;'>
+			<roles>fire_support</roles>
+			<availability>General:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
@@ -11908,9 +11902,9 @@
 	</chassis>
 	<chassis name='Nyx' unitType='Mek'>
 		<availability>RD:4,LA:4,ROS:6,MERC:4,FS:4,DC:5</availability>
-		<model name='NX-80C'>
+		<model name='NX-110'>
 			<roles>recon</roles>
-			<availability>ROS:3,MERC:3,DC:3</availability>
+			<availability>DC:5</availability>
 		</model>
 		<model name='NX-80'>
 			<roles>recon</roles>
@@ -11920,28 +11914,28 @@
 			<roles>recon</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='NX-110'>
-			<roles>recon</roles>
-			<availability>DC:5</availability>
-		</model>
 		<model name='NX-100'>
 			<roles>recon</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='NX-80C'>
+			<roles>recon</roles>
+			<availability>ROS:3,MERC:3,DC:3</availability>
+		</model>
 	</chassis>
 	<chassis name='O-Bakemono' unitType='Mek'>
 		<availability>DC:3</availability>
-		<model name='OBK-M12'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>DC:2</availability>
+		<model name='OBK-M10'>
+			<roles>missile_artillery</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='OBK-M11'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='OBK-M10'>
-			<roles>missile_artillery</roles>
-			<availability>General:8</availability>
+		<model name='OBK-M12'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>DC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ocelot' unitType='Mek'>
@@ -11949,22 +11943,22 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='4'>
-			<availability>CP:3,DC:3</availability>
-		</model>
 		<model name='3'>
 			<availability>CDS:4,CP:4</availability>
+		</model>
+		<model name='4'>
+			<availability>CP:3,DC:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Odin Scout Tank' unitType='Tank'>
 		<availability>ROS:4,CLAN:5,CJF:4</availability>
-		<model name='(Standard)'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8,ROS:8,CLAN:8</availability>
-		</model>
 		<model name='(Spotter)'>
 			<roles>recon,spotter</roles>
 			<availability>RD:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon</roles>
+			<availability>MERC.WD:8,ROS:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Odyssey Jumpship' unitType='Jumpship'>
@@ -12000,17 +11994,17 @@
 	</chassis>
 	<chassis name='Onager' unitType='Mek'>
 		<availability>CJF:4</availability>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='2'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Oni Battle Armor' unitType='BattleArmor'>
 		<availability>DC.pm:6,DC:3-</availability>
-		<model name='[Narc]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[PPC]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[MRR]' mechanized='true'>
 			<availability>General:8</availability>
@@ -12018,45 +12012,45 @@
 		<model name='[Bearhunter]' mechanized='true'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[PPC]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Narc]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Oni' unitType='Aero'>
 		<availability>CP:4,DC:6</availability>
-		<model name='ON-1'>
-			<availability>General:8</availability>
-		</model>
 		<model name='ON-2'>
 			<availability>DC:6</availability>
+		</model>
+		<model name='ON-1'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Ontos Heavy Tank' unitType='Tank'>
 		<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
-		<model name='(3053 Upgrade)'>
-			<availability>MOC:4,IS:4,CP:8</availability>
+		<model name='HEAT'>
+			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
 		</model>
-		<model name='(Light Gauss)'>
-			<availability>CC:6,MOC:6,IS:6,FWL:6,CP:6</availability>
+		<model name='(Fusion)'>
+			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1,CP:1</availability>
 		</model>
 		<model name='(Sealed)'>
 			<availability>IS:4</availability>
 		</model>
-		<model name='(MML)'>
-			<availability>MOC:6,IS:6</availability>
+		<model name='(Light Gauss)'>
+			<availability>CC:6,MOC:6,IS:6,FWL:6,CP:6</availability>
 		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>CC:1,LA:1,ROS:1,FWL:1,FS:1,MERC:1</availability>
 		</model>
-		<model name='(Fusion)'>
-			<availability>CC:1,FVC:1,LA:1,ROS:1,FWL:1,FS:1,CP:1</availability>
+		<model name='(MML)'>
+			<availability>MOC:6,IS:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:1-,Periphery:4</availability>
 		</model>
-		<model name='HEAT'>
-			<availability>RF:2,LA:2,ROS:2,FS:2</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>MOC:4,IS:4,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Oo-Suzumebachi' unitType='Small Craft'>
@@ -12068,16 +12062,16 @@
 	</chassis>
 	<chassis name='Orc' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
+		<model name='3'>
+			<availability>CHH:4</availability>
+		</model>
 		<model name='2'>
 			<availability>General:5</availability>
-		</model>
-		<model name='4'>
-			<availability>CHH:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
+		<model name='4'>
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
@@ -12089,33 +12083,33 @@
 	</chassis>
 	<chassis name='Orion' unitType='Mek'>
 		<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,Periphery:3,TC:1,CWIE:2,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
-		<model name='ON1-MD'>
-			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MERC:2,FS:2,CP:4</availability>
-		</model>
-		<model name='ON1-MA'>
-			<availability>MOC:4,FWL:6,IS:4,MH:4,CP:6</availability>
-		</model>
-		<model name='ON1-MB'>
-			<availability>CC:2,MOC:2,ROS:4,FWL:4,DA:4,MERC:2,CP:4,DC:2</availability>
-		</model>
-		<model name='ON2-M'>
-			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3,CP:4</availability>
-		</model>
-		<model name='ON1-MC'>
-			<availability>FS:2,MERC:2,DC:4</availability>
-		</model>
-		<model name='ON1-M'>
-			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8,DC:6</availability>
-		</model>
-		<model name='ON1-M-DC'>
-			<availability>IS:5,DC:8</availability>
-		</model>
 		<model name='ON3-M'>
 			<roles>spotter</roles>
 			<availability>CC:6,FWL:6,MERC:5,CP:6</availability>
 		</model>
+		<model name='ON1-MA'>
+			<availability>MOC:4,FWL:6,IS:4,MH:4,CP:6</availability>
+		</model>
+		<model name='ON1-MC'>
+			<availability>FS:2,MERC:2,DC:4</availability>
+		</model>
+		<model name='ON1-MB'>
+			<availability>CC:2,MOC:2,ROS:4,FWL:4,DA:4,MERC:2,CP:4,DC:2</availability>
+		</model>
 		<model name='ON1-K'>
 			<availability>CLAN:2-,Periphery:2-</availability>
+		</model>
+		<model name='ON1-M'>
+			<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8,DC:6</availability>
+		</model>
+		<model name='ON1-MD'>
+			<availability>MOC:4,CC:4,RF:4,ROS:4,FWL:4,MERC:2,FS:2,CP:4</availability>
+		</model>
+		<model name='ON2-M'>
+			<availability>MOC:3,FWL:4,IS:3,MH:3,MERC:3,CP:4</availability>
+		</model>
+		<model name='ON1-M-DC'>
+			<availability>IS:5,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Oro Heavy Tank' unitType='Tank'>
@@ -12136,23 +12130,23 @@
 	</chassis>
 	<chassis name='Osiris' unitType='Mek'>
 		<availability>FVC:6,ROS:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='OSR-4D'>
-			<availability>IS:4</availability>
-		</model>
 		<model name='OSR-5D'>
 			<availability>FS:6</availability>
 		</model>
 		<model name='OSR-3D'>
 			<availability>General:8</availability>
 		</model>
+		<model name='OSR-4D'>
+			<availability>IS:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Osprey' unitType='Mek'>
 		<availability>CC:4,LA:4,ROS:7,FS:4,MERC:4,DC:4</availability>
-		<model name='OSP-36'>
-			<availability>ROS:5</availability>
-		</model>
 		<model name='OSP-26'>
 			<availability>CC:4,ROS:8</availability>
+		</model>
+		<model name='OSP-36'>
+			<availability>ROS:5</availability>
 		</model>
 		<model name='OSP-25'>
 			<availability>General:6</availability>
@@ -12160,6 +12154,12 @@
 	</chassis>
 	<chassis name='Ostroc' unitType='Mek'>
 		<availability>MOC:4,CC:3,LA:4,ROS:4,IS:4,TC:4,DC:5,Periphery:2</availability>
+		<model name='OSR-4K'>
+			<availability>ROS:4,MERC:4,DC:6</availability>
+		</model>
+		<model name='OSR-5C'>
+			<availability>TC:6</availability>
+		</model>
 		<model name='OSR-2C'>
 			<roles>urban</roles>
 			<availability>Periphery:2-</availability>
@@ -12167,12 +12167,6 @@
 		<model name='OSR-2Cb'>
 			<roles>urban</roles>
 			<availability>CLAN:4,IS:4,BAN:2,Periphery:3</availability>
-		</model>
-		<model name='OSR-5C'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='OSR-4K'>
-			<availability>ROS:4,MERC:4,DC:6</availability>
 		</model>
 		<model name='OSR-2D'>
 			<availability>ROS:6,IS:4,Periphery:4</availability>
@@ -12186,14 +12180,11 @@
 	</chassis>
 	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
-		<model name='D'>
+		<model name='B'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
@@ -12201,12 +12192,15 @@
 		<model name='A'>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Ostscout' unitType='Mek'>
 		<availability>CC:2,FVC:1,RF:4,LA:2,ROS:3,FWL:2,FS:2,MERC:3,CP:2,DC:3</availability>
-		<model name='OTT-7Jb'>
-			<roles>recon</roles>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='OTT-7K'>
+			<roles>recon,spotter</roles>
+			<availability>FVC:8,IS:8,DC:8</availability>
 		</model>
 		<model name='OTT-11J'>
 			<roles>recon,spotter</roles>
@@ -12216,9 +12210,9 @@
 			<roles>recon,spotter</roles>
 			<availability>CC:4,RF:5,LA:8,ROS:5,FWL:5,MERC:5,FS:4,CP:5,DC:4</availability>
 		</model>
-		<model name='OTT-7K'>
-			<roles>recon,spotter</roles>
-			<availability>FVC:8,IS:8,DC:8</availability>
+		<model name='OTT-7Jb'>
+			<roles>recon</roles>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostsol' unitType='Mek'>
@@ -12226,17 +12220,14 @@
 		<model name='OTL-7M'>
 			<availability>ROS:6,FWL:6,MERC:4,CP:6</availability>
 		</model>
-		<model name='OTL-5D'>
-			<availability>FVC:3,Periphery.HR:4,PIR:3,FS:2,Periphery:4</availability>
-		</model>
 		<model name='OTL-9M'>
 			<availability>ROS:4,FWL:6,CP:6</availability>
 		</model>
+		<model name='OTL-8D'>
+			<availability>FS:8</availability>
+		</model>
 		<model name='OTL-6D'>
 			<availability>FS:4</availability>
-		</model>
-		<model name='OTL-9R'>
-			<availability>ROS:6,FWL:4,MERC:5,CP:4</availability>
 		</model>
 		<model name='OTL-5M'>
 			<availability>FWL:2,MERC:4,CP:2</availability>
@@ -12244,8 +12235,11 @@
 		<model name='OTL-8M'>
 			<availability>RF:8,FWL:6,MERC:3,CP:6</availability>
 		</model>
-		<model name='OTL-8D'>
-			<availability>FS:8</availability>
+		<model name='OTL-9R'>
+			<availability>ROS:6,FWL:4,MERC:5,CP:4</availability>
+		</model>
+		<model name='OTL-5D'>
+			<availability>FVC:3,Periphery.HR:4,PIR:3,FS:2,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ostwar' unitType='Mek'>
@@ -12256,13 +12250,13 @@
 	</chassis>
 	<chassis name='Outpost' unitType='Dropship'>
 		<availability>CWE:4,CHH:8</availability>
-		<model name='(3063)'>
-			<roles>troop_carrier</roles>
-			<availability>CLAN:4</availability>
-		</model>
 		<model name='(3070)'>
 			<roles>troop_carrier</roles>
 			<availability>CLAN:8</availability>
+		</model>
+		<model name='(3063)'>
+			<roles>troop_carrier</roles>
+			<availability>CLAN:4</availability>
 		</model>
 		<model name='(Defender)'>
 			<roles>artillery,missile_artillery,assault</roles>
@@ -12278,49 +12272,29 @@
 	</chassis>
 	<chassis name='Overlord' unitType='Dropship'>
 		<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
-		<model name='A3A'>
-			<availability>LA:2,ROS:2,FS:2</availability>
-		</model>
-		<model name='(2762)'>
-			<roles>mech_carrier</roles>
-			<availability>General:2,BAN:1</availability>
-		</model>
 		<model name='(3056)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:8,IS:6,FS:8</availability>
+		</model>
+		<model name='A3A'>
+			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 		<model name='A3'>
 			<roles>assault</roles>
 			<availability>FS:3</availability>
 		</model>
+		<model name='(2762)'>
+			<roles>mech_carrier</roles>
+			<availability>General:2,BAN:1</availability>
+		</model>
 	</chassis>
 	<chassis name='Owens' unitType='Mek' omni='IS'>
 		<availability>CC:4,ROS:4,FWL:4,FS:2,MERC:2,CP:4,DC:6</availability>
-		<model name='OW-1'>
-			<roles>recon,spotter</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='OW-1B'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='OW-1D'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='OW-1E'>
-			<roles>recon,spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='OW-1C'>
-			<roles>recon,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='OW-1R'>
-			<roles>recon,spotter</roles>
-			<availability>General:2,CLAN:6</availability>
-		</model>
-		<model name='OW-1A'>
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
@@ -12328,9 +12302,29 @@
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
 		</model>
+		<model name='OW-1'>
+			<roles>recon,spotter</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='OW-1A'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='OW-1R'>
+			<roles>recon,spotter</roles>
+			<availability>General:2,CLAN:6</availability>
+		</model>
+		<model name='OW-1E'>
+			<roles>recon,spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='OW-1F'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='OW-1B'>
+			<roles>recon,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='PAB-28 Sniper Suit' unitType='BattleArmor'>
@@ -12354,8 +12348,8 @@
 	</chassis>
 	<chassis name='Pack Hunter' unitType='Mek'>
 		<availability>CDS:4,CP:4,CWIE:7</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
+		<model name='2'>
+			<availability>CDS:5,CP:5,CWIE:5</availability>
 		</model>
 		<model name='3'>
 			<availability>CWIE:4</availability>
@@ -12363,16 +12357,12 @@
 		<model name='4'>
 			<availability>CWIE:4</availability>
 		</model>
-		<model name='2'>
-			<availability>CDS:5,CP:5,CWIE:5</availability>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Packrat LRPV' unitType='Tank'>
 		<availability>MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
-		<model name='PKR-T5 (SRM2)'>
-			<roles>recon,raider,apc</roles>
-			<availability>CC:5,MOC:5</availability>
-		</model>
 		<model name='PKR-T5'>
 			<roles>recon,raider</roles>
 			<availability>General:8,Periphery:5</availability>
@@ -12381,13 +12371,17 @@
 			<roles>recon,raider</roles>
 			<availability>CC:1,PIR:2,General:1,FWL:1,MERC:1,FS:2,CP:1,Periphery:3,DC:1</availability>
 		</model>
-		<model name='&apos;Gespenst&apos;'>
-			<roles>recon,specops</roles>
-			<availability>LA:2</availability>
+		<model name='PKR-T5 (SRM2)'>
+			<roles>recon,raider,apc</roles>
+			<availability>CC:5,MOC:5</availability>
 		</model>
 		<model name='PKR-T5 (ML)'>
 			<roles>recon,raider</roles>
 			<availability>FWL.pm:4,DA:3-</availability>
+		</model>
+		<model name='&apos;Gespenst&apos;'>
+			<roles>recon,specops</roles>
+			<availability>LA:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Padilla Anti-Missile Tank' unitType='Tank'>
@@ -12406,17 +12400,17 @@
 	</chassis>
 	<chassis name='Padilla Tube Artillery Tank' unitType='Tank'>
 		<availability>IS:4</availability>
-		<model name='(Standard)'>
+		<model name='(LTC)'>
 			<roles>artillery</roles>
-			<availability>General:8</availability>
+			<availability>LA:3,ROS:3,FWL.OG:3,FWL.OH:3,FWL.FO:3,FS:3,DC:3</availability>
 		</model>
 		<model name='(Thumper)'>
 			<roles>artillery</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='(LTC)'>
+		<model name='(Standard)'>
 			<roles>artillery</roles>
-			<availability>LA:3,ROS:3,FWL.OG:3,FWL.OH:3,FWL.FO:3,FS:3,DC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Paladin Defense System' unitType='Tank'>
@@ -12449,6 +12443,30 @@
 	</chassis>
 	<chassis name='Panther' unitType='Mek'>
 		<availability>Periphery.DD:5,FS.RR:4,RD:4,ROS:2,FS.DMM:4,MERC:2,Periphery.OS:5,RA:4,Periphery:2,DC:6</availability>
+		<model name='PNT-10KA'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
+		</model>
+		<model name='PNT-12A'>
+			<roles>fire_support</roles>
+			<availability>ROS:2,DC:2</availability>
+		</model>
+		<model name='PNT-12K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3</availability>
+		</model>
+		<model name='PNT-10K2'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:2,RD:2,ROS:2,FS.DMM:2,MERC:2,RA:2,TC:2,DC:2</availability>
+		</model>
+		<model name='PNT-10K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
+		</model>
+		<model name='PNT-12K'>
+			<roles>fire_support</roles>
+			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
+		</model>
 		<model name='PNT-12KC'>
 			<roles>raider</roles>
 			<availability>DC:4</availability>
@@ -12457,56 +12475,28 @@
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
 		</model>
-		<model name='PNT-10KA'>
+		<model name='PNT-9R'>
 			<roles>fire_support</roles>
-			<availability>FS.RR:1,PIR:3,FS.DMM:1,MERC:1,DC:1,TC:3</availability>
-		</model>
-		<model name='PNT-10K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
-		</model>
-		<model name='PNT-10K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:2,FVC:2,RD:2,ROS:2,FS.DMM:2,MERC:2,RA:2,TC:2,DC:2</availability>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='PNT-13K'>
 			<roles>fire_support</roles>
 			<availability>RD:4,DC:8</availability>
 		</model>
-		<model name='PNT-12A'>
-			<roles>fire_support</roles>
-			<availability>ROS:2,DC:2</availability>
-		</model>
-		<model name='PNT-9R'>
-			<roles>fire_support</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='PNT-12K'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:4,FS.DMM:4,MERC:4,DC:4</availability>
-		</model>
-		<model name='PNT-12K2'>
-			<roles>fire_support</roles>
-			<availability>FS.RR:3,RD:3,ROS:3,FS.DMM:3,MERC:3,DC:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
 		<availability>FWL:2,CP:2</availability>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(MFB)'>
 			<roles>support</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Standard)'>
+			<roles>support</roles>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Parash' unitType='Mek'>
 		<availability>CHH:8</availability>
-		<model name='3'>
-			<roles>recon,spotter</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='2'>
 			<roles>recon,spotter</roles>
 			<availability>General:4</availability>
@@ -12514,6 +12504,10 @@
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<roles>recon,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Partisan AA Vehicle' unitType='Tank'>
@@ -12529,20 +12523,20 @@
 	</chassis>
 	<chassis name='Partisan Air Defense Tank' unitType='Tank'>
 		<availability>CC:5,LA:7,IS:5,FS:8,CP:5,DC:6,Periphery:5,CWIE:5</availability>
-		<model name='(Lance Command)'>
-			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:5,FS:5</availability>
-		</model>
 		<model name='(Quad RAC)'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:4</availability>
 		</model>
+		<model name='(RAC)'>
+			<roles>anti_aircraft</roles>
+			<availability>ROS:5,FS:6</availability>
+		</model>
 		<model name='(LRM)'>
 			<availability>IS:5,Periphery:5</availability>
 		</model>
-		<model name='(Company Command)'>
+		<model name='(Lance Command)'>
 			<roles>spotter,anti_aircraft</roles>
-			<availability>ROS:2,FS:2</availability>
+			<availability>ROS:5,FS:5</availability>
 		</model>
 		<model name='(XL)'>
 			<roles>anti_aircraft</roles>
@@ -12551,13 +12545,13 @@
 		<model name='(Cell)'>
 			<availability>General:5</availability>
 		</model>
-		<model name='(RAC)'>
-			<roles>anti_aircraft</roles>
-			<availability>ROS:5,FS:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>anti_aircraft</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Company Command)'>
+			<roles>spotter,anti_aircraft</roles>
+			<availability>ROS:2,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Partisan Heavy Tank' unitType='Tank'>
@@ -12566,12 +12560,12 @@
 			<roles>anti_aircraft</roles>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='(LRM)'>
+			<availability>Periphery:2-</availability>
+		</model>
 		<model name='(C3)'>
 			<roles>anti_aircraft</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='(LRM)'>
-			<availability>Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Pathfinder' unitType='Mek'>
@@ -12613,20 +12607,20 @@
 	</chassis>
 	<chassis name='Patton Tank' unitType='Tank'>
 		<availability>FVC:5,RF:5,LA:5,ROS:5,FS:4,CWIE:5</availability>
-		<model name='(Standard)'>
-			<availability>Periphery:2</availability>
-		</model>
 		<model name='(Ultra)'>
 			<availability>LA:8,General:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>Periphery:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Peacekeeper' unitType='Mek'>
 		<availability>ROS:6,DC:6</availability>
-		<model name='PKP-2K'>
-			<availability>DC:5</availability>
-		</model>
 		<model name='PKP-1B'>
 			<availability>General:4</availability>
+		</model>
+		<model name='PKP-2K'>
+			<availability>DC:5</availability>
 		</model>
 		<model name='PKP-1A'>
 			<availability>General:8</availability>
@@ -12638,14 +12632,6 @@
 			<roles>recon,spotter</roles>
 			<availability>LA:4,FS:4,DC:8</availability>
 		</model>
-		<model name='X-Pulse'>
-			<roles>recon</roles>
-			<availability>General:4</availability>
-		</model>
-		<model name='(3058 Upgrade)'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,FS:8,DC:7</availability>
-		</model>
 		<model name='(MRM)'>
 			<roles>recon</roles>
 			<availability>DC:6</availability>
@@ -12653,6 +12639,14 @@
 		<model name='(Sealed)'>
 			<roles>recon,spotter</roles>
 			<availability>LA:6,ROS:6,FS:6,DC:6</availability>
+		</model>
+		<model name='X-Pulse'>
+			<roles>recon</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='(3058 Upgrade)'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,FS:8,DC:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Pendragon' unitType='Mek'>
@@ -12664,20 +12658,20 @@
 	</chassis>
 	<chassis name='Penetrator' unitType='Mek'>
 		<availability>FVC:7,LA:5,FS:7,MERC:4</availability>
+		<model name='PTR-6S'>
+			<availability>LA:5,FS:5</availability>
+		</model>
 		<model name='PTR-4F'>
 			<availability>LA:3,FS:3</availability>
-		</model>
-		<model name='PTR-4D'>
-			<availability>General:8</availability>
-		</model>
-		<model name='PTR-6T'>
-			<availability>FS.DBG:8,FS:4</availability>
 		</model>
 		<model name='PTR-6M'>
 			<availability>LA:5,FS:5</availability>
 		</model>
-		<model name='PTR-6S'>
-			<availability>LA:5,FS:5</availability>
+		<model name='PTR-6T'>
+			<availability>FS.DBG:8,FS:4</availability>
+		</model>
+		<model name='PTR-4D'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Penthesilea' unitType='Mek'>
@@ -12685,11 +12679,11 @@
 		<model name='PEN-2MAF'>
 			<availability>General:4</availability>
 		</model>
-		<model name='PEN-3H'>
-			<availability>MOC:6,CC:5</availability>
-		</model>
 		<model name='PEN-2H'>
 			<availability>General:8</availability>
+		</model>
+		<model name='PEN-3H'>
+			<availability>MOC:6,CC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
@@ -12710,31 +12704,31 @@
 	</chassis>
 	<chassis name='Perseus' unitType='Mek' omni='IS'>
 		<availability>ROS:4,FWL:5,CP:5</availability>
-		<model name='P1E'>
-			<availability>General:4</availability>
-		</model>
-		<model name='P1P'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='P1D'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1'>
-			<availability>General:8</availability>
-		</model>
-		<model name='P1C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='P1B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='P1A'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='P1B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='P1'>
+			<availability>General:8</availability>
+		</model>
+		<model name='P1P'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
+		<model name='P1C'>
+			<availability>General:7</availability>
+		</model>
 		<model name='P1W'>
 			<availability>General:2</availability>
+		</model>
+		<model name='P1E'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Phalanx Battle Armor' unitType='BattleArmor'>
@@ -12748,70 +12742,70 @@
 	</chassis>
 	<chassis name='Phalanx Support Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,FWL:5,IS:4,FS:4,MERC:4,CP:5,DC:4</availability>
+		<model name='(Prototype)'>
+			<availability>LA:2</availability>
+		</model>
 		<model name='(Production)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Prototype)'>
-			<availability>LA:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Phantom' unitType='Mek' omni='Clan'>
 		<availability>CWE:8,CHH:7,CJF:7,RA:6,CWIE:8</availability>
-		<model name='Prime'>
-			<roles>recon,spotter</roles>
-			<availability>RD:9,General:8</availability>
-		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
-			<availability>RD:6,CDS:4,General:5,CP:5</availability>
+		<model name='E'>
+			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
+		<model name='D'>
+			<availability>RD:4,General:5</availability>
 		</model>
 		<model name='H'>
 			<availability>CLAN:4,General:3</availability>
 		</model>
-		<model name='D'>
-			<availability>RD:4,General:5</availability>
+		<model name='Prime'>
+			<roles>recon,spotter</roles>
+			<availability>RD:9,General:8</availability>
 		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>RD:7,General:6</availability>
 		</model>
-		<model name='E'>
-			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
 		<model name='F'>
 			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='C'>
+			<availability>RD:6,CDS:4,General:5,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk IIC' unitType='Mek'>
 		<availability>CC:3,CDS:5,RF:3,LA:3,ROS:4,CLAN:3,CP:5,MERC:3,FS:3,RA:5,DC:3</availability>
-		<model name='5'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:8,RF:4,LA:4,ROS:4,FS:4,MERC:4,CP:8,DC:4</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>IS:3,CP:1,DC:3</availability>
-		</model>
-		<model name='4'>
-			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,CP:6,DC:4</availability>
-		</model>
-		<model name='6'>
-			<availability>RD:6,CDS:8,CP:8</availability>
 		</model>
 		<model name='7'>
 			<availability>RD:8,CDS:6,General:6,DC:6</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:8,CP:8</availability>
+		<model name='4'>
+			<availability>CDS:6,LA:4,ROS:4,FS:4,MERC:4,CP:6,DC:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:8,RF:4,LA:4,ROS:4,FS:4,MERC:4,CP:8,DC:4</availability>
+		</model>
+		<model name='6'>
+			<availability>RD:6,CDS:8,CP:8</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>RA:2</availability>
+		</model>
+		<model name='5'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='8'>
+			<availability>CDS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Phoenix Hawk L' unitType='Mek'>
@@ -12825,57 +12819,57 @@
 	</chassis>
 	<chassis name='Phoenix Hawk' unitType='Mek'>
 		<availability>RD:4,IS:7,FWL:8,CP:8,Periphery:6</availability>
-		<model name='PXH-6D'>
-			<availability>FS:8</availability>
-		</model>
-		<model name='PXH-1c (Special)'>
-			<roles>recon</roles>
-			<availability>CC:4,CLAN:3,FWL:4,MERC:4,DA:4,CP:4</availability>
+		<model name='PXH-7K'>
+			<availability>DC:4</availability>
 		</model>
 		<model name='PXH-7S'>
 			<availability>RF:4,LA:8,ROS:4,MERC:6</availability>
 		</model>
+		<model name='PXH-4W'>
+			<availability>MOC:6,TC:6</availability>
+		</model>
 		<model name='PXH-4L'>
 			<availability>CC:8,MOC:4,MH:4,DA:4,TC:4</availability>
 		</model>
-		<model name='PXH-3PL'>
-			<availability>ROS:4,FS:6,MERC:4</availability>
-		</model>
-		<model name='PXH-1'>
-			<roles>recon</roles>
-			<availability>BAN:6,Periphery:1-</availability>
-		</model>
-		<model name='PXH-8CS'>
-			<availability>RD:4,ROS:2,DC:2</availability>
-		</model>
-		<model name='PXH-3D'>
-			<roles>recon</roles>
-			<availability>FVC:8,FS:8,MERC:6</availability>
-		</model>
 		<model name='PXH-5L'>
 			<availability>CC:6,MOC:4</availability>
-		</model>
-		<model name='PXH-3M'>
-			<roles>recon</roles>
-			<availability>RF:8,FWL:8,IS:4,DA:8,CP:8</availability>
-		</model>
-		<model name='PXH-3K'>
-			<roles>recon</roles>
-			<availability>RD:6,DC:8</availability>
 		</model>
 		<model name='PXH-1b (Special)'>
 			<roles>recon</roles>
 			<availability>CLAN:5,FWL:5,CP:5,BAN:1</availability>
 		</model>
+		<model name='PXH-6D'>
+			<availability>FS:8</availability>
+		</model>
+		<model name='PXH-3K'>
+			<roles>recon</roles>
+			<availability>RD:6,DC:8</availability>
+		</model>
 		<model name='PXH-3S'>
 			<roles>recon</roles>
 			<availability>LA:2,MERC:4</availability>
 		</model>
-		<model name='PXH-7K'>
-			<availability>DC:4</availability>
+		<model name='PXH-3M'>
+			<roles>recon</roles>
+			<availability>RF:8,FWL:8,IS:4,DA:8,CP:8</availability>
 		</model>
-		<model name='PXH-4W'>
-			<availability>MOC:6,TC:6</availability>
+		<model name='PXH-3PL'>
+			<availability>ROS:4,FS:6,MERC:4</availability>
+		</model>
+		<model name='PXH-8CS'>
+			<availability>RD:4,ROS:2,DC:2</availability>
+		</model>
+		<model name='PXH-1'>
+			<roles>recon</roles>
+			<availability>BAN:6,Periphery:1-</availability>
+		</model>
+		<model name='PXH-1c (Special)'>
+			<roles>recon</roles>
+			<availability>CC:4,CLAN:3,FWL:4,MERC:4,DA:4,CP:4</availability>
+		</model>
+		<model name='PXH-3D'>
+			<roles>recon</roles>
+			<availability>FVC:8,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Picaroon' unitType='Aero'>
@@ -12886,17 +12880,17 @@
 	</chassis>
 	<chassis name='Pike Support Vehicle' unitType='Tank'>
 		<availability>RA.OA:1-,CC:3,CHH:3,MERC.WD:3,CDS:4,CLAN:3,MH:1-,CP:3,CWIE:4,Periphery:2-</availability>
+		<model name='(Missile)'>
+			<availability>MOC:2</availability>
+		</model>
 		<model name='(Clan)'>
 			<availability>CC:8,MERC.WD:8,CLAN:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>Periphery:2</availability>
 		</model>
 		<model name='(RAC) &apos;Assault Pike&apos;'>
 			<availability>CC:8,MOC:6,FS:6,MERC:8,DA:8,TC:6</availability>
 		</model>
-		<model name='(Missile)'>
-			<availability>MOC:2</availability>
+		<model name='(Standard)'>
+			<availability>Periphery:2</availability>
 		</model>
 		<model name='(AC5)'>
 			<availability>MOC:2</availability>
@@ -12904,6 +12898,9 @@
 	</chassis>
 	<chassis name='Pillager' unitType='Mek'>
 		<availability>CC:6,MOC:3,MERC.WD:4,MERC.KH:4,ROS:4,MERC:4,CP:6</availability>
+		<model name='PLG-5Z'>
+			<availability>CC:4</availability>
+		</model>
 		<model name='PLG-5L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:5</availability>
@@ -12914,19 +12911,16 @@
 		<model name='PLG-3Z'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PLG-5Z'>
-			<availability>CC:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Pilum Heavy Tank' unitType='Tank'>
 		<availability>LA:4,ROS:5,FS:7,MERC:5</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pinion' unitType='Mek'>
@@ -12949,9 +12943,6 @@
 	</chassis>
 	<chassis name='Piranha' unitType='Mek'>
 		<availability>CHH:6,CDS:5,CP:5,RA:3,CWIE:3</availability>
-		<model name='2'>
-			<availability>CHH:8,CDS:8,CP:8</availability>
-		</model>
 		<model name='4'>
 			<roles>anti_infantry</roles>
 			<availability>CDS:4,CP:4</availability>
@@ -12961,6 +12952,9 @@
 		</model>
 		<model name='3'>
 			<availability>CDS:6,CP:6,RA:6</availability>
+		</model>
+		<model name='2'>
+			<availability>CHH:8,CDS:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Pirate' unitType='Infantry'>
@@ -12978,9 +12972,6 @@
 	</chassis>
 	<chassis name='Plainsman Medium Hovertank' unitType='Tank'>
 		<availability>MERC.WD:3,RD:3,LA:5,FWL:4,IS:3,CP:4,TC:8,Periphery:3</availability>
-		<model name='(Sealed)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Streak)'>
 			<availability>IS:6,TC:6,Periphery:4</availability>
 		</model>
@@ -12990,6 +12981,9 @@
 		</model>
 		<model name='(Standard)'>
 			<availability>IS:2,Periphery:2</availability>
+		</model>
+		<model name='(Sealed)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
@@ -13027,30 +13021,30 @@
 	</chassis>
 	<chassis name='Po II Heavy Tank' unitType='Tank'>
 		<availability>CC:7,MOC:5,DA:5</availability>
-		<model name='(Stealth)'>
-			<availability>CC:4,MOC:4</availability>
-		</model>
 		<model name='(Gauss)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(Stealth)'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
 		<model name='(Arrow IV)'>
 			<roles>missile_artillery</roles>
 			<availability>MOC:8,CC:8</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CC:4,MOC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Poignard' unitType='Aero'>
 		<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
-		<model name='PGD-R3'>
-			<roles>ground_support</roles>
+		<model name='PGD-L3'>
 			<availability>General:4</availability>
 		</model>
 		<model name='PGD-Y3'>
 			<availability>General:8</availability>
 		</model>
-		<model name='PGD-L3'>
+		<model name='PGD-R3'>
+			<roles>ground_support</roles>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -13062,38 +13056,38 @@
 	</chassis>
 	<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
 		<availability>CHH:1,CDS:5,CP:5,RA:5,CWIE:1</availability>
-		<model name='(2875)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2611)'>
 			<roles>cruiser</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2875)'>
+			<roles>cruiser</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Pouncer' unitType='Mek' omni='Clan'>
 		<availability>CWE:8,CHH:4,CP:4,CWIE:8</availability>
-		<model name='Prime'>
-			<availability>RD:8,CDS:6,General:8,CP:6,CJF:7</availability>
+		<model name='F'>
+			<availability>CLAN:4,General:3</availability>
+		</model>
+		<model name='H'>
+			<availability>CWE:5,RD:3,CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
 		<model name='D'>
 			<availability>General:6</availability>
 		</model>
+		<model name='Prime'>
+			<availability>RD:8,CDS:6,General:8,CP:6,CJF:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CLAN:4,General:3,CP:5</availability>
+		</model>
 		<model name='C'>
 			<availability>General:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CWE:5,RD:3,CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4,General:3</availability>
 		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
@@ -13117,17 +13111,17 @@
 	</chassis>
 	<chassis name='Prefect' unitType='Mek'>
 		<availability>ROS:4</availability>
-		<model name='PRF-2R'>
-			<availability>General:4</availability>
-		</model>
-		<model name='PRF-1R'>
-			<availability>General:8</availability>
-		</model>
 		<model name='PRF-3R'>
 			<availability>General:5</availability>
 		</model>
+		<model name='PRF-2R'>
+			<availability>General:4</availability>
+		</model>
 		<model name='PRF-1C'>
 			<availability>General:6</availability>
+		</model>
+		<model name='PRF-1R'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Prey Seeker' unitType='Mek'>
@@ -13139,11 +13133,11 @@
 	</chassis>
 	<chassis name='Procyon' unitType='ProtoMek'>
 		<availability>CHH:6</availability>
-		<model name='(Standard)'>
-			<availability>CHH:8</availability>
-		</model>
 		<model name='(Quad)'>
 			<availability>CHH:6+</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CHH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Prometheus Combat Support Bridgelayer' unitType='Tank'>
@@ -13154,44 +13148,51 @@
 		</model>
 	</chassis>
 	<chassis name='Protector Combat Support Fighter' unitType='Conventional Fighter'>
-		<availability>MOC:5,FS:2,Periphery:4,DC:2,OA.RA:5</availability>
+		<availability>MOC:5,OA.RA:5,FS:2,Periphery:4,DC:2</availability>
 		<model name='ASF-23'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Prowler Multi-Terrain Vehicle' unitType='Tank'>
 		<availability>General:4-</availability>
-		<model name='(RAF)'>
-			<roles>apc</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Succession Wars)'>
 			<roles>support</roles>
 			<availability>Periphery:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>support</roles>
-			<availability>General:8,CLAN:8</availability>
 		</model>
 		<model name='(ECM)'>
 			<roles>support</roles>
 			<availability>General:4,Periphery:4</availability>
 		</model>
+		<model name='(Sealed)'>
+			<roles>support</roles>
+			<availability>RD:4,IS:4,Periphery:4,RA:4</availability>
+		</model>
 		<model name='(Security)'>
 			<roles>apc</roles>
 			<availability>ROS:6</availability>
+		</model>
+		<model name='(RAF)'>
+			<roles>apc</roles>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='(3140 Upgrade)'>
 			<roles>apc</roles>
 			<availability>ROS:5</availability>
 		</model>
-		<model name='(Sealed)'>
+		<model name='(Standard)'>
 			<roles>support</roles>
-			<availability>RD:4,IS:4,Periphery:4,RA:4</availability>
+			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
 		<availability>CWE:7,MERC.WD:4,RD:5,CDS:7,ROS:4+,CLAN:6,MERC:3+,CP:7,CJF:4,RA:6,BAN:5,CWIE:7</availability>
+		<model name='H'>
+			<availability>CWE:6,CHH:6,CLAN:4,General:3,CJF:6</availability>
+		</model>
+		<model name='J'>
+			<roles>anti_infantry</roles>
+			<availability>CHH:5,General:2</availability>
+		</model>
 		<model name='D'>
 			<availability>CWE:5,RD:3,CDS:5,General:4,CP:5</availability>
 		</model>
@@ -13199,25 +13200,18 @@
 			<roles>fire_support</roles>
 			<availability>CWE:6,CHH:6,RD:3,CDS:7,General:5,CP:5,CJF:6</availability>
 		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:4,CDS:5,General:3,CP:5,CJF:4</availability>
+		</model>
 		<model name='A'>
 			<roles>fire_support</roles>
 			<availability>CWE:5,RD:5,CDS:8,General:7,CP:8,CWIE:6</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:6,RD:4,CDS:5,General:3,CP:5,CJF:4</availability>
-		</model>
-		<model name='J'>
-			<roles>anti_infantry</roles>
-			<availability>CHH:5,General:2</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CLAN:4,General:3,CP:5</availability>
-		</model>
 		<model name='Prime'>
 			<availability>CWE:6,CHH:6,RD:8,CDS:6,General:8,CP:6,CJF:7</availability>
 		</model>
-		<model name='H'>
-			<availability>CWE:6,CHH:6,CLAN:4,General:3,CJF:6</availability>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -13234,15 +13228,15 @@
 	</chassis>
 	<chassis name='Purifier Adaptive Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:5</availability>
-		<model name='[Laser] (RAF)' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[PPC] (RAF)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[TAG] (RAF)' mechanized='true'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='[PPC] (RAF)' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[Laser] (RAF)' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
 		<model name='[Narc] (RAF)' mechanized='true'>
 			<availability>General:4</availability>
@@ -13275,31 +13269,31 @@
 	</chassis>
 	<chassis name='Quickdraw' unitType='Mek'>
 		<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,DA:4,DC:4</availability>
-		<model name='QKD-8K'>
-			<availability>RD:5,ROS:5,MERC:4,DC:8</availability>
+		<model name='QKD-5K'>
+			<availability>MERC:5,DC:4</availability>
 		</model>
 		<model name='QKD-8P'>
 			<roles>spotter</roles>
 			<availability>ROS:6</availability>
 		</model>
-		<model name='QKD-5K'>
-			<availability>MERC:5,DC:4</availability>
-		</model>
-		<model name='QKD-5Mr'>
-			<availability>General:6,FWL:8,CP:8</availability>
-		</model>
-		<model name='QKD-5M'>
-			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
-		</model>
 		<model name='QKD-9M'>
 			<roles>spotter</roles>
 			<availability>CC:5,MOC:5,ROS:4,DA:5,FS:4</availability>
 		</model>
-		<model name='QKD-4G'>
-			<availability>MOC:2-,Periphery:2-,TC:2-</availability>
+		<model name='QKD-8K'>
+			<availability>RD:5,ROS:5,MERC:4,DC:8</availability>
 		</model>
 		<model name='QKD-C'>
 			<availability>MERC:6,DC:8</availability>
+		</model>
+		<model name='QKD-4G'>
+			<availability>MOC:2-,Periphery:2-,TC:2-</availability>
+		</model>
+		<model name='QKD-5M'>
+			<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
+		</model>
+		<model name='QKD-5Mr'>
+			<availability>General:6,FWL:8,CP:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Quirinus Battle Armor' unitType='BattleArmor'>
@@ -13347,24 +13341,24 @@
 	</chassis>
 	<chassis name='Raiden Battle Armor' unitType='BattleArmor'>
 		<availability>DC:4</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>urban</roles>
-			<availability>General:4</availability>
+		<model name='[Laser]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='[Flamer]' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
-		<model name='[Tsunami]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='[MRM]' mechanized='true'>
+			<availability>General:7</availability>
 		</model>
-		<model name='[Laser]' mechanized='true'>
-			<availability>General:6</availability>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
 		</model>
 		<model name='[MG]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[MRM]' mechanized='true'>
-			<availability>General:7</availability>
+		<model name='[Tsunami]' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Raiden II Battle Armor' unitType='BattleArmor'>
@@ -13378,8 +13372,8 @@
 	</chassis>
 	<chassis name='Rakshasa' unitType='Mek'>
 		<availability>LA:2,ROS:3,FS:3,MERC:3</availability>
-		<model name='MDG-2A'>
-			<availability>FS.CMM:9,FS:6</availability>
+		<model name='MDG-1B'>
+			<availability>LA:6,FS:6,MERC:4</availability>
 		</model>
 		<model name='MDG-1Ar'>
 			<availability>ROS:8,FS:4,MERC:4</availability>
@@ -13387,23 +13381,19 @@
 		<model name='MDG-1A'>
 			<availability>LA:8,FS:8,MERC:8</availability>
 		</model>
-		<model name='MDG-1B'>
-			<availability>LA:6,FS:6,MERC:4</availability>
+		<model name='MDG-2A'>
+			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Ranger Armored Fighting Vehicle' unitType='Tank'>
 		<availability>FVC:6,LA:4,ROS:5,ROS.pm:7,FWL:4,MH:6,MERC:6,FS:5,CP:4,CDP:6,DC:4</availability>
-		<model name='VV1'>
+		<model name='VV1 (MG)'>
 			<roles>urban</roles>
-			<availability>General:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VV1 (Interdictor)'>
 			<roles>urban</roles>
 			<availability>FS:4</availability>
-		</model>
-		<model name='VV1 (MG)'>
-			<roles>urban</roles>
-			<availability>General:8</availability>
 		</model>
 		<model name='VV2'>
 			<roles>urban</roles>
@@ -13413,17 +13403,21 @@
 			<roles>urban</roles>
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
+		<model name='VV1'>
+			<roles>urban</roles>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rapier' unitType='Aero'>
 		<availability>LA:6,ROS:4,CLAN:1</availability>
-		<model name='RPR-100b'>
-			<availability>CLAN:4,BAN:2</availability>
+		<model name='RPR-100'>
+			<availability>General:1</availability>
 		</model>
 		<model name='RPR-300S'>
 			<availability>LA:6</availability>
 		</model>
-		<model name='RPR-100'>
-			<availability>General:1</availability>
+		<model name='RPR-100b'>
+			<availability>CLAN:4,BAN:2</availability>
 		</model>
 		<model name='RPR-300'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -13431,11 +13425,11 @@
 	</chassis>
 	<chassis name='Raptor II' unitType='Mek'>
 		<availability>ROS:4</availability>
-		<model name='RPT-5X'>
+		<model name='RPT-2X'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='RPT-2X2'>
+		<model name='RPT-5X'>
 			<roles>specops</roles>
 			<availability>General:4</availability>
 		</model>
@@ -13443,28 +13437,40 @@
 			<roles>specops</roles>
 			<availability>General:2</availability>
 		</model>
+		<model name='RPT-2X2'>
+			<roles>specops</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='RPT-3X'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='RPT-2X'>
-			<roles>specops</roles>
-			<availability>General:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Raptor' unitType='Mek' omni='IS'>
 		<availability>DC:6</availability>
-		<model name='RTX1-O'>
-			<availability>General:8</availability>
+		<model name='RTX1-OE'>
+			<availability>General:7</availability>
+		</model>
+		<model name='RTX1-OF'>
+			<availability>General:7</availability>
 		</model>
 		<model name='RTX1-OR'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='RTX1-OU'>
-			<availability>General:2</availability>
+		<model name='RTX1-OC'>
+			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OG'>
+			<availability>General:4</availability>
+		</model>
+		<model name='RTX1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RTX1-OB'>
 			<availability>General:6</availability>
+		</model>
+		<model name='RTX1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='RTX1-OA'>
 			<availability>General:6</availability>
@@ -13473,32 +13479,20 @@
 			<roles>recon,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='RTX1-OE'>
-			<availability>General:7</availability>
-		</model>
-		<model name='RTX1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='RTX1-OC'>
-			<availability>General:6</availability>
-		</model>
-		<model name='RTX1-OF'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
 		<availability>Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
-		<model name='(LRM)' mechanized='false'>
-			<availability>General:4,MH:0</availability>
-		</model>
 		<model name='(MH)' mechanized='false'>
 			<availability>MH:8</availability>
 		</model>
-		<model name='(LRM) [MH]' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:8,MH:0</availability>
+		</model>
+		<model name='(LRM)' mechanized='false'>
+			<availability>General:4,MH:0</availability>
+		</model>
+		<model name='(LRM) [MH]' mechanized='false'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Raven II' unitType='Mek'>
@@ -13510,40 +13504,40 @@
 	</chassis>
 	<chassis name='Raven' unitType='Mek'>
 		<availability>CC:6,MOC:2,FWL:2,MERC:2,DA:4,CP:2,TC:2</availability>
-		<model name='RVN-4Lr'>
-			<roles>spotter</roles>
-			<availability>CC:7,MOC:6</availability>
-		</model>
-		<model name='RVN-3L'>
-			<roles>spotter</roles>
-			<availability>CC:1,MOC:1,MERC:1,DC:1,TC:1</availability>
-		</model>
 		<model name='RVN-3M'>
 			<roles>fire_support</roles>
 			<availability>CC:2,MOC:3,FWL:3,MERC:3,CP:3,TC:3</availability>
 		</model>
-		<model name='RVN-4L'>
+		<model name='RVN-4Lr'>
 			<roles>spotter</roles>
-			<availability>CC:4,MOC:4,DA:6,TC:4</availability>
+			<availability>CC:7,MOC:6</availability>
 		</model>
 		<model name='RVN-4LC'>
 			<roles>spotter</roles>
 			<availability>CC:2,MOC:2,DA:4,TC:2</availability>
 		</model>
+		<model name='RVN-3L'>
+			<roles>spotter</roles>
+			<availability>CC:1,MOC:1,MERC:1,DC:1,TC:1</availability>
+		</model>
+		<model name='RVN-4L'>
+			<roles>spotter</roles>
+			<availability>CC:4,MOC:4,DA:6,TC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Razorback' unitType='Mek'>
 		<availability>RF:4,LA:6,ROS:4,FWL:2,MH:4,MERC:4,FS:4,DA:4,CP:2</availability>
-		<model name='RZK-9S'>
-			<availability>General:8</availability>
-		</model>
 		<model name='RZK-10T'>
 			<availability>LA:4</availability>
 		</model>
-		<model name='RZK-10S'>
-			<availability>LA:6</availability>
+		<model name='RZK-9S'>
+			<availability>General:8</availability>
 		</model>
 		<model name='RZK-9T'>
 			<availability>:0,General:6</availability>
+		</model>
+		<model name='RZK-10S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Recon Infantry' unitType='Infantry'>
@@ -13577,23 +13571,15 @@
 		<model name='(Stealth)'>
 			<availability>CC:8</availability>
 		</model>
-		<model name='(RAC)'>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:2</availability>
+		</model>
+		<model name='(RAC)'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Revenant' unitType='Mek'>
 		<availability>ROS:3</availability>
-		<model name='UBM-2R3'>
-			<roles>specops</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='UBM-2R2'>
-			<roles>specops</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='UBM-2R'>
 			<roles>specops</roles>
 			<availability>General:8</availability>
@@ -13602,6 +13588,14 @@
 			<roles>specops</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='UBM-2R3'>
+			<roles>specops</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='UBM-2R2'>
+			<roles>specops</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='UBM-2R4'>
 			<roles>spotter,specops</roles>
 			<availability>General:6</availability>
@@ -13609,84 +13603,94 @@
 	</chassis>
 	<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 		<availability>MOC:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,RA.OA:7,LA:7,ROS:7,DC:6</availability>
-		<model name='(MG)'>
-			<roles>fire_support</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>CWE:1,CHH:1,General:8,CP:1</availability>
 		</model>
-		<model name='(ML)'>
+		<model name='(MG)'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>General:6</availability>
 		</model>
 		<model name='(SL)'>
 			<roles>fire_support</roles>
 			<availability>IS:4,Periphery:4</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(ML)'>
 			<roles>fire_support</roles>
-			<availability>CLAN:4,BAN:2</availability>
+			<availability>TC:6</availability>
 		</model>
 		<model name='(Flamer)'>
 			<roles>fire_support</roles>
 			<availability>IS:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
+		<model name='(Royal)'>
+			<roles>fire_support</roles>
+			<availability>CLAN:4,BAN:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Riever' unitType='Aero'>
 		<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
+		<model name='F-700a'>
+			<availability>CC:7,MOC:5,RF:6,ROS:8,FWL:6,FS:5,MERC:7,DA:6,CP:6</availability>
+		</model>
 		<model name='F-100a'>
 			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 		<model name='F-700'>
 			<availability>CC:8,MOC:5,RF:8,ROS:8,FWL:8,MERC:8,DA:8,CP:8</availability>
 		</model>
-		<model name='F-100'>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
-		<model name='F-700a'>
-			<availability>CC:7,MOC:5,RF:6,ROS:8,FWL:6,FS:5,MERC:7,DA:6,CP:6</availability>
-		</model>
 		<model name='F-700b'>
 			<availability>MOC:5,CC:5,ROS:6,FWL:8,MERC:8,CP:8,DC:8</availability>
+		</model>
+		<model name='F-100'>
+			<availability>FVC:2-,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman IIC' unitType='Mek'>
 		<availability>CHH:5,RD:5,CDS:5,IS:3,CP:5,RA:5</availability>
-		<model name='6'>
-			<availability>CHH:4,CDS:6,CP:6</availability>
-		</model>
 		<model name='8'>
 			<availability>CC:4,RD:6,CDS:4,LA:4,IS:4,FS:4,MERC:4,CP:4,DC:4</availability>
-		</model>
-		<model name='3'>
-			<availability>CDS:4,ROS:4,MERC:4,FS:4,CP:4</availability>
-		</model>
-		<model name='7'>
-			<availability>ROS:4,CP:8,DC:6</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CDS:1,CP:1,RA:2</availability>
 		</model>
 		<model name='5'>
 			<availability>CDS:4,IS:4,CP:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>CDS:1,CP:1,RA:2</availability>
+		</model>
+		<model name='7'>
+			<availability>ROS:4,CP:8,DC:6</availability>
+		</model>
 		<model name='4'>
 			<availability>ROS:5,FS:5</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:4,CDS:6,CP:6</availability>
+		</model>
+		<model name='3'>
+			<availability>CDS:4,ROS:4,MERC:4,FS:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Rifleman' unitType='Mek'>
 		<availability>CC:4,ROS:6,IS:4,FWL:7,FS:8,CP:7,CJF:6,Periphery:2</availability>
+		<model name='RFL-7M'>
+			<availability>MOC:4,RF:8,FWL:8,IS:4,DA:8,CP:8,CDP:4,DC:5,TC:4</availability>
+		</model>
+		<model name='RFL-3N'>
+			<roles>fire_support,anti_aircraft</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='RFL-5D'>
+			<availability>FVC:3,LA:1,FS:2,MERC:2</availability>
+		</model>
+		<model name='RFL-3Cr'>
+			<availability>FS:2</availability>
+		</model>
 		<model name='RFL-1N'>
 			<roles>fire_support</roles>
 			<availability>MOC:1-,PIR:1-,MH:1-</availability>
 		</model>
-		<model name='RFL-7M'>
-			<availability>MOC:4,RF:8,FWL:8,IS:4,DA:8,CP:8,CDP:4,DC:5,TC:4</availability>
-		</model>
-		<model name='RFL-5D'>
-			<availability>FVC:3,LA:1,FS:2,MERC:2</availability>
+		<model name='C 2'>
+			<availability>CJF:4</availability>
 		</model>
 		<model name='RFL-8D'>
 			<availability>FS:2</availability>
@@ -13701,49 +13705,39 @@
 			<roles>fire_support</roles>
 			<availability>ROS:5,MERC:5</availability>
 		</model>
-		<model name='C 2'>
-			<availability>CJF:4</availability>
-		</model>
 		<model name='RFL-5M'>
 			<availability>Periphery.MW:3,Periphery.ME:3,FWL:1,MH:3,CP:1</availability>
-		</model>
-		<model name='RFL-3Cr'>
-			<availability>FS:2</availability>
-		</model>
-		<model name='RFL-3N'>
-			<roles>fire_support,anti_aircraft</roles>
-			<availability>Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Ripper Infantry Transport' unitType='VTOL'>
 		<availability>CC:5,CHH:4,FVC:4,LA:5,ROS:6,CLAN:2,FS:5,DC:5</availability>
-		<model name='(SPL)'>
+		<model name='(Standard)'>
 			<roles>apc</roles>
-			<availability>FVC:4,IS:4</availability>
+			<availability>General:8,BAN:2</availability>
 		</model>
-		<model name='(ERML)'>
+		<model name='(Royal)'>
 			<roles>apc</roles>
-			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
+			<availability>CHH:8,CLAN:6</availability>
 		</model>
 		<model name='(Light PPC)'>
 			<roles>apc</roles>
 			<availability>FS:4,CP:4,DC:5</availability>
 		</model>
-		<model name='(Infantry)'>
+		<model name='(ERML)'>
 			<roles>apc</roles>
-			<availability>LA:5,ROS:4,FS:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8,BAN:2</availability>
+			<availability>CC:6,LA:6,ROS:6,FS:6,DC:6</availability>
 		</model>
 		<model name='(MG)'>
 			<roles>apc</roles>
 			<availability>CC:6,FVC:6,LA:6,FS:6,DC:6</availability>
 		</model>
-		<model name='(Royal)'>
+		<model name='(Infantry)'>
 			<roles>apc</roles>
-			<availability>CHH:8,CLAN:6</availability>
+			<availability>LA:5,ROS:4,FS:4</availability>
+		</model>
+		<model name='(SPL)'>
+			<roles>apc</roles>
+			<availability>FVC:4,IS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Roadrunner (Emerald Harrier)' unitType='Mek'>
@@ -13755,27 +13749,27 @@
 	</chassis>
 	<chassis name='Roc' unitType='ProtoMek'>
 		<availability>CHH:4,CP:7,RA:7</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:5</availability>
+		</model>
+		<model name='2'>
+			<availability>RA:8</availability>
+		</model>
 		<model name='3'>
 			<availability>CP:4,RA:6</availability>
 		</model>
 		<model name='4'>
 			<availability>RA:6</availability>
 		</model>
-		<model name='2'>
-			<availability>RA:8</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:5</availability>
-		</model>
 	</chassis>
 	<chassis name='Rogue Bear Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>RD:6-</availability>
-		<model name='(Upgrade)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Hybrid)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>General:4</availability>
+		</model>
+		<model name='(Upgrade)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:8</availability>
@@ -13783,30 +13777,30 @@
 	</chassis>
 	<chassis name='Rokurokubi' unitType='Mek'>
 		<availability>DC:8</availability>
-		<model name='RK-4T'>
-			<availability>General:4</availability>
-		</model>
 		<model name='RK-4K'>
 			<availability>General:8</availability>
 		</model>
 		<model name='RK-4X'>
 			<availability>General:2</availability>
 		</model>
+		<model name='RK-4T'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Rommel Tank' unitType='Tank'>
 		<availability>RA.OA:5,FVC:4,RF:4,LA:5,ROS:4,FS:3,MERC:2,CWIE:6,TC:6</availability>
+		<model name='(Gauss)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Sealed)'>
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
-		<model name='(Gauss)'>
-			<availability>General:8</availability>
+		<model name='(Standard)'>
+			<availability>RF:0,ROS:0,General:1-,TC:0,CWIE:0</availability>
 		</model>
 		<model name='(Howitzer) Production'>
 			<roles>artillery,fire_support</roles>
 			<availability>LA:4,CWIE:4</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>RF:0,ROS:0,General:1-,TC:0,CWIE:0</availability>
 		</model>
 	</chassis>
 	<chassis name='Rondel' unitType='Aero'>
@@ -13837,16 +13831,16 @@
 			<roles>urban</roles>
 			<availability>LA:4</availability>
 		</model>
-		<model name='(Firedrake)' mechanized='false'>
-			<roles>anti_infantry</roles>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<roles>recon</roles>
 			<availability>LA:4</availability>
 		</model>
 		<model name='(Upgrade)' mechanized='false'>
 			<availability>LA:8</availability>
+		</model>
+		<model name='(Firedrake)' mechanized='false'>
+			<roles>anti_infantry</roles>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Rotunda Scout Vehicle' unitType='Tank'>
@@ -13859,44 +13853,44 @@
 	</chassis>
 	<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
 		<availability>MERC.WD:5,CDS:4,CLAN:4,MERC:3+,CP:4,CJF:4,RA:5,BAN:5,CWIE:5,DC:4+</availability>
-		<model name='G'>
-			<availability>CHH:5,General:3</availability>
+		<model name='D'>
+			<availability>CWE:3,RD:3,CDS:8,General:5,CP:7,CJF:4</availability>
 		</model>
 		<model name='B'>
 			<availability>CWE:5,RD:3,CDS:8,General:6,CP:8,CJF:4,CWIE:5</availability>
 		</model>
-		<model name='H'>
-			<availability>CLAN:3,General:2</availability>
+		<model name='A'>
+			<availability>CWE:6,RD:3,CDS:9,General:6,CP:9,CJF:5</availability>
 		</model>
-		<model name='I'>
+		<model name='H'>
 			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='Prime'>
 			<availability>CWE:8,RD:8,CDS:5,General:7,CP:6,CJF:9</availability>
 		</model>
-		<model name='A'>
-			<availability>CWE:6,RD:3,CDS:9,General:6,CP:9,CJF:5</availability>
+		<model name='F'>
+			<availability>General:3,CJF:5</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:3,RD:3,CDS:8,General:5,CP:7,CJF:4</availability>
+		<model name='I'>
+			<availability>CLAN:3,General:2</availability>
 		</model>
 		<model name='E'>
 			<availability>CHH:4,CDS:6,General:5,CP:5,CJF:4,RA:6,CWIE:6</availability>
 		</model>
-		<model name='F'>
-			<availability>General:3,CJF:5</availability>
-		</model>
 		<model name='C'>
 			<availability>RD:6,General:5,RA:6,CWIE:5</availability>
+		</model>
+		<model name='G'>
+			<availability>CHH:5,General:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Ryoken III-XP' unitType='Mek' omni='IS'>
 		<availability>CWE:3</availability>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>General:7</availability>
 		</model>
 		<model name='D'>
 			<availability>General:7</availability>
@@ -13904,20 +13898,20 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Ryoken II' unitType='Mek'>
 		<availability>CHH:4,RD:5,CDS:4,ROS:3,IS:2,CP:4</availability>
-		<model name='2'>
-			<availability>RD:6,ROS:6</availability>
+		<model name='3'>
+			<availability>CHH:8,RD:4,ROS:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>RD:8,CDS:8,IS:8,CP:8</availability>
 		</model>
-		<model name='3'>
-			<availability>CHH:8,RD:4,ROS:4</availability>
+		<model name='2'>
+			<availability>RD:6,ROS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SM1 Tank Destroyer' unitType='Tank'>
@@ -13958,13 +13952,13 @@
 			<roles>sr_fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(3054 Upgrade)'>
-			<roles>sr_fire_support</roles>
-			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,CP:8,DC:6,Periphery:6</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>sr_fire_support</roles>
 			<availability>CC:4,LA:5,FWL:4,IS:2,FS:5,CP:4,DC:8,Periphery:4</availability>
+		</model>
+		<model name='(3054 Upgrade)'>
+			<roles>sr_fire_support</roles>
+			<availability>CC:8,LA:8,FWL:8,IS:8,FS:8,CP:8,DC:6,Periphery:6</availability>
 		</model>
 	</chassis>
 	<chassis name='SRM Foot Infantry' unitType='Infantry'>
@@ -13981,33 +13975,27 @@
 		<model name='SB-29'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
-		<model name='SB-31D'>
-			<roles>escort</roles>
-			<availability>DC:6</availability>
+		<model name='SB-28'>
+			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SB-27b'>
 			<availability>CC:8,MOC:6,ROS:6,CLAN:4,FS:8,MERC:6</availability>
 		</model>
-		<model name='SB-28'>
-			<availability>LA:8,ROS:6,FS:6,MERC:6</availability>
+		<model name='SB-31D'>
+			<roles>escort</roles>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
+		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='X'>
-			<availability>General:1,CJF:3,RA:3</availability>
-		</model>
-		<model name='E'>
-			<availability>General:2,CJF:5,RA:5</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -14016,17 +14004,23 @@
 			<roles>spotter</roles>
 			<availability>General:6</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='X'>
+			<availability>General:1,CJF:3,RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Sagittaire' unitType='Mek'>
 		<availability>FVC:4,ROS:4,FS:6,MERC:4</availability>
+		<model name='SGT-8R'>
+			<availability>FVC:8,FS:4</availability>
+		</model>
 		<model name='SGT-10X'>
 			<availability>ROS:6,FS:6,MERC:6</availability>
 		</model>
 		<model name='SGT-14D'>
 			<availability>FS:5</availability>
-		</model>
-		<model name='SGT-8R'>
-			<availability>FVC:8,FS:4</availability>
 		</model>
 		<model name='SGT-9D'>
 			<roles>spotter</roles>
@@ -14035,20 +14029,20 @@
 	</chassis>
 	<chassis name='Sagittarii' unitType='Aero'>
 		<availability>ROS:8</availability>
-		<model name='SGT-4R'>
-			<availability>General:6</availability>
-		</model>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
 		</model>
 		<model name='SGT-3R'>
 			<availability>General:6</availability>
 		</model>
+		<model name='SGT-4R'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Sai' unitType='Aero'>
 		<availability>CWE:4,RD:4,CDS:4,ROS:5,FS:4,CP:4,BAN:1,DC:7,CWIE:4</availability>
-		<model name='S-7'>
-			<availability>CP:6,DC:4</availability>
+		<model name='S-4C'>
+			<availability>ROS:4,CLAN:8,DC:4</availability>
 		</model>
 		<model name='S-8'>
 			<availability>ROS:8,DC:8</availability>
@@ -14056,54 +14050,46 @@
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
 		</model>
-		<model name='S-4C'>
-			<availability>ROS:4,CLAN:8,DC:4</availability>
+		<model name='S-7'>
+			<availability>CP:6,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
 		<availability>CC:4,LA:4,DC.AL:7,IS:4,FWL:4,MERC:4,FS:3,CJF:4,DC:5</availability>
-		<model name='(Ultra)'>
-			<availability>IS:8,DC:8</availability>
+		<model name='(LB-X)'>
+			<availability>IS:6,DC:8</availability>
 		</model>
 		<model name='(Clan Cargo)'>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(LB-X)'>
-			<availability>IS:6,DC:8</availability>
+		<model name='(Ultra)'>
+			<availability>IS:8,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Saladin Mk II HCV' unitType='Tank'>
 		<availability>FWL:5,MERC:5,CP:4,DC:6</availability>
-		<model name='(BC3)'>
-			<availability>DC:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(BC3)'>
+			<availability>DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Salamander Battle Armor' unitType='BattleArmor'>
 		<availability>CHH:4,CLAN:3</availability>
-		<model name='(Anti-Infantry)' mechanized='true'>
-			<roles>anti_infantry</roles>
-			<availability>CJF:5</availability>
-		</model>
 		<model name='(Laser)' mechanized='true'>
 			<availability>CWE:6,RA:6</availability>
 		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Anti-Infantry)' mechanized='true'>
+			<roles>anti_infantry</roles>
+			<availability>CJF:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Salamander' unitType='Mek'>
 		<availability>LA:7,ROS:4,FS:5,MERC:5</availability>
-		<model name='PPR-6T'>
-			<roles>fire_support</roles>
-			<availability>LA:6,MERC:4,FS:4</availability>
-		</model>
-		<model name='PPR-5S'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='PPR-7T'>
 			<roles>fire_support</roles>
 			<availability>LA:6</availability>
@@ -14112,13 +14098,21 @@
 			<roles>fire_support</roles>
 			<availability>LA:5,MERC:3,FS:3</availability>
 		</model>
-		<model name='PPR-6S'>
-			<roles>fire_support</roles>
-			<availability>LA:4,FS:2,MERC:2</availability>
-		</model>
 		<model name='PPR-7S'>
 			<roles>fire_support</roles>
 			<availability>LA:4</availability>
+		</model>
+		<model name='PPR-6T'>
+			<roles>fire_support</roles>
+			<availability>LA:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='PPR-5S'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
+		</model>
+		<model name='PPR-6S'>
+			<roles>fire_support</roles>
+			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Samurai' unitType='Aero'>
@@ -14142,13 +14136,13 @@
 	</chassis>
 	<chassis name='Saracen Mk II HCV' unitType='Tank'>
 		<availability>FWL:5,MERC:5,CP:4,DC:7</availability>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(BC3)'>
 			<roles>fire_support</roles>
 			<availability>DC:6</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarath' unitType='Mek' omni='IS'>
@@ -14156,11 +14150,11 @@
 		<model name='SRTH-1OA'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SRTH-1O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='SRTH-1OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SRTH-1O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sarissa SecurityMech' unitType='Mek'>
@@ -14185,39 +14179,39 @@
 	</chassis>
 	<chassis name='Satyr' unitType='ProtoMek'>
 		<availability>CP:3,RA:4</availability>
-		<model name='4'>
-			<roles>recon,raider,spotter</roles>
-			<availability>CP:4,RA:4</availability>
+		<model name='2'>
+			<roles>recon,raider</roles>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>recon,raider</roles>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='2'>
-			<roles>recon,raider</roles>
-			<availability>CLAN:8</availability>
+		<model name='4'>
+			<roles>recon,raider,spotter</roles>
+			<availability>CP:4,RA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Savage Coyote' unitType='Mek' omni='Clan'>
 		<availability>CWE:5,CHH:4</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
-		</model>
-		<model name='C'>
-			<availability>CLAN:6</availability>
-		</model>
-		<model name='W'>
-			<roles>spotter,anti_infantry</roles>
-			<availability>CWE:3,CHH:3</availability>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
+		<model name='C'>
+			<availability>CLAN:6</availability>
 		</model>
 		<model name='J'>
 			<availability>CWE:4,CHH:4</availability>
+		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='W'>
+			<roles>spotter,anti_infantry</roles>
+			<availability>CWE:3,CHH:3</availability>
 		</model>
 	</chassis>
 	<chassis name='Savannah Master Hovercraft' unitType='Tank'>
@@ -14239,77 +14233,77 @@
 			<roles>apc</roles>
 			<availability>General:4</availability>
 		</model>
-		<model name='(MASH)'>
-			<roles>apc,support</roles>
-			<availability>General:4</availability>
+		<model name='(HQ)'>
+			<roles>apc,support,spotter</roles>
+			<availability>General:2</availability>
 		</model>
 		<model name='(Standard)'>
 			<roles>apc</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='(HQ)'>
-			<roles>apc,support,spotter</roles>
-			<availability>General:2</availability>
+		<model name='(MASH)'>
+			<roles>apc,support</roles>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scapha Hovertank' unitType='Tank' omni='IS'>
 		<availability>ROS:8+</availability>
-		<model name='(J)'>
-			<availability>General:7</availability>
+		<model name='(Primary)'>
+			<availability>General:8</availability>
 		</model>
-		<model name='(B)'>
+		<model name='(H)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(G)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Primary)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='(E)'>
-			<roles>artillery</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='(C)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(H)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(D)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(A)'>
-			<availability>General:7</availability>
-		</model>
-		<model name='(F)'>
-			<roles>spotter</roles>
+		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(I)'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
+		<model name='(C)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(D)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(J)'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(E)'>
+			<roles>artillery</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(F)'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='(A)'>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Scarabus' unitType='Mek'>
 		<availability>RF:5,LA:3,ROS:5,FS:6,MERC:4,DA:5</availability>
-		<model name='SCB-9T'>
-			<roles>spotter</roles>
-			<availability>RF:5,LA:6,ROS:4,FS:2,MERC:5,DA:5</availability>
-		</model>
 		<model name='SCB-9A'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCB-9T'>
+			<roles>spotter</roles>
+			<availability>RF:5,LA:6,ROS:4,FS:2,MERC:5,DA:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Scarecrow' unitType='Mek'>
 		<availability>FS:4</availability>
-		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
-			<availability>General:4</availability>
-		</model>
 		<model name='UCU-F4'>
 			<roles>anti_infantry</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='UCU-F4r &apos;Hobbled Scarecrow&apos;'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Schildkrote Line Tank' unitType='Tank'>
@@ -14323,6 +14317,10 @@
 	</chassis>
 	<chassis name='Schiltron Mobile Fire-Support Platform' unitType='Tank' omni='IS'>
 		<availability>RD:4,ROS:5,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
+		<model name='F'>
+			<roles>spotter</roles>
+			<availability>General:4</availability>
+		</model>
 		<model name='D'>
 			<roles>spotter</roles>
 			<availability>General:5</availability>
@@ -14330,6 +14328,10 @@
 		<model name='A'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='Prime'>
+			<roles>missile_artillery,spotter</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='B'>
 			<roles>fire_support,spotter</roles>
@@ -14339,14 +14341,6 @@
 			<roles>spotter</roles>
 			<availability>General:5</availability>
 		</model>
-		<model name='Prime'>
-			<roles>missile_artillery,spotter</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='F'>
-			<roles>spotter</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='C'>
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
@@ -14354,10 +14348,6 @@
 	</chassis>
 	<chassis name='Schrack' unitType='Aero' omni='IS'>
 		<availability>ROS:8</availability>
-		<model name='SCK-OA'>
-			<roles>interceptor</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='SCK-OB'>
 			<availability>General:7</availability>
 		</model>
@@ -14365,9 +14355,17 @@
 			<roles>interceptor</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='SCK-OA'>
+			<roles>interceptor</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Schrek PPC Carrier' unitType='Tank'>
 		<availability>RA.OA:1,RD:2,CP:2,Periphery:2,RA:2</availability>
+		<model name='(C3M)'>
+			<roles>spotter</roles>
+			<availability>IS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
@@ -14375,10 +14373,6 @@
 		<model name='(Anti-Infantry)'>
 			<roles>fire_support</roles>
 			<availability>IS:1</availability>
-		</model>
-		<model name='(C3M)'>
-			<roles>spotter</roles>
-			<availability>IS:6</availability>
 		</model>
 		<model name='(Armor)'>
 			<availability>RD:8,IS:6,CP:8,RA:8</availability>
@@ -14402,21 +14396,15 @@
 		<model name='(Standard)'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(3136 Upgrade)'>
-			<availability>FWL:6,MERC:6,CP:5,DC:6</availability>
-		</model>
 		<model name='(BC3)'>
 			<availability>DC:8</availability>
+		</model>
+		<model name='(3136 Upgrade)'>
+			<availability>FWL:6,MERC:6,CP:5,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion Light Tank' unitType='Tank'>
 		<availability>CC:6,FVC:6,LA:6,FWL:6,IS:7,Periphery.Deep:5,FS:6,CP:6,CJF:4,DC:6,Periphery:7</availability>
-		<model name='(MRM)'>
-			<availability>IS:5,DC:5,Periphery:4</availability>
-		</model>
-		<model name='(LAC)'>
-			<availability>CC:6,MOC:5,IS:5,FS:6,MERC:6,CP:6,CDP:5,TC:5,LA:6,ROS:6,FWL:6,MH:5,DC:6</availability>
-		</model>
 		<model name='(Minesweeper)'>
 			<roles>minesweeper</roles>
 			<availability>CC:4-,MOC:2-</availability>
@@ -14424,8 +14412,14 @@
 		<model name='(Standard)'>
 			<availability>General:1-</availability>
 		</model>
+		<model name='(LAC)'>
+			<availability>CC:6,MOC:5,IS:5,FS:6,MERC:6,CP:6,CDP:5,TC:5,LA:6,ROS:6,FWL:6,MH:5,DC:6</availability>
+		</model>
 		<model name='(SRM)'>
 			<availability>General:1-</availability>
+		</model>
+		<model name='(MRM)'>
+			<availability>IS:5,DC:5,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Scorpion' unitType='Mek'>
@@ -14433,18 +14427,18 @@
 		<model name='SCP-1N'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='SCP-10M'>
-			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
-		</model>
-		<model name='SCP-12S'>
-			<availability>LA:2,ROS:2,MERC:2</availability>
-		</model>
 		<model name='SCP-12K'>
 			<roles>spotter</roles>
 			<availability>DC:6</availability>
 		</model>
 		<model name='SCP-1O'>
 			<availability>IS:1,Periphery.Deep:4,Periphery:6</availability>
+		</model>
+		<model name='SCP-12S'>
+			<availability>LA:2,ROS:2,MERC:2</availability>
+		</model>
+		<model name='SCP-10M'>
+			<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
 		</model>
 		<model name='SCP-1TB'>
 			<availability>ROS:4,MERC:4</availability>
@@ -14474,14 +14468,14 @@
 	</chassis>
 	<chassis name='Scylla' unitType='Mek'>
 		<availability>CHH:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:6</availability>
-		</model>
 		<model name='2'>
 			<availability>CHH:6</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Scytha' unitType='Aero' omni='Clan'>
@@ -14489,26 +14483,26 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<availability>General:5</availability>
+		</model>
 		<model name='F'>
 			<availability>General:4</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 		<model name='D'>
 			<availability>General:4</availability>
 		</model>
 		<model name='X'>
 			<availability>General:2</availability>
-		</model>
-		<model name='C'>
-			<availability>General:5</availability>
-		</model>
-		<model name='B'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sea Fox Amphibious Armor' unitType='BattleArmor'>
@@ -14519,6 +14513,9 @@
 	</chassis>
 	<chassis name='Sea Skimmer Hydrofoil' unitType='Naval'>
 		<availability>LA:4,ROS:3</availability>
+		<model name='(ELRM)'>
+			<availability>ROS:8</availability>
+		</model>
 		<model name='(SRM6)'>
 			<availability>General:1</availability>
 		</model>
@@ -14527,9 +14524,6 @@
 		</model>
 		<model name='(SRM2)'>
 			<availability>General:1</availability>
-		</model>
-		<model name='(ELRM)'>
-			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='SeaBuster Strike Fighter' unitType='Conventional Fighter'>
@@ -14585,22 +14579,22 @@
 	</chassis>
 	<chassis name='Seydlitz' unitType='Aero'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,ROS:8,MH:2</availability>
-		<model name='SYD-Z1'>
-			<roles>interceptor</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='SYD-Z4'>
-			<availability>CC:8,FVC:4,LA:6,ROS:4,MERC:5,FS:4,Periphery:4</availability>
-		</model>
 		<model name='SYD-Z2A'>
 			<roles>interceptor</roles>
 			<availability>RD:6,LA:8,ROS:4,FS:8,MERC:6</availability>
 		</model>
-		<model name='SYD-Z2B'>
-			<availability>RA.OA:4,LA:4,ROS:4,PIR:3,FS:4,MERC:4,RA:4</availability>
+		<model name='SYD-Z1'>
+			<roles>interceptor</roles>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='SYD-Z3A'>
 			<availability>RD:3,LA:6,ROS:3,MERC:3,FS:3</availability>
+		</model>
+		<model name='SYD-Z4'>
+			<availability>CC:8,FVC:4,LA:6,ROS:4,MERC:5,FS:4,Periphery:4</availability>
+		</model>
+		<model name='SYD-Z2B'>
+			<availability>RA.OA:4,LA:4,ROS:4,PIR:3,FS:4,MERC:4,RA:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sha Yu' unitType='Mek'>
@@ -14609,27 +14603,27 @@
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='SYU-4B'>
+		<model name='SYU-6B'>
 			<availability>General:4</availability>
 		</model>
-		<model name='SYU-6B'>
+		<model name='SYU-4B'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat II' unitType='Mek'>
 		<availability>CJF:6</availability>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='4'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
-		<model name='3'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
+		</model>
+		<model name='3'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Cat' unitType='Mek' omni='Clan'>
@@ -14637,38 +14631,35 @@
 		<model name='C'>
 			<availability>CLAN:6,IS:3</availability>
 		</model>
-		<model name='F'>
-			<availability>General:4</availability>
-		</model>
 		<model name='B'>
 			<roles>recon</roles>
 			<availability>CWE:3,General:6,RA:8</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8,RA:3</availability>
-		</model>
-		<model name='E'>
+		<model name='F'>
 			<availability>General:4</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:6,IS:3</availability>
-		</model>
-		<model name='J'>
-			<availability>General:5</availability>
 		</model>
 		<model name='A'>
 			<roles>recon</roles>
 			<availability>CWE:3,General:6,RA:3</availability>
 		</model>
+		<model name='J'>
+			<availability>General:5</availability>
+		</model>
+		<model name='H'>
+			<availability>CLAN:6,IS:3</availability>
+		</model>
+		<model name='E'>
+			<availability>General:4</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8,RA:3</availability>
+		</model>
 	</chassis>
 	<chassis name='Shadow Hawk IIC' unitType='Mek'>
 		<availability>CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,RA.OA:3,RD:4,CDS:4,RF:3,LA:3,ROS:4,FWL:3,DA:3,DC:3</availability>
-		<model name='3'>
-			<availability>CDS:5,IS:6,CP:5</availability>
-		</model>
-		<model name='6'>
-			<availability>CHH:8</availability>
+		<model name='8'>
+			<availability>CDS:4,LA:6,IS:4,CP:5,CWIE:6</availability>
 		</model>
 		<model name='9'>
 			<availability>ROS:6,MERC:4</availability>
@@ -14676,14 +14667,17 @@
 		<model name='7'>
 			<availability>RA.OA:8,RA:8</availability>
 		</model>
-		<model name='5'>
-			<availability>RD:4,CDS:8,LA:8,FWL:8,IS:8,FS:8,MERC:8,CP:8,DC:8</availability>
-		</model>
 		<model name='4'>
 			<availability>CDS:5,IS:6,CP:5,RA:6</availability>
 		</model>
-		<model name='8'>
-			<availability>CDS:4,LA:6,IS:4,CP:5,CWIE:6</availability>
+		<model name='3'>
+			<availability>CDS:5,IS:6,CP:5</availability>
+		</model>
+		<model name='5'>
+			<availability>RD:4,CDS:8,LA:8,FWL:8,IS:8,FS:8,MERC:8,CP:8,DC:8</availability>
+		</model>
+		<model name='6'>
+			<availability>CHH:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shadow Hawk' unitType='Mek'>
@@ -14691,44 +14685,44 @@
 		<model name='SHD-2D2'>
 			<availability>FVC:5,FS:4</availability>
 		</model>
-		<model name='SHD-2Hb'>
-			<availability>CC:4,MOC:4,ROS:4,CLAN:4,FWL:4,MERC:4,DA:4,CP:4,BAN:2</availability>
-		</model>
 		<model name='SHD-2H'>
 			<availability>General:1-,Periphery:2-</availability>
 		</model>
-		<model name='SHD-9D'>
-			<availability>FS:6</availability>
-		</model>
-		<model name='SHD-5M'>
-			<availability>CC:6,Periphery.MW:4,Periphery.ME:4,FWL:4,MERC:6,CP:4,Periphery:4,DC:6</availability>
-		</model>
-		<model name='SHD-3K'>
-			<availability>RD:4,DC:8</availability>
-		</model>
-		<model name='SHD-5D'>
-			<availability>LA:4,ROS:4,FS:8,MERC:6</availability>
-		</model>
-		<model name='SHD-7M'>
-			<availability>CC:4,MOC:3,FVC:3,ROS:4,FWL:8,MERC:4,CP:8,CDP:3,TC:3</availability>
+		<model name='SHD-2Hb'>
+			<availability>CC:4,MOC:4,ROS:4,CLAN:4,FWL:4,MERC:4,DA:4,CP:4,BAN:2</availability>
 		</model>
 		<model name='SHD-12C'>
 			<availability>RD:8,ROS:5,DC:4</availability>
 		</model>
+		<model name='SHD-5M'>
+			<availability>CC:6,Periphery.MW:4,Periphery.ME:4,FWL:4,MERC:6,CP:4,Periphery:4,DC:6</availability>
+		</model>
 		<model name='SHD-8L'>
 			<availability>CC:8</availability>
+		</model>
+		<model name='SHD-7M'>
+			<availability>CC:4,MOC:3,FVC:3,ROS:4,FWL:8,MERC:4,CP:8,CDP:3,TC:3</availability>
+		</model>
+		<model name='SHD-9D'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='SHD-5D'>
+			<availability>LA:4,ROS:4,FS:8,MERC:6</availability>
+		</model>
+		<model name='SHD-3K'>
+			<availability>RD:4,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shamash Reconnaissance Vehicle' unitType='Tank'>
 		<availability>CWE:5,RD:5,CDS:5,ROS:4,CLAN:3,CP:5</availability>
+		<model name='(Flamer)'>
+			<availability>CDS:4,CP:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='(Interdictor)'>
 			<availability>CWE:4,CHH:4,RD:6,CDS:4,ROS:8,CP:4,CJF:4,RA:4,CWIE:4</availability>
-		</model>
-		<model name='(Flamer)'>
-			<availability>CDS:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Shandra Advanced Scout Vehicle' unitType='Tank'>
@@ -14747,20 +14741,20 @@
 		<model name='[MRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
+		<model name='[Interdictor]' mechanized='false'>
+			<availability>General:4</availability>
+		</model>
 		<model name='[Pop-Up Mine]' mechanized='false'>
 			<availability>General:5</availability>
-		</model>
-		<model name='[MG]' mechanized='false'>
-			<availability>General:8</availability>
 		</model>
 		<model name='[SRM]' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='[Interdictor]' mechanized='false'>
-			<availability>General:4</availability>
-		</model>
 		<model name='[David Light Gauss]' mechanized='false'>
 			<availability>General:7</availability>
+		</model>
+		<model name='[MG]' mechanized='false'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Shen Yi' unitType='Mek'>
@@ -14794,11 +14788,11 @@
 	</chassis>
 	<chassis name='Shilone' unitType='Aero'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
-		<model name='SL-17'>
-			<availability>ROS:0,Periphery:2-</availability>
-		</model>
 		<model name='SL-18'>
 			<availability>ROS:6,MERC:6,DC:8</availability>
+		</model>
+		<model name='SL-17'>
+			<availability>ROS:0,Periphery:2-</availability>
 		</model>
 		<model name='SL-17R'>
 			<availability>RD:2,RA:2</availability>
@@ -14806,11 +14800,11 @@
 	</chassis>
 	<chassis name='Shiro' unitType='Mek'>
 		<availability>DC:4+</availability>
-		<model name='SH-1V'>
-			<availability>General:1+</availability>
-		</model>
 		<model name='SH-2P'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SH-1V'>
+			<availability>General:1+</availability>
 		</model>
 	</chassis>
 	<chassis name='Shiva' unitType='Aero'>
@@ -14821,11 +14815,14 @@
 	</chassis>
 	<chassis name='Shiva' unitType='Aero' omni='IS'>
 		<availability>RF:6,ROS:4,FWL:6,DA:6,CP:6</availability>
-		<model name='SHV-OB'>
+		<model name='SHV-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='SHV-OD'>
 			<availability>General:5</availability>
+		</model>
+		<model name='SHV-OB'>
+			<availability>General:7</availability>
 		</model>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -14833,15 +14830,9 @@
 		<model name='SHV-OC'>
 			<availability>General:7</availability>
 		</model>
-		<model name='SHV-OA'>
-			<availability>General:7</availability>
-		</model>
 	</chassis>
 	<chassis name='Shockwave' unitType='Mek'>
 		<availability>CC:4,ROS:4,FWL:6,FS:3,CP:6,DC:3</availability>
-		<model name='SKW-4G'>
-			<availability>General:2</availability>
-		</model>
 		<model name='SKW-2F'>
 			<availability>General:8</availability>
 		</model>
@@ -14852,18 +14843,21 @@
 		<model name='SKW-6H'>
 			<availability>General:6</availability>
 		</model>
+		<model name='SKW-4G'>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Shoden Assault Vehicle' unitType='Tank'>
 		<availability>CWE:3,CHH:3,RD:4,CDS:4,ROS:3,CP:4,CWIE:3,DC:3</availability>
+		<model name='(LB-X)'>
+			<roles>anti_infantry</roles>
+			<availability>CP:6,DC:6</availability>
+		</model>
 		<model name='(Streak)'>
 			<availability>CWE:6,CDS:4,ROS:4,CP:5,CJF:6,DC:4</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='(LB-X)'>
-			<roles>anti_infantry</roles>
-			<availability>CP:6,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Sholagar' unitType='Aero'>
@@ -14907,6 +14901,18 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
+	<chassis name='Silverback Coastal Cutter' unitType='Naval'>
+		<availability>LA:7</availability>
+		<model name='(Standard)'>
+			<availability>LA:7</availability>
+		</model>
+	</chassis>
+	<chassis name='Silverfin Coastal Cutter' unitType='Naval'>
+		<availability>IS:8</availability>
+		<model name='(Standard)'>
+			<availability>IS:8</availability>
+		</model>
+	</chassis>
 	<chassis name='Simian Battle Armor' unitType='BattleArmor'>
 		<availability>ROS:6</availability>
 		<model name='(LRR)' mechanized='true'>
@@ -14915,22 +14921,22 @@
 		<model name='(Flamer)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='(SL)' mechanized='true'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Heavy MG)' mechanized='true'>
 			<availability>General:7</availability>
+		</model>
+		<model name='(SL)' mechanized='true'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Simurgh' unitType='Aero' omni='IS'>
 		<availability>ROS:8</availability>
-		<model name='SMG-O'>
-			<roles>assault</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='SMG-OA'>
 			<roles>assault</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='SMG-O'>
+			<roles>assault</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='SMG-OB'>
 			<roles>assault</roles>
@@ -14939,14 +14945,14 @@
 	</chassis>
 	<chassis name='Sirocco' unitType='Mek'>
 		<availability>CC:3,ROS:3,FWL:4,MERC:3,CP:4</availability>
-		<model name='SRC-6C'>
-			<availability>ROS:6,FWL:6,CP:6</availability>
-		</model>
 		<model name='SRC-5C'>
 			<availability>ROS:5,FWL:5,CP:5</availability>
 		</model>
 		<model name='SRC-3C'>
 			<availability>General:8</availability>
+		</model>
+		<model name='SRC-6C'>
+			<availability>ROS:6,FWL:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Skadi Swift Attack VTOL' unitType='VTOL'>
@@ -14970,9 +14976,9 @@
 	</chassis>
 	<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
 		<availability>CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,ROS:1-,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
-		<model name='(MG)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
-			<availability>FVC:4,IS.pm:4</availability>
+			<availability>General:1-</availability>
 		</model>
 		<model name='(C3M)'>
 			<roles>spotter</roles>
@@ -14982,9 +14988,9 @@
 			<roles>recon</roles>
 			<availability>FVC:3,IS.pm:1</availability>
 		</model>
-		<model name='(Standard)'>
+		<model name='(MG)'>
 			<roles>recon</roles>
-			<availability>General:1-</availability>
+			<availability>FVC:4,IS.pm:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Slayer' unitType='Aero'>
@@ -14992,23 +14998,23 @@
 		<model name='SL-15R'>
 			<availability>RA.OA:6,RD:6,ROS:6,FS:6,MERC:6,CDP:4,RA:6,DC:8,TC:4</availability>
 		</model>
-		<model name='SL-15'>
-			<availability>ROS:0,FS:0,Periphery:2-</availability>
-		</model>
 		<model name='SL-15K'>
 			<availability>RD:4,ROS:4,MERC:4,DC:4</availability>
+		</model>
+		<model name='SL-15'>
+			<availability>ROS:0,FS:0,Periphery:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Sloth Battle Armor' unitType='BattleArmor'>
 		<availability>LA:4,ROS:4,FS:4,MERC:4</availability>
-		<model name='(Huntsman)' mechanized='false'>
-			<availability>LA:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>LA:1</availability>
 		</model>
 		<model name='(Interdictor)' mechanized='false'>
 			<availability>General:8</availability>
+		</model>
+		<model name='(Huntsman)' mechanized='false'>
+			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Snake' unitType='Mek'>
@@ -15039,11 +15045,11 @@
 	</chassis>
 	<chassis name='Snow Fox' unitType='Mek'>
 		<availability>CP:4,CJF:4</availability>
-		<model name='3'>
-			<availability>CJF:8</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CP:8</availability>
+		</model>
+		<model name='3'>
+			<availability>CJF:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sokar Urban Combat Unit' unitType='Tank'>
@@ -15070,11 +15076,11 @@
 	</chassis>
 	<chassis name='Solitaire' unitType='Mek'>
 		<availability>RD:3,CDS:6+,CP:6+</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CLAN:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sortek Assault Craft' unitType='Tank'>
@@ -15097,18 +15103,14 @@
 			<roles>cruiser</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2845)'>
-			<roles>cruiser</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Spad' unitType='Aero'>
 		<availability>RA.OA:1,ROS:3,RA:1</availability>
-		<model name='SPD-504'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
+		</model>
+		<model name='SPD-504'>
+			<availability>ROS:4</availability>
 		</model>
 		<model name='SPD-503'>
 			<availability>ROS:6,BAN:2</availability>
@@ -15116,17 +15118,17 @@
 	</chassis>
 	<chassis name='Sparrowhawk' unitType='Aero'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
-		<model name='SPR-7D'>
-			<availability>ROS:5,FS:5,MERC:5</availability>
-		</model>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 		</model>
-		<model name='SPR-DH'>
-			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:3-</availability>
+		<model name='SPR-7D'>
+			<availability>ROS:5,FS:5,MERC:5</availability>
 		</model>
 		<model name='SPR-7Dr'>
 			<availability>ROS:4,FS:5,MERC:4</availability>
+		</model>
+		<model name='SPR-DH'>
+			<availability>RA.OA:4-,FVC:4-,MERC:4-,Periphery:3-</availability>
 		</model>
 	</chassis>
 	<chassis name='SpecOps Paratrooper' unitType='Infantry'>
@@ -15151,11 +15153,11 @@
 	</chassis>
 	<chassis name='Spectre Stealth Battle Armor' unitType='BattleArmor'>
 		<availability>FVC:8,MERC:4,CDP:8,RA:6</availability>
-		<model name='(RA)' mechanized='true'>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>IS:8,Periphery:8</availability>
+		</model>
+		<model name='(RA)' mechanized='true'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sphinx' unitType='Mek'>
@@ -15178,41 +15180,41 @@
 		<model name='SDR-5V'>
 			<availability>Periphery:2-</availability>
 		</model>
+		<model name='SDR-7Kr'>
+			<availability>ROS:1,MERC:1,DC:1</availability>
+		</model>
+		<model name='SDR-10K'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='SDR-7K'>
+			<availability>ROS:4,MERC:4,DC:5</availability>
+		</model>
 		<model name='SDR-7M'>
 			<availability>MOC:4,CC:8,FWL:8,MH:4,MERC:3,FS:8,CP:8,DC:6</availability>
 		</model>
-		<model name='SDR-7K2'>
-			<availability>ROS:3,MERC:3,DC:4</availability>
+		<model name='SDR-7KC'>
+			<availability>ROS:5,MERC:5,DC:5</availability>
+		</model>
+		<model name='SDR-C'>
+			<availability>CC:4,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 		<model name='SDR-8K'>
 			<availability>ROS:4,MERC:4,DC:6</availability>
 		</model>
-		<model name='SDR-8R'>
-			<availability>ROS:6,MERC:4</availability>
-		</model>
-		<model name='SDR-7Kr'>
-			<availability>ROS:1,MERC:1,DC:1</availability>
-		</model>
 		<model name='SDR-8Xr'>
 			<availability>ROS:6,MERC:6,DC:6</availability>
+		</model>
+		<model name='SDR-7K2'>
+			<availability>ROS:3,MERC:3,DC:4</availability>
+		</model>
+		<model name='SDR-8R'>
+			<availability>ROS:6,MERC:4</availability>
 		</model>
 		<model name='SDR-8M'>
 			<availability>MOC:4,CC:4,FWL:8,MH:4,MERC:2,CP:8</availability>
 		</model>
 		<model name='SDR-8X'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
-		</model>
-		<model name='SDR-10K'>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='SDR-C'>
-			<availability>CC:4,FWL:4,FS:4,MERC:4,CP:4,DC:4</availability>
-		</model>
-		<model name='SDR-7K'>
-			<availability>ROS:4,MERC:4,DC:5</availability>
-		</model>
-		<model name='SDR-7KC'>
-			<availability>ROS:5,MERC:5,DC:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Spindrift Aquatic SecurityMech' unitType='Mek'>
@@ -15223,34 +15225,34 @@
 	</chassis>
 	<chassis name='Spirit' unitType='Mek'>
 		<availability>CJF:5-</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<availability>CJF:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprint Scout Helicopter' unitType='VTOL'>
 		<availability>MOC:5,FVC:5,LA:7,ROS:7,IS:6,MH:4,FS:7,DC:7</availability>
-		<model name='(Interdictor)'>
-			<roles>spotter</roles>
-			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,CP:4,DC:4</availability>
-		</model>
 		<model name='(C3)'>
 			<roles>recon</roles>
 			<availability>IS:4,DC:6</availability>
+		</model>
+		<model name='(Troop Transport)'>
+			<roles>recon,apc</roles>
+			<availability>General:5</availability>
 		</model>
 		<model name='(Laser)'>
 			<roles>recon</roles>
 			<availability>General:5</availability>
 		</model>
+		<model name='(Interdictor)'>
+			<roles>spotter</roles>
+			<availability>FVC:3,LA:4,ROS:4,FWL:4,IS:3,MERC:4,FS:4,CP:4,DC:4</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>recon,spotter</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(Troop Transport)'>
-			<roles>recon,apc</roles>
-			<availability>General:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Sprite' unitType='ProtoMek'>
@@ -15267,17 +15269,17 @@
 	</chassis>
 	<chassis name='Stalker' unitType='Mek'>
 		<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,ROS:2,FWL:6,DC:1</availability>
-		<model name='STK-3H'>
-			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		<model name='STK-8S'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
-		<model name='STK-7D'>
-			<availability>ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='STK-4N'>
-			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
+		<model name='STK-5M'>
+			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:4,CP:6,DC:6,TC:3</availability>
 		</model>
 		<model name='STK-7C3BS'>
 			<availability>IS:2</availability>
+		</model>
+		<model name='STK-7D'>
+			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
 		<model name='STK-3F'>
 			<availability>Periphery:2-</availability>
@@ -15285,17 +15287,17 @@
 		<model name='STK-3Fb'>
 			<availability>CC:3,MOC:3,RF:3,CLAN:8,FWL:3,MERC:3,DA:3,CP:3,BAN:2</availability>
 		</model>
-		<model name='STK-5M'>
-			<availability>CC:3,MOC:3,FWL:6,IS:3,MH:4,CP:6,DC:6,TC:3</availability>
+		<model name='STK-3H'>
+			<availability>MOC:1-,IS:1-,TC:1-,Periphery:1-</availability>
+		</model>
+		<model name='STK-4N'>
+			<availability>MOC:1-,IS:1-,Periphery:1-,TC:1-</availability>
 		</model>
 		<model name='STK-6M'>
 			<availability>CC:5,MOC:5,RF:6,ROS:6,FWL:6,MERC:6,DA:5,CP:6</availability>
 		</model>
 		<model name='STK-5S'>
 			<availability>CDS:3,LA:5,MERC:4,FS:5,CP:3,CJF:3,TC:4</availability>
-		</model>
-		<model name='STK-8S'>
-			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stalking Spider II' unitType='Mek'>
@@ -15322,12 +15324,12 @@
 			<roles>raider</roles>
 			<availability>MOC:4,CC:2,LA:4,ROS:2,FWL:2,FS:2,MERC:4,CP:2</availability>
 		</model>
+		<model name='STY-3Dr'>
+			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
+		</model>
 		<model name='STY-3C'>
 			<roles>raider</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STY-3Dr'>
-			<availability>CC:6,MOC:6,RF:6,LA:6,ROS:6,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stealth' unitType='Mek'>
@@ -15336,32 +15338,32 @@
 			<roles>recon,spotter</roles>
 			<availability>FS:4</availability>
 		</model>
-		<model name='STH-3S'>
-			<roles>recon</roles>
-			<availability>FS:4</availability>
-		</model>
 		<model name='STH-1D'>
 			<roles>recon</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='STH-2D1'>
-			<roles>recon</roles>
-			<availability>FS:4,MERC:4</availability>
 		</model>
 		<model name='STH-2D'>
 			<roles>recon</roles>
 			<availability>FS:6,MERC:4</availability>
 		</model>
+		<model name='STH-3S'>
+			<roles>recon</roles>
+			<availability>FS:4</availability>
+		</model>
+		<model name='STH-2D1'>
+			<roles>recon</roles>
+			<availability>FS:4,MERC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
 		<availability>MERC.KH:6,LA:8,MERC:2</availability>
+		<model name='STM-OB'>
+			<availability>General:7</availability>
+		</model>
 		<model name='STM-O'>
 			<availability>General:8</availability>
 		</model>
 		<model name='STM-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='STM-OB'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -15370,14 +15372,14 @@
 		<model name='STO-4C'>
 			<availability>LA:4,MERC:6</availability>
 		</model>
-		<model name='STO-6S'>
-			<availability>LA:6</availability>
+		<model name='STO-4B'>
+			<availability>General:4</availability>
 		</model>
 		<model name='STO-4A'>
 			<availability>General:8</availability>
 		</model>
-		<model name='STO-4B'>
-			<availability>General:4</availability>
+		<model name='STO-6S'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stinger IIC' unitType='Mek'>
@@ -15392,49 +15394,52 @@
 	</chassis>
 	<chassis name='Stinger' unitType='Mek'>
 		<availability>MOC:6,RD:1-,IS:7,MERC:7,Periphery:6,DC:4</availability>
-		<model name='STG-5R'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:4,FVC:4,PIR:4,MERC:4,CDP:4,TC:4,Periphery:4</availability>
-		</model>
-		<model name='STG-5M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,CP:8,DC:6</availability>
-		</model>
-		<model name='STG-5T'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
-		</model>
 		<model name='STG-3R'>
 			<roles>recon</roles>
 			<availability>BAN:8,Periphery:2-</availability>
-		</model>
-		<model name='STG-6L'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:4,DA:4</availability>
-		</model>
-		<model name='STG-7S'>
-			<roles>recon</roles>
-			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 		<model name='STG-5G'>
 			<roles>recon</roles>
 			<availability>CC:5,FVC:4,ROS:4,FWL:4,MH:4,DA:4,FS:4,CP:4,CDP:5,TC:5</availability>
 		</model>
+		<model name='STG-6S'>
+			<roles>recon</roles>
+			<availability>LA:8,ROS:5,MERC:8,FS:4</availability>
+		</model>
 		<model name='STG-3Gb'>
 			<roles>recon</roles>
 			<availability>CC:4,CLAN:8,FWL:5,DA:6,MERC:4,CP:5,BAN:2</availability>
+		</model>
+		<model name='STG-5M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,FS:6,MERC:6,CP:8,DC:6</availability>
+		</model>
+		<model name='STG-6L'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:4,DA:4</availability>
+		</model>
+		<model name='STG-5T'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,FVC:4,MERC:4,DA:4,TC:4,Periphery:4</availability>
 		</model>
 		<model name='STG-3P'>
 			<roles>recon</roles>
 			<availability>RD:3,LA:2,ROS:5,IS:6,Periphery.Deep:4,MERC:6,DC:2,Periphery:6</availability>
 		</model>
-		<model name='STG-6S'>
+		<model name='STG-5R'>
 			<roles>recon</roles>
-			<availability>LA:8,ROS:5,MERC:8,FS:4</availability>
+			<availability>CC:4,MOC:4,FVC:4,PIR:4,MERC:4,CDP:4,TC:4,Periphery:4</availability>
+		</model>
+		<model name='STG-7S'>
+			<roles>recon</roles>
+			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Stingray' unitType='Aero'>
 		<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
+		<model name='F-95'>
+			<availability>CC:5,RF:6,LA:5,ROS:5,FWL:6,MERC:5,DA:6,CP:6</availability>
+		</model>
 		<model name='F-94'>
 			<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,IS:4,MH:4</availability>
 		</model>
@@ -15444,38 +15449,35 @@
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
 		</model>
-		<model name='F-95'>
-			<availability>CC:5,RF:6,LA:5,ROS:5,FWL:6,MERC:5,DA:6,CP:6</availability>
-		</model>
 		<model name='F-96R'>
 			<availability>RF:5,LA:4,FWL:5,DA:5,CP:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
 		<availability>RD:3</availability>
-		<model name='G'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>:0,General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>:0,CLAN:6</availability>
+		<model name='C'>
+			<availability>General:7</availability>
 		</model>
 		<model name='E'>
 			<availability>CLAN:6</availability>
 		</model>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
-		<model name='F'>
+		<model name='G'>
 			<availability>CLAN:4</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='Prime'>
+			<availability>:0,General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
+		</model>
+		<model name='D'>
+			<availability>:0,CLAN:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -15502,7 +15504,7 @@
 	</chassis>
 	<chassis name='Strider' unitType='Mek' omni='IS'>
 		<availability>CC:5,MOC:5,LA:5,ROS:6,FWL:5,FS:6,MERC:5,DA:5,CP:5,DC:7</availability>
-		<model name='SR1-OA'>
+		<model name='SR1-OD'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
@@ -15510,46 +15512,50 @@
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='SR1-OF'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-OC'>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OD'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
-		</model>
-		<model name='SR1-OE'>
-			<availability>General:6</availability>
-		</model>
-		<model name='SR1-O'>
-			<availability>General:8</availability>
-		</model>
-		<model name='SR1-OH'>
+		<model name='SR1-OG'>
 			<availability>General:4</availability>
 		</model>
 		<model name='SR1-OR'>
 			<availability>CLAN:6,General:3</availability>
 		</model>
-		<model name='SR1-OG'>
-			<availability>General:4</availability>
-		</model>
 		<model name='SR1-OB'>
 			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OH'>
+			<availability>General:4</availability>
+		</model>
+		<model name='SR1-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-OA'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='SR1-O'>
+			<availability>General:8</availability>
+		</model>
+		<model name='SR1-OF'>
+			<availability>General:6</availability>
 		</model>
 		<model name='SR1-OX'>
 			<availability>General:2</availability>
 		</model>
+		<model name='SR1-OE'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Striker Light Tank' unitType='Tank'>
 		<availability>CC:2,IS:2,FS:5,MERC:3,CP:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,DC:1</availability>
+		<model name='(Narc)'>
+			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>fire_support</roles>
+			<availability>General:1-</availability>
+		</model>
 		<model name='(LRM)'>
 			<roles>fire_support</roles>
 			<availability>FVC:1-</availability>
-		</model>
-		<model name='(3053 Upgrade)'>
-			<availability>FVC:7,CDS:6,LA:6,ROS:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2</availability>
@@ -15560,30 +15566,26 @@
 		<model name='(SRM)'>
 			<availability>FVC:1-</availability>
 		</model>
-		<model name='(Narc)'>
-			<availability>LA:2,ROS:2,FS:2,DC:1</availability>
-		</model>
 		<model name='(Sealed)'>
 			<availability>General:4</availability>
 		</model>
 		<model name='(3061 Upgrade)'>
 			<availability>LA:4,ROS:4,FS:4,MERC:4,DC:5</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>fire_support</roles>
-			<availability>General:1-</availability>
+		<model name='(3053 Upgrade)'>
+			<availability>FVC:7,CDS:6,LA:6,ROS:6,FS:7,DC:5,CWIE:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Striker' unitType='Mek'>
 		<availability>CC:3,MOC:3</availability>
+		<model name='STC-2S'>
+			<availability>LA:5</availability>
+		</model>
 		<model name='STC-2C'>
 			<availability>General:8</availability>
 		</model>
 		<model name='STC-2D'>
 			<availability>CC:8,MOC:8</availability>
-		</model>
-		<model name='STC-2S'>
-			<availability>LA:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Strix Stealth VTOL' unitType='VTOL'>
@@ -15610,12 +15612,12 @@
 	</chassis>
 	<chassis name='Sturmfeur Heavy Tank' unitType='Tank'>
 		<availability>Periphery.R:2,CDS:2,RF:3,LA:2,ROS:3,FS:2,CP:2,CWIE:2</availability>
+		<model name='(SRM)'>
+			<availability>LA:3,FS:3,MERC:3</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='(SRM)'>
-			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 		<model name='(Heavy Gauss)'>
 			<availability>RF:6,LA:6,CP:6,CWIE:6</availability>
@@ -15623,13 +15625,13 @@
 	</chassis>
 	<chassis name='Stygian Strike Tank' unitType='Tank'>
 		<availability>FWL:5,IS:3,CP:5,Periphery:3</availability>
-		<model name='(Standard)'>
-			<roles>recon,fire_support</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Armor)'>
 			<roles>recon,fire_support</roles>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>recon,fire_support</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Sulla' unitType='Aero' omni='Clan'>
@@ -15637,17 +15639,17 @@
 		<model name='E'>
 			<availability>CWE:5,RD:5,CLAN:2</availability>
 		</model>
+		<model name='Prime'>
+			<availability>General:8</availability>
+		</model>
+		<model name='F'>
+			<availability>CLAN:4</availability>
+		</model>
 		<model name='C'>
 			<availability>RD:6,General:2</availability>
 		</model>
 		<model name='D'>
 			<availability>CWE:6,RD:6,General:2</availability>
-		</model>
-		<model name='F'>
-			<availability>CLAN:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>General:8</availability>
 		</model>
 		<model name='B'>
 			<availability>RD:6,General:2,CJF:6</availability>
@@ -15658,30 +15660,27 @@
 	</chassis>
 	<chassis name='Sun Cobra' unitType='Mek'>
 		<availability>CWE:5,CDS:3,ROS:3,FS:5,MERC:2,CP:3</availability>
-		<model name='(Standard)'>
-			<availability>CWE:8,CDS:4,CP:4</availability>
-		</model>
 		<model name='2'>
 			<availability>CDS:8,ROS:8,MERC:8,FS:8,CP:8</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>CWE:8,CDS:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Sunder' unitType='Mek' omni='IS'>
 		<availability>CC:4,LA:5,ROS:5,FS:5,MERC:4,DC:7</availability>
-		<model name='SD1-OB'>
-			<roles>spotter</roles>
-			<availability>General:7</availability>
+		<model name='SD1-OF'>
+			<availability>General:4</availability>
 		</model>
 		<model name='SD1-O'>
 			<availability>General:8</availability>
 		</model>
+		<model name='SD1-OB'>
+			<roles>spotter</roles>
+			<availability>General:7</availability>
+		</model>
 		<model name='SD1-OR'>
 			<availability>General:3+,CLAN:6,DC:3+</availability>
-		</model>
-		<model name='SD1-OG'>
-			<availability>General:4</availability>
-		</model>
-		<model name='SD1-OF'>
-			<availability>General:4</availability>
 		</model>
 		<model name='SD1-OA'>
 			<roles>fire_support</roles>
@@ -15696,6 +15695,9 @@
 		<model name='SD1-OE'>
 			<availability>General:4</availability>
 		</model>
+		<model name='SD1-OG'>
+			<availability>General:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Supernova' unitType='Mek'>
 		<availability>CWE:5,RD:3,CDS:4,ROS:3,CP:7,CWIE:5</availability>
@@ -15705,11 +15707,11 @@
 		<model name='3'>
 			<availability>ROS:6,CP:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:4</availability>
-		</model>
 		<model name='4'>
 			<availability>ROS:5,CP:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Suzaku' unitType='Aero'>
@@ -15735,28 +15737,28 @@
 	</chassis>
 	<chassis name='Svartalfa Ultra ProtoMech' unitType='ProtoMek'>
 		<availability>CHH:4+</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(LRM Variant)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swallow Attack WIGE' unitType='Tank'>
 		<availability>RF:5,LA:6,ROS:5,FWL:5,MH:4,FS:5,MERC:5,CP:5,TC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Original)'>
 			<availability>LA:4,MERC:4,Periphery:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift Wind Scout Car' unitType='Tank'>
 		<availability>CC:1,MOC:1,DA:1,CDP:1,TC:1</availability>
-		<model name='(Standard)'>
+		<model name='(ICE - Speed)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>General:8</availability>
+			<availability>CC:3</availability>
 		</model>
 		<model name='(ICE - Cargo)'>
 			<roles>recon</roles>
@@ -15768,37 +15770,37 @@
 			<deployedWith>solo</deployedWith>
 			<availability>General:2</availability>
 		</model>
-		<model name='(ICE - Speed)'>
+		<model name='(Standard)'>
 			<roles>recon</roles>
 			<deployedWith>solo</deployedWith>
-			<availability>CC:3</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Swift' unitType='Aero'>
 		<availability>ROS:4,CLAN:4</availability>
-		<model name='C'>
-			<availability>CLAN:8,RA:9</availability>
-		</model>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:3</availability>
 		</model>
 		<model name='SWF-606R'>
 			<availability>ROS:4</availability>
 		</model>
+		<model name='C'>
+			<availability>CLAN:8,RA:9</availability>
+		</model>
 	</chassis>
 	<chassis name='Sylph Battle Armor' unitType='BattleArmor'>
 		<availability>CDS:2,CP:2,RA:4</availability>
-		<model name='(Standard)' mechanized='true'>
+		<model name='(Upgrade)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:6</availability>
+			<availability>General:7</availability>
 		</model>
 		<model name='(Enhanced)' mechanized='true'>
 			<roles>recon</roles>
 			<availability>RA:8</availability>
 		</model>
-		<model name='(Upgrade)' mechanized='true'>
+		<model name='(Standard)' mechanized='true'>
 			<roles>recon</roles>
-			<availability>General:7</availability>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Tai-sho' unitType='Mek'>
@@ -15832,11 +15834,11 @@
 	</chassis>
 	<chassis name='Tamerlane Strike Sled' unitType='Tank'>
 		<availability>MOC:6,CC:5,MERC:4</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Flamer)'>
 			<availability>MOC:4,CC:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
 		</model>
 		<model name='(RL)'>
 			<availability>MOC:4</availability>
@@ -15850,36 +15852,36 @@
 	</chassis>
 	<chassis name='Tarantula' unitType='Mek'>
 		<availability>MOC:3,CC:5,ROS:4,FWL:6,MERC:4,CP:6,DC:6</availability>
-		<model name='ZPH-5A'>
-			<roles>recon</roles>
-			<availability>ROS:6,DC:6</availability>
-		</model>
-		<model name='ZPH-3A'>
-			<roles>recon</roles>
-			<availability>ROS:5,FWL:8,MERC:4,CP:8,DC:4</availability>
-		</model>
 		<model name='ZPH-2A'>
 			<roles>recon</roles>
 			<availability>MOC:6,CC:3,ROS:3,FWL:3,MERC:3,CP:3,DC:3</availability>
-		</model>
-		<model name='ZPH-1A'>
-			<roles>recon</roles>
-			<availability>CC:2,MOC:2,ROS:2,FWL:2,MERC:2,CP:2,DC:2</availability>
 		</model>
 		<model name='ZPH-4A'>
 			<roles>recon</roles>
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
+		<model name='ZPH-5A'>
+			<roles>recon</roles>
+			<availability>ROS:6,DC:6</availability>
+		</model>
+		<model name='ZPH-1A'>
+			<roles>recon</roles>
+			<availability>CC:2,MOC:2,ROS:2,FWL:2,MERC:2,CP:2,DC:2</availability>
+		</model>
+		<model name='ZPH-3A'>
+			<roles>recon</roles>
+			<availability>ROS:5,FWL:8,MERC:4,CP:8,DC:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Targe' unitType='Mek'>
 		<availability>ROS:4,MERC:2</availability>
-		<model name='TRG-1N'>
-			<roles>recon</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='TRG-2N'>
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
+		</model>
+		<model name='TRG-1N'>
+			<roles>recon</roles>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='TRG-3M'>
 			<roles>recon</roles>
@@ -15888,23 +15890,23 @@
 	</chassis>
 	<chassis name='Tatsu' unitType='Aero' omni='IS'>
 		<availability>CC:4,ROS:4,CP:4,DC:6</availability>
+		<model name='MIK-OC'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-O'>
+			<availability>General:8</availability>
+		</model>
 		<model name='MIK-OB'>
+			<availability>General:7</availability>
+		</model>
+		<model name='MIK-OA'>
 			<availability>General:7</availability>
 		</model>
 		<model name='MIK-OE'>
 			<availability>General:5</availability>
 		</model>
-		<model name='MIK-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='MIK-OC'>
-			<availability>General:7</availability>
-		</model>
 		<model name='MIK-OD'>
 			<availability>General:5</availability>
-		</model>
-		<model name='MIK-O'>
-			<availability>General:8</availability>
 		</model>
 		<model name='MIK-OF'>
 			<availability>General:4</availability>
@@ -15919,8 +15921,8 @@
 	</chassis>
 	<chassis name='Tempest' unitType='Mek'>
 		<availability>FWL.MM:8,RF:8,ROS:5,Periphery.MW:4,Periphery.ME:4,FWL:8,MH:4,MERC:4,CP:8</availability>
-		<model name='TMP-3G'>
-			<availability>ROS:2,FWL:2,MERC:2,CP:2</availability>
+		<model name='TMP-3M'>
+			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,CP:4,Periphery:8</availability>
 		</model>
 		<model name='TMP-3MA'>
 			<availability>RF:4,ROS:4,FWL:4,MERC:4,CP:4</availability>
@@ -15928,8 +15930,8 @@
 		<model name='TMP-3M2 &apos;Storm Tempest&apos;'>
 			<availability>ROS:6,FWL:6,MERC:4,CP:6</availability>
 		</model>
-		<model name='TMP-3M'>
-			<availability>ROS:4,FWL:4,Periphery.Deep:6,MERC:4,CP:4,Periphery:8</availability>
+		<model name='TMP-3G'>
+			<availability>ROS:2,FWL:2,MERC:2,CP:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar III' unitType='Mek' omni='IS'>
@@ -15937,17 +15939,17 @@
 		<model name='TLR2-OC'>
 			<availability>General:7</availability>
 		</model>
+		<model name='TLR2-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='TLR2-OB'>
 			<availability>General:7</availability>
 		</model>
-		<model name='TLR2-OA'>
+		<model name='TLR2-OD'>
 			<availability>General:7</availability>
 		</model>
 		<model name='TLR2-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='TLR2-OD'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Templar' unitType='Mek' omni='IS'>
@@ -15955,45 +15957,48 @@
 		<model name='TLR1-OD'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TLR1-OH'>
-			<availability>General:5</availability>
+		<model name='TLR1-OB'>
+			<availability>General:4</availability>
+		</model>
+		<model name='TLR1-O'>
+			<availability>General:8</availability>
 		</model>
 		<model name='TLR1-OR'>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OB'>
-			<availability>General:4</availability>
-		</model>
-		<model name='TLR1-OG'>
-			<roles>fire_support</roles>
-			<availability>General:4</availability>
-		</model>
 		<model name='TLR1-OC'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OI'>
+			<availability>General:5</availability>
+		</model>
+		<model name='TLR1-OH'>
 			<availability>General:5</availability>
 		</model>
 		<model name='TLR1-OE'>
 			<roles>spotter</roles>
 			<availability>General:3</availability>
 		</model>
-		<model name='TLR1-OA'>
-			<availability>General:7</availability>
-		</model>
-		<model name='TLR1-O'>
-			<availability>General:8</availability>
+		<model name='TLR1-OU'>
+			<availability>General:2</availability>
 		</model>
 		<model name='TLR1-OF'>
 			<roles>spotter</roles>
 			<availability>General:2</availability>
 		</model>
-		<model name='TLR1-OI'>
-			<availability>General:5</availability>
+		<model name='TLR1-OG'>
+			<roles>fire_support</roles>
+			<availability>General:4</availability>
 		</model>
-		<model name='TLR1-OU'>
-			<availability>General:2</availability>
+		<model name='TLR1-OA'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Tenshi' unitType='Mek' omni='IS'>
 		<availability>DC.GHO:7,DC:7</availability>
+		<model name='TN-10-OA'>
+			<availability>General:7</availability>
+		</model>
 		<model name='TN-10-OB'>
 			<availability>General:7</availability>
 		</model>
@@ -16002,9 +16007,6 @@
 		</model>
 		<model name='TN-10-O'>
 			<availability>General:8</availability>
-		</model>
-		<model name='TN-10-OA'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Teppo Artillery Vehicle' unitType='Tank'>
@@ -16020,11 +16022,11 @@
 			<roles>recon,spotter</roles>
 			<availability>ROS:8,DC:8</availability>
 		</model>
-		<model name='TSN-C3M'>
+		<model name='TSN-1Cr'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
-		<model name='TSN-1Cr'>
+		<model name='TSN-C3M'>
 			<roles>recon,spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
@@ -16038,25 +16040,25 @@
 	</chassis>
 	<chassis name='Texas Battleship' unitType='Warship'>
 		<availability>CWE:1,CJF:1,RA:1</availability>
-		<model name='(2835)'>
-			<roles>battleship</roles>
-			<availability>CLAN:8</availability>
-		</model>
 		<model name='(2618)'>
 			<roles>battleship</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(2835)'>
+			<roles>battleship</roles>
+			<availability>CLAN:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thanatos' unitType='Mek'>
 		<availability>LA:6,ROS:4,MH:4,FS:6,MERC:4,CDP:4</availability>
-		<model name='TNS-4T'>
-			<availability>IS:5</availability>
-		</model>
 		<model name='TNS-4S'>
 			<availability>General:8</availability>
 		</model>
 		<model name='TNS-6S'>
 			<availability>LA:6,IS:4</availability>
+		</model>
+		<model name='TNS-4T'>
+			<availability>IS:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thang-Ta APC' unitType='Tank'>
@@ -16075,46 +16077,46 @@
 	</chassis>
 	<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CWE:1,CHH:1,MERC.WD:1,RD:1,CDS:1,ROS:3+,CLAN:1,CP:1,CJF:4,RA:1,BAN:3,CWIE:2</availability>
-		<model name='B'>
-			<roles>fire_support</roles>
-			<availability>CWE:4,RD:3,CDS:4,General:6,CP:4,CJF:7,CWIE:5</availability>
+		<model name='H'>
+			<availability>CLAN:4,General:3</availability>
 		</model>
 		<model name='G'>
 			<availability>CWE:6,CHH:4,RD:4,CDS:4,General:2,CP:4,CJF:5,CWIE:5</availability>
 		</model>
+		<model name='D'>
+			<availability>CWE:8,RD:8,General:5,CP:6,CWIE:6</availability>
+		</model>
 		<model name='AA'>
 			<availability>CLAN:6</availability>
-		</model>
-		<model name='HH'>
-			<availability>CWE:5,CHH:6,CDS:4,CLAN:2,General:2,CP:4,CJF:5</availability>
-		</model>
-		<model name='H'>
-			<availability>CLAN:4,General:3</availability>
-		</model>
-		<model name='U'>
-			<availability>General:2</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:6,CHH:8,RD:4,CDS:8,General:7,CP:7,CJF:8,CWIE:6</availability>
-		</model>
-		<model name='M'>
-			<availability>General:2,CJF:3</availability>
 		</model>
 		<model name='F'>
 			<availability>General:4</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:5,CDS:5,CLAN:4,General:3,CP:5,CWIE:5</availability>
+		<model name='A'>
+			<availability>CWE:6,CHH:8,RD:4,CDS:8,General:7,CP:7,CJF:8,CWIE:6</availability>
+		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>CWE:4,RD:3,CDS:4,General:6,CP:4,CJF:7,CWIE:5</availability>
 		</model>
 		<model name='Prime'>
 			<roles>raider</roles>
 			<availability>CWE:6,RD:6,CDS:9,General:8,CP:9,CJF:9</availability>
 		</model>
-		<model name='D'>
-			<availability>CWE:8,RD:8,General:5,CP:6,CWIE:6</availability>
+		<model name='HH'>
+			<availability>CWE:5,CHH:6,CDS:4,CLAN:2,General:2,CP:4,CJF:5</availability>
+		</model>
+		<model name='U'>
+			<availability>General:2</availability>
 		</model>
 		<model name='C'>
 			<availability>CWE:6,RD:6,General:5,CJF:6</availability>
+		</model>
+		<model name='M'>
+			<availability>General:2,CJF:3</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:5,CDS:5,CLAN:4,General:3,CP:5,CWIE:5</availability>
 		</model>
 	</chassis>
 	<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -16130,9 +16132,6 @@
 	</chassis>
 	<chassis name='Thor II (Grand Summoner)' unitType='Mek' omni='Clan'>
 		<availability>CC:3,CWE:6,RD:6,CDS:6,ROS:4,MERC:3,CP:6,CJF:8,CWIE:6</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='B'>
 			<roles>fire_support</roles>
 			<availability>General:7</availability>
@@ -16143,55 +16142,58 @@
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Thorn' unitType='Mek'>
 		<availability>ROS:5</availability>
-		<model name='THE-N1'>
+		<model name='THE-N2'>
 			<availability>ROS:8</availability>
 		</model>
-		<model name='THE-N2'>
+		<model name='THE-N1'>
 			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thresher' unitType='Mek'>
 		<availability>CHH:5,CDS:2,CP:2,RA:2</availability>
-		<model name='(Standard)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='(Standard)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thrush' unitType='Aero'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+		<model name='TR-7'>
+			<roles>escort,interceptor</roles>
+			<availability>FVC:2-,Periphery:2-</availability>
+		</model>
 		<model name='TR-8'>
 			<availability>CC:6,MOC:4,MERC:4</availability>
 		</model>
 		<model name='TR-7p'>
 			<availability>CC:2,FVC:2,FWL:2,FS:2,MERC:2,CP:2,Periphery:2</availability>
 		</model>
-		<model name='TR-7'>
-			<roles>escort,interceptor</roles>
-			<availability>FVC:2-,Periphery:2-</availability>
-		</model>
 	</chassis>
 	<chassis name='Thug' unitType='Mek'>
 		<availability>MOC:4,CHH:2,CLAN:3,IS:4,CP:2,CWIE:4,DC.GHO:4,CWE:4,RA.OA:4,RD:4,CDS:2,RF:5,Periphery.MW:4,ROS:4,PIR:4,Periphery.ME:4,FWL:4,MH:4,DA:5,CJF:4</availability>
-		<model name='THG-11Eb'>
-			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,CP:6,BAN:2</availability>
-		</model>
 		<model name='THG-11E'>
 			<availability>MOC:8,CLAN:6,IS:8,FS:8,CP:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
 		</model>
-		<model name='THG-12K'>
-			<availability>ROS:5,DC:8</availability>
+		<model name='THG-11Eb'>
+			<availability>ROS:6,CLAN:4,FWL:6,MERC:6,CP:6,BAN:2</availability>
 		</model>
 		<model name='THG-10E'>
 			<availability>MOC:1-,PIR:2-,MH:1-,Periphery:4</availability>
+		</model>
+		<model name='THG-12K'>
+			<availability>ROS:5,DC:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -16211,25 +16213,22 @@
 	</chassis>
 	<chassis name='Thunder Fox' unitType='Mek'>
 		<availability>LA:5,ROS:6,DC:4</availability>
-		<model name='TFT-L8'>
-			<availability>LA:8</availability>
+		<model name='TFT-A9'>
+			<availability>ROS:8,General:4</availability>
 		</model>
 		<model name='TFT-F11'>
 			<availability>LA:4</availability>
-		</model>
-		<model name='TFT-A9'>
-			<availability>ROS:8,General:4</availability>
 		</model>
 		<model name='TFT-C3'>
 			<roles>spotter</roles>
 			<availability>DC:8</availability>
 		</model>
+		<model name='TFT-L8'>
+			<availability>LA:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Thunder Hawk' unitType='Mek'>
 		<availability>LA:8,ROS:6,MERC:4</availability>
-		<model name='TDK-7Y'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
 		<model name='TDK-7KMA'>
 			<roles>missile_artillery</roles>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -16239,6 +16238,9 @@
 		</model>
 		<model name='TDK-7X'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TDK-7Y'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunder Stallion' unitType='Mek'>
@@ -16255,30 +16257,30 @@
 	</chassis>
 	<chassis name='Thunder' unitType='Mek'>
 		<availability>CC:8,MOC:5,RF:5,MERC:4,DA:5,TC:4</availability>
-		<model name='THR-2L'>
-			<availability>CC:5</availability>
-		</model>
 		<model name='THR-3L'>
 			<roles>missile_artillery</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='THR-C4'>
-			<availability>CC:4,MOC:4,CC.LCC:6</availability>
-		</model>
 		<model name='THR-1L'>
 			<availability>General:4</availability>
+		</model>
+		<model name='THR-2L'>
+			<availability>CC:5</availability>
+		</model>
+		<model name='THR-C4'>
+			<availability>CC:4,MOC:4,CC.LCC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbird Battle Armor' unitType='BattleArmor'>
 		<availability>CP:8,DC:4</availability>
+		<model name='[AP Gauss]' mechanized='true'>
+			<availability>General:4</availability>
+		</model>
 		<model name='[Upgrade](Pulse Laser)' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
 		<model name='[Upgrade](ER Laser)' mechanized='true'>
 			<availability>General:8</availability>
-		</model>
-		<model name='[ER Laser]' mechanized='true'>
-			<availability>General:4</availability>
 		</model>
 		<model name='[Pulse Laser]' mechanized='true'>
 			<availability>General:4</availability>
@@ -16286,7 +16288,7 @@
 		<model name='(Upgrade)[LBX]' mechanized='true'>
 			<availability>General:8</availability>
 		</model>
-		<model name='[AP Gauss]' mechanized='true'>
+		<model name='[ER Laser]' mechanized='true'>
 			<availability>General:4</availability>
 		</model>
 	</chassis>
@@ -16298,23 +16300,23 @@
 	</chassis>
 	<chassis name='Thunderbird' unitType='Aero'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
-		<model name='TRB-D46'>
-			<roles>escort,ground_support</roles>
-			<availability>CC:6,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
-		</model>
-		<model name='TRB-D36'>
-			<roles>escort,ground_support</roles>
-			<availability>General:2-</availability>
-		</model>
-		<model name='TRB-D36b'>
-			<roles>ground_support</roles>
-			<availability>CLAN:4,FS:4,MERC:4</availability>
-		</model>
 		<model name='TRB-D56'>
 			<availability>LA:8,ROS:4,MERC:4</availability>
 		</model>
 		<model name='TRB-D50'>
 			<availability>TC:8</availability>
+		</model>
+		<model name='TRB-D46'>
+			<roles>escort,ground_support</roles>
+			<availability>CC:6,MOC:4,LA:8,ROS:8,MH:4,MERC:6</availability>
+		</model>
+		<model name='TRB-D36b'>
+			<roles>ground_support</roles>
+			<availability>CLAN:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='TRB-D36'>
+			<roles>escort,ground_support</roles>
+			<availability>General:2-</availability>
 		</model>
 	</chassis>
 	<chassis name='Thunderbolt IIC' unitType='Mek'>
@@ -16325,26 +16327,20 @@
 	</chassis>
 	<chassis name='Thunderbolt' unitType='Mek'>
 		<availability>CC:4,LA:6,ROS:5,MH:4,FS:5,MERC:6,Periphery:2,TC:4,DC:3</availability>
-		<model name='TDR-5Sb'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='TDR-9M'>
-			<availability>MOC:3,CC:3,PIR:3,FWL:5,MH:3,DA:5,MERC:4,CP:5</availability>
-		</model>
-		<model name='TDR-9S'>
-			<availability>FVC:3,LA:4,FS:2,MERC:3</availability>
-		</model>
 		<model name='TDR-1C'>
 			<availability>MOC:1-,TC:1-</availability>
-		</model>
-		<model name='TDR-7SE'>
-			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
 		</model>
 		<model name='TDR-60-RLA'>
 			<availability>ROS:2,MERC:2,DC:2</availability>
 		</model>
-		<model name='TDR-10SE'>
-			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
+		<model name='TDR-9SE'>
+			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
+		</model>
+		<model name='TDR-9S'>
+			<availability>FVC:3,LA:4,FS:2,MERC:3</availability>
+		</model>
+		<model name='TDR-11SE'>
+			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2,CP:2</availability>
 		</model>
 		<model name='TDR-9T'>
 			<availability>TC:5</availability>
@@ -16352,26 +16348,32 @@
 		<model name='TDR-5S'>
 			<availability>Periphery:2-</availability>
 		</model>
-		<model name='TDR-10S'>
-			<availability>LA:6,MERC:6</availability>
-		</model>
-		<model name='TDR-9SE'>
-			<availability>FVC:4,LA:4,ROS:6,MERC:4,FS:4</availability>
-		</model>
-		<model name='TDR-10M'>
-			<availability>CC:4,ROS:6,FWL:5,MERC:4,CP:5</availability>
-		</model>
 		<model name='TDR-7M'>
 			<availability>CC:2,MOC:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MH:4,MERC:2,CP:2</availability>
 		</model>
-		<model name='TDR-11SE'>
-			<availability>LA:2,ROS:3,FWL:2,MH:2,MERC:4,FS:2,CP:2</availability>
+		<model name='TDR-9M'>
+			<availability>MOC:3,CC:3,PIR:3,FWL:5,MH:3,DA:5,MERC:4,CP:5</availability>
+		</model>
+		<model name='TDR-5Sb'>
+			<availability>TC:6</availability>
+		</model>
+		<model name='TDR-7SE'>
+			<availability>CC:3,ROS:3,PIR:3,MH:3,MERC:3,FS:2</availability>
 		</model>
 		<model name='TDR-9Nr'>
 			<availability>FS:4,MERC:4</availability>
 		</model>
+		<model name='TDR-10M'>
+			<availability>CC:4,ROS:6,FWL:5,MERC:4,CP:5</availability>
+		</model>
+		<model name='TDR-10S'>
+			<availability>LA:6,MERC:6</availability>
+		</model>
 		<model name='TDR-17S'>
 			<availability>LA:6</availability>
+		</model>
+		<model name='TDR-10SE'>
+			<availability>CC:2,ROS:4,MH:2,MERC:6,FS:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Ti Ts&apos;ang' unitType='Mek'>
@@ -16379,9 +16381,8 @@
 		<model name='TSG-9J'>
 			<availability>General:5</availability>
 		</model>
-		<model name='TSG-9H'>
-			<roles>spotter</roles>
-			<availability>General:8</availability>
+		<model name='TSG-9DDC'>
+			<availability>CC:6,CC.WHO:8</availability>
 		</model>
 		<model name='TSG-10L'>
 			<roles>spotter</roles>
@@ -16390,8 +16391,9 @@
 		<model name='TSG-9C'>
 			<availability>CC:4,MOC:4</availability>
 		</model>
-		<model name='TSG-9DDC'>
-			<availability>CC:6,CC.WHO:8</availability>
+		<model name='TSG-9H'>
+			<roles>spotter</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tiamat II' unitType='Dropship'>
@@ -16441,6 +16443,10 @@
 	</chassis>
 	<chassis name='Titan' unitType='Dropship'>
 		<availability>CLAN:4,RA:5</availability>
+		<model name='(2647)'>
+			<roles>asf_carrier</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='(Monitor)'>
 			<roles>assault</roles>
 			<availability>RA:8</availability>
@@ -16449,56 +16455,52 @@
 			<roles>asf_carrier</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2647)'>
-			<roles>asf_carrier</roles>
-			<availability>General:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Titan' unitType='Mek'>
 		<availability>ROS:5,MERC:4,FS:5</availability>
-		<model name='TI-1Ar'>
-			<availability>General:4</availability>
-		</model>
 		<model name='TI-1Aj'>
 			<availability>General:8</availability>
+		</model>
+		<model name='TI-1Ar'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Tokugawa Heavy Tank' unitType='Tank'>
 		<availability>CDS:4,ROS:5,CP:5,DC:8</availability>
-		<model name='(C3)'>
-			<availability>ROS:5,DC:5</availability>
-		</model>
-		<model name='TKG-150'>
-			<availability>DC:1-</availability>
-		</model>
 		<model name='TKG-151'>
 			<availability>DC:1-</availability>
 		</model>
-		<model name='(Streak)'>
-			<availability>CDS:8,ROS:6,CP:8,DC:6</availability>
+		<model name='(C3)'>
+			<availability>ROS:5,DC:5</availability>
 		</model>
 		<model name='(Standard)'>
 			<availability>ROS:8,DC:8</availability>
+		</model>
+		<model name='(Streak)'>
+			<availability>CDS:8,ROS:6,CP:8,DC:6</availability>
 		</model>
 		<model name='(MRM)'>
 			<roles>spotter</roles>
 			<availability>ROS:4,DC:4</availability>
 		</model>
+		<model name='TKG-150'>
+			<availability>DC:1-</availability>
+		</model>
 	</chassis>
 	<chassis name='Tomahawk II' unitType='Mek' omni='Clan'>
 		<availability>CWE:6,CHH:4</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
-			<roles>urban</roles>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<roles>urban</roles>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -16507,15 +16509,15 @@
 		<model name='CH'>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='THK-63CS'>
-			<availability>ROS:8</availability>
+		<model name='THK-63'>
+			<roles>escort</roles>
+			<availability>General:8</availability>
 		</model>
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6</availability>
 		</model>
-		<model name='THK-63'>
-			<roles>escort</roles>
-			<availability>General:8</availability>
+		<model name='THK-63CS'>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tomahawk' unitType='Mek' omni='Clan'>
@@ -16526,10 +16528,10 @@
 		<model name='B'>
 			<availability>General:7</availability>
 		</model>
-		<model name='C'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
-		<model name='A'>
+		<model name='C'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -16542,23 +16544,23 @@
 	</chassis>
 	<chassis name='Tornado PA(L)' unitType='BattleArmor'>
 		<availability>FWL:1,MH:1,CP:1</availability>
-		<model name='G13 [Grenade Launcher]' mechanized='true'>
-			<availability>MH:4</availability>
-		</model>
-		<model name='G13 [Machine Gun]' mechanized='true'>
+		<model name='G13 [Flamer]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 		<model name='G12' mechanized='true'>
 			<roles>specops</roles>
 			<availability>FWL:8,CP:8</availability>
 		</model>
+		<model name='G13 [Small Laser]' mechanized='true'>
+			<availability>MH:4</availability>
+		</model>
 		<model name='G13 [David Light Gauss]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G13 [Flamer]' mechanized='true'>
+		<model name='G13 [Machine Gun]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
-		<model name='G13 [Small Laser]' mechanized='true'>
+		<model name='G13 [Grenade Launcher]' mechanized='true'>
 			<availability>MH:4</availability>
 		</model>
 	</chassis>
@@ -16567,10 +16569,10 @@
 		<model name='(C3)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(aSRM)' mechanized='false'>
+		<model name='(LRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(LRM)' mechanized='false'>
+		<model name='(aSRM)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(SRM)' mechanized='false'>
@@ -16579,13 +16581,13 @@
 	</chassis>
 	<chassis name='Trajan Assault Infantry Fighting Vehicle' unitType='Tank'>
 		<availability>ROS:6</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='(ICE)'>
 			<roles>apc</roles>
 			<availability>ROS:2</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>ROS:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Tramp JumpShip' unitType='Jumpship'>
@@ -16596,36 +16598,33 @@
 		<model name='(2754)'>
 			<availability>General:8,BAN:4</availability>
 		</model>
-		<model name='(2754)'>
-			<availability>General:8,BAN:4</availability>
-		</model>
 	</chassis>
 	<chassis name='Transgressor' unitType='Aero'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,CP:3,TC:5</availability>
-		<model name='TR-16'>
-			<availability>CC:7,MOC:5,RF:8,FWL:5,MERC:5,CP:5,TC:5</availability>
-		</model>
-		<model name='TR-13'>
-			<availability>Periphery:2-</availability>
-		</model>
 		<model name='TR-13A'>
 			<availability>CC:8,MOC:7,General:5</availability>
 		</model>
 		<model name='TR-15'>
 			<availability>CC:6,MOC:2</availability>
 		</model>
+		<model name='TR-13'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='TR-16'>
+			<availability>CC:7,MOC:5,RF:8,FWL:5,MERC:5,CP:5,TC:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Transit' unitType='Aero'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
-		<model name='TR-10'>
-			<availability>MOC:2,General:6,TC:2</availability>
-		</model>
 		<model name='TR-12'>
 			<availability>CC:6,MOC:6</availability>
 		</model>
 		<model name='TR-13G'>
 			<roles>ground_support,assault</roles>
 			<availability>CC:6</availability>
+		</model>
+		<model name='TR-10'>
+			<availability>MOC:2,General:6,TC:2</availability>
 		</model>
 	</chassis>
 	<chassis name='Transportable Field Repair Unit' unitType='Tank'>
@@ -16637,50 +16636,50 @@
 	</chassis>
 	<chassis name='Trebaruna' unitType='Mek'>
 		<availability>CC:5,LA:6,ROS:5,FWL:4,MERC:4,DA:4,CP:4</availability>
-		<model name='TR-XJ'>
-			<availability>FWL:8,MERC:4,CP:8</availability>
-		</model>
 		<model name='TR-XB'>
 			<availability>CC:4,ROS:8,MERC:4</availability>
-		</model>
-		<model name='TR-XL'>
-			<availability>CC:8</availability>
 		</model>
 		<model name='TR-XH'>
 			<availability>CC:4,LA:8,DA:8</availability>
 		</model>
+		<model name='TR-XJ'>
+			<availability>FWL:8,MERC:4,CP:8</availability>
+		</model>
+		<model name='TR-XL'>
+			<availability>CC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Trebuchet' unitType='Mek'>
 		<availability>RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,CP:6,Periphery:3,TC:4,DC:4</availability>
-		<model name='TBT-7M'>
+		<model name='TBT-5N'>
 			<roles>fire_support</roles>
-			<availability>CC:4,FWL:4,MH:4,FS:4,MERC:4,CP:4,TC:2,DC:4</availability>
-		</model>
-		<model name='TBT-9K'>
-			<roles>fire_support</roles>
-			<availability>DC:8</availability>
-		</model>
-		<model name='TBT-K7R'>
-			<availability>ROS:4</availability>
-		</model>
-		<model name='TBT-8B'>
-			<roles>fire_support</roles>
-			<availability>ROS:6,FWL:4,MERC:5,CP:4</availability>
+			<availability>MOC:4-,Periphery:4-</availability>
 		</model>
 		<model name='TBT-3C'>
 			<roles>fire_support</roles>
 			<availability>RF:4,ROS:5,FWL:4,MERC:4,CP:4</availability>
 		</model>
-		<model name='TBT-XK7'>
+		<model name='TBT-K7R'>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='TBT-7M'>
 			<roles>fire_support</roles>
-			<availability>TC:6</availability>
+			<availability>CC:4,FWL:4,MH:4,FS:4,MERC:4,CP:4,TC:2,DC:4</availability>
+		</model>
+		<model name='TBT-8B'>
+			<roles>fire_support</roles>
+			<availability>ROS:6,FWL:4,MERC:5,CP:4</availability>
 		</model>
 		<model name='TBT-9R'>
 			<availability>RF:8</availability>
 		</model>
-		<model name='TBT-5N'>
+		<model name='TBT-9K'>
 			<roles>fire_support</roles>
-			<availability>MOC:4-,Periphery:4-</availability>
+			<availability>DC:8</availability>
+		</model>
+		<model name='TBT-XK7'>
+			<roles>fire_support</roles>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trident' unitType='Aero'>
@@ -16694,17 +16693,8 @@
 	</chassis>
 	<chassis name='Trinity Medium Battle Armor' unitType='BattleArmor'>
 		<availability>MOC:8,CC:8,MH:4,TC:8</availability>
-		<model name='(Theseus RL)[LRR]' mechanized='true'>
-			<availability>MOC:6</availability>
-		</model>
-		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
-			<availability>TC:6</availability>
-		</model>
-		<model name='(Asterion)[PPC]' mechanized='true'>
-			<availability>MH:2,TC:2</availability>
-		</model>
-		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
-			<availability>MOC:6</availability>
+		<model name='(Theseus)[MRR]' mechanized='true'>
+			<availability>MOC:8</availability>
 		</model>
 		<model name='(Asterion)[MRR]' mechanized='true'>
 			<availability>MH:2,TC:2</availability>
@@ -16712,11 +16702,20 @@
 		<model name='(Ying Long)(Plasma)' mechanized='true'>
 			<availability>CC:8</availability>
 		</model>
+		<model name='(Theseus Support)&apos;Killshot&apos;' mechanized='true'>
+			<availability>MOC:6</availability>
+		</model>
 		<model name='(Asterion Upgrade)[MRR]' mechanized='true'>
 			<availability>TC:6</availability>
 		</model>
-		<model name='(Theseus)[MRR]' mechanized='true'>
-			<availability>MOC:8</availability>
+		<model name='(Theseus RL)[LRR]' mechanized='true'>
+			<availability>MOC:6</availability>
+		</model>
+		<model name='(Asterion)[PPC]' mechanized='true'>
+			<availability>MH:2,TC:2</availability>
+		</model>
+		<model name='(Asterion Upgrade)[PPC]' mechanized='true'>
+			<availability>TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Trireme Infantry Transport' unitType='VTOL'>
@@ -16743,14 +16742,14 @@
 	</chassis>
 	<chassis name='Troika' unitType='Aero'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
+		<model name='CMT-3T'>
+			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
+		</model>
 		<model name='CMT-4U'>
 			<availability>General:5</availability>
 		</model>
 		<model name='CMT-6T'>
 			<availability>MOC:5,CC:5,MERC:4,DA:4</availability>
-		</model>
-		<model name='CMT-3T'>
-			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
 		</model>
 		<model name='CMT-7T'>
 			<availability>CC:6</availability>
@@ -16772,10 +16771,10 @@
 	</chassis>
 	<chassis name='Tsunami' unitType='Mek'>
 		<availability>MERC:3</availability>
-		<model name='TS-P1D'>
+		<model name='TS-P1'>
 			<availability>General:8</availability>
 		</model>
-		<model name='TS-P1'>
+		<model name='TS-P1D'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
@@ -16792,17 +16791,17 @@
 	</chassis>
 	<chassis name='Tundra Wolf' unitType='Mek'>
 		<availability>CWE:6+,ROS:3,CWIE:3</availability>
-		<model name='4'>
-			<availability>General:8</availability>
+		<model name='(Standard)'>
+			<availability>General:2</availability>
 		</model>
 		<model name='3'>
 			<availability>CWE:3,ROS:2</availability>
 		</model>
+		<model name='4'>
+			<availability>General:8</availability>
+		</model>
 		<model name='5'>
 			<availability>CWE:2</availability>
-		</model>
-		<model name='(Standard)'>
-			<availability>General:2</availability>
 		</model>
 		<model name='2'>
 			<availability>General:2</availability>
@@ -16817,24 +16816,24 @@
 	</chassis>
 	<chassis name='Turk' unitType='Aero' omni='Clan'>
 		<availability>CWE:2,CLAN:3,CJF:2,BAN:1,CWIE:2</availability>
-		<model name='Prime'>
-			<availability>General:8</availability>
+		<model name='B'>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<availability>General:7</availability>
-		</model>
-		<model name='D'>
-			<availability>RD:6,General:2</availability>
 		</model>
 		<model name='E'>
 			<roles>escort</roles>
 			<availability>RD:4,CLAN:2</availability>
 		</model>
+		<model name='D'>
+			<availability>RD:6,General:2</availability>
+		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<availability>General:6</availability>
+		<model name='Prime'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Turkina' unitType='Mek' omni='Clan'>
@@ -16842,11 +16841,21 @@
 		<model name='A'>
 			<availability>CWE:7,CHH:7,CP:7,CJF:7</availability>
 		</model>
-		<model name='E'>
-			<availability>CWE:4,CHH:4,CP:4,CJF:4</availability>
+		<model name='Prime'>
+			<availability>CWE:8,CHH:8,CP:8,CJF:8</availability>
+		</model>
+		<model name='U'>
+			<roles>marine</roles>
+			<availability>CLAN:2</availability>
+		</model>
+		<model name='D'>
+			<availability>CWE:6,CHH:6,CP:6,CJF:6</availability>
 		</model>
 		<model name='C'>
 			<availability>CWE:7,CHH:7,CP:7,CJF:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CHH:4,CP:4,CJF:4</availability>
 		</model>
 		<model name='B'>
 			<availability>CWE:9,RD:9,General:7</availability>
@@ -16854,19 +16863,13 @@
 		<model name='H'>
 			<availability>CWE:6,CHH:5,CP:5,CJF:5</availability>
 		</model>
-		<model name='U'>
-			<roles>marine</roles>
-			<availability>CLAN:2</availability>
-		</model>
-		<model name='Prime'>
-			<availability>CWE:8,CHH:8,CP:8,CJF:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:6,CHH:6,CP:6,CJF:6</availability>
-		</model>
 	</chassis>
 	<chassis name='Typhoon Urban Assault Vehicle' unitType='Tank'>
 		<availability>LA:3,ROS:3,FS:6,MERC:3</availability>
+		<model name='(RAC)'>
+			<roles>urban</roles>
+			<availability>General:4,FS:6</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>General:8</availability>
@@ -16874,10 +16877,6 @@
 		<model name='(LB-X)'>
 			<roles>urban</roles>
 			<availability>General:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<roles>urban</roles>
-			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Typhoon' unitType='Aero'>
@@ -16889,63 +16888,30 @@
 	</chassis>
 	<chassis name='Tyr Infantry Support Tank' unitType='Tank'>
 		<availability>CHH:4,RD:5,CDS:4,ROS:3,CP:4,DC:2</availability>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>CLAN:8</availability>
+		</model>
 		<model name='(Kurita)'>
 			<roles>apc</roles>
 			<availability>IS:8</availability>
 		</model>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Tyre' unitType='Aero'>
 		<availability>CLAN:7</availability>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='2'>
+			<availability>CLAN:5</availability>
 		</model>
 		<model name='3'>
 			<roles>assault</roles>
 			<availability>RD:4,CHH:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CLAN:5</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
 		<availability>CWE:2,CHH:2,MERC.WD:1,MERC:2+,CJF:3,RA:3,CWIE:2</availability>
-		<model name='B'>
-			<availability>CWE:6,RD:5,CDS:8,General:7,CP:8,CWIE:6</availability>
-		</model>
-		<model name='H'>
-			<availability>CDS:5,CLAN:4,IS:2,CP:5</availability>
-		</model>
-		<model name='I'>
-			<availability>General:6</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:4,CDS:4,General:2,CP:4,CWIE:4</availability>
-		</model>
-		<model name='C'>
-			<roles>urban,spotter,anti_infantry</roles>
-			<availability>CWE:6,RD:2,General:2,CWIE:6</availability>
-		</model>
-		<model name='R'>
-			<availability>General:6</availability>
-		</model>
-		<model name='A'>
-			<availability>CWE:6,CHH:6,RD:4,CDS:6,General:5,CP:6,CJF:6,CWIE:6</availability>
-		</model>
-		<model name='G'>
-			<roles>fire_support</roles>
-			<availability>General:5,RA:6</availability>
-		</model>
-		<model name='S'>
-			<roles>urban</roles>
-			<availability>CWE:4,RD:1,CDS:2,General:1,CP:2,CJF:2,CWIE:4</availability>
-		</model>
-		<model name='Prime'>
-			<availability>RD:8,CDS:9,General:8,CP:9,CJF:9</availability>
-		</model>
 		<model name='F'>
 			<availability>CWE:4,CHH:6,RD:5,CDS:4,CLAN:3,IS:1,CP:4,CJF:4</availability>
 		</model>
@@ -16953,12 +16919,45 @@
 			<roles>fire_support</roles>
 			<availability>CWE:2,CHH:5,RD:2,CDS:4,General:4,CP:3,CWIE:2</availability>
 		</model>
+		<model name='R'>
+			<availability>General:6</availability>
+		</model>
+		<model name='C'>
+			<roles>urban,spotter,anti_infantry</roles>
+			<availability>CWE:6,RD:2,General:2,CWIE:6</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CDS:4,General:2,CP:4,CWIE:4</availability>
+		</model>
+		<model name='A'>
+			<availability>CWE:6,CHH:6,RD:4,CDS:6,General:5,CP:6,CJF:6,CWIE:6</availability>
+		</model>
 		<model name='U'>
 			<availability>General:2</availability>
+		</model>
+		<model name='G'>
+			<roles>fire_support</roles>
+			<availability>General:5,RA:6</availability>
+		</model>
+		<model name='B'>
+			<availability>CWE:6,RD:5,CDS:8,General:7,CP:8,CWIE:6</availability>
+		</model>
+		<model name='Prime'>
+			<availability>RD:8,CDS:9,General:8,CP:9,CJF:9</availability>
+		</model>
+		<model name='S'>
+			<roles>urban</roles>
+			<availability>CWE:4,RD:1,CDS:2,General:1,CP:2,CJF:2,CWIE:4</availability>
+		</model>
+		<model name='H'>
+			<availability>CDS:5,CLAN:4,IS:2,CP:5</availability>
 		</model>
 		<model name='W'>
 			<roles>training</roles>
 			<availability>CWE:3,General:1,CWIE:2</availability>
+		</model>
+		<model name='I'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Umbra' unitType='Aero'>
@@ -16986,24 +16985,24 @@
 	</chassis>
 	<chassis name='Union-X' unitType='Dropship'>
 		<availability>LA:4</availability>
-		<model name='(3065)'>
-			<roles>troop_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 		<model name='(3071)'>
 			<roles>troop_carrier</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='(3065)'>
+			<roles>troop_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 	</chassis>
 	<chassis name='Union' unitType='Dropship'>
 		<availability>IS:8,Periphery:6</availability>
-		<model name='(2708)'>
-			<roles>mech_carrier</roles>
-			<availability>General:5,BAN:4</availability>
-		</model>
 		<model name='(3055)'>
 			<roles>mech_carrier</roles>
 			<availability>LA:8,IS:8,FS:8</availability>
+		</model>
+		<model name='(2708)'>
+			<roles>mech_carrier</roles>
+			<availability>General:5,BAN:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Uraeus' unitType='Mek'>
@@ -17025,6 +17024,10 @@
 	</chassis>
 	<chassis name='UrbanMech' unitType='Mek'>
 		<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
+		<model name='UM-R80'>
+			<roles>urban,spotter</roles>
+			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
+		</model>
 		<model name='UM-R69'>
 			<roles>urban</roles>
 			<availability>FWL:6,IS:6,CP:6,Periphery:6</availability>
@@ -17037,30 +17040,26 @@
 			<roles>urban</roles>
 			<availability>Periphery:1</availability>
 		</model>
-		<model name='UM-AIV'>
-			<roles>missile_artillery,urban</roles>
-			<deployedWith>missile artillery,fire support</deployedWith>
-			<availability>CC:6,IS:4,Periphery:4</availability>
-		</model>
-		<model name='UM-R80'>
-			<roles>urban,spotter</roles>
-			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
-		</model>
 		<model name='UM-R93'>
 			<roles>urban</roles>
 			<availability>CC:4</availability>
 		</model>
-		<model name='UM-R63'>
+		<model name='UM-R60'>
 			<roles>urban</roles>
-			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+			<availability>Periphery:2-</availability>
 		</model>
 		<model name='UM-R70'>
 			<roles>urban</roles>
 			<availability>CC:4,MOC:4,FS.CMM:6,FWL:4,FS:4,CP:4</availability>
 		</model>
-		<model name='UM-R60'>
+		<model name='UM-R63'>
 			<roles>urban</roles>
-			<availability>Periphery:2-</availability>
+			<availability>CC:8,MOC:4,MERC:4,TC:4</availability>
+		</model>
+		<model name='UM-AIV'>
+			<roles>missile_artillery,urban</roles>
+			<deployedWith>missile artillery,fire support</deployedWith>
+			<availability>CC:6,IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Ursa' unitType='Mek'>
@@ -17080,23 +17079,23 @@
 	</chassis>
 	<chassis name='Ursus' unitType='Mek'>
 		<availability>CHH:4,RD:7,ROS:4</availability>
-		<model name='(Standard)'>
+		<model name='3'>
+			<roles>anti_infantry,specops</roles>
 			<deployedWith>IS</deployedWith>
-			<availability>General:8</availability>
+			<availability>RD:1</availability>
+		</model>
+		<model name='PR'>
+			<roles>anti_infantry</roles>
+			<availability>RD:1</availability>
 		</model>
 		<model name='2'>
 			<roles>anti_infantry</roles>
 			<deployedWith>IS</deployedWith>
 			<availability>CLAN:4</availability>
 		</model>
-		<model name='PR'>
-			<roles>anti_infantry</roles>
-			<availability>RD:1</availability>
-		</model>
-		<model name='3'>
-			<roles>anti_infantry,specops</roles>
+		<model name='(Standard)'>
 			<deployedWith>IS</deployedWith>
-			<availability>RD:1</availability>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Uziel' unitType='Mek'>
@@ -17114,8 +17113,8 @@
 	</chassis>
 	<chassis name='Valiant' unitType='Mek'>
 		<availability>LA:6,IS:5,FS:6,MERC:5,CDP:5,DC:6</availability>
-		<model name='V4-LNT-J3'>
-			<availability>ROS:6,FS:8,MERC:6</availability>
+		<model name='V4-LNT-K7'>
+			<availability>General:8</availability>
 		</model>
 		<model name='VLT-3E'>
 			<availability>ROS:8</availability>
@@ -17123,31 +17122,27 @@
 		<model name='VLN-3T'>
 			<availability>LA:2,General:2,FS:2,MERC:2</availability>
 		</model>
-		<model name='V4-LNT-K7'>
-			<availability>General:8</availability>
+		<model name='V4-LNT-J3'>
+			<availability>ROS:6,FS:8,MERC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Valkyrie' unitType='Mek'>
 		<availability>FVC:8,LA:2,ROS:4,FS:9,MERC:4,CDP:4,TC:4</availability>
-		<model name='VLK-QD4'>
+		<model name='VLK-QS5'>
 			<roles>recon,fire_support</roles>
-			<availability>ROS:6,FS:6</availability>
+			<availability>LA:6,ROS:4,MERC:4</availability>
+		</model>
+		<model name='VLK-QD'>
+			<roles>recon,fire_support</roles>
+			<availability>FVC:4,LA:4,ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='VLK-QD2'>
 			<roles>recon,fire_support</roles>
 			<availability>FVC:4,FS:4</availability>
 		</model>
-		<model name='VLK-QS5'>
-			<roles>recon,fire_support</roles>
-			<availability>LA:6,ROS:4,MERC:4</availability>
-		</model>
 		<model name='VLK-QD8'>
 			<roles>recon,fire_support</roles>
 			<availability>FS:6,MERC:4</availability>
-		</model>
-		<model name='VLK-QD'>
-			<roles>recon,fire_support</roles>
-			<availability>FVC:4,LA:4,ROS:5,FS:3,MERC:6</availability>
 		</model>
 		<model name='VLK-QD1'>
 			<roles>recon,fire_support</roles>
@@ -17161,6 +17156,10 @@
 			<roles>recon,fire_support</roles>
 			<availability>ROS:4,FS:4,MERC:4</availability>
 		</model>
+		<model name='VLK-QD4'>
+			<roles>recon,fire_support</roles>
+			<availability>ROS:6,FS:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Vampire II' unitType='Dropship'>
 		<availability>FS:2</availability>
@@ -17171,27 +17170,27 @@
 	</chassis>
 	<chassis name='Vandal' unitType='Aero' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
-		<model name='A'>
-			<roles>bomber</roles>
-			<availability>General:6</availability>
+		<model name='D'>
+			<availability>CWE:4,CHH:6,CLAN:2,CJF:4</availability>
 		</model>
 		<model name='E'>
 			<roles>recon</roles>
 			<availability>CWE:4,CLAN:2,CJF:4</availability>
 		</model>
-		<model name='Prime'>
-			<roles>recon</roles>
-			<availability>General:8</availability>
-		</model>
-		<model name='D'>
-			<availability>CWE:4,CHH:6,CLAN:2,CJF:4</availability>
+		<model name='B'>
+			<roles>ground_support</roles>
+			<availability>General:5,RA:6</availability>
 		</model>
 		<model name='C'>
 			<availability>General:5</availability>
 		</model>
-		<model name='B'>
-			<roles>ground_support</roles>
-			<availability>General:5,RA:6</availability>
+		<model name='A'>
+			<roles>bomber</roles>
+			<availability>General:6</availability>
+		</model>
+		<model name='Prime'>
+			<roles>recon</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vandal' unitType='Mek' omni='IS'>
@@ -17200,12 +17199,12 @@
 			<roles>spotter</roles>
 			<availability>General:7</availability>
 		</model>
-		<model name='LI-O'>
-			<availability>General:8</availability>
-		</model>
 		<model name='LI-OB'>
 			<roles>spotter</roles>
 			<availability>General:7</availability>
+		</model>
+		<model name='LI-O'>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vanir Assault Dropship' unitType='Dropship'>
@@ -17217,17 +17216,11 @@
 	</chassis>
 	<chassis name='Vedette Medium Tank' unitType='Tank'>
 		<availability>CWE:4,CHH:5,IS:10,CJF:4,Periphery:10</availability>
-		<model name='V-G7X'>
-			<availability>LA:1</availability>
-		</model>
-		<model name='V7'>
-			<availability>LA:4,ROS:4,FS:4,MERC:6</availability>
+		<model name='(NETC)'>
+			<availability>IS:3</availability>
 		</model>
 		<model name='(Ultra)'>
 			<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
-		</model>
-		<model name='(RAC)'>
-			<availability>IS:4,FS:6</availability>
 		</model>
 		<model name='V9'>
 			<availability>LA:4,CLAN:8</availability>
@@ -17235,11 +17228,17 @@
 		<model name='(LB-X)'>
 			<availability>CC:5,MOC:5,RF:5,FWL:4,DA:5,CP:4,CDP:5,TC:5</availability>
 		</model>
+		<model name='(RAC)'>
+			<availability>IS:4,FS:6</availability>
+		</model>
 		<model name='(Light Gauss)'>
 			<availability>IS:2</availability>
 		</model>
-		<model name='(NETC)'>
-			<availability>IS:3</availability>
+		<model name='V-G7X'>
+			<availability>LA:1</availability>
+		</model>
+		<model name='V7'>
+			<availability>LA:4,ROS:4,FS:4,MERC:6</availability>
 		</model>
 		<model name='(Cell)'>
 			<availability>CC:6,LA:4,FWL:6,IS:4,FS:4,MERC:5,CP:6,DC:4,Periphery:4</availability>
@@ -17247,6 +17246,10 @@
 	</chassis>
 	<chassis name='Vengeance' unitType='Dropship'>
 		<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,CP:4,Periphery:1,TC:1,DC:4</availability>
+		<model name='(2682)'>
+			<roles>asf_carrier</roles>
+			<availability>General:2</availability>
+		</model>
 		<model name='(Danai Centrella)'>
 			<availability>MOC:4,CC:4</availability>
 		</model>
@@ -17254,51 +17257,60 @@
 			<roles>asf_carrier</roles>
 			<availability>IS:4,FS:8</availability>
 		</model>
-		<model name='(2682)'>
-			<roles>asf_carrier</roles>
-			<availability>General:2</availability>
-		</model>
 	</chassis>
 	<chassis name='Venom' unitType='Mek'>
 		<availability>ROS:4,FWL:3,MERC:3,CP:3,DC:8</availability>
+		<model name='SDR-9KC'>
+			<availability>ROS:6,FWL:6,MERC:6,CP:6,DC:6</availability>
+		</model>
 		<model name='SDR-9K'>
 			<availability>General:8</availability>
-		</model>
-		<model name='SDR-9KB'>
-			<availability>FWL:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 		<model name='SDR-9KA'>
 			<availability>FWL:5,MERC:5,CP:5,DC:5</availability>
 		</model>
-		<model name='SDR-9KC'>
-			<availability>ROS:6,FWL:6,MERC:6,CP:6,DC:6</availability>
+		<model name='SDR-9KB'>
+			<availability>FWL:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Verfolger' unitType='Mek'>
 		<availability>MERC.KH:4,MERC.WD:3,LA:3,ROS:3,CWIE:2</availability>
-		<model name='VR6-T'>
+		<model name='VR5-R'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>MERC.KH:4</availability>
+			<availability>General:8</availability>
 		</model>
 		<model name='VR6-C'>
 			<deployedWith>Wolfhound</deployedWith>
 			<availability>MERC.KH:4</availability>
 		</model>
-		<model name='VR5-R'>
+		<model name='VR6-T'>
 			<deployedWith>Wolfhound</deployedWith>
-			<availability>General:8</availability>
+			<availability>MERC.KH:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Victor' unitType='Mek'>
 		<availability>MOC:2,CC:5,RA.OA:2,LA:3,Periphery.HR:2,FWL:2,FS:7,Periphery.OS:2,CP:2,Periphery:3,TC:2,DC:4</availability>
-		<model name='VTR-C'>
-			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
+		<model name='VTR-9B'>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='VTR-9K'>
+			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
+		</model>
+		<model name='VTR-9Ka'>
+			<availability>CC:4,FVC:4,ROS:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
+		</model>
+		<model name='VTR-Cr'>
+			<availability>FS:1,DC:2</availability>
 		</model>
 		<model name='VTR-10S'>
 			<availability>LA:8</availability>
 		</model>
-		<model name='VTR-9B'>
-			<availability>Periphery:2-</availability>
+		<model name='VTR-C'>
+			<availability>CC:4,ROS:5,MERC:4,FS:4,DC:6</availability>
+		</model>
+		<model name='VTR-11D'>
+			<roles>urban</roles>
+			<availability>ROS:2,FS:2,MERC:1</availability>
 		</model>
 		<model name='C'>
 			<availability>CLAN:8</availability>
@@ -17306,21 +17318,8 @@
 		<model name='VTR-10D'>
 			<availability>ROS:5,FS:6,MERC:2</availability>
 		</model>
-		<model name='VTR-11D'>
-			<roles>urban</roles>
-			<availability>ROS:2,FS:2,MERC:1</availability>
-		</model>
-		<model name='VTR-Cr'>
-			<availability>FS:1,DC:2</availability>
-		</model>
 		<model name='VTR-10L'>
 			<availability>CC:4,MOC:4,ROS:3,MERC:3</availability>
-		</model>
-		<model name='VTR-9K'>
-			<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
-		</model>
-		<model name='VTR-9Ka'>
-			<availability>CC:4,FVC:4,ROS:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vidar Heavy Defense Tank' unitType='Tank'>
@@ -17338,12 +17337,12 @@
 	</chassis>
 	<chassis name='Viking' unitType='Mek'>
 		<availability>RD:7,ROS:6,MERC:5</availability>
+		<model name='VKG-2G'>
+			<availability>RD:6,ROS:6,MERC:6</availability>
+		</model>
 		<model name='VKG-2F'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
-		</model>
-		<model name='VKG-2G'>
-			<availability>RD:6,ROS:6,MERC:6</availability>
 		</model>
 		<model name='VKG-3A'>
 			<roles>missile_artillery</roles>
@@ -17363,20 +17362,20 @@
 	</chassis>
 	<chassis name='Vindicator' unitType='Mek'>
 		<availability>CC:9,MOC:6,PIR:5,MERC:4,TC:6</availability>
+		<model name='VND-5L'>
+			<availability>CC:2,MOC:1,MERC:1</availability>
+		</model>
 		<model name='VND-4L'>
 			<availability>CC:8,MOC:6</availability>
-		</model>
-		<model name='VND-3Lr'>
-			<availability>CC:6,MOC:6,PIR:4,MERC:6,TC:6</availability>
 		</model>
 		<model name='VND-3L'>
 			<availability>CC:2,MOC:2,General:2,TC:2</availability>
 		</model>
-		<model name='VND-5L'>
-			<availability>CC:2,MOC:1,MERC:1</availability>
-		</model>
 		<model name='VND-6L'>
 			<availability>CC:1+</availability>
+		</model>
+		<model name='VND-3Lr'>
+			<availability>CC:6,MOC:6,PIR:4,MERC:6,TC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Violator' unitType='Mek'>
@@ -17399,23 +17398,23 @@
 	</chassis>
 	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
-		<model name='B'>
-			<availability>General:7</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='D'>
-			<availability>General:2,CJF:6,RA:6</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
+		<model name='D'>
+			<availability>General:2,CJF:6,RA:6</availability>
+		</model>
 		<model name='E'>
 			<availability>General:2,CJF:5,RA:5</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Vixen (Incubus)' unitType='Mek'>
@@ -17423,27 +17422,27 @@
 		<model name='(Standard)'>
 			<availability>CJF:4</availability>
 		</model>
-		<model name='5'>
+		<model name='4'>
 			<availability>CHH:6</availability>
 		</model>
-		<model name='4'>
+		<model name='5'>
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Void Medium Battle Armor' unitType='BattleArmor'>
 		<availability>CP:5,DC:6+</availability>
-		<model name='(Minelayer)' mechanized='true'>
-			<roles>minelayer</roles>
-			<availability>DC:6</availability>
-		</model>
-		<model name='(Nova Cat)' mechanized='true'>
-			<availability>CP:8</availability>
-		</model>
 		<model name='(Standard)' mechanized='true'>
 			<availability>DC:8</availability>
 		</model>
 		<model name='(DCA)' mechanized='true'>
 			<roles>marine</roles>
+			<availability>DC:6</availability>
+		</model>
+		<model name='(Nova Cat)' mechanized='true'>
+			<availability>CP:8</availability>
+		</model>
+		<model name='(Minelayer)' mechanized='true'>
+			<roles>minelayer</roles>
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
@@ -17457,18 +17456,14 @@
 			<roles>cargo</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='(2836)'>
-			<roles>cargo</roles>
-			<availability>CLAN:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
 		<availability>PIR:2,FS:1,DC:2</availability>
-		<model name='VNL-X71 (Yakuza)'>
-			<availability>PIR:8</availability>
-		</model>
 		<model name='VNL-K75N'>
 			<availability>LA:8,FWL:8,FS:8,CP:8,DC:8</availability>
+		</model>
+		<model name='VNL-X71 (Yakuza)'>
+			<availability>PIR:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulcan' unitType='Aero'>
@@ -17482,9 +17477,17 @@
 	</chassis>
 	<chassis name='Vulcan' unitType='Mek'>
 		<availability>MOC:4,RD:4,LA:4,FWL:4,IS:1,CP:4,Periphery:4,TC:4</availability>
+		<model name='VT-6M'>
+			<roles>anti_infantry</roles>
+			<availability>FWL:4,DA:6,CP:4</availability>
+		</model>
 		<model name='VL-2T'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:2-,General:2-</availability>
+		</model>
+		<model name='VL-5T'>
+			<roles>anti_infantry</roles>
+			<availability>MOC:2,FVC:2,PIR:2,IS:2,Periphery:2,TC:2</availability>
 		</model>
 		<model name='VT-5M'>
 			<roles>anti_infantry</roles>
@@ -17494,17 +17497,9 @@
 			<roles>anti_infantry</roles>
 			<availability>FVC:6,RD:6,LA:6,ROS:6,MH:4,FS:6,MERC:6</availability>
 		</model>
-		<model name='VL-5T'>
-			<roles>anti_infantry</roles>
-			<availability>MOC:2,FVC:2,PIR:2,IS:2,Periphery:2,TC:2</availability>
-		</model>
 		<model name='VT-5S'>
 			<roles>anti_infantry</roles>
 			<availability>FVC:4,LA:8,MH:5,FS:4,MERC:5</availability>
-		</model>
-		<model name='VT-6M'>
-			<roles>anti_infantry</roles>
-			<availability>FWL:4,DA:6,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Vulpes' unitType='Mek'>
@@ -17515,11 +17510,20 @@
 	</chassis>
 	<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
 		<availability>CHH:4,MERC.WD:4,RD:4,ROS:4+,CLAN:3,MERC:2+,CJF:3,BAN:5,CWIE:4,DC:3+</availability>
+		<model name='B'>
+			<availability>CWE:7,CDS:7,General:6,CP:7,CJF:5</availability>
+		</model>
 		<model name='A'>
 			<availability>CWE:7,RD:4,CDS:7,General:6,CP:7</availability>
 		</model>
 		<model name='Prime'>
 			<availability>RD:8,General:8,CP:7,CJF:7</availability>
+		</model>
+		<model name='C'>
+			<availability>CHH:5,RD:3,CDS:7,General:5,CP:7</availability>
+		</model>
+		<model name='E'>
+			<availability>CWE:4,CHH:5,CDS:3,General:2,CP:3,CJF:4</availability>
 		</model>
 		<model name='D'>
 			<availability>RD:5,CDS:5,General:4,CP:5,RA:5</availability>
@@ -17530,15 +17534,6 @@
 		<model name='U'>
 			<availability>General:2</availability>
 		</model>
-		<model name='B'>
-			<availability>CWE:7,CDS:7,General:6,CP:7,CJF:5</availability>
-		</model>
-		<model name='C'>
-			<availability>CHH:5,RD:3,CDS:7,General:5,CP:7</availability>
-		</model>
-		<model name='E'>
-			<availability>CWE:4,CHH:5,CDS:3,General:2,CP:3,CJF:4</availability>
-		</model>
 		<model name='H'>
 			<availability>CDS:5,CLAN:4,General:3,CP:5</availability>
 		</model>
@@ -17548,27 +17543,27 @@
 	</chassis>
 	<chassis name='Vulture Mk III (Mad Dog Mk III)' unitType='Mek' omni='Clan'>
 		<availability>RD:8,ROS:5,RA:8</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='D'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
-			<roles>fire_support</roles>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Prime)'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='B'>
+			<roles>fire_support</roles>
+			<availability>General:7</availability>
+		</model>
 	</chassis>
 	<chassis name='Vulture Mk IV (Mad Dog Mk IV)' unitType='Mek' omni='Clan'>
 		<availability>IS:5+,CLAN.IS:7</availability>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:7</availability>
 		</model>
 		<model name='D'>
@@ -17577,7 +17572,7 @@
 		<model name='Prime'>
 			<availability>General:8</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='C'>
@@ -17595,109 +17590,109 @@
 	</chassis>
 	<chassis name='Warg Assault Battle Armor' unitType='BattleArmor'>
 		<availability>CWE:4</availability>
-		<model name='(Reactive)' mechanized='false'>
-			<availability>General:6</availability>
-		</model>
 		<model name='(Standard)' mechanized='false'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(Reactive)' mechanized='false'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer IIC' unitType='Mek'>
 		<availability>MOC:3,CLAN:7,IS:4,TC:3</availability>
-		<model name='6'>
-			<availability>RD:6,RA:6</availability>
+		<model name='9'>
+			<availability>CDS:6,CP:6</availability>
+		</model>
+		<model name='5'>
+			<availability>CDS:5,IS:4,CP:5</availability>
+		</model>
+		<model name='10'>
+			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
+		</model>
+		<model name='8'>
+			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
 		</model>
 		<model name='12'>
 			<availability>CDS:5,CP:5</availability>
+		</model>
+		<model name='6'>
+			<availability>RD:6,RA:6</availability>
+		</model>
+		<model name='7'>
+			<availability>RA:7</availability>
+		</model>
+		<model name='4'>
+			<availability>CC:4,CHH:5,RD:5,CDS:6,LA:4,ROS:4,FS:4,CP:5,RA:5,CWIE:5,DC:4</availability>
+		</model>
+		<model name='3'>
+			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,CP:4,DC:4</availability>
 		</model>
 		<model name='2'>
 			<roles>fire_support</roles>
 			<availability>IS:3</availability>
 		</model>
-		<model name='9'>
-			<availability>CDS:6,CP:6</availability>
-		</model>
-		<model name='3'>
-			<availability>CC:4,CDS:5,LA:4,ROS:4,FWL:4,CP:4,DC:4</availability>
-		</model>
-		<model name='5'>
-			<availability>CDS:5,IS:4,CP:5</availability>
-		</model>
-		<model name='8'>
-			<availability>MOC:6,CLAN:6,IS:6,TC:6</availability>
-		</model>
-		<model name='7'>
-			<availability>RA:7</availability>
-		</model>
 		<model name='11'>
 			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
-		</model>
-		<model name='10'>
-			<availability>MOC:4,CLAN:4,IS:4,TC:4</availability>
-		</model>
-		<model name='4'>
-			<availability>CC:4,CHH:5,RD:5,CDS:6,LA:4,ROS:4,FS:4,CP:5,RA:5,CWIE:5,DC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Warhammer' unitType='Mek'>
 		<availability>LA:6,IS:6,FWL:6,CP:6,TC:8,Periphery:5</availability>
-		<model name='WHM-6R'>
-			<availability>BAN:8,Periphery:2-</availability>
+		<model name='WHM-9S'>
+			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
 		</model>
-		<model name='WHM-10T'>
-			<availability>FS:4,TC:8</availability>
+		<model name='WHM-8M'>
+			<availability>RF:6,FWL:4,CP:4</availability>
 		</model>
 		<model name='WHM-7K'>
 			<roles>spotter</roles>
 			<availability>DC:4</availability>
 		</model>
-		<model name='WHM-9D'>
-			<availability>ROS:4,FS:8,MERC:4</availability>
-		</model>
-		<model name='WHM-8K'>
-			<availability>DC:8</availability>
-		</model>
-		<model name='WHM-8M'>
-			<availability>RF:6,FWL:4,CP:4</availability>
-		</model>
-		<model name='WHM-11T'>
-			<availability>MOC:4,TC:6</availability>
-		</model>
-		<model name='WHM-5L'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='WHD-10CT'>
-			<availability>CC:4,LA:4,ROS:4</availability>
-		</model>
-		<model name='WHM-6Rb'>
-			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
-		</model>
 		<model name='WHM-8D'>
 			<availability>MOC:4,FVC:2,PIR:4,IS:2,MH:4,FS:2,MERC:3,CDP:4,TC:4</availability>
 		</model>
-		<model name='WHM-7S'>
-			<availability>FVC:4,LA:4,FS:2,MERC:4</availability>
-		</model>
-		<model name='WHM-7M'>
-			<availability>CC:3,FVC:3,ROS:4,FWL:4,CP:4,Periphery:3</availability>
-		</model>
-		<model name='WHM-9S'>
-			<availability>LA:8,ROS:4,MH:4,MERC:4</availability>
-		</model>
-		<model name='WHM-8D2'>
-			<availability>FS:6</availability>
+		<model name='WHM-6R'>
+			<availability>BAN:8,Periphery:2-</availability>
 		</model>
 		<model name='WHM-4L'>
 			<availability>CC:6,MOC:4</availability>
 		</model>
+		<model name='WHM-11T'>
+			<availability>MOC:4,TC:6</availability>
+		</model>
+		<model name='WHM-8K'>
+			<availability>DC:8</availability>
+		</model>
+		<model name='WHD-10CT'>
+			<availability>CC:4,LA:4,ROS:4</availability>
+		</model>
+		<model name='WHM-8D2'>
+			<availability>FS:6</availability>
+		</model>
+		<model name='WHM-5L'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='WHM-7M'>
+			<availability>CC:3,FVC:3,ROS:4,FWL:4,CP:4,Periphery:3</availability>
+		</model>
+		<model name='WHM-7S'>
+			<availability>FVC:4,LA:4,FS:2,MERC:4</availability>
+		</model>
+		<model name='WHM-9D'>
+			<availability>ROS:4,FS:8,MERC:4</availability>
+		</model>
+		<model name='WHM-10T'>
+			<availability>FS:4,TC:8</availability>
+		</model>
+		<model name='WHM-6Rb'>
+			<availability>FVC:4,CLAN:4,MERC:4,BAN:2,TC:6,Periphery:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Warlord' unitType='Mek'>
 		<availability>FS.DBG:6,ROS:4,FS:6</availability>
-		<model name='BLR-2G'>
-			<availability>General:4</availability>
-		</model>
 		<model name='BLR-2D'>
 			<availability>General:8</availability>
+		</model>
+		<model name='BLR-2G'>
+			<availability>General:4</availability>
 		</model>
 		<model name='BLR-2Dr'>
 			<availability>General:6</availability>
@@ -17715,11 +17710,11 @@
 		<model name='H-8'>
 			<availability>RD:8,LA:3,FS.CH:8,ROS:6,IS:6,FWL:3,FS:6,CP:3,RA:8</availability>
 		</model>
-		<model name='H-9'>
-			<availability>LA:6</availability>
-		</model>
 		<model name='H-7A'>
 			<availability>IS:1-,Periphery:1-</availability>
+		</model>
+		<model name='H-9'>
+			<availability>LA:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Warrior Stealth Helicopter' unitType='VTOL'>
@@ -17731,32 +17726,52 @@
 	</chassis>
 	<chassis name='Warwolf' unitType='Mek' omni='Clan'>
 		<availability>CWE:3+</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
-		<model name='H'>
-			<availability>General:6</availability>
-		</model>
 		<model name='C'>
-			<availability>General:7</availability>
-		</model>
-		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(Prime)'>
 			<roles>spotter</roles>
 			<availability>General:8</availability>
 		</model>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
+		<model name='B'>
+			<availability>General:7</availability>
+		</model>
+		<model name='H'>
+			<availability>General:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wasp' unitType='Mek'>
 		<availability>IS:8,Periphery:6,RA:4</availability>
-		<model name='WSP-1'>
+		<model name='WSP-7MAF'>
+			<roles>fire_support</roles>
+			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
+		</model>
+		<model name='WSP-3W'>
 			<roles>recon</roles>
-			<availability>MOC:1-,FVC:1-,Periphery:1-</availability>
+			<availability>MERC.WD:8</availability>
 		</model>
 		<model name='WSP-8T'>
 			<roles>recon</roles>
 			<availability>CC:6,MOC:6,ROS:2,IS:4,TC:8</availability>
+		</model>
+		<model name='WSP-3S'>
+			<roles>recon,spotter</roles>
+			<availability>LA:6,ROS:5,FS:4,MERC:4</availability>
+		</model>
+		<model name='WSP-1S'>
+			<roles>recon</roles>
+			<availability>FVC:2,LA:3,MERC:2</availability>
+		</model>
+		<model name='WSP-3M'>
+			<roles>recon</roles>
+			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,CP:8,DC:6</availability>
+		</model>
+		<model name='WSP-1'>
+			<roles>recon</roles>
+			<availability>MOC:1-,FVC:1-,Periphery:1-</availability>
 		</model>
 		<model name='WSP-3L'>
 			<roles>recon</roles>
@@ -17765,29 +17780,9 @@
 		<model name='WSP-3P'>
 			<availability>FVC:6,Periphery.Deep:4,Periphery:6</availability>
 		</model>
-		<model name='WSP-3S'>
-			<roles>recon,spotter</roles>
-			<availability>LA:6,ROS:5,FS:4,MERC:4</availability>
-		</model>
-		<model name='WSP-7MAF'>
-			<roles>fire_support</roles>
-			<availability>MOC:6,CC:4,DA:4,TC:5</availability>
-		</model>
 		<model name='WSP-3A'>
 			<roles>recon</roles>
 			<availability>RA.OA:6,RA:8</availability>
-		</model>
-		<model name='WSP-1S'>
-			<roles>recon</roles>
-			<availability>FVC:2,LA:3,MERC:2</availability>
-		</model>
-		<model name='WSP-3W'>
-			<roles>recon</roles>
-			<availability>MERC.WD:8</availability>
-		</model>
-		<model name='WSP-3M'>
-			<roles>recon</roles>
-			<availability>CC:6,MOC:6,FWL:8,MH:6,MERC:6,CP:8,DC:6</availability>
 		</model>
 		<model name='WSP-3K'>
 			<availability>DC:6</availability>
@@ -17804,15 +17799,18 @@
 	</chassis>
 	<chassis name='Wendigo-VP' unitType='Mek' omni='Clan'>
 		<availability>FWL:1,CP:1,DC:1</availability>
-		<model name='A'>
-			<availability>General:7</availability>
-		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Wendigo' unitType='Mek' omni='Clan'>
 		<availability>CDS:4,FWL:5,CP:5,DC:5</availability>
+		<model name='A'>
+			<availability>General:7</availability>
+		</model>
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
@@ -17821,9 +17819,6 @@
 		</model>
 		<model name='(Prime)'>
 			<availability>General:8</availability>
-		</model>
-		<model name='A'>
-			<availability>General:7</availability>
 		</model>
 	</chassis>
 	<chassis name='Whirlwind Destroyer' unitType='Warship'>
@@ -17842,12 +17837,6 @@
 		<model name='WTH-3'>
 			<availability>FS.CMM:8</availability>
 		</model>
-		<model name='WTH-1H'>
-			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
-		</model>
-		<model name='WTH-K'>
-			<availability>DC:8</availability>
-		</model>
 		<model name='WTH-2A'>
 			<availability>DC:1</availability>
 		</model>
@@ -17855,11 +17844,17 @@
 			<roles>fire_support</roles>
 			<availability>RA.OA:6,MH:6,MERC:6,CDP:6,TC:6</availability>
 		</model>
+		<model name='WTH-1H'>
+			<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
+		</model>
+		<model name='WTH-K'>
+			<availability>DC:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Wight' unitType='Mek'>
 		<availability>CC:6,LA:5,FWL:5,IS:4,CP:3-,MERC:5,DC:8</availability>
-		<model name='WGT-3SC'>
-			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
+		<model name='WGT-2LAW'>
+			<availability>DC:6</availability>
 		</model>
 		<model name='WGT-1LAW/SC3'>
 			<availability>ROS:5,DC:6</availability>
@@ -17867,14 +17862,14 @@
 		<model name='WGT-2LAWC3'>
 			<availability>DC:6</availability>
 		</model>
-		<model name='WGT-2LAW'>
-			<availability>DC:6</availability>
+		<model name='WGT-1LAW/SC'>
+			<availability>LA:4,FWL:4,IS:4,MERC:4,CP:4,DC:4</availability>
 		</model>
 		<model name='WGT-2SC'>
 			<availability>LA:6,FWL:6,IS:4,MERC:6,CP:6</availability>
 		</model>
-		<model name='WGT-1LAW/SC'>
-			<availability>LA:4,FWL:4,IS:4,MERC:4,CP:4,DC:4</availability>
+		<model name='WGT-3SC'>
+			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wildkatze' unitType='Aero'>
@@ -17888,8 +17883,8 @@
 	</chassis>
 	<chassis name='Winston Combat Vehicle' unitType='Tank'>
 		<availability>ROS:5,ROS.pm:8</availability>
-		<model name='(LAC)'>
-			<availability>General:4</availability>
+		<model name='(Standard)'>
+			<availability>General:5</availability>
 		</model>
 		<model name='(TSEMP)'>
 			<availability>General:6</availability>
@@ -17898,11 +17893,11 @@
 			<roles>fire_support,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>General:5</availability>
-		</model>
 		<model name='(XXL)'>
 			<availability>General:5</availability>
+		</model>
+		<model name='(LAC)'>
+			<availability>General:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Winterhawk APC' unitType='Tank'>
@@ -17914,14 +17909,8 @@
 	</chassis>
 	<chassis name='Wolf Trap (Tora)' unitType='Mek'>
 		<availability>ROS:2,MERC:2,DC:5-</availability>
-		<model name='WFT-C'>
-			<availability>MERC:4,DC:4</availability>
-		</model>
 		<model name='WFT-2'>
 			<availability>DC:4</availability>
-		</model>
-		<model name='WFT-2B'>
-			<availability>DC.SZC:8,DC:6</availability>
 		</model>
 		<model name='WFT-B'>
 			<availability>ROS:6</availability>
@@ -17929,21 +17918,15 @@
 		<model name='WFT-1'>
 			<availability>General:4</availability>
 		</model>
+		<model name='WFT-C'>
+			<availability>MERC:4,DC:4</availability>
+		</model>
+		<model name='WFT-2B'>
+			<availability>DC.SZC:8,DC:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolfhound' unitType='Mek'>
 		<availability>MOC:4,MERC.KH:7,MERC.WD:5,FVC:1,LA:7,ROS:5,FWL:3,MH:4,MERC:4,FS:1,CP:3,CWIE:5</availability>
-		<model name='WLF-4W'>
-			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
-		</model>
-		<model name='WLF-5'>
-			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
-		</model>
-		<model name='WLF-2'>
-			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
-		</model>
-		<model name='WLF-3M'>
-			<availability>FWL:8,CP:8</availability>
-		</model>
 		<model name='WLF-4WA'>
 			<roles>ew_support</roles>
 			<availability>MERC.KH:2,MERC.WD:2,LA:2,MERC:2,CWIE:2</availability>
@@ -17951,65 +17934,77 @@
 		<model name='WLF-1'>
 			<availability>Periphery.Deep:6,Periphery:8</availability>
 		</model>
-		<model name='WLF-3S'>
-			<availability>LA:4</availability>
+		<model name='WLF-3M'>
+			<availability>FWL:8,CP:8</availability>
+		</model>
+		<model name='WLF-2'>
+			<availability>MERC.KH:1,MERC.WD:1,FVC:2,LA:3,ROS:4,FS:2,MERC:6</availability>
+		</model>
+		<model name='WLF-4W'>
+			<availability>MERC.KH:5,MERC.WD:3,LA:4,MERC:4,CWIE:5</availability>
 		</model>
 		<model name='WLF-2H'>
 			<availability>LA:6,MERC:3,CWIE:4</availability>
 		</model>
+		<model name='WLF-5'>
+			<availability>MERC.KH:8,LA:6,ROS:6,MERC:4,FS:6,CWIE:6</availability>
+		</model>
+		<model name='WLF-3S'>
+			<availability>LA:4</availability>
+		</model>
 	</chassis>
 	<chassis name='Wolverine' unitType='Mek'>
 		<availability>CC:5,RD:2,LA:5,IS:5,FWL:8,MH:4,FS:6,CP:6,DC:5,Periphery:4,TC:4</availability>
-		<model name='WVR-9K'>
-			<availability>ROS:3,DC:6</availability>
-		</model>
-		<model name='WVR-6R'>
+		<model name='WVR-7M'>
 			<roles>recon</roles>
-			<availability>Periphery:2-</availability>
-		</model>
-		<model name='WVR-7D'>
-			<roles>recon</roles>
-			<availability>FVC:4,LA:2,ROS:4,FS:4,MERC:4</availability>
-		</model>
-		<model name='WVR-8C'>
-			<availability>ROS:4,MERC:4,DC:8</availability>
-		</model>
-		<model name='WVR-9W2'>
-			<availability>IS:4,DC:8</availability>
+			<availability>CC:4,MOC:6,FWL:4,MH:6,MERC:6,CP:4,DC:4</availability>
 		</model>
 		<model name='WVR-9D'>
 			<roles>spotter</roles>
 			<availability>FS:6,MERC:4</availability>
 		</model>
-		<model name='WVR-7M'>
-			<roles>recon</roles>
-			<availability>CC:4,MOC:6,FWL:4,MH:6,MERC:6,CP:4,DC:4</availability>
+		<model name='WVR-8K'>
+			<availability>RD:5,ROS:4,MERC:3,CP:4</availability>
 		</model>
-		<model name='WVR-8D'>
-			<availability>FS:6</availability>
+		<model name='WVR-9W2'>
+			<availability>IS:4,DC:8</availability>
 		</model>
 		<model name='WVR-7K'>
 			<roles>recon</roles>
 			<availability>RD:8,MERC:6,DC:6</availability>
 		</model>
-		<model name='WVR-9M'>
-			<availability>LA:4,ROS:4,FWL:6,MH:4,MERC:4,CP:6</availability>
+		<model name='WVR-8D'>
+			<availability>FS:6</availability>
 		</model>
 		<model name='WVR-6M'>
 			<roles>recon</roles>
 			<availability>Periphery.MW:2-,PIR:2-,Periphery.ME:2-,MH:2-</availability>
 		</model>
-		<model name='WVR-8K'>
-			<availability>RD:5,ROS:4,MERC:3,CP:4</availability>
+		<model name='WVR-8C'>
+			<availability>ROS:4,MERC:4,DC:8</availability>
+		</model>
+		<model name='WVR-6R'>
+			<roles>recon</roles>
+			<availability>Periphery:2-</availability>
+		</model>
+		<model name='WVR-9M'>
+			<availability>LA:4,ROS:4,FWL:6,MH:4,MERC:4,CP:6</availability>
+		</model>
+		<model name='WVR-7D'>
+			<roles>recon</roles>
+			<availability>FVC:4,LA:2,ROS:4,FS:4,MERC:4</availability>
+		</model>
+		<model name='WVR-9K'>
+			<availability>ROS:3,DC:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Woodsman' unitType='Mek' omni='Clan'>
 		<availability>BAN:1</availability>
-		<model name='A'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Prime'>
 			<availability>General:8</availability>
+		</model>
+		<model name='A'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wraith Battle Armor' unitType='BattleArmor'>
@@ -18033,12 +18028,6 @@
 	</chassis>
 	<chassis name='Wulfen' unitType='Mek' omni='Clan'>
 		<availability>CWE:6+</availability>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
-		<model name='E'>
-			<availability>General:7</availability>
-		</model>
 		<model name='A'>
 			<availability>General:7</availability>
 		</model>
@@ -18048,10 +18037,16 @@
 		<model name='C'>
 			<availability>General:7</availability>
 		</model>
-		<model name='B'>
+		<model name='H'>
 			<availability>General:7</availability>
 		</model>
-		<model name='H'>
+		<model name='E'>
+			<availability>General:7</availability>
+		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
+		<model name='B'>
 			<availability>General:7</availability>
 		</model>
 	</chassis>
@@ -18064,10 +18059,7 @@
 	</chassis>
 	<chassis name='Wusun' unitType='Aero' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
-		<model name='D'>
-			<availability>General:6</availability>
-		</model>
-		<model name='B'>
+		<model name='A'>
 			<availability>General:6</availability>
 		</model>
 		<model name='Prime'>
@@ -18076,29 +18068,32 @@
 		<model name='C'>
 			<availability>General:6</availability>
 		</model>
-		<model name='A'>
+		<model name='B'>
+			<availability>General:6</availability>
+		</model>
+		<model name='D'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Wyvern IIC' unitType='Mek'>
 		<availability>CWE:4,CHH:4</availability>
+		<model name='2'>
+			<availability>CWE:8</availability>
+		</model>
 		<model name='(Standard)'>
 			<roles>urban</roles>
 			<availability>CLAN:8</availability>
 		</model>
-		<model name='2'>
-			<availability>CWE:8</availability>
-		</model>
 	</chassis>
 	<chassis name='Wyvern' unitType='Mek'>
 		<availability>DC.GHO:2,CC:1,FVC:2,RF:1,ROS:5,IS:1,FS:7,MERC:5,DA:1,DC:6</availability>
-		<model name='WVE-9N'>
-			<roles>urban</roles>
-			<availability>ROS:8</availability>
-		</model>
 		<model name='WVE-5N'>
 			<roles>urban</roles>
 			<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
+		</model>
+		<model name='WVE-9N'>
+			<roles>urban</roles>
+			<availability>ROS:8</availability>
 		</model>
 		<model name='WVE-6N'>
 			<roles>urban</roles>
@@ -18114,20 +18109,20 @@
 	</chassis>
 	<chassis name='Xanthos' unitType='Mek'>
 		<availability>CC:6,LA:4,ROS:4,Periphery.CM:4,MERC:4,DA:4,Periphery:2,TC:4</availability>
-		<model name='XNT-2O'>
-			<availability>General:1-</availability>
-		</model>
 		<model name='XNT-6O'>
 			<availability>CC:6,MOC:6,DA:8</availability>
 		</model>
-		<model name='XNT-7O'>
-			<availability>CC:4</availability>
+		<model name='XNT-2O'>
+			<availability>General:1-</availability>
 		</model>
 		<model name='XNT-5O'>
 			<availability>CC:6,MOC:6,LA:6,ROS:6,MERC:6</availability>
 		</model>
 		<model name='XNT-4O'>
 			<availability>CC:6,MOC:6,LA:6</availability>
+		</model>
+		<model name='XNT-7O'>
+			<availability>CC:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Xenoplanetary Infantry' unitType='Infantry'>
@@ -18139,25 +18134,25 @@
 	</chassis>
 	<chassis name='Xerxes' unitType='Aero'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
-		<model name='2'>
-			<availability>CHH:6</availability>
-		</model>
 		<model name='(Standard)'>
 			<availability>CLAN:8</availability>
 		</model>
 		<model name='3'>
 			<availability>CHH:4</availability>
 		</model>
+		<model name='2'>
+			<availability>CHH:6</availability>
+		</model>
 	</chassis>
 	<chassis name='Xiphos Assault Battle Armor' unitType='BattleArmor'>
 		<availability>FWL:6,CP:6</availability>
-		<model name='(B)' mechanized='false'>
+		<model name='(C)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 		<model name='(A)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
-		<model name='(C)' mechanized='false'>
+		<model name='(B)' mechanized='false'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
@@ -18169,6 +18164,9 @@
 	</chassis>
 	<chassis name='Yasha VTOL' unitType='VTOL'>
 		<availability>CHH:4,CDS:4,IS:5,CP:4,CWIE:5</availability>
+		<model name='&apos;Spectre&apos;'>
+			<availability>General:3</availability>
+		</model>
 		<model name='(Interdictor)'>
 			<roles>ew_support</roles>
 			<availability>General:4</availability>
@@ -18176,17 +18174,11 @@
 		<model name='(Standard)'>
 			<availability>General:8</availability>
 		</model>
-		<model name='&apos;Spectre&apos;'>
-			<availability>General:3</availability>
-		</model>
 	</chassis>
 	<chassis name='Yellow Jacket Gunship' unitType='VTOL'>
 		<availability>FVC:8,LA:6,IS:5,FS:8,MERC:5,Periphery:4</availability>
 		<model name='(RAC)'>
 			<availability>IS:3,FS:5</availability>
-		</model>
-		<model name='(PPC)'>
-			<availability>IS:5</availability>
 		</model>
 		<model name='(Ammo)'>
 			<availability>General:2,FS:4</availability>
@@ -18198,15 +18190,18 @@
 			<roles>missile_artillery</roles>
 			<availability>MOC:2,FVC:3,IS:2,FS:3</availability>
 		</model>
+		<model name='(PPC)'>
+			<availability>IS:5</availability>
+		</model>
 	</chassis>
 	<chassis name='Yeoman' unitType='Mek'>
 		<availability>ROS:4,FWL:4,MH:3,MERC:3,CP:4</availability>
-		<model name='YMN-10-OR'>
-			<availability>ROS:4,FWL:4,MERC:4,CP:4</availability>
-		</model>
 		<model name='YMN-6Y'>
 			<roles>fire_support</roles>
 			<availability>General:8</availability>
+		</model>
+		<model name='YMN-10-OR'>
+			<availability>ROS:4,FWL:4,MERC:4,CP:4</availability>
 		</model>
 	</chassis>
 	<chassis name='Yinghuochong' unitType='Mek'>
@@ -18232,18 +18227,18 @@
 		<model name='Y-H9GB'>
 			<availability>CC:4</availability>
 		</model>
-		<model name='Y-H11G'>
-			<availability>CC:6</availability>
-		</model>
-		<model name='Y-H10G'>
-			<availability>General:6</availability>
-		</model>
 		<model name='Y-H9G'>
 			<availability>General:8</availability>
 		</model>
 		<model name='Y-H9GC'>
 			<roles>spotter</roles>
 			<availability>CC:3</availability>
+		</model>
+		<model name='Y-H11G'>
+			<availability>CC:6</availability>
+		</model>
+		<model name='Y-H10G'>
+			<availability>General:6</availability>
 		</model>
 	</chassis>
 	<chassis name='Yun' unitType='Aero'>
@@ -18279,11 +18274,11 @@
 			<roles>recon</roles>
 			<availability>ROS:4</availability>
 		</model>
-		<model name='(Omnidrone) C'>
-			<availability>ROS:4</availability>
-		</model>
 		<model name='(Omnidrone) A'>
 			<roles>spotter</roles>
+			<availability>ROS:4</availability>
+		</model>
+		<model name='(Omnidrone) C'>
 			<availability>ROS:4</availability>
 		</model>
 		<model name='(Omnidrone) Prime'>
@@ -18292,13 +18287,13 @@
 	</chassis>
 	<chassis name='Zephyros Infantry Support Vehicle' unitType='Tank'>
 		<availability>CWE:4,CHH:8,RD:4,CWIE:4</availability>
-		<model name='(Standard)'>
-			<roles>apc</roles>
-			<availability>General:8</availability>
-		</model>
 		<model name='(Dual Turret)'>
 			<roles>apc</roles>
 			<availability>CHH:4</availability>
+		</model>
+		<model name='(Standard)'>
+			<roles>apc</roles>
+			<availability>General:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zero' unitType='Aero'>
@@ -18309,8 +18304,8 @@
 	</chassis>
 	<chassis name='Zeus-X' unitType='Mek'>
 		<availability>MERC.WD:4,MERC.KH:3,LA:7,ROS:3</availability>
-		<model name='ZEU-X4'>
-			<availability>LA:8</availability>
+		<model name='ZEU-X2'>
+			<availability>LA:3-</availability>
 		</model>
 		<model name='ZEU-X3'>
 			<availability>LA:2-</availability>
@@ -18321,26 +18316,26 @@
 		<model name='ZEU-9WD'>
 			<availability>General:4</availability>
 		</model>
-		<model name='ZEU-X2'>
-			<availability>LA:3-</availability>
+		<model name='ZEU-X4'>
+			<availability>LA:8</availability>
 		</model>
 	</chassis>
 	<chassis name='Zeus' unitType='Mek'>
 		<availability>Periphery.R:5,LA:10,ROS:5,PIR:2,MH:2,FS:1-,MERC:5,CDP:2,TC:2</availability>
-		<model name='ZEU-10WB'>
-			<availability>LA:4,ROS:4</availability>
-		</model>
-		<model name='ZEU-6S'>
-			<availability>Periphery:2</availability>
-		</model>
 		<model name='ZEU-9S'>
 			<availability>FVC:6,LA:8,PIR:6,MH:6,MERC:6,CDP:6,TC:6</availability>
+		</model>
+		<model name='ZEU-9S-DC'>
+			<availability>LA:2</availability>
+		</model>
+		<model name='ZEU-10WB'>
+			<availability>LA:4,ROS:4</availability>
 		</model>
 		<model name='ZEU-9S2'>
 			<availability>LA:4,ROS:4,FS:8,MERC:4</availability>
 		</model>
-		<model name='ZEU-9S-DC'>
-			<availability>LA:2</availability>
+		<model name='ZEU-6S'>
+			<availability>Periphery:2</availability>
 		</model>
 		<model name='ZEU-9T'>
 			<availability>LA:6,ROS:6,MERC:4</availability>
@@ -18370,39 +18365,43 @@
 		<model name='(A)'>
 			<availability>General:7</availability>
 		</model>
-		<model name='(Prime)'>
-			<availability>General:8</availability>
-		</model>
 		<model name='(B)'>
 			<availability>General:7</availability>
 		</model>
 		<model name='(D)'>
 			<availability>General:7</availability>
 		</model>
+		<model name='(Prime)'>
+			<availability>General:8</availability>
+		</model>
 	</chassis>
 	<chassis name='Zorya Light Tank' unitType='Tank'>
 		<availability>CWE:10,ROS:6,CLAN:9</availability>
-		<model name='(Ammo)'>
-			<availability>CHH:5,CLAN:4,CJF:1</availability>
+		<model name='(Standard)'>
+			<availability>CLAN:8</availability>
 		</model>
 		<model name='(ATM)'>
 			<availability>CWE:6,ROS:4</availability>
 		</model>
-		<model name='(Standard)'>
-			<availability>CLAN:8</availability>
+		<model name='(Ammo)'>
+			<availability>CHH:5,CLAN:4,CJF:1</availability>
 		</model>
 	</chassis>
 	<chassis name='Zou Heavy Battle Armor' unitType='BattleArmor'>
 		<availability>DC:6</availability>
-		<model name='(Standard)' mechanized='true'>
-			<availability>General:6-</availability>
-		</model>
 		<model name='(C3)' mechanized='true'>
 			<availability>General:6</availability>
+		</model>
+		<model name='(Standard)' mechanized='true'>
+			<availability>General:6-</availability>
 		</model>
 	</chassis>
 	<chassis name='Zugvogel Omni Support Aircraft' unitType='Conventional Fighter'>
 		<availability>RD:2,LA:4,IS:2,Periphery:2</availability>
+		<model name='Prime'>
+			<roles>cargo</roles>
+			<availability>General:8</availability>
+		</model>
 		<model name='C'>
 			<roles>support</roles>
 			<availability>General:6</availability>
@@ -18411,23 +18410,19 @@
 			<roles>support</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='Prime'>
-			<roles>cargo</roles>
-			<availability>General:8</availability>
+		<model name='B'>
+			<roles>support</roles>
+			<availability>General:6</availability>
 		</model>
 		<model name='A'>
 			<roles>support,spotter</roles>
 			<availability>General:6</availability>
 		</model>
-		<model name='B'>
-			<roles>support</roles>
+		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
 		<model name='F'>
 			<roles>support</roles>
-			<availability>General:6</availability>
-		</model>
-		<model name='D &apos;Raubvogel&apos;'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>

--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -5,6 +5,7 @@ VERSION HISTORY:
 + PR #1808: Abandon ship! Large spacecraft can now launch escape pods, giving the opposing player more opportunity to commit war crimes.
 + Issue #1824: Implementing Tactical Operations Low Visibility Errata
 + Issue #1768: Resizing the map no longer messes up building/road layout. Note that resizing westward needs to be done by an even number of hexes.
++ Issue #1812: Semi-guided warheads indirectly fired at TAGged targets are no longer subject to terrain modifiers for the purposes of "to-hit" numbers.
 
 0.47.5 (2020-4-01 2000 UTC)
 + Data: Removing broken Unit from Fan Council TRO

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -3279,7 +3279,7 @@ public class FireControl {
         }
         
         if(bestTarget != null) {
-            SearchlightAttackAction slaa = new SearchlightAttackAction(shooter.getId(), bestTarget.getTargetId());
+            SearchlightAttackAction slaa = new SearchlightAttackAction(shooter.getId(), bestTarget.getTargetType(), bestTarget.getTargetId());
             return slaa;
         }
         

--- a/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
@@ -614,13 +614,10 @@ class ForceGenerationOptionsPanel extends JPanel implements ActionListener, Focu
                     addWeightClasses(panWeightClass, EntityWeightClass.WEIGHT_ULTRA_LIGHT,
                             EntityWeightClass.WEIGHT_COLOSSAL, false);
                     break;
+                case UnitType.NAVAL:
                 case UnitType.TANK:
                     addWeightClasses(panWeightClass, EntityWeightClass.WEIGHT_LIGHT,
                             EntityWeightClass.WEIGHT_ASSAULT, false);
-                    break;
-                case UnitType.NAVAL:
-                    addWeightClasses(panWeightClass, EntityWeightClass.WEIGHT_ULTRA_LIGHT,
-                            EntityWeightClass.WEIGHT_ASSAULT, false);                    
                     break;
                 case UnitType.PROTOMEK:
                     addWeightClasses(panWeightClass, EntityWeightClass.WEIGHT_LIGHT,

--- a/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
@@ -204,11 +204,11 @@ class ForceGenerationOptionsPanel extends JPanel implements ActionListener, Focu
         c.weighty = 0.0;
         add(new JLabel(Messages.getString("RandomArmyDialog.UnitType")), c);
 
-        if (use.equals(Use.FORMATION_BUILDER)) {
-            for (int unitType : UNIT_TYPES) {
-                if (unitType < UnitType.JUMPSHIP) {
-                    cbUnitType.addItem(UnitType.getTypeName(unitType));
-                }
+        boolean restrictUnitType = use == Use.FORMATION_BUILDER;
+        
+        for (int unitType : UNIT_TYPES) {
+            if ((unitType < UnitType.JUMPSHIP) || !restrictUnitType) {
+                cbUnitType.addItem(UnitType.getTypeName(unitType));
             }
         }
         cbUnitType.setSelectedItem(0);
@@ -615,9 +615,12 @@ class ForceGenerationOptionsPanel extends JPanel implements ActionListener, Focu
                             EntityWeightClass.WEIGHT_COLOSSAL, false);
                     break;
                 case UnitType.TANK:
-                case UnitType.NAVAL:
                     addWeightClasses(panWeightClass, EntityWeightClass.WEIGHT_LIGHT,
                             EntityWeightClass.WEIGHT_ASSAULT, false);
+                    break;
+                case UnitType.NAVAL:
+                    addWeightClasses(panWeightClass, EntityWeightClass.WEIGHT_ULTRA_LIGHT,
+                            EntityWeightClass.WEIGHT_ASSAULT, false);                    
                     break;
                 case UnitType.PROTOMEK:
                     addWeightClasses(panWeightClass, EntityWeightClass.WEIGHT_LIGHT,

--- a/megamek/src/megamek/common/MechSummary.java
+++ b/megamek/src/megamek/common/MechSummary.java
@@ -375,6 +375,7 @@ public class MechSummary implements Serializable {
         if (isSupport()) {
             return EntityWeightClass.getSupportWeightClass(m_nTons, m_sUnitSubType);
         }
+        
         return EntityWeightClass.getWeightClass(tons, getUnitType());
     }
 


### PR DESCRIPTION
I'm really disliking how the RAT generator save mechanism randomly swaps around the order of units for no reason, which clutters the diff. I may look at it in the future. 

This PR basically adds the silverfin and silverback to the RAT Generator's tables, fixes a bug where the unit type dropdown wouldn't show up in the RATGen UI, and adds ultra-light weight class to the RATGen UI for naval vessels.