### PR TITLE
restore bot capability to physically attack gun emplacements

### DIFF
--- a/megamek/src/megamek/client/bot/PhysicalCalculator.java
+++ b/megamek/src/megamek/client/bot/PhysicalCalculator.java
@@ -17,6 +17,7 @@ package megamek.client.bot;
 import java.util.Iterator;
 
 import megamek.common.BattleArmor;
+import megamek.common.BuildingTarget;
 import megamek.common.Compute;
 import megamek.common.Coords;
 import megamek.common.Entity;
@@ -29,6 +30,7 @@ import megamek.common.Mounted;
 import megamek.common.Protomech;
 import megamek.common.Tank;
 import megamek.common.TargetRoll;
+import megamek.common.Targetable;
 import megamek.common.Terrains;
 import megamek.common.ToHitData;
 import megamek.common.actions.BrushOffAttackAction;
@@ -306,7 +308,14 @@ public final class PhysicalCalculator {
     }
 
     static PhysicalOption getBestPhysicalAttack(Entity from, Entity to,
-                                                IGame game) {
+                                                IGame game) {        
+        Targetable target = to;
+        
+        // if the object of our affections is in a building, we have to target the building instead
+        if(Compute.isInBuilding(game, to)) {
+            target = new BuildingTarget(to.getPosition(), game.getBoard(), false);
+        }
+        
         double bestDmg = 0.0;
         double dmg;
         int damage;
@@ -347,7 +356,7 @@ public final class PhysicalCalculator {
             location_table = ToHitData.HIT_NORMAL;
         }
 
-        ToHitData odds = PunchAttackAction.toHit(game, from.getId(), to,
+        ToHitData odds = PunchAttackAction.toHit(game, from.getId(), target,
                                                  PunchAttackAction.LEFT, false);
         if (odds.getValue() != TargetRoll.IMPOSSIBLE) {
             damage = PunchAttackAction.getDamageFor(from,
@@ -359,7 +368,7 @@ public final class PhysicalCalculator {
                                        bestDmg);
         }
 
-        odds = PunchAttackAction.toHit(game, from.getId(), to,
+        odds = PunchAttackAction.toHit(game, from.getId(), target,
                                        PunchAttackAction.RIGHT, false);
         if (odds.getValue() != TargetRoll.IMPOSSIBLE) {
             damage = PunchAttackAction.getDamageFor(from,
@@ -374,7 +383,7 @@ public final class PhysicalCalculator {
         }
 
         // Check for a double punch
-        odds = PunchAttackAction.toHit(game, from.getId(), to,
+        odds = PunchAttackAction.toHit(game, from.getId(), target,
                                        PunchAttackAction.LEFT, false);
         ToHitData odds_a = PunchAttackAction.toHit(game, from.getId(), to,
                                                    PunchAttackAction.RIGHT, false);
@@ -441,7 +450,7 @@ public final class PhysicalCalculator {
             } else {
                 location_table = ToHitData.HIT_NORMAL;
             }
-            odds = ClubAttackAction.toHit(game, from.getId(), to, club,
+            odds = ClubAttackAction.toHit(game, from.getId(), target, club,
                                           ToHitData.HIT_NORMAL, false);
             if (odds.getValue() != TargetRoll.IMPOSSIBLE) {
                 damage = ClubAttackAction.getDamageFor(from, club, targetConvInfantry, false);
@@ -459,7 +468,7 @@ public final class PhysicalCalculator {
             }
         }
         // Check for a push attack
-        odds = PushAttackAction.toHit(game, from.getId(), to);
+        odds = PushAttackAction.toHit(game, from.getId(), target);
         if (odds.getValue() != TargetRoll.IMPOSSIBLE) {
             int elev_diff;
             double breach;
@@ -558,7 +567,7 @@ public final class PhysicalCalculator {
         }
 
         if (bestDmg > 0) {
-            return new PhysicalOption(from, to, bestDmg, bestType, bestClub);
+            return new PhysicalOption(from, target, bestDmg, bestType, bestClub);
         }
         return null;
     }
@@ -586,7 +595,15 @@ public final class PhysicalCalculator {
         double coll_damage = 0.0;
         int damage;
         boolean targetConvInfantry = false;
-        ToHitData odds = KickAttackAction.toHit(game, from.getId(), to, action);
+        
+        Targetable target = to;
+        
+        // if the object of our affections is in a building, we have to target the building instead
+        if(Compute.isInBuilding(game, to)) {
+            target = new BuildingTarget(to.getPosition(), game.getBoard(), false);
+        }
+        
+        ToHitData odds = KickAttackAction.toHit(game, from.getId(), target, action);
         if (odds.getValue() > 12) {
             return 0.0;
         }

--- a/megamek/src/megamek/client/bot/PhysicalOption.java
+++ b/megamek/src/megamek/client/bot/PhysicalOption.java
@@ -55,7 +55,7 @@ public class PhysicalOption {
     public static final int THRASH_INF = 13;
 
     Entity attacker;
-    Entity target;
+    Targetable target;
     INarcPod i_target;
     double expectedDmg;
     int type;
@@ -69,9 +69,8 @@ public class PhysicalOption {
     public PhysicalOption(Entity attacker, Targetable target, double dmg,
             int type, Mounted club) {
         this.attacker = attacker;
-        if (target instanceof Entity) {
-            this.target = (Entity) target;
-        }
+        this.target = target;
+        
         if (target instanceof INarcPod) {
             this.i_target = (INarcPod) target;
         }
@@ -83,28 +82,28 @@ public class PhysicalOption {
     public AbstractAttackAction toAction() {
         switch (type) {
             case PUNCH_LEFT:
-                return new PunchAttackAction(attacker.getId(), target.getId(),
+                return new PunchAttackAction(attacker.getId(), target.getTargetType(), target.getTargetId(),
                         PunchAttackAction.LEFT);
             case PUNCH_RIGHT:
-                return new PunchAttackAction(attacker.getId(), target.getId(),
+                return new PunchAttackAction(attacker.getId(), target.getTargetType(), target.getTargetId(),
                         PunchAttackAction.RIGHT);
             case PUNCH_BOTH:
-                return new PunchAttackAction(attacker.getId(), target.getId(),
+                return new PunchAttackAction(attacker.getId(), target.getTargetType(), target.getTargetId(),
                         PunchAttackAction.BOTH);
             case KICK_LEFT:
-                return new KickAttackAction(attacker.getId(), target.getId(),
+                return new KickAttackAction(attacker.getId(), target.getTargetType(), target.getTargetId(),
                         KickAttackAction.LEFT);
             case KICK_RIGHT:
-                return new KickAttackAction(attacker.getId(), target.getId(),
+                return new KickAttackAction(attacker.getId(), target.getTargetType(), target.getTargetId(),
                         KickAttackAction.RIGHT);
             case USE_CLUB:
                 if (club != null) {
-                    return new ClubAttackAction(attacker.getId(), target
-                            .getId(), club, ToHitData.HIT_NORMAL);
+                    return new ClubAttackAction(attacker.getId(), target.getTargetType(), target
+                            .getTargetId(), club, ToHitData.HIT_NORMAL, false);
                 }
                 return null;
             case PUSH_ATTACK:
-                return new PushAttackAction(attacker.getId(), target.getId(),
+                return new PushAttackAction(attacker.getId(), target.getTargetId(),
                         target.getPosition());
             case TRIP_ATTACK:
                 return null; // Trip attack not implemented yet
@@ -115,7 +114,7 @@ public class PhysicalOption {
                             BrushOffAttackAction.LEFT);
                 }
                 return new BrushOffAttackAction(attacker.getId(), target
-                        .getTargetType(), target.getId(),
+                        .getTargetType(), target.getTargetId(),
                         BrushOffAttackAction.LEFT);
             case BRUSH_RIGHT:
                 if (target == null) {
@@ -124,7 +123,7 @@ public class PhysicalOption {
                             BrushOffAttackAction.RIGHT);
                 }
                 return new BrushOffAttackAction(attacker.getId(), target
-                        .getTargetType(), target.getId(),
+                        .getTargetType(), target.getTargetId(),
                         BrushOffAttackAction.RIGHT);
             case BRUSH_BOTH:
                 if (target == null) {
@@ -133,7 +132,7 @@ public class PhysicalOption {
                             BrushOffAttackAction.BOTH);
                 }
                 return new BrushOffAttackAction(attacker.getId(), target
-                        .getTargetType(), target.getId(),
+                        .getTargetType(), target.getTargetId(),
                         BrushOffAttackAction.BOTH);
                 /*
                  * case THRASH_INF : return new

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -467,6 +467,14 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         frame.addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
+                // let's not nag the players about this in the lounge
+                if(client.getGame().getPhase() == Phase.PHASE_LOUNGE) {
+                    frame.setVisible(false);
+                    saveSettings();
+                    die();
+                    return;
+                }
+                
                 ignoreHotKeys = true;
                 int savePrompt = JOptionPane.showConfirmDialog(null,
                         "Do you want to save the game before quitting MegaMek?",

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -467,14 +467,6 @@ public class ClientGUI extends JPanel implements WindowListener, BoardViewListen
         frame.addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
-                // let's not nag the players about this in the lounge
-                if(client.getGame().getPhase() == Phase.PHASE_LOUNGE) {
-                    frame.setVisible(false);
-                    saveSettings();
-                    die();
-                    return;
-                }
-                
                 ignoreHotKeys = true;
                 int savePrompt = JOptionPane.showConfirmDialog(null,
                         "Do you want to save the game before quitting MegaMek?",

--- a/megamek/src/megamek/common/actions/PunchAttackAction.java
+++ b/megamek/src/megamek/common/actions/PunchAttackAction.java
@@ -50,6 +50,14 @@ public class PunchAttackAction extends PhysicalAttackAction {
         super(entityId, targetId);
         this.arm = arm;
     }
+    
+    /**
+     * Punch attack vs an entity or other type of target (e.g. building)
+     */
+    public PunchAttackAction(int entityId, int targetType, int targetId, int arm) {
+        super(entityId, targetType, targetId);
+        this.arm = arm;
+    }
 
     public PunchAttackAction(int entityId, int targetType, int targetId, int arm, boolean leftBlade,
                              boolean rightBlade, boolean zweihandering) {


### PR DESCRIPTION
Somewhere along the line, the bot gained the capability to brush off swarming infantry and do push attacks, but forgot how to attack units inside buildings (including turrets, infantry, etc). This PR restores that capability.