### PR TITLE
Munitions BV and cost rounding

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -15832,6 +15832,7 @@ public class AmmoType extends EquipmentType {
                     && (munition.getMunitionType() == AmmoType.M_COOLANT)) {
                 cost = 3000;
             }
+            // Account for floating point imprecision
             munition.bv = Math.round(bv * 1000.0) / 1000.0;
             munition.cost = Math.round(cost * 1000.0) / 1000.0;
 

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -15832,8 +15832,8 @@ public class AmmoType extends EquipmentType {
                     && (munition.getMunitionType() == AmmoType.M_COOLANT)) {
                 cost = 3000;
             }
-            munition.bv = bv;
-            munition.cost = cost;
+            munition.bv = Math.round(bv * 1000.0) / 1000.0;
+            munition.cost = Math.round(cost * 1000.0) / 1000.0;
 
             // Copy over all other values.
             munition.damagePerShot = base.damagePerShot;


### PR DESCRIPTION
Rounds calculated bv and cost for munitions to three decimal places to remove floating point errors.

Fixes MegaMek/megameklab#533.