### PR TITLE
Additional construction rules for naval comm scanner suite

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -7666,7 +7666,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName("ISSmallNavalCommScannerSuite");
         misc.addLookupName("CLSmallNavalCommScannerSuite");
         misc.flags = misc.flags.or(F_SMALL_COMM_SCANNER_SUITE).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT)
-                .or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
+                .or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT);
         misc.rulesRefs = "332,TO";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
                 .setTechRating(RATING_D).setAvailability(RATING_D, RATING_E, RATING_E, RATING_E)
@@ -7686,7 +7686,7 @@ public class MiscType extends EquipmentType {
         misc.name = "Naval Comm-Scanner Suite (Large)";
         misc.setInternalName("ISLargeNavalCommScannerSuite");
         misc.addLookupName("CLLargeNavalCommScannerSuite");
-        misc.flags = misc.flags.or(F_LARGE_COMM_SCANNER_SUITE).or(F_SC_EQUIPMENT).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT)
+        misc.flags = misc.flags.or(F_LARGE_COMM_SCANNER_SUITE).or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT)
                 .or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
         misc.rulesRefs = "332,TO";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -349,6 +349,12 @@ public abstract class TestEntity implements TestEntityOption {
                 // Mobile HPG has crew requirement of 10; ground-mobile has requirement of 1.
                 return eq.hasFlag(MiscType.F_TANK_EQUIPMENT)? 1 : 10;
             }
+            if (eq.hasFlag(MiscType.F_SMALL_COMM_SCANNER_SUITE)) {
+                return 6;
+            }
+            if (eq.hasFlag(MiscType.F_LARGE_COMM_SCANNER_SUITE)) {
+                return 12;
+            }
         }
         return 0;
     }

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -528,7 +528,8 @@ public class TestTank extends TestEntity {
             }
             if (eq.hasFlag(MiscType.F_SASRCS)
                     || eq.hasFlag(MiscType.F_LIGHT_SAIL)
-                    || eq.hasFlag(MiscType.F_SPACE_MINE_DISPENSER)) {
+                    || eq.hasFlag(MiscType.F_SPACE_MINE_DISPENSER)
+                    || eq.hasFlag(MiscType.F_SMALL_COMM_SCANNER_SUITE)) {
                 return mode.equals(EntityMovementMode.STATION_KEEPING);
             }
             if (eq.hasFlag(MiscType.F_VEHICLE_MINE_DISPENSER)) {


### PR DESCRIPTION
The naval comm-scanner suite adds six to the minimum crew requirements for the small, and twelve for the large. The small can be mounted on satellite support vehicles. The large can only be mounted on large craft, so the small craft flag is incorrect.

See TO, p. 332

Fixes MegaMek/megameklab#559