### PR TITLE
Fix exception in TRO entry for mechs with certain armor types

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -759,6 +759,18 @@ public class EquipmentType implements ITechnology {
         return clan ? "Clan " + armorNames[armorType] : "IS "
                 + armorNames[armorType];
     }
+
+    /**
+     * Convenience method to test whether an EquipmentType instance is armor. This works
+     * by comparing the results of {@link #getName()} to the armor names array and returning
+     * {@code true} if there is a match.
+     *
+     * @param et The equipment instance to test
+     * @return   Whether the equipment is an armor type
+     */
+    public static boolean isArmorType(EquipmentType et) {
+        return getArmorType(et) != T_ARMOR_UNKNOWN;
+    }
     
     public static int getStructureType(EquipmentType et) {
         if (et == null) {
@@ -785,6 +797,18 @@ public class EquipmentType implements ITechnology {
         }
         return clan ? "Clan " + structureNames[structureType] : "IS "
                 + structureNames[structureType];
+    }
+
+    /**
+     * Convenience method to test whether an EquipmentType instance is mech structure. This works
+     * by comparing the results of {@link #getName()} to the structure names array and returning
+     * {@code true} if there is a match.
+     *
+     * @param et The equipment instance to test
+     * @return   Whether the equipment is a structure type
+     */
+    public static boolean isStructureType(EquipmentType et) {
+        return getStructureType(et) != T_STRUCTURE_UNKNOWN;
     }
 
     public static String getBaArmorTypeName(int armorType) {

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -6724,8 +6724,8 @@ public abstract class Mech extends Entity {
         for (Mounted mounted : getMisc()) {
             if ((mounted.getType().getCriticals(this) == 0)
                     && !mounted.getType().hasFlag(MiscType.F_CASE)
-                    && (EquipmentType.getStructureType(mounted.getType()) == EquipmentType.T_STRUCTURE_UNKNOWN)
-                    && (EquipmentType.getArmorType(mounted.getType()) == EquipmentType.T_ARMOR_UNKNOWN)) {
+                    && !EquipmentType.isArmorType(mounted.getType())
+                    && !EquipmentType.isStructureType(mounted.getType())) {
                 sb.append(MtfFile.NO_CRIT).append(mounted.getType().getInternalName())
                         .append(":").append(getLocationAbbr(mounted.getLocation()))
                         .append(newLine);

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -6723,7 +6723,9 @@ public abstract class Mech extends Entity {
         }
         for (Mounted mounted : getMisc()) {
             if ((mounted.getType().getCriticals(this) == 0)
-                    && !mounted.getType().hasFlag(MiscType.F_CASE)) {
+                    && !mounted.getType().hasFlag(MiscType.F_CASE)
+                    && (EquipmentType.getStructureType(mounted.getType()) == EquipmentType.T_STRUCTURE_UNKNOWN)
+                    && (EquipmentType.getArmorType(mounted.getType()) == EquipmentType.T_ARMOR_UNKNOWN)) {
                 sb.append(MtfFile.NO_CRIT).append(mounted.getType().getInternalName())
                         .append(":").append(getLocationAbbr(mounted.getLocation()))
                         .append(newLine);

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -948,17 +948,8 @@ public class MechView {
                         && entity.isClan())
                     || (name.contains("Heat Sink") 
                         && !name.contains("Radical"))
-                    || name.contains("Endo Steel")
-                    || name.contains("Ferro-Fibrous")
-                    || name.contains("Reactive")
-                    || name.contains("BA Stealth")
-                    || name.contains("BA Fire Resistant")
-                    || name.contains("BA Mimetic")
-                    || name.contains("BA Standard")
-                    || name.contains("BA Advanced")
-                    || name.contains("Reflective")
-                    || name.contains("Ferro-Lamellor")
-                    || name.contains("Standard")) {
+                    || EquipmentType.isArmorType(mounted.getType())
+                    || EquipmentType.isStructureType(mounted.getType())) {
                 // These items are displayed elsewhere, so skip them here.
                 continue;
             }

--- a/megamek/src/megamek/common/templates/MechTROView.java
+++ b/megamek/src/megamek/common/templates/MechTROView.java
@@ -248,8 +248,12 @@ public class MechTROView extends TROView {
     @Override
     protected boolean skipMount(Mounted mount, boolean includeAmmo) {
         if (mount.getLocation() == Entity.LOC_NONE) {
+            // Skip heat sinks, Clan CASE, armor, and structure. We do want to show things
+            // like robotic control systems.
             return (mount.getType().getCriticals(mech) > 0)
-                    || mount.getType().hasFlag(MiscType.F_CASE);
+                    || mount.getType().hasFlag(MiscType.F_CASE)
+                    || (EquipmentType.getArmorType(mount.getType()) != EquipmentType.T_ARMOR_UNKNOWN)
+                    || (EquipmentType.getStructureType(mount.getType()) != EquipmentType.T_STRUCTURE_UNKNOWN);
         }
         return super.skipMount(mount, includeAmmo);
     }

--- a/megamek/src/megamek/common/templates/MechTROView.java
+++ b/megamek/src/megamek/common/templates/MechTROView.java
@@ -252,8 +252,8 @@ public class MechTROView extends TROView {
             // like robotic control systems.
             return (mount.getType().getCriticals(mech) > 0)
                     || mount.getType().hasFlag(MiscType.F_CASE)
-                    || (EquipmentType.getArmorType(mount.getType()) != EquipmentType.T_ARMOR_UNKNOWN)
-                    || (EquipmentType.getStructureType(mount.getType()) != EquipmentType.T_STRUCTURE_UNKNOWN);
+                    || EquipmentType.isArmorType(mount.getType())
+                    || EquipmentType.isStructureType(mount.getType());
         }
         return super.skipMount(mount, includeAmmo);
     }

--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -406,6 +406,13 @@ public class TROView {
         return addEquipment(entity, true);
     }
 
+    /**
+     * Test for whether the mount should be included in the equipment inventory section.
+     *
+     * @param mount        The equipment mount
+     * @param includeAmmo  Whether to include ammo in the list
+     * @return             Whether to list the equipment in the inventory section
+     */
     protected boolean skipMount(Mounted mount, boolean includeAmmo) {
         return mount.getLocation() < 0
                 || mount.isWeaponGroup()


### PR DESCRIPTION
This cleans up some side-effects of the implementation of construction data for the smart robotic control system, a piece of equipment that occupies no critical slots. Unlike vehicles and aerospace units, there is no location for such things, and they get dumped into LOC_NONE along with one-shot ammo and engine-integrated heat sinks. There is also an entry for structure and armor that does not have to be allocated space, and the problem comes from failing to account for this.

1. When building the inventory section of the TRO, any equipment that matches the armor of its location is skipped. It has to be checked by section to account for patchwork armor. But if it's zero-crit armor in LOC_NONE, this throws an exception.

2. The MechView filters out standard, but hasn't been filtering out other zero-crit armor and structure types. It was already filtering out bulky armor and structure, so I simplified the check by making it filter out all armor and structure (which is shown elsewhere.

3. The section of the mtf where the smart robotic control system is written is also writing zero-crit armor and structure entries. This doesn't cause any problems, but it's cruft.

Fixes #1853