### PR TITLE
Large SV equipment location validation

### DIFF
--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -859,7 +859,8 @@ public class TestTank extends TestEntity {
         }
         final boolean isRearLocation;
         final boolean isTurretLocation;
-        if (tank instanceof SuperHeavyTank) {
+        // SuperHeavyTank and LargeSupportTank have the same location indices.
+        if ((tank instanceof SuperHeavyTank) || (tank instanceof LargeSupportTank)) {
             isRearLocation = location == SuperHeavyTank.LOC_REAR;
             isTurretLocation = (location == SuperHeavyTank.LOC_TURRET) || (location == SuperHeavyTank.LOC_TURRET_2);
         } else {


### PR DESCRIPTION
Location indices for LargeSupportTank are the same as those for SuperHeavyTank, but the location validation method is using the Tank location indices.

Fixes MegaMek/megameklab#582