### PR TITLE
Micro bomb ammo

### DIFF
--- a/megamek/data/mechfiles/battlearmor/RS3058Uu/Sylph Battle Armor.blk
+++ b/megamek/data/mechfiles/battlearmor/RS3058Uu/Sylph Battle Armor.blk
@@ -46,7 +46,6 @@ biped
 <Point Equipment>
 CLBAMicroPulseLaser:RA
 CLBAMicro Bomb:Body
-BA-Micro Bomb Ammo:Body
 BABattleClaw:RA
 </Point Equipment>
 

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMicroBomb.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMicroBomb.java
@@ -1,4 +1,4 @@
-/**
+/*
  * MegaMek - Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
  *
  *  This program is free software; you can redistribute it and/or modify it
@@ -10,10 +10,6 @@
  *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
  *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  *  for more details.
- */
-/*
- * Created on Sep 24, 2004
- *
  */
 package megamek.common.weapons.battlearmor;
 
@@ -28,6 +24,7 @@ import megamek.server.Server;
 
 /**
  * @author Sebastian Brocks
+ * Created on Sep 24, 2004
  */
 public class CLBAMicroBomb extends Weapon {
     /**
@@ -52,7 +49,7 @@ public class CLBAMicroBomb extends Weapon {
         longRange = 0;
         extremeRange = 0;
         bv = 11;
-        flags = flags.or(F_NO_FIRES).or(F_BA_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
+        flags = flags.or(F_NO_FIRES).or(F_BA_WEAPON).or(F_ONESHOT).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
         tonnage = .1;
         criticals = 2;
         cost = 30000;


### PR DESCRIPTION
The BA bomb rack is a one-shot weapon (TM, p. 253) but is missing the F_ONESHOT flag, so ammo isn't being added on load. The one example we have works because it has the ammo added as equipment, but this requires a critical slot that it shouldn't.

Fixes MegaMek/megameklab#550.