### PR TITLE
enable bot editing via right click on bot player row

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
@@ -95,7 +95,17 @@ public class BotConfigDialog extends JDialog implements ActionListener, KeyListe
     private final JPanel botSpecificCardsPanel;
 
     public BotConfigDialog(JFrame parent) {
-        this(parent, null);
+        this(parent, new HashSet<IPlayer>());
+    }
+    
+    public BotConfigDialog(JFrame parent, BotClient existingBot) {
+        this(parent, new HashSet<IPlayer>());
+        
+        if(existingBot instanceof Princess) {
+            this.princessBehavior = ((Princess) existingBot).getBehaviorSettings();
+            nameField.setText(existingBot.getName());
+            setPrincessFields();
+        }
     }
 
     public BotConfigDialog(JFrame parent, Set<IPlayer> ghostPlayers) {
@@ -186,6 +196,10 @@ public class BotConfigDialog extends JDialog implements ActionListener, KeyListe
             return false;
         }
         return true;
+    }
+    
+    public BehaviorSettings getBehaviorSettings() {
+        return princessBehavior;
     }
 
     protected void setPrincessFields() {

--- a/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/swing/BotConfigDialog.java
@@ -95,13 +95,13 @@ public class BotConfigDialog extends JDialog implements ActionListener, KeyListe
     private final JPanel botSpecificCardsPanel;
 
     public BotConfigDialog(JFrame parent) {
-        this(parent, new HashSet<IPlayer>());
+        this(parent, new HashSet<>());
     }
     
     public BotConfigDialog(JFrame parent, BotClient existingBot) {
-        this(parent, new HashSet<IPlayer>());
+        this(parent, new HashSet<>());
         
-        if(existingBot instanceof Princess) {
+        if (existingBot instanceof Princess) {
             this.princessBehavior = ((Princess) existingBot).getBehaviorSettings();
             nameField.setText(existingBot.getName());
             setPrincessFields();
@@ -111,7 +111,6 @@ public class BotConfigDialog extends JDialog implements ActionListener, KeyListe
     public BotConfigDialog(JFrame parent, Set<IPlayer> ghostPlayers) {
         super(parent, "Configure Bot", true);
 
-        //        setLocationRelativeTo(parent);
         if (ghostPlayers != null) {
             this.ghostPlayers.addAll(ghostPlayers);
         }

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -3234,7 +3234,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener, 
                 menuItem.setEnabled(isOwner || isBot);
                 popup.add(menuItem);
                 
-                if(isBot) {
+                if (isBot) {
                     JMenuItem botConfig = new JMenuItem("Bot Settings ...");
                     botConfig.setActionCommand("BOTCONFIG|" + row);
                     botConfig.addActionListener(this);
@@ -3251,7 +3251,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener, 
             String command = st.nextToken();
             if (command.equalsIgnoreCase("CONFIGURE")) {
                 customizePlayer();
-            } else if(command.equalsIgnoreCase("BOTCONFIG")) {
+            } else if (command.equalsIgnoreCase("BOTCONFIG")) {
                 int row = Integer.parseInt(st.nextToken());
                 IPlayer player = playerModel.getPlayerAt(row);
                 BotClient bot = (BotClient) clientgui.getBots().get(player.getName());
@@ -3260,7 +3260,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener, 
 
                 if (bcd.dialogAborted) {
                     return; // user didn't click 'ok', add no bot
-                } else if(bot instanceof Princess) {
+                } else if (bot instanceof Princess) {
                     ((Princess) bot).setBehaviorSettings(bcd.getBehaviorSettings());
                     
                     // bookkeeping:

--- a/megamek/src/megamek/client/ui/swing/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/ChatLounge.java
@@ -61,6 +61,7 @@ import javax.swing.table.TableColumn;
 import megamek.client.Client;
 import megamek.client.RandomNameGenerator;
 import megamek.client.bot.BotClient;
+import megamek.client.bot.princess.Princess;
 import megamek.client.bot.ui.swing.BotGUI;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.ImageFileFactory;
@@ -3227,12 +3228,19 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener, 
             boolean isBot = clientgui.getBots().get(player.getName()) != null;
             if (e.isPopupTrigger()) {
                 JMenuItem menuItem = null;
-                // JMenu menu = null;
                 menuItem = new JMenuItem("Configure ...");
                 menuItem.setActionCommand("CONFIGURE|" + row);
                 menuItem.addActionListener(this);
                 menuItem.setEnabled(isOwner || isBot);
                 popup.add(menuItem);
+                
+                if(isBot) {
+                    JMenuItem botConfig = new JMenuItem("Bot Settings ...");
+                    botConfig.setActionCommand("BOTCONFIG|" + row);
+                    botConfig.addActionListener(this);
+                    popup.add(botConfig);
+                }
+                
                 popup.show(e.getComponent(), e.getX(), e.getY());
             }
         }
@@ -3243,6 +3251,25 @@ public class ChatLounge extends AbstractPhaseDisplay implements ActionListener, 
             String command = st.nextToken();
             if (command.equalsIgnoreCase("CONFIGURE")) {
                 customizePlayer();
+            } else if(command.equalsIgnoreCase("BOTCONFIG")) {
+                int row = Integer.parseInt(st.nextToken());
+                IPlayer player = playerModel.getPlayerAt(row);
+                BotClient bot = (BotClient) clientgui.getBots().get(player.getName());
+                BotConfigDialog bcd = new BotConfigDialog(clientgui.frame, bot);
+                bcd.setVisible(true);
+
+                if (bcd.dialogAborted) {
+                    return; // user didn't click 'ok', add no bot
+                } else if(bot instanceof Princess) {
+                    ((Princess) bot).setBehaviorSettings(bcd.getBehaviorSettings());
+                    
+                    // bookkeeping:
+                    clientgui.getBots().remove(player.getName());
+                    bot.setName(bcd.getBotName());
+                    clientgui.getBots().put(bot.getName(), bot);
+                    player.setName(bcd.getBotName());
+                    clientgui.chatlounge.refreshPlayerInfo();
+                }
             }
         }
 


### PR DESCRIPTION
For bot players, added a 'bot settings' right click option, so you can edit an existing bot's behavior rather than have to boot it and create a new one.