### PR TITLE
FIx rounding in weight breakdown

### DIFF
--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -19,6 +19,7 @@
 
 package megamek.common.verifier;
 
+import java.text.DecimalFormat;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -254,7 +255,12 @@ public abstract class TestEntity implements TestEntityOption {
         if (kg) {
             weight *= 1000;
         }
-        return String.format("%3.1f%s", weight, (kg ? " kg" : ""));
+        if (weight < 0.5) {
+            // For small equipment show as many decimal places as needed.
+            return DecimalFormat.getInstance().format(weight);
+        } else {
+            return String.format("%3.1f%s", weight, (kg ? " kg" : ""));
+        }
     }
 
     /**


### PR DESCRIPTION
The weight breakdown shows all weights rounded to one decimal place. Some equipment < 0.5 tons require more decimal places to show the weight accurately.

Fixes MegaMek/megameklab#540