### PR TITLE
Include hydrofoil in naval support vehicle weight class determination

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -6775,6 +6775,8 @@ public abstract class Entity extends TurnOrdered implements Transporter,
                 return "Rail";
             case MAGLEV:
                 return "MagLev";
+            case STATION_KEEPING:
+                return "Station-Keeping";
             default:
                 return "ERROR";
         }

--- a/megamek/src/megamek/common/EntityMovementMode.java
+++ b/megamek/src/megamek/common/EntityMovementMode.java
@@ -41,7 +41,7 @@ public enum EntityMovementMode {
     INF_UMU ("umu", "scuba", "motorized scuba"),
     AEROSPACE, // this might be a synonym for AERODYNE.
     AIRSHIP ("airship"),
-    STATION_KEEPING ("station", "station_keeping", "satellite"),
+    STATION_KEEPING ("station", "station_keeping", "satellite", "station-keeping"),
     RAIL ("rail"),
     MAGLEV ("maglev");
 

--- a/megamek/src/megamek/common/EntityWeightClass.java
+++ b/megamek/src/megamek/common/EntityWeightClass.java
@@ -177,85 +177,51 @@ public class EntityWeightClass {
      * @return        The weight class
      */
     public static int getSupportWeightClass(double tonnage, String type) {
-        int i = 0;
-
-        switch (type) {
-            case "Wheeled":
-                for (i = WEIGHT_SMALL_SUPPORT; i < (wheeledSupportVehicleWeightLimits.length - 1); i++) {
-                    if (tonnage <= wheeledSupportVehicleWeightLimits[i]) {
-                        break;
-                    }
-                }
+        double[] weightLimits;
+        switch (EntityMovementMode.getMode(type)) {
+            case WHEELED:
+                weightLimits = wheeledSupportVehicleWeightLimits;
                 break;
-            case "Tracked":
-                for (i = WEIGHT_SMALL_SUPPORT; i < (trackedSupportVehicleWeightLimits.length - 1); i++) {
-                    if (tonnage <= trackedSupportVehicleWeightLimits[i]) {
-                        break;
-                    }
-                }
+            case TRACKED:
+                weightLimits = trackedSupportVehicleWeightLimits;
                 break;
-            case "Hover":
-                for (i = WEIGHT_SMALL_SUPPORT; i < (hoverSupportVehicleWeightLimits.length - 1); i++) {
-                    if (tonnage <= hoverSupportVehicleWeightLimits[i]) {
-                        break;
-                    }
-                }
+            case HOVER:
+                weightLimits = hoverSupportVehicleWeightLimits;
                 break;
-            case "VTOL":
-                for (i = WEIGHT_SMALL_SUPPORT; i < (vtolSupportVehicleWeightLimits.length - 1); i++) {
-                    if (tonnage <= vtolSupportVehicleWeightLimits[i]) {
-                        break;
-                    }
-                }
+            case VTOL:
+                weightLimits = vtolSupportVehicleWeightLimits;
                 break;
-            case "WiGE":
-                for (i = WEIGHT_SMALL_SUPPORT; i < (wigeSupportVehicleWeightLimits.length - 1); i++) {
-                    if (tonnage <= wigeSupportVehicleWeightLimits[i]) {
-                        break;
-                    }
-                }
+            case WIGE:
+                weightLimits = wigeSupportVehicleWeightLimits;
                 break;
-            case "Naval":
-            case "Hydrofoil":
-            case "Submarine":
-                for (i = WEIGHT_SMALL_SUPPORT; i < (navalSupportVehicleWeightLimits.length - 1); i++) {
-                    if (tonnage <= navalSupportVehicleWeightLimits[i]) {
-                        break;
-                    }
-                }
+            case NAVAL:
+            case HYDROFOIL:
+            case SUBMARINE:
+                weightLimits = navalSupportVehicleWeightLimits;
                 break;
-            case "Rail":
-            case "MagLev":
-                for (i = WEIGHT_SMALL_SUPPORT; i < (railSupportVehicleWeightLimits.length - 1); i++) {
-                    if (tonnage <= railSupportVehicleWeightLimits[i]) {
-                        break;
-                    }
-                }
+            case RAIL:
+            case MAGLEV:
+                weightLimits = railSupportVehicleWeightLimits;
                 break;
-            case "Aerodyne":
-                for (i = WEIGHT_SMALL_SUPPORT; i < (fixedwingSupportVehicleWeightLimits.length - 1); i++) {
-                    if (tonnage <= fixedwingSupportVehicleWeightLimits[i]) {
-                        break;
-                    }
-                }
+            case AERODYNE:
+                weightLimits = fixedwingSupportVehicleWeightLimits;
                 break;
-            case "Airship":
-                for (i = WEIGHT_SMALL_SUPPORT; i < (airshipSupportVehicleWeightLimits.length - 1); i++) {
-                    if (tonnage <= airshipSupportVehicleWeightLimits[i]) {
-                        break;
-                    }
-                }
+            case AIRSHIP:
+                weightLimits = airshipSupportVehicleWeightLimits;
                 break;
-            case "Satellite":
-                for (i = WEIGHT_SMALL_SUPPORT; i < (satelliteSupportVehicleWeightLimits.length - 1); i++) {
-                    if (tonnage <= satelliteSupportVehicleWeightLimits[i]) {
-                        break;
-                    }
-                }
+            case STATION_KEEPING:
+                weightLimits = satelliteSupportVehicleWeightLimits;
                 break;
+            default:
+                return WEIGHT_MEDIUM_SUPPORT;
+        }
+        for (int i = WEIGHT_SMALL_SUPPORT; i < weightLimits.length; i++) {
+            if (tonnage <= weightLimits[i]) {
+                return i;
+            }
         }
 
-        return i;
+        return WEIGHT_MEDIUM_SUPPORT;
     }
 
     public static int getWeightClass(double tonnage, Entity en) {

--- a/megamek/src/megamek/common/EntityWeightClass.java
+++ b/megamek/src/megamek/common/EntityWeightClass.java
@@ -179,78 +179,80 @@ public class EntityWeightClass {
     public static int getSupportWeightClass(double tonnage, String type) {
         int i = 0;
 
-        if (type.equals("Wheeled")) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (wheeledSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= wheeledSupportVehicleWeightLimits[i]) {
-                    break;
+        switch (type) {
+            case "Wheeled":
+                for (i = WEIGHT_SMALL_SUPPORT; i < (wheeledSupportVehicleWeightLimits.length - 1); i++) {
+                    if (tonnage <= wheeledSupportVehicleWeightLimits[i]) {
+                        break;
+                    }
                 }
-            }
-        } else if (type.equals("Tracked")) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (trackedSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= trackedSupportVehicleWeightLimits[i]) {
-                    break;
+                break;
+            case "Tracked":
+                for (i = WEIGHT_SMALL_SUPPORT; i < (trackedSupportVehicleWeightLimits.length - 1); i++) {
+                    if (tonnage <= trackedSupportVehicleWeightLimits[i]) {
+                        break;
+                    }
                 }
-            }
-        } else if (type.equals("Hover")) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (hoverSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= hoverSupportVehicleWeightLimits[i]) {
-                    break;
+                break;
+            case "Hover":
+                for (i = WEIGHT_SMALL_SUPPORT; i < (hoverSupportVehicleWeightLimits.length - 1); i++) {
+                    if (tonnage <= hoverSupportVehicleWeightLimits[i]) {
+                        break;
+                    }
                 }
-            }
-        } else if (type.equals(UnitType.getTypeName(UnitType.VTOL))) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (vtolSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= vtolSupportVehicleWeightLimits[i]) {
-                    break;
+                break;
+            case "VTOL":
+                for (i = WEIGHT_SMALL_SUPPORT; i < (vtolSupportVehicleWeightLimits.length - 1); i++) {
+                    if (tonnage <= vtolSupportVehicleWeightLimits[i]) {
+                        break;
+                    }
                 }
-            }
-        } else if (type.equals("WiGE")) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (wigeSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= wigeSupportVehicleWeightLimits[i]) {
-                    break;
+                break;
+            case "WiGE":
+                for (i = WEIGHT_SMALL_SUPPORT; i < (wigeSupportVehicleWeightLimits.length - 1); i++) {
+                    if (tonnage <= wigeSupportVehicleWeightLimits[i]) {
+                        break;
+                    }
                 }
-            }
-        } else if (type.equals(UnitType.getTypeName(UnitType.NAVAL))) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (navalSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= navalSupportVehicleWeightLimits[i]) {
-                    break;
+                break;
+            case "Naval":
+            case "Hydrofoil":
+            case "Submarine":
+                for (i = WEIGHT_SMALL_SUPPORT; i < (navalSupportVehicleWeightLimits.length - 1); i++) {
+                    if (tonnage <= navalSupportVehicleWeightLimits[i]) {
+                        break;
+                    }
                 }
-            }
-        } else if (type.equals("Submarine")) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (navalSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= navalSupportVehicleWeightLimits[i]) {
-                    break;
+                break;
+            case "Rail":
+            case "MagLev":
+                for (i = WEIGHT_SMALL_SUPPORT; i < (railSupportVehicleWeightLimits.length - 1); i++) {
+                    if (tonnage <= railSupportVehicleWeightLimits[i]) {
+                        break;
+                    }
                 }
-            }
-        } else if (type.equals("Rail")) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (railSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= railSupportVehicleWeightLimits[i]) {
-                    break;
+                break;
+            case "Aerodyne":
+                for (i = WEIGHT_SMALL_SUPPORT; i < (fixedwingSupportVehicleWeightLimits.length - 1); i++) {
+                    if (tonnage <= fixedwingSupportVehicleWeightLimits[i]) {
+                        break;
+                    }
                 }
-            }
-        } else if (type.equals("MagLev")) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (railSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= railSupportVehicleWeightLimits[i]) {
-                    break;
+                break;
+            case "Airship":
+                for (i = WEIGHT_SMALL_SUPPORT; i < (airshipSupportVehicleWeightLimits.length - 1); i++) {
+                    if (tonnage <= airshipSupportVehicleWeightLimits[i]) {
+                        break;
+                    }
                 }
-            }
-        } else if (type.equals("Aerodyne")) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (fixedwingSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= fixedwingSupportVehicleWeightLimits[i]) {
-                    break;
+                break;
+            case "Satellite":
+                for (i = WEIGHT_SMALL_SUPPORT; i < (satelliteSupportVehicleWeightLimits.length - 1); i++) {
+                    if (tonnage <= satelliteSupportVehicleWeightLimits[i]) {
+                        break;
+                    }
                 }
-            }
-        } else if (type.equals("Airship")) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (airshipSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= airshipSupportVehicleWeightLimits[i]) {
-                    break;
-                }
-            }
-        } else if (type.equals("Satellite")) {
-            for (i = WEIGHT_SMALL_SUPPORT; i < (satelliteSupportVehicleWeightLimits.length - 1); i++) {
-                if (tonnage <= satelliteSupportVehicleWeightLimits[i]) {
-                    break;
-                }
-            }
+                break;
         }
 
         return i;


### PR DESCRIPTION
Hydrofoil support vehicles were missing from the method that determines support vehicle weight class. I also reworked the method to remove a lot of code repetition and fragile reliance on String literal matching. The type parameter passed to EntityWeightClass#getSupportWeightClass comes from Entity#getMovementModeAsString. I took advantage of the lookup aliases in EntityMovementMode to match to the enum value.