### PR TITLE
Round advanced aero fuel tank and pump weight to next ton.

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -22,20 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.Bay;
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.Jumpship;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.NavalRepairFacility;
-import megamek.common.TechConstants;
-import megamek.common.Warship;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.capitalweapons.ScreenLauncherWeapon;
@@ -524,8 +511,9 @@ public class TestAdvancedAerospace extends TestAero {
     
     @Override
     public double getWeightFuel() {
-        // Add 2% for pumps and round up to the half ton
-        return ceil(vessel.getFuelTonnage() * 1.02, Ceil.TON);
+        // Fuel tanks and pumps add an additional 2%, rounded to the nearest ton
+        double pumpWeight = RoundWeight.nextTon(vessel.getFuelTonnage() * 0.02);
+        return vessel.getFuelTonnage() + pumpWeight;
     }
 
     @Override


### PR DESCRIPTION
Advanced aerospace units add an additional 2% of the fuel weight for fuel tanks and pump, rounded up to the nearest ton (StratOps, 2018 printing, p. 147). This is a change from older editions which only required it to be rounded to the half ton.

Fixes MegaMek/megameklab#562.