### PR TITLE
Enable bot to turn fighters at end of move

### DIFF
--- a/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
@@ -56,7 +56,7 @@ public class AeroGroundPathFinder {
         return 3;
     }
 
-    private IGame game;
+    protected IGame game;
     private List<MovePath> aeroGroundPaths;
     protected int maxThrust;
     private MMLogger logger;

--- a/megamek/src/megamek/common/pathfinder/AeroLowAltitudePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroLowAltitudePathFinder.java
@@ -59,7 +59,7 @@ public class AeroLowAltitudePathFinder extends AeroGroundPathFinder {
         
         List<MovePath> fullMovePathsWithTurns = new ArrayList<>();
         
-        for(MovePath movePath : fullMovePaths) {
+        for (MovePath movePath : fullMovePaths) {
             fullMovePathsWithTurns.add(movePath);
             
             MoveStep lastStep = movePath.getLastStep();

--- a/megamek/src/megamek/common/pathfinder/AeroLowAltitudePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroLowAltitudePathFinder.java
@@ -10,6 +10,7 @@ import megamek.common.Coords;
 import megamek.common.IAero;
 import megamek.common.IGame;
 import megamek.common.MovePath;
+import megamek.common.MovePath.MoveStepType;
 import megamek.common.MoveStep;
 import megamek.common.pathfinder.MovePathFinder.CoordsWithFacing;
 
@@ -56,7 +57,25 @@ public class AeroLowAltitudePathFinder extends AeroGroundPathFinder {
             fullMovePaths.addAll(super.GenerateAllPaths(altitudePath.clone()));
         }
         
-        return fullMovePaths;
+        List<MovePath> fullMovePathsWithTurns = new ArrayList<>();
+        
+        for(MovePath movePath : fullMovePaths) {
+            fullMovePathsWithTurns.add(movePath);
+            
+            MoveStep lastStep = movePath.getLastStep();
+            
+            if(lastStep != null && lastStep.canAeroTurn(game)) {
+                MovePath left = movePath.clone();
+                left.addStep(MoveStepType.TURN_LEFT);
+                fullMovePathsWithTurns.add(left);
+                
+                MovePath right = movePath.clone();
+                right.addStep(MoveStepType.TURN_RIGHT);
+                fullMovePathsWithTurns.add(right);
+            }
+        }
+        
+        return fullMovePathsWithTurns;
     }
     
     /**

--- a/megamek/src/megamek/common/pathfinder/AeroLowAltitudePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroLowAltitudePathFinder.java
@@ -64,7 +64,7 @@ public class AeroLowAltitudePathFinder extends AeroGroundPathFinder {
             
             MoveStep lastStep = movePath.getLastStep();
             
-            if(lastStep != null && lastStep.canAeroTurn(game)) {
+            if ((lastStep != null) && lastStep.canAeroTurn(game)) {
                 MovePath left = movePath.clone();
                 left.addStep(MoveStepType.TURN_LEFT);
                 fullMovePathsWithTurns.add(left);


### PR DESCRIPTION
This PR fixes a "dumb" bot behavior that I observed quite a bit but couldn't quite figure out.  Basically, in low-altitude air combat, the bot would move its aircraft all the way up to your ship, but fail to make that last turn and not be able to fire.

Turns out the pathfinder wasn't providing the appropriate paths to it in the first place.