### PR TITLE
Fix TRO weapon bay ammo shot count

### DIFF
--- a/megamek/src/megamek/common/templates/AeroTROView.java
+++ b/megamek/src/megamek/common/templates/AeroTROView.java
@@ -210,7 +210,7 @@ public class AeroTROView extends TROView {
             weapons.add(sb.toString());
         }
         shotsByAmmoType.forEach((at, count) -> weapons.add(
-                String.format("%s (%d %s)", at.getName(), at.getShots() * count, Messages.getString("TROView.shots"))));
+                String.format("%s (%d %s)", at.getName(), count, Messages.getString("TROView.shots"))));
         retVal.put("weapons", weapons);
         retVal.put("heat", heat);
         retVal.put("srv", Math.round(srv / 10.0) + "(" + srv + ")");


### PR DESCRIPTION
When calculating the number of shots of ammo in a weapon bay, the total number of shots is incorrectly multiplied by the number of shots per ton, giving an inflated count.

Partial fix for MegaMek/megameklab#593