### PR TITLE
Remove all but primitive from list of armors for primitive jumpships

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -3852,11 +3852,7 @@ public class Aero extends Entity implements IAero, IBomber {
         }
     }
 
-    /**
-     * Is this a primitive ASF?
-     *
-     * @return
-     */
+    @Override
     public boolean isPrimitive() {
         return (getCockpitType() == Aero.COCKPIT_PRIMITIVE);
     }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15145,6 +15145,13 @@ public abstract class Entity extends TurnOrdered implements Transporter,
         return false;
     }
 
+    /**
+     * @return Whether the unit uses primitive or retrotech construction rules
+     */
+    public boolean isPrimitive() {
+        return false;
+    }
+
     public int getStructuralTechRating() {
         return structuralTechRating;
     }

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -7940,11 +7940,7 @@ public abstract class Mech extends Entity {
         }
     }
 
-    /**
-     * Is this a primitive Mech?
-     *
-     * @return
-     */
+    @Override
     public boolean isPrimitive() {
         return (getCockpitType() == Mech.COCKPIT_PRIMITIVE)
                 || (getCockpitType() == Mech.COCKPIT_PRIMITIVE_INDUSTRIAL);

--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -15,12 +15,7 @@
 package megamek.common.verifier;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import megamek.common.*;
 import megamek.common.util.StringUtil;
@@ -37,7 +32,7 @@ public class TestAdvancedAerospace extends TestAero {
     
     private final Jumpship vessel;
 
-    public static enum CapitalArmor{
+    public enum CapitalArmor{
         PRIMITIVE(EquipmentType.T_ARMOR_PRIMITIVE_AERO, false),   
         STANDARD(EquipmentType.T_ARMOR_AEROSPACE, false),   
         CLAN_STANDARD(EquipmentType.T_ARMOR_AEROSPACE, true),
@@ -131,10 +126,13 @@ public class TestAdvancedAerospace extends TestAero {
     /**
      * Filters all capital armor according to given tech constraints
      * 
-     * @param techManager
+     * @param techManager Constraints used to filter the possible armor types
      * @return A list of all armors that meet the tech constraints
      */
-    public static List<EquipmentType> legalArmorsFor(ITechManager techManager) {
+    public static List<EquipmentType> legalArmorsFor(ITechManager techManager, boolean primitive) {
+        if (primitive) {
+            return Collections.singletonList(CapitalArmor.PRIMITIVE.getArmorEqType());
+        }
         List<EquipmentType> retVal = new ArrayList<>();
         for (CapitalArmor armor : CapitalArmor.values()) {
             final EquipmentType eq = armor.getArmorEqType();

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -285,18 +285,19 @@ public abstract class TestEntity implements TestEntityOption {
      * @param etype         The entity type bit mask
      * @param industrial    For mechs; industrial mechs can only use certain armor types
      *                      unless allowing experimental rules
+     * @param primitive     Whether the unit is primitive/retrotech
      * @param movementMode  For vehicles; hardened armor is illegal for some movement modes 
      * @param techManager   The constraints used to filter the armor types
      * @return A list of all armors that meet the tech constraints
      */
-    public static List<EquipmentType> legalArmorsFor(long etype, boolean industrial,
+    public static List<EquipmentType> legalArmorsFor(long etype, boolean industrial, boolean primitive,
             EntityMovementMode movementMode, ITechManager techManager) {
         if ((etype & Entity.ETYPE_BATTLEARMOR) != 0) {
             return TestBattleArmor.legalArmorsFor(techManager);
         } else if ((etype & Entity.ETYPE_SMALL_CRAFT) != 0) {
             return TestSmallCraft.legalArmorsFor(techManager);
         } else if ((etype & Entity.ETYPE_JUMPSHIP) != 0) {
-            return TestAdvancedAerospace.legalArmorsFor(techManager);
+            return TestAdvancedAerospace.legalArmorsFor(techManager, primitive);
         } else if ((etype & (Entity.ETYPE_FIXED_WING_SUPPORT | Entity.ETYPE_SUPPORT_TANK | Entity.ETYPE_SUPPORT_VTOL)) != 0) {
             return TestSupportVehicle.legalArmorsFor(techManager);
         } else if ((etype & Entity.ETYPE_AERO) != 0) {


### PR DESCRIPTION
MML currently presents primitive and standard aerospace armor for primitive jumpships if the date is late enough for standard. This is a vestige of the original implementation based on the text of IO, which was not clear on whether the reduced point value was a function of the ship or the armor. The errata has since made it clear that the armor points per ton are reduced as part of the unit construction itself, so there is no option to mount standard and get more points. This changes the method that MML uses to get the available armors to reflect that.